### PR TITLE
feat(agents): declarative status rules for custom agents

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -141,6 +141,7 @@ Notification = "waiting"
 | `acp.allowed_agents` | `[]` | ACP registry keys a structured view session may run while `acp.restrict_agents` is on, e.g. `["claude", "codex"]`. These are registry keys, not binary names, and each alias counts separately (allowing `claude` does not allow `claude-code`). With the restriction on, an empty list denies every agent. Governs the structured view only; a terminal session runs in a pane where any binary can be launched, so it is not constrained here. A policy change applies to new sessions immediately and to an already-running worker when it next respawns or when the daemon restarts, at which point a worker on a now-disallowed agent is terminated rather than reattached. |
 | `acp.acp_defaults` | `{}` | Per-agent defaults for structured view startup (under the `[acp]` section, not `[session]`). `model` is forwarded when the worker starts; `effort` (thinking) and `mode` are applied through the agent's ACP config options (`thought_level`, `mode`) when advertised, and skipped with a warning otherwise. `effort_by_model` (a `{model = effort}` map) overrides `effort` for the resolved model. Editable per agent from the web dashboard (Structured view tab, Structured View Defaults). Example: `[acp.acp_defaults.opencode] model = "openai/gpt-5.5" effort = "high" mode = "plan"`. |
 | `agents.<name>.status_map` | `{}` | Trusted global/profile-only hook event to AoE status mappings. Valid statuses are `running`, `waiting`, `idle`, and `error`. Entries apply by event name to built-in hook defaults, so duplicate event names with different matchers all receive the same status; new event names are added to the installed hooks when the agent format supports event keys. Existing hook files update on the next hook install, usually a new or restarted session. Agent processes with installed status hooks receive `AOE_PROFILE`, so hook scripts can query the resolved map with `aoe -p "$AOE_PROFILE" profile show --status-map <agent> --json`. |
+| `agents.<name>.status_rules` | `[]` | Trusted global/profile-only declarative pane status rules (`[[agents.<name>.status_rules]]` array of tables). Each rule has `status` (`running`, `waiting`, `idle`, or `error`) and exactly one of `contains` (case-insensitive substring) or `regex` (Rust regex, matched as written; use `(?i)` for case-insensitive). Rules are evaluated in order against the ANSI-stripped pane snapshot; first match wins, no match reports `idle`. Rules take precedence over `agent_detect_as` and over a built-in detector of the same name. Invalid rules are skipped with a warning in the debug log. Takes effect on the next config resolve (TUI or daemon start). |
 
 For Codex, AoE preserves existing `[hooks.state]` trust data and writes `~/.codex/config.toml` through `config.toml.lock` plus an atomic replace. This keeps repeated or concurrent AoE launches from duplicating hook blocks or leaving partial TOML.
 
@@ -193,11 +194,30 @@ agent_detect_as = { "lenovo-claude" = "claude" }
 ```
 
 - **`custom_agents`**: Maps a display name to the shell command AoE runs in a tmux pane when that agent is selected. Names appear in the TUI picker alongside built-ins like `claude`, `opencode`, and `codex`, and work with `aoe add --tool <name>`.
-- **`agent_detect_as`** (optional): Reuses a built-in agent's status detection for the custom agent. Without it, custom agents default to `Idle`.
+- **`agent_detect_as`** (optional): Reuses a built-in agent's status detection for the custom agent. Without it (and without `status_rules`, below), custom agents default to `Idle`. Best for wrappers that run the *same* binary differently (SSH, scripts); for an agent whose output differs from every built-in, use `status_rules` instead.
 - **`agent_acp_cmd`** (optional): ACP launch command that lets the agent run in the structured view (see below).
 - **`default_tool`** (optional): Can point at a custom-agent name to default new sessions to it.
 
 Custom agents are always shown as available in the picker since their command may target a remote host or wrapper. All three maps are editable in config files or the TUI settings screen and support profile/repo overrides; profile/repo values fully replace the global map (redeclare any agents you want to keep). The Web wizard can select a configured custom agent but does not expose or edit the command strings.
+
+#### Status rules for custom agents
+
+`agent_detect_as` only works when the custom agent renders the same output as the built-in it aliases. For a harness that is *similar to but not the same binary as* any built-in, declare pane status rules instead — no change to the agent needed:
+
+```toml
+[session.custom_agents]
+gjc = "gjc"
+
+[[agents.gjc.status_rules]]
+status = "waiting"
+contains = "(y/n)"
+
+[[agents.gjc.status_rules]]
+status = "running"
+regex = "esc to interrupt|thinking"
+```
+
+Rules are checked in order against the last screenful of ANSI-stripped pane text every status poll; the first match wins and no match reports `idle`. Put the more specific states (`waiting`, `error`) before the broad `running` matchers. When an agent has rules, they take precedence over its `agent_detect_as` alias and over a built-in detector of the same name.
 
 #### Running a custom agent in the structured view
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -202,7 +202,7 @@ Custom agents are always shown as available in the picker since their command ma
 
 #### Status rules for custom agents
 
-`agent_detect_as` only works when the custom agent renders the same output as the built-in it aliases. For a harness that is *similar to but not the same binary as* any built-in, declare pane status rules instead — no change to the agent needed:
+`agent_detect_as` only works when the custom agent renders the same output as the built-in it aliases. For a harness that is *similar to but not the same binary as* any built-in, declare pane status rules instead; no change to the agent is needed:
 
 ```toml
 [session.custom_agents]

--- a/src/cli/ps.rs
+++ b/src/cli/ps.rs
@@ -562,7 +562,15 @@ fn load_instances(profile: &str, profile_explicit: bool) -> Vec<Instance> {
     };
     for name in &profiles {
         if let Ok(storage) = Storage::open_unwatched(name) {
-            if let Ok((instances, _)) = storage.load_with_groups() {
+            if let Ok((mut instances, _)) = storage.load_with_groups() {
+                // `load_with_groups` does not stamp the source profile (it is
+                // `#[serde(default, skip_serializing)]`), so set it here the way
+                // the serve loader does. The status poll keys the profile-scoped
+                // status-rule registry on it; without it a profile's rules would
+                // install and look up under the empty profile and never match.
+                for inst in &mut instances {
+                    inst.source_profile = name.clone();
+                }
                 out.extend(instances);
             }
         }
@@ -582,6 +590,19 @@ fn is_agent_session_name(name: &str) -> bool {
 
 fn collect_tmux_states(instances: &mut [Instance]) -> Vec<TmuxState> {
     use std::collections::HashSet;
+
+    // The poll below never loads config, so install the declarative status-rule
+    // registry once per distinct profile up front; otherwise a rules-having
+    // custom agent reports Idle. The registry is keyed by profile, so each
+    // install replaces only that profile's entries.
+    {
+        let mut resolved: HashSet<&str> = HashSet::new();
+        for inst in instances.iter() {
+            if resolved.insert(inst.source_profile.as_str()) {
+                crate::session::profile_config::resolve_config_or_warn(&inst.source_profile);
+            }
+        }
+    }
 
     crate::tmux::refresh_session_cache();
     let meta = crate::tmux::batch_pane_metadata().unwrap_or_default();
@@ -1242,5 +1263,28 @@ mod tests {
         for (version, stale, expected) in cases {
             assert_eq!(render_build_cell(version, stale), expected, "{version:?}");
         }
+    }
+
+    /// C1 regression guard: `load_instances` must stamp `source_profile` on
+    /// each loaded instance. The status poll keys the profile-scoped
+    /// status-rule registry on it; if it stayed empty, a profile's rules would
+    /// install and look up under the empty profile and never match in `aoe ps`.
+    #[test]
+    #[serial_test::serial]
+    fn load_instances_stamps_source_profile() {
+        let temp = tempfile::tempdir().unwrap();
+        let _guard = crate::session::test_support::isolate_app_dir_at(temp.path());
+
+        let storage = Storage::new_unwatched("pstest").unwrap();
+        storage
+            .update(|i, _| {
+                *i = vec![Instance::new("sess", "/tmp/sess")];
+                Ok(())
+            })
+            .unwrap();
+
+        let loaded = load_instances("pstest", true);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].source_profile, "pstest");
     }
 }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1563,6 +1563,11 @@ async fn show_session(profile: &str, args: ShowArgs) -> Result<()> {
         }
     };
 
+    // Resolving the profile config installs the declarative status-rule
+    // registry for this profile; the status detection below never loads config
+    // itself, so a rules-having custom agent would otherwise report Idle.
+    crate::session::profile_config::resolve_config_or_warn(profile);
+
     // Refresh status from tmux so the output reflects current state
     // rather than the stale persisted value.
     crate::tmux::refresh_session_cache();
@@ -1624,6 +1629,11 @@ async fn capture_session(profile: &str, args: CaptureArgs) -> Result<()> {
         }
     };
 
+    // Resolving the profile config installs the declarative status-rule
+    // registry for this profile; the status detection below never loads config
+    // itself, so a rules-having custom agent would otherwise report Idle.
+    crate::session::profile_config::resolve_config_or_warn(profile);
+
     let tmux_session = crate::tmux::Session::new(&inst.id, &inst.title)?;
 
     let (content, status) = if !tmux_session.exists() {
@@ -1652,7 +1662,7 @@ async fn capture_session(profile: &str, args: CaptureArgs) -> Result<()> {
             }
         } else {
             tmux_session
-                .detect_status(detection_tool)
+                .detect_status(profile, detection_tool)
                 .unwrap_or_default()
         };
         let content = if args.strip_ansi {

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1562,6 +1562,7 @@ async fn show_session(profile: &str, args: ShowArgs) -> Result<()> {
             bail!("Not in a tmux session. Specify a session ID or run inside tmux.");
         }
     };
+    inst.source_profile = storage.profile().to_string();
 
     // Resolving the profile config installs the declarative status-rule
     // registry for this profile; the status detection below never loads config
@@ -1640,11 +1641,8 @@ async fn capture_session(profile: &str, args: CaptureArgs) -> Result<()> {
         (String::new(), "stopped".to_string())
     } else {
         let raw = tmux_session.capture_pane(args.lines)?;
-        let detection_tool = if inst.detect_as.is_empty() {
-            &inst.tool
-        } else {
-            &inst.detect_as
-        };
+        let detection_tool =
+            crate::tmux::status_rules::detection_tool(profile, &inst.tool, &inst.detect_as);
         let status = if let Some(hook_status) = crate::hooks::read_hook_status(&inst.id) {
             if detection_tool == "codex" && hook_status == crate::session::Status::Running {
                 let status_raw;

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -59,6 +59,11 @@ pub async fn run(profile: &str, args: StatusArgs) -> Result<()> {
         return Ok(());
     }
 
+    // Resolving the profile config installs the declarative status-rule
+    // registry (`[[agents.<name>.status_rules]]`); the per-instance poll
+    // below never loads config itself.
+    crate::session::profile_config::resolve_config_or_warn(profile);
+
     // Refresh tmux session cache
     crate::tmux::refresh_session_cache();
 

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -45,6 +45,9 @@ struct StatusJson {
 pub async fn run(profile: &str, args: StatusArgs) -> Result<()> {
     let storage = Storage::open_unwatched(profile)?;
     let (mut instances, _) = storage.load_with_groups()?;
+    for inst in &mut instances {
+        inst.source_profile = storage.profile().to_string();
+    }
 
     if instances.is_empty() {
         if args.json {

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -118,6 +118,37 @@ pub struct AgentRuntimeConfig {
     /// defaults by event name when status hooks are installed.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub status_map: BTreeMap<String, crate::agents::HookStatus>,
+
+    /// Declarative pane status rules (`[[agents.<name>.status_rules]]`).
+    /// Gives an agent with no built-in pane detector — typically a
+    /// `[session.custom_agents]` harness that is not the same binary as any
+    /// built-in — basic status detection without a code change. Ordered,
+    /// first match wins, no match reports `idle`. Rules take precedence over
+    /// `agent_detect_as` and over a built-in detector of the same name.
+    /// Compiled into `tmux::status_rules` on config resolve.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub status_rules: Vec<StatusRule>,
+}
+
+/// One declarative pane status rule. `status` is required; exactly one of
+/// `contains` (case-insensitive substring) or `regex` (Rust regex syntax)
+/// must be set. Both are matched against the ANSI-stripped pane snapshot.
+/// A rule with neither, both, or an invalid regex is skipped with a warning
+/// at compile time (`tmux::status_rules::install_from_config`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StatusRule {
+    /// Status to report when the rule matches: `running`, `waiting`,
+    /// `idle`, or `error`.
+    pub status: crate::agents::HookStatus,
+
+    /// Case-insensitive substring to look for in the pane text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contains: Option<String>,
+
+    /// Regex (Rust `regex` crate syntax) matched against the pane text as
+    /// written; prefix with `(?i)` for case-insensitive matching.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub regex: Option<String>,
 }
 
 /// Configuration for one plugin: whether it is enabled, its install source and
@@ -4118,6 +4149,45 @@ mod tests {
         let toml = r#"
             [agents.claude.status_map]
             Stop = "stopped"
+        "#;
+
+        let err = toml::from_str::<Config>(toml).unwrap_err();
+        assert!(err.to_string().contains("stopped"));
+    }
+
+    #[test]
+    fn agent_status_rules_roundtrip() {
+        let toml = r#"
+            [[agents.gjc.status_rules]]
+            status = "running"
+            contains = "esc to interrupt"
+
+            [[agents.gjc.status_rules]]
+            status = "waiting"
+            regex = "\\(y/n\\)"
+        "#;
+
+        let config: Config = toml::from_str(toml).unwrap();
+        let rules = &config.agents["gjc"].status_rules;
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].status, crate::agents::HookStatus::Running);
+        assert_eq!(rules[0].contains.as_deref(), Some("esc to interrupt"));
+        assert!(rules[0].regex.is_none());
+        assert_eq!(rules[1].status, crate::agents::HookStatus::Waiting);
+        assert_eq!(rules[1].regex.as_deref(), Some(r"\(y/n\)"));
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        assert!(serialized.contains("[[agents.gjc.status_rules]]"));
+        let reparsed: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.agents["gjc"].status_rules, *rules);
+    }
+
+    #[test]
+    fn agent_status_rules_reject_invalid_status() {
+        let toml = r#"
+            [[agents.gjc.status_rules]]
+            status = "stopped"
+            contains = "x"
         "#;
 
         let err = toml::from_str::<Config>(toml).unwrap_err();

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -120,9 +120,9 @@ pub struct AgentRuntimeConfig {
     pub status_map: BTreeMap<String, crate::agents::HookStatus>,
 
     /// Declarative pane status rules (`[[agents.<name>.status_rules]]`).
-    /// Gives an agent with no built-in pane detector — typically a
+    /// Gives an agent with no built-in pane detector, typically a
     /// `[session.custom_agents]` harness that is not the same binary as any
-    /// built-in — basic status detection without a code change. Ordered,
+    /// built-in, basic status detection without a code change. Ordered,
     /// first match wins, no match reports `idle`. Rules take precedence over
     /// `agent_detect_as` and over a built-in detector of the same name.
     /// Compiled into `tmux::status_rules` on config resolve.

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -5676,9 +5676,11 @@ impl Instance {
 
         // Pane-fallback identity: the session's own configured status rules
         // outrank the `agent_detect_as` alias; without rules the alias applies.
-        let pane_tool = tmux::status_rules::detection_tool(&self.tool, &self.detect_as);
+        let pane_tool =
+            tmux::status_rules::detection_tool(&self.source_profile, &self.tool, &self.detect_as);
         let pane_content = session.capture_pane(50).unwrap_or_default();
-        let detected = tmux::detect_status_from_content(&pane_content, pane_tool);
+        let detected =
+            tmux::detect_status_from_content_in(&self.source_profile, &pane_content, pane_tool);
         tracing::trace!(target: "session.store",
             "status '{}': detected={:?}, cmd_override={}, custom_cmd={}",
             self.title,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -5583,9 +5583,16 @@ impl Instance {
             self.has_command_override()
         );
 
-        // The session's own configured status rules outrank an
-        // `agent_detect_as` alias; without rules the alias applies.
-        let detection_tool = tmux::status_rules::detection_tool(&self.tool, &self.detect_as);
+        // Two detection identities: hooks are installed for (and must be
+        // interpreted by) the `agent_detect_as` alias when one is set, so
+        // hook reconciliation keeps the alias identity. The pane fallback
+        // below instead prefers the session's own configured status rules
+        // over the alias.
+        let hook_tool: &str = if self.detect_as.is_empty() {
+            &self.tool
+        } else {
+            &self.detect_as
+        };
 
         if let Some(hook_status) = crate::hooks::read_hook_status(&self.id) {
             tracing::trace!(target: "session.store",
@@ -5625,20 +5632,20 @@ impl Instance {
                 //    keeps parked sessions (the dominant steady state) from
                 //    paying a capture per poll; see
                 //    reconcile_claude_idle_hook_status.
-                let reconciles_running = (detection_tool == "codex" || detection_tool == "claude")
+                let reconciles_running = (hook_tool == "codex" || hook_tool == "claude")
                     && hook_status == Status::Running;
                 let reconciles_waiting = hook_status == Status::Waiting;
-                let reconciles_idle = detection_tool == "claude"
+                let reconciles_idle = hook_tool == "claude"
                     && hook_status == Status::Idle
                     && matches!(self.status, Status::Running | Status::Waiting);
                 self.status = if reconciles_running || reconciles_waiting || reconciles_idle {
                     match session.capture_pane(50) {
                         Ok(pane_content) => {
                             if reconciles_waiting {
-                                tmux::reconcile_waiting_hook(detection_tool, &pane_content)
+                                tmux::reconcile_waiting_hook(hook_tool, &pane_content)
                             } else if reconciles_idle {
                                 tmux::reconcile_claude_idle_hook_status(&pane_content)
-                            } else if detection_tool == "codex" {
+                            } else if hook_tool == "codex" {
                                 tmux::reconcile_codex_hook_status(hook_status, &pane_content)
                             } else {
                                 let running_age = crate::hooks::read_hook_status_age(&self.id);
@@ -5653,7 +5660,7 @@ impl Instance {
                             tracing::trace!(
                                 "status '{}': {} hook fallback pane capture failed: {}",
                                 self.title,
-                                detection_tool,
+                                hook_tool,
                                 e
                             );
                             hook_status
@@ -5667,8 +5674,11 @@ impl Instance {
             return;
         }
 
+        // Pane-fallback identity: the session's own configured status rules
+        // outrank the `agent_detect_as` alias; without rules the alias applies.
+        let pane_tool = tmux::status_rules::detection_tool(&self.tool, &self.detect_as);
         let pane_content = session.capture_pane(50).unwrap_or_default();
-        let detected = tmux::detect_status_from_content(&pane_content, detection_tool);
+        let detected = tmux::detect_status_from_content(&pane_content, pane_tool);
         tracing::trace!(target: "session.store",
             "status '{}': detected={:?}, cmd_override={}, custom_cmd={}",
             self.title,
@@ -5710,7 +5720,7 @@ impl Instance {
             && !shell_stale
             && !is_dead
             && self.status == Status::Running
-            && detection_tool == "claude"
+            && pane_tool == "claude"
             && tmux::claude_pane_is_ambiguous_typed_prompt(&pane_content)
         {
             tracing::debug!(target: "session.store",

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -5583,11 +5583,9 @@ impl Instance {
             self.has_command_override()
         );
 
-        let detection_tool = if self.detect_as.is_empty() {
-            &self.tool
-        } else {
-            &self.detect_as
-        };
+        // The session's own configured status rules outrank an
+        // `agent_detect_as` alias; without rules the alias applies.
+        let detection_tool = tmux::status_rules::detection_tool(&self.tool, &self.detect_as);
 
         if let Some(hook_status) = crate::hooks::read_hook_status(&self.id) {
             tracing::trace!(target: "session.store",

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -116,6 +116,11 @@ pub fn resolve_config(profile: &str) -> Result<Config> {
     let profile_config = load_profile_config(profile)?;
     let mut config = merge_configs(global, &profile_config);
     apply_cityhall_overrides(&mut config);
+    // (Re)install the declarative status-rule registry from the effective
+    // config. The status poll hot path never loads config, so this resolve
+    // every polling surface passes through at startup. This is where
+    // `[[agents.<name>.status_rules]]` edits become visible.
+    crate::tmux::status_rules::install_from_config(&config);
     Ok(config)
 }
 

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -117,8 +117,8 @@ pub fn resolve_config(profile: &str) -> Result<Config> {
     let mut config = merge_configs(global, &profile_config);
     apply_cityhall_overrides(&mut config);
     // (Re)install the declarative status-rule registry from the effective
-    // config. The status poll hot path never loads config, so this resolve
-    // every polling surface passes through at startup. This is where
+    // config. The status poll hot path never loads config, so this resolve,
+    // which every polling surface passes through at startup, is where
     // `[[agents.<name>.status_rules]]` edits become visible.
     crate::tmux::status_rules::install_from_config(&config);
     Ok(config)
@@ -134,9 +134,13 @@ pub fn resolve_config_or_warn(profile: &str) -> Config {
                 "Failed to load config for profile '{}', using defaults: {e}",
                 profile
             );
-            let mut config = Config::default();
-            apply_cityhall_overrides(&mut config);
-            config
+            let mut fallback = Config::default();
+            apply_cityhall_overrides(&mut fallback);
+            // Keep the status-rule registry consistent with the config the
+            // caller proceeds with: a failed resolve must not leave rules
+            // from an earlier successful resolve installed.
+            crate::tmux::status_rules::install_from_config(&fallback);
+            fallback
         }
     }
 }

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -120,7 +120,7 @@ pub fn resolve_config(profile: &str) -> Result<Config> {
     // config. The status poll hot path never loads config, so this resolve,
     // which every polling surface passes through at startup, is where
     // `[[agents.<name>.status_rules]]` edits become visible.
-    crate::tmux::status_rules::install_from_config(&config);
+    crate::tmux::status_rules::install_from_config(profile, &config);
     Ok(config)
 }
 
@@ -137,9 +137,11 @@ pub fn resolve_config_or_warn(profile: &str) -> Config {
             let mut fallback = Config::default();
             apply_cityhall_overrides(&mut fallback);
             // Keep the status-rule registry consistent with the config the
-            // caller proceeds with: a failed resolve must not leave rules
-            // from an earlier successful resolve installed.
-            crate::tmux::status_rules::install_from_config(&fallback);
+            // caller proceeds with: a failed resolve must not leave this
+            // profile's rules from an earlier successful resolve installed.
+            // Only this profile's entries are cleared; other profiles' rules
+            // are untouched.
+            crate::tmux::status_rules::install_from_config(profile, &fallback);
             fallback
         }
     }

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -1124,7 +1124,7 @@ pub async fn run_terminal_rename(
     // have started another turn since. Only proceed while the pane still reads
     // idle; a later idle edge retries.
     if let Ok(content) = tmux.capture_pane(50) {
-        if crate::tmux::detect_status_from_content(&content, detect_tool)
+        if crate::tmux::detect_status_from_content_in(profile, &content, detect_tool)
             == crate::session::Status::Running
         {
             return Ok(());

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod env;
 mod session;
 pub mod status_bar;
 pub(crate) mod status_detection;
+pub(crate) mod status_rules;
 mod terminal_session;
 #[cfg(test)]
 pub(crate) mod test_helpers;

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -16,12 +16,12 @@ pub(crate) mod vt;
 
 pub use session::{PaneCursor, Session, SIZE_OWNER_HEARTBEAT, SIZE_OWNER_TTL};
 pub use status_bar::{get_session_info_for_current, get_status_for_current_session};
-pub use status_detection::detect_status_from_content;
 pub(crate) use status_detection::{
     claude_pane_is_ambiguous_typed_prompt, claude_pane_marker_fingerprint,
     reconcile_claude_hook_status, reconcile_claude_idle_hook_status, reconcile_codex_hook_status,
     reconcile_waiting_hook,
 };
+pub use status_detection::{detect_status_from_content, detect_status_from_content_in};
 pub use terminal_session::{kill_all_terminals_for_id, ContainerTerminalSession, TerminalSession};
 pub use tool_session::{kill_all_tool_sessions_for_id, ToolSession};
 pub use utils::tmux_prefix_display;

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -1010,10 +1010,10 @@ impl Session {
         process::get_foreground_pid(pane_pid).or(Some(pane_pid))
     }
 
-    pub fn detect_status(&self, tool: &str) -> Result<Status> {
+    pub fn detect_status(&self, profile: &str, tool: &str) -> Result<Status> {
         let content = self.capture_pane(50)?;
-        Ok(super::status_detection::detect_status_from_content(
-            &content, tool,
+        Ok(super::status_detection::detect_status_from_content_in(
+            profile, &content, tool,
         ))
     }
 

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -80,18 +80,31 @@ fn matches_input_prompt(non_empty_lines: &[&str], take_n: usize, tool_prompts: &
     false
 }
 
-pub fn detect_status_from_content(content: &str, tool: &str) -> Status {
+/// Rules-aware pane detection for `profile`'s session. Configured declarative
+/// rules outrank the built-in detector: they are the only detection path for a
+/// custom agent that is not the same binary as any built-in, and an explicit
+/// override when the user writes rules for a built-in name. Rules are looked up
+/// per `(profile, tool)`, so a session consults only its own profile's rules.
+pub fn detect_status_from_content_in(profile: &str, content: &str, tool: &str) -> Status {
     // Strip ANSI escape codes before passing to detectors. capture-pane is
     // called with -e (to preserve colors for the TUI preview), but color codes
     // interspersed in text like "esc interrupt" break plain substring matches.
     let clean = strip_ansi(content);
-    // Configured declarative rules outrank the built-in detector: they are
-    // the only detection path for a custom agent that is not the same binary
-    // as any built-in, and an explicit override when the user writes rules
-    // for a built-in name.
-    if let Some(status) = super::status_rules::detect(tool, &clean) {
+    if let Some(status) = super::status_rules::detect(profile, tool, &clean) {
         return status;
     }
+    crate::agents::get_agent(tool)
+        .map(|a| (a.detect_status)(&clean))
+        .unwrap_or(Status::Idle)
+}
+
+/// Rules-free pane detection: strip ANSI, then the built-in detector only, no
+/// status-rule registry consult. Used by callers that are keyed to the
+/// built-in / alias identity rather than to a session's profile (see
+/// `reconcile_waiting_hook`), so their behavior is independent of any
+/// configured `[[agents.<name>.status_rules]]`.
+pub fn detect_status_from_content(content: &str, tool: &str) -> Status {
+    let clean = strip_ansi(content);
     crate::agents::get_agent(tool)
         .map(|a| (a.detect_status)(&clean))
         .unwrap_or(Status::Idle)

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -85,6 +85,13 @@ pub fn detect_status_from_content(content: &str, tool: &str) -> Status {
     // called with -e (to preserve colors for the TUI preview), but color codes
     // interspersed in text like "esc interrupt" break plain substring matches.
     let clean = strip_ansi(content);
+    // Configured declarative rules outrank the built-in detector: they are
+    // the only detection path for a custom agent that is not the same binary
+    // as any built-in, and an explicit override when the user writes rules
+    // for a built-in name.
+    if let Some(status) = super::status_rules::detect(tool, &clean) {
+        return status;
+    }
     crate::agents::get_agent(tool)
         .map(|a| (a.detect_status)(&clean))
         .unwrap_or(Status::Idle)

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -9,8 +9,13 @@
 //! The compiled rules live in a process-global registry rather than on each
 //! `Instance` because the status poll hot path deliberately never loads
 //! config (see `Instance::detect_as`, resolved once at build for the same
-//! reason). The registry is (re)installed by
-//! `profile_config::resolve_config`, which every status-polling surface
+//! reason). The registry is keyed by `(profile, agent)`: `resolve_config`
+//! runs per profile many times per process, so an install must replace only
+//! the calling profile's entries and leave every other profile's rules
+//! standing (a bare `gjc` in profile A and a `gjc` in profile B are distinct
+//! keys with independent rules). Consumers pass their session's profile so a
+//! poll consults exactly that profile's rules. The registry is (re)installed
+//! by `profile_config::resolve_config`, which every status-polling surface
 //! (TUI boot, `aoe serve`, the session CLI) passes through, so editing the
 //! rules takes effect on the next config resolve instead of requiring the
 //! session to be re-created.
@@ -37,8 +42,12 @@ enum Matcher {
     Regex(regex::Regex),
 }
 
-fn registry() -> &'static RwLock<HashMap<String, Vec<CompiledRule>>> {
-    static REGISTRY: OnceLock<RwLock<HashMap<String, Vec<CompiledRule>>>> = OnceLock::new();
+/// Compiled rules keyed by `(profile, agent)`, so each profile's rules are
+/// installed and consulted independently.
+type Registry = HashMap<(String, String), Vec<CompiledRule>>;
+
+fn registry() -> &'static RwLock<Registry> {
+    static REGISTRY: OnceLock<RwLock<Registry>> = OnceLock::new();
     REGISTRY.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
@@ -85,39 +94,60 @@ fn compile_rules(agent: &str, rules: &[StatusRule]) -> Vec<CompiledRule> {
     compiled
 }
 
-/// Replace the registry with the rules from `config`. Called on every
-/// config resolve; an agent whose rules all fail to compile ends up with no
-/// entry (falling back to the built-in detector or Idle), matching the
-/// behavior of not configuring rules at all.
-pub fn install_from_config(config: &crate::session::Config) {
-    let mut map = HashMap::new();
+/// Install `profile`'s rules from `config`, replacing only that profile's
+/// entries and leaving every other profile's rules standing. Called on every
+/// config resolve, once per profile; an agent whose rules all fail to compile
+/// ends up with no entry (falling back to the built-in detector or Idle),
+/// matching the behavior of not configuring rules at all.
+pub fn install_from_config(profile: &str, config: &crate::session::Config) {
+    // Normalize so an empty `source_profile` keys the same slot as the resolved
+    // default profile; the lookup side (`detect` / `has_rules`) normalizes the
+    // same way, so an unpopulated field degrades to the default profile's rules
+    // instead of silently missing.
+    let profile = crate::session::config::effective_profile(profile);
+    let mut map = registry().write().unwrap_or_else(|p| p.into_inner());
+    // Drop this profile's previous entries; other profiles' keys are untouched.
+    map.retain(|(p, _), _| p != &profile);
     for (agent, runtime) in &config.agents {
         if runtime.status_rules.is_empty() {
             continue;
         }
         let compiled = compile_rules(agent, &runtime.status_rules);
-        if !compiled.is_empty() {
-            map.insert(agent.clone(), compiled);
+        if compiled.is_empty() {
+            continue;
         }
+        // Rules for a name that also has a built-in detector fully replace it:
+        // a pane matching no rule reports Idle instead of falling through to the
+        // built-in, so a single narrow rule on a built-in name silently loses
+        // that agent's detection everywhere it doesn't match.
+        if crate::agents::get_agent(agent).is_some() {
+            tracing::warn!(target: "tmux.status",
+                "agents.{agent}.status_rules shadow the built-in '{agent}' detector; \
+                 panes matching no rule will report Idle rather than using the built-in detector");
+        }
+        map.insert((profile.clone(), agent.clone()), compiled);
     }
-    *registry().write().unwrap_or_else(|p| p.into_inner()) = map;
 }
 
-/// Whether `tool` has configured rules. Used by the status poller to let an
-/// agent's own rules take precedence over its `agent_detect_as` alias.
-pub fn has_rules(tool: &str) -> bool {
+/// Whether `tool` has configured rules under `profile`. Used by the status
+/// poller to let an agent's own rules take precedence over its
+/// `agent_detect_as` alias.
+pub fn has_rules(profile: &str, tool: &str) -> bool {
+    let profile = crate::session::config::effective_profile(profile);
     registry()
         .read()
         .unwrap_or_else(|p| p.into_inner())
-        .contains_key(tool)
+        .contains_key(&(profile, tool.to_string()))
 }
 
-/// Evaluate `tool`'s rules against ANSI-stripped pane text. Returns `None`
-/// when the tool has no rules (caller falls back to the built-in detector),
-/// `Some(Idle)` when rules exist but none match.
-pub fn detect(tool: &str, clean_content: &str) -> Option<Status> {
+/// Evaluate `tool`'s rules under `profile` against ANSI-stripped pane text.
+/// Returns `None` when the tool has no rules for that profile (caller falls
+/// back to the built-in detector), `Some(Idle)` when rules exist but none
+/// match.
+pub fn detect(profile: &str, tool: &str, clean_content: &str) -> Option<Status> {
+    let profile = crate::session::config::effective_profile(profile);
     let reg = registry().read().unwrap_or_else(|p| p.into_inner());
-    let rules = reg.get(tool)?;
+    let rules = reg.get(&(profile, tool.to_string()))?;
     let lower = clean_content.to_lowercase();
     for rule in rules {
         let matched = match &rule.matcher {
@@ -140,8 +170,8 @@ pub fn detect(tool: &str, clean_content: &str) -> Option<Status> {
 /// reconciliation deliberately does not use this helper: hooks are
 /// installed for the alias, so their reconcilers keep the alias identity
 /// (see `Instance::update_status_with_metadata`).
-pub fn detection_tool<'a>(tool: &'a str, detect_as: &'a str) -> &'a str {
-    if detect_as.is_empty() || has_rules(tool) {
+pub fn detection_tool<'a>(profile: &str, tool: &'a str, detect_as: &'a str) -> &'a str {
+    if detect_as.is_empty() || has_rules(profile, tool) {
         tool
     } else {
         detect_as
@@ -181,132 +211,200 @@ mod tests {
     #[test]
     fn no_rules_returns_none() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
-        install_from_config(&crate::session::Config::default());
-        assert_eq!(detect("anything", "some pane text"), None);
-        assert!(!has_rules("anything"));
+        install_from_config("default", &crate::session::Config::default());
+        assert_eq!(detect("default", "anything", "some pane text"), None);
+        assert!(!has_rules("default", "anything"));
     }
 
     #[test]
     fn first_match_wins_and_no_match_is_idle() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
-        install_from_config(&config_with_rules(
-            "rules-agent",
-            vec![
-                rule(HookStatus::Waiting, Some("(y/n)"), None),
-                rule(HookStatus::Running, Some("esc to interrupt"), None),
-            ],
-        ));
+        install_from_config(
+            "default",
+            &config_with_rules(
+                "rules-agent",
+                vec![
+                    rule(HookStatus::Waiting, Some("(y/n)"), None),
+                    rule(HookStatus::Running, Some("esc to interrupt"), None),
+                ],
+            ),
+        );
         // Both substrings present: the earlier rule wins.
         assert_eq!(
-            detect("rules-agent", "approve? (y/n)\nesc to interrupt"),
+            detect("default", "rules-agent", "approve? (y/n)\nesc to interrupt"),
             Some(Status::Waiting)
         );
         assert_eq!(
-            detect("rules-agent", "working... esc to interrupt"),
+            detect("default", "rules-agent", "working... esc to interrupt"),
             Some(Status::Running)
         );
-        assert_eq!(detect("rules-agent", "$ "), Some(Status::Idle));
-        install_from_config(&crate::session::Config::default());
+        assert_eq!(detect("default", "rules-agent", "$ "), Some(Status::Idle));
+        install_from_config("default", &crate::session::Config::default());
     }
 
     #[test]
     fn contains_is_case_insensitive_and_regex_is_as_written() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
-        install_from_config(&config_with_rules(
-            "rules-agent",
-            vec![
-                rule(HookStatus::Running, Some("Thinking"), None),
-                rule(
-                    HookStatus::Waiting,
-                    None,
-                    Some(r"waiting for [0-9]+ approvals?"),
-                ),
-            ],
-        ));
+        install_from_config(
+            "default",
+            &config_with_rules(
+                "rules-agent",
+                vec![
+                    rule(HookStatus::Running, Some("Thinking"), None),
+                    rule(
+                        HookStatus::Waiting,
+                        None,
+                        Some(r"waiting for [0-9]+ approvals?"),
+                    ),
+                ],
+            ),
+        );
         assert_eq!(
-            detect("rules-agent", "THINKING hard"),
+            detect("default", "rules-agent", "THINKING hard"),
             Some(Status::Running)
         );
         assert_eq!(
-            detect("rules-agent", "waiting for 2 approvals"),
+            detect("default", "rules-agent", "waiting for 2 approvals"),
             Some(Status::Waiting)
         );
         // Regex is case-sensitive unless the pattern opts in.
         assert_eq!(
-            detect("rules-agent", "WAITING FOR 2 APPROVALS"),
+            detect("default", "rules-agent", "WAITING FOR 2 APPROVALS"),
             Some(Status::Idle)
         );
-        install_from_config(&crate::session::Config::default());
+        install_from_config("default", &crate::session::Config::default());
     }
 
     #[test]
     fn malformed_rules_are_skipped_and_all_skipped_means_no_entry() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
-        install_from_config(&config_with_rules(
-            "rules-agent",
-            vec![
-                rule(HookStatus::Running, None, Some("(unclosed")),
-                rule(HookStatus::Running, Some("x"), Some("y")),
-                rule(HookStatus::Running, None, None),
-                rule(HookStatus::Running, Some(""), None),
-            ],
-        ));
+        install_from_config(
+            "default",
+            &config_with_rules(
+                "rules-agent",
+                vec![
+                    rule(HookStatus::Running, None, Some("(unclosed")),
+                    rule(HookStatus::Running, Some("x"), Some("y")),
+                    rule(HookStatus::Running, None, None),
+                    rule(HookStatus::Running, Some(""), None),
+                ],
+            ),
+        );
         // Every rule was invalid: the agent has no entry at all.
-        assert!(!has_rules("rules-agent"));
-        assert_eq!(detect("rules-agent", "x"), None);
+        assert!(!has_rules("default", "rules-agent"));
+        assert_eq!(detect("default", "rules-agent", "x"), None);
 
         // A valid rule survives alongside a skipped one.
-        install_from_config(&config_with_rules(
-            "rules-agent",
-            vec![
-                rule(HookStatus::Running, None, Some("(unclosed")),
-                rule(HookStatus::Error, Some("panicked at"), None),
-            ],
-        ));
+        install_from_config(
+            "default",
+            &config_with_rules(
+                "rules-agent",
+                vec![
+                    rule(HookStatus::Running, None, Some("(unclosed")),
+                    rule(HookStatus::Error, Some("panicked at"), None),
+                ],
+            ),
+        );
         assert_eq!(
-            detect("rules-agent", "thread 'main' panicked at src/x.rs"),
+            detect(
+                "default",
+                "rules-agent",
+                "thread 'main' panicked at src/x.rs"
+            ),
             Some(Status::Error)
         );
-        install_from_config(&crate::session::Config::default());
+        install_from_config("default", &crate::session::Config::default());
     }
 
     #[test]
     fn install_replaces_previous_rules() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
-        install_from_config(&config_with_rules(
-            "rules-agent",
-            vec![rule(HookStatus::Running, Some("spin"), None)],
-        ));
-        assert!(has_rules("rules-agent"));
-        install_from_config(&crate::session::Config::default());
-        assert!(!has_rules("rules-agent"));
+        install_from_config(
+            "default",
+            &config_with_rules(
+                "rules-agent",
+                vec![rule(HookStatus::Running, Some("spin"), None)],
+            ),
+        );
+        assert!(has_rules("default", "rules-agent"));
+        install_from_config("default", &crate::session::Config::default());
+        assert!(!has_rules("default", "rules-agent"));
+    }
+
+    #[test]
+    fn install_is_scoped_to_its_profile() {
+        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        // p1's `gjc` maps a marker to Running; p2's `gjc` maps the same marker
+        // to Error. Distinct keys, so neither install touches the other.
+        install_from_config(
+            "p1",
+            &config_with_rules(
+                "gjc",
+                vec![rule(HookStatus::Running, Some("busy marker"), None)],
+            ),
+        );
+        install_from_config(
+            "p2",
+            &config_with_rules(
+                "gjc",
+                vec![rule(HookStatus::Error, Some("busy marker"), None)],
+            ),
+        );
+        assert_eq!(
+            detect("p1", "gjc", "busy marker"),
+            Some(Status::Running),
+            "p1 rules must survive p2's install"
+        );
+        assert_eq!(
+            detect("p2", "gjc", "busy marker"),
+            Some(Status::Error),
+            "p2 rules are independent of p1's"
+        );
+
+        // Reinstalling p2 with no rules clears only p2; p1 still detects.
+        install_from_config("p2", &crate::session::Config::default());
+        assert!(!has_rules("p2", "gjc"));
+        assert_eq!(detect("p1", "gjc", "busy marker"), Some(Status::Running));
+
+        install_from_config("p1", &crate::session::Config::default());
+        assert!(!has_rules("p1", "gjc"));
     }
 
     #[test]
     fn detection_tool_prefers_own_rules_over_detect_as() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
-        install_from_config(&config_with_rules(
-            "rules-agent",
-            vec![rule(HookStatus::Running, Some("spin"), None)],
-        ));
+        install_from_config(
+            "default",
+            &config_with_rules(
+                "rules-agent",
+                vec![rule(HookStatus::Running, Some("spin"), None)],
+            ),
+        );
         // Rules configured: the alias is ignored.
-        assert_eq!(detection_tool("rules-agent", "claude"), "rules-agent");
+        assert_eq!(
+            detection_tool("default", "rules-agent", "claude"),
+            "rules-agent"
+        );
         // No rules: alias applies, and no alias means the tool itself.
-        assert_eq!(detection_tool("other-agent", "claude"), "claude");
-        assert_eq!(detection_tool("other-agent", ""), "other-agent");
-        install_from_config(&crate::session::Config::default());
+        assert_eq!(detection_tool("default", "other-agent", "claude"), "claude");
+        assert_eq!(detection_tool("default", "other-agent", ""), "other-agent");
+        install_from_config("default", &crate::session::Config::default());
     }
 
     #[test]
-    fn rules_dispatch_through_detect_status_from_content() {
+    fn rules_dispatch_through_detect_status_from_content_in() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
-        install_from_config(&config_with_rules(
-            "rules-agent",
-            vec![rule(HookStatus::Running, Some("esc to interrupt"), None)],
-        ));
+        install_from_config(
+            "default",
+            &config_with_rules(
+                "rules-agent",
+                vec![rule(HookStatus::Running, Some("esc to interrupt"), None)],
+            ),
+        );
         // ANSI codes are stripped by the dispatcher before rules run.
         assert_eq!(
-            super::super::status_detection::detect_status_from_content(
+            super::super::status_detection::detect_status_from_content_in(
+                "default",
                 "\x1b[31mesc to interrupt\x1b[0m",
                 "rules-agent"
             ),
@@ -314,31 +412,38 @@ mod tests {
         );
         // An unknown tool without rules still reports Idle.
         assert_eq!(
-            super::super::status_detection::detect_status_from_content("anything", "no-rules"),
+            super::super::status_detection::detect_status_from_content_in(
+                "default", "anything", "no-rules"
+            ),
             Status::Idle
         );
-        install_from_config(&crate::session::Config::default());
+        install_from_config("default", &crate::session::Config::default());
     }
 
     #[test]
     fn rules_override_builtin_detector() {
         let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
         // "claude" has a built-in pane detector; configured rules outrank it.
-        install_from_config(&config_with_rules(
-            "claude",
-            vec![rule(HookStatus::Error, Some("custom fail marker"), None)],
-        ));
+        install_from_config(
+            "default",
+            &config_with_rules(
+                "claude",
+                vec![rule(HookStatus::Error, Some("custom fail marker"), None)],
+            ),
+        );
         assert_eq!(
-            super::super::status_detection::detect_status_from_content(
+            super::super::status_detection::detect_status_from_content_in(
+                "default",
                 "custom fail marker",
                 "claude"
             ),
             Status::Error
         );
-        install_from_config(&crate::session::Config::default());
+        install_from_config("default", &crate::session::Config::default());
         // Registry cleared: the built-in detector is back in charge.
         assert_eq!(
-            super::super::status_detection::detect_status_from_content(
+            super::super::status_detection::detect_status_from_content_in(
+                "default",
                 "custom fail marker",
                 "claude"
             ),

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -1,8 +1,8 @@
 //! Declarative pane status rules for custom agents.
 //!
 //! `[[agents.<name>.status_rules]]` config entries give an agent without a
-//! built-in pane detector — typically a `[session.custom_agents]` harness
-//! that is *similar to but not the same binary as* a built-in agent — basic
+//! built-in pane detector, typically a `[session.custom_agents]` harness
+//! that is *similar to but not the same binary as* a built-in agent, basic
 //! status detection: ordered `contains`/`regex` rules evaluated against the
 //! ANSI-stripped pane snapshot, first match wins, no match reports Idle.
 //!
@@ -134,9 +134,12 @@ pub fn detect(tool: &str, clean_content: &str) -> Option<Status> {
     Some(Status::Idle)
 }
 
-/// The tool whose detection heuristics apply to a session: the session's own
-/// tool when it has configured rules, else the `agent_detect_as` alias when
-/// set, else the tool itself.
+/// The tool whose *pane* detection heuristics apply to a session: the
+/// session's own tool when it has configured rules, else the
+/// `agent_detect_as` alias when set, else the tool itself. Hook
+/// reconciliation deliberately does not use this helper: hooks are
+/// installed for the alias, so their reconcilers keep the alias identity
+/// (see `Instance::update_status_with_metadata`).
 pub fn detection_tool<'a>(tool: &'a str, detect_as: &'a str) -> &'a str {
     if detect_as.is_empty() || has_rules(tool) {
         tool

--- a/src/tmux/status_rules.rs
+++ b/src/tmux/status_rules.rs
@@ -1,0 +1,345 @@
+//! Declarative pane status rules for custom agents.
+//!
+//! `[[agents.<name>.status_rules]]` config entries give an agent without a
+//! built-in pane detector — typically a `[session.custom_agents]` harness
+//! that is *similar to but not the same binary as* a built-in agent — basic
+//! status detection: ordered `contains`/`regex` rules evaluated against the
+//! ANSI-stripped pane snapshot, first match wins, no match reports Idle.
+//!
+//! The compiled rules live in a process-global registry rather than on each
+//! `Instance` because the status poll hot path deliberately never loads
+//! config (see `Instance::detect_as`, resolved once at build for the same
+//! reason). The registry is (re)installed by
+//! `profile_config::resolve_config`, which every status-polling surface
+//! (TUI boot, `aoe serve`, the session CLI) passes through, so editing the
+//! rules takes effect on the next config resolve instead of requiring the
+//! session to be re-created.
+
+use std::collections::HashMap;
+use std::sync::{OnceLock, RwLock};
+
+use crate::agents::HookStatus;
+use crate::session::config::StatusRule;
+use crate::session::Status;
+
+/// A rule compiled for the poll loop: the matcher is pre-lowered /
+/// pre-compiled so per-tick evaluation is substring or regex work only.
+struct CompiledRule {
+    status: Status,
+    matcher: Matcher,
+}
+
+enum Matcher {
+    /// Case-insensitive substring: stored lowercased, tested against the
+    /// lowercased pane text.
+    Contains(String),
+    /// Compiled regex, tested against the pane text as written.
+    Regex(regex::Regex),
+}
+
+fn registry() -> &'static RwLock<HashMap<String, Vec<CompiledRule>>> {
+    static REGISTRY: OnceLock<RwLock<HashMap<String, Vec<CompiledRule>>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn hook_status_to_status(status: HookStatus) -> Status {
+    match status {
+        HookStatus::Running => Status::Running,
+        HookStatus::Waiting => Status::Waiting,
+        HookStatus::Idle => Status::Idle,
+        HookStatus::Error => Status::Error,
+    }
+}
+
+/// Compile one agent's rules, skipping (with a warning) any rule that has
+/// neither or both of `contains`/`regex`, or a regex that fails to compile.
+fn compile_rules(agent: &str, rules: &[StatusRule]) -> Vec<CompiledRule> {
+    let mut compiled = Vec::with_capacity(rules.len());
+    for (i, rule) in rules.iter().enumerate() {
+        let matcher = match (&rule.contains, &rule.regex) {
+            (Some(needle), None) if !needle.is_empty() => Matcher::Contains(needle.to_lowercase()),
+            (None, Some(pattern)) if !pattern.is_empty() => match regex::Regex::new(pattern) {
+                Ok(re) => Matcher::Regex(re),
+                Err(e) => {
+                    tracing::warn!(target: "tmux.status",
+                        "agents.{agent}.status_rules[{i}]: invalid regex {pattern:?}, rule skipped: {e}");
+                    continue;
+                }
+            },
+            (Some(_), Some(_)) => {
+                tracing::warn!(target: "tmux.status",
+                    "agents.{agent}.status_rules[{i}]: set exactly one of `contains` or `regex`, not both; rule skipped");
+                continue;
+            }
+            _ => {
+                tracing::warn!(target: "tmux.status",
+                    "agents.{agent}.status_rules[{i}]: needs a non-empty `contains` or `regex`; rule skipped");
+                continue;
+            }
+        };
+        compiled.push(CompiledRule {
+            status: hook_status_to_status(rule.status),
+            matcher,
+        });
+    }
+    compiled
+}
+
+/// Replace the registry with the rules from `config`. Called on every
+/// config resolve; an agent whose rules all fail to compile ends up with no
+/// entry (falling back to the built-in detector or Idle), matching the
+/// behavior of not configuring rules at all.
+pub fn install_from_config(config: &crate::session::Config) {
+    let mut map = HashMap::new();
+    for (agent, runtime) in &config.agents {
+        if runtime.status_rules.is_empty() {
+            continue;
+        }
+        let compiled = compile_rules(agent, &runtime.status_rules);
+        if !compiled.is_empty() {
+            map.insert(agent.clone(), compiled);
+        }
+    }
+    *registry().write().unwrap_or_else(|p| p.into_inner()) = map;
+}
+
+/// Whether `tool` has configured rules. Used by the status poller to let an
+/// agent's own rules take precedence over its `agent_detect_as` alias.
+pub fn has_rules(tool: &str) -> bool {
+    registry()
+        .read()
+        .unwrap_or_else(|p| p.into_inner())
+        .contains_key(tool)
+}
+
+/// Evaluate `tool`'s rules against ANSI-stripped pane text. Returns `None`
+/// when the tool has no rules (caller falls back to the built-in detector),
+/// `Some(Idle)` when rules exist but none match.
+pub fn detect(tool: &str, clean_content: &str) -> Option<Status> {
+    let reg = registry().read().unwrap_or_else(|p| p.into_inner());
+    let rules = reg.get(tool)?;
+    let lower = clean_content.to_lowercase();
+    for rule in rules {
+        let matched = match &rule.matcher {
+            Matcher::Contains(needle) => lower.contains(needle),
+            Matcher::Regex(re) => re.is_match(clean_content),
+        };
+        if matched {
+            tracing::trace!(target: "tmux.status",
+                "status rules for '{tool}': matched -> {:?}", rule.status);
+            return Some(rule.status);
+        }
+    }
+    tracing::trace!(target: "tmux.status", "status rules for '{tool}': no match -> Idle");
+    Some(Status::Idle)
+}
+
+/// The tool whose detection heuristics apply to a session: the session's own
+/// tool when it has configured rules, else the `agent_detect_as` alias when
+/// set, else the tool itself.
+pub fn detection_tool<'a>(tool: &'a str, detect_as: &'a str) -> &'a str {
+    if detect_as.is_empty() || has_rules(tool) {
+        tool
+    } else {
+        detect_as
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// The registry is process-global; serialize the tests that write to it
+    /// so parallel test threads can't clobber each other's installs.
+    fn test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn rule(status: HookStatus, contains: Option<&str>, regex: Option<&str>) -> StatusRule {
+        StatusRule {
+            status,
+            contains: contains.map(str::to_string),
+            regex: regex.map(str::to_string),
+        }
+    }
+
+    fn config_with_rules(agent: &str, rules: Vec<StatusRule>) -> crate::session::Config {
+        let mut config = crate::session::Config::default();
+        config
+            .agents
+            .entry(agent.to_string())
+            .or_default()
+            .status_rules = rules;
+        config
+    }
+
+    #[test]
+    fn no_rules_returns_none() {
+        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        install_from_config(&crate::session::Config::default());
+        assert_eq!(detect("anything", "some pane text"), None);
+        assert!(!has_rules("anything"));
+    }
+
+    #[test]
+    fn first_match_wins_and_no_match_is_idle() {
+        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        install_from_config(&config_with_rules(
+            "rules-agent",
+            vec![
+                rule(HookStatus::Waiting, Some("(y/n)"), None),
+                rule(HookStatus::Running, Some("esc to interrupt"), None),
+            ],
+        ));
+        // Both substrings present: the earlier rule wins.
+        assert_eq!(
+            detect("rules-agent", "approve? (y/n)\nesc to interrupt"),
+            Some(Status::Waiting)
+        );
+        assert_eq!(
+            detect("rules-agent", "working... esc to interrupt"),
+            Some(Status::Running)
+        );
+        assert_eq!(detect("rules-agent", "$ "), Some(Status::Idle));
+        install_from_config(&crate::session::Config::default());
+    }
+
+    #[test]
+    fn contains_is_case_insensitive_and_regex_is_as_written() {
+        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        install_from_config(&config_with_rules(
+            "rules-agent",
+            vec![
+                rule(HookStatus::Running, Some("Thinking"), None),
+                rule(
+                    HookStatus::Waiting,
+                    None,
+                    Some(r"waiting for [0-9]+ approvals?"),
+                ),
+            ],
+        ));
+        assert_eq!(
+            detect("rules-agent", "THINKING hard"),
+            Some(Status::Running)
+        );
+        assert_eq!(
+            detect("rules-agent", "waiting for 2 approvals"),
+            Some(Status::Waiting)
+        );
+        // Regex is case-sensitive unless the pattern opts in.
+        assert_eq!(
+            detect("rules-agent", "WAITING FOR 2 APPROVALS"),
+            Some(Status::Idle)
+        );
+        install_from_config(&crate::session::Config::default());
+    }
+
+    #[test]
+    fn malformed_rules_are_skipped_and_all_skipped_means_no_entry() {
+        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        install_from_config(&config_with_rules(
+            "rules-agent",
+            vec![
+                rule(HookStatus::Running, None, Some("(unclosed")),
+                rule(HookStatus::Running, Some("x"), Some("y")),
+                rule(HookStatus::Running, None, None),
+                rule(HookStatus::Running, Some(""), None),
+            ],
+        ));
+        // Every rule was invalid: the agent has no entry at all.
+        assert!(!has_rules("rules-agent"));
+        assert_eq!(detect("rules-agent", "x"), None);
+
+        // A valid rule survives alongside a skipped one.
+        install_from_config(&config_with_rules(
+            "rules-agent",
+            vec![
+                rule(HookStatus::Running, None, Some("(unclosed")),
+                rule(HookStatus::Error, Some("panicked at"), None),
+            ],
+        ));
+        assert_eq!(
+            detect("rules-agent", "thread 'main' panicked at src/x.rs"),
+            Some(Status::Error)
+        );
+        install_from_config(&crate::session::Config::default());
+    }
+
+    #[test]
+    fn install_replaces_previous_rules() {
+        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        install_from_config(&config_with_rules(
+            "rules-agent",
+            vec![rule(HookStatus::Running, Some("spin"), None)],
+        ));
+        assert!(has_rules("rules-agent"));
+        install_from_config(&crate::session::Config::default());
+        assert!(!has_rules("rules-agent"));
+    }
+
+    #[test]
+    fn detection_tool_prefers_own_rules_over_detect_as() {
+        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        install_from_config(&config_with_rules(
+            "rules-agent",
+            vec![rule(HookStatus::Running, Some("spin"), None)],
+        ));
+        // Rules configured: the alias is ignored.
+        assert_eq!(detection_tool("rules-agent", "claude"), "rules-agent");
+        // No rules: alias applies, and no alias means the tool itself.
+        assert_eq!(detection_tool("other-agent", "claude"), "claude");
+        assert_eq!(detection_tool("other-agent", ""), "other-agent");
+        install_from_config(&crate::session::Config::default());
+    }
+
+    #[test]
+    fn rules_dispatch_through_detect_status_from_content() {
+        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        install_from_config(&config_with_rules(
+            "rules-agent",
+            vec![rule(HookStatus::Running, Some("esc to interrupt"), None)],
+        ));
+        // ANSI codes are stripped by the dispatcher before rules run.
+        assert_eq!(
+            super::super::status_detection::detect_status_from_content(
+                "\x1b[31mesc to interrupt\x1b[0m",
+                "rules-agent"
+            ),
+            Status::Running
+        );
+        // An unknown tool without rules still reports Idle.
+        assert_eq!(
+            super::super::status_detection::detect_status_from_content("anything", "no-rules"),
+            Status::Idle
+        );
+        install_from_config(&crate::session::Config::default());
+    }
+
+    #[test]
+    fn rules_override_builtin_detector() {
+        let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+        // "claude" has a built-in pane detector; configured rules outrank it.
+        install_from_config(&config_with_rules(
+            "claude",
+            vec![rule(HookStatus::Error, Some("custom fail marker"), None)],
+        ));
+        assert_eq!(
+            super::super::status_detection::detect_status_from_content(
+                "custom fail marker",
+                "claude"
+            ),
+            Status::Error
+        );
+        install_from_config(&crate::session::Config::default());
+        // Registry cleared: the built-in detector is back in charge.
+        assert_eq!(
+            super::super::status_detection::detect_status_from_content(
+                "custom fail marker",
+                "claude"
+            ),
+            Status::Idle
+        );
+    }
+}


### PR DESCRIPTION
## Description

Implements the primary proposal from #3137: `[[agents.<name>.status_rules]]` — declarative pane status rules that give a custom agent basic status detection without a code change.

A `[session.custom_agents]` harness that is *similar to but not the same binary as* any built-in currently has no working detection path: `agent_detect_as` aliases a built-in's pane detector (which matches the wrong output — cf. the OMP-aliased-to-`pi` misread noted in #3076), and `agent_status_hooks` installs hooks into the *built-in's* config file, which a custom harness never reads. Such sessions sit at Idle forever and never fire status-transition notifications.

With this PR:

```toml
[session.custom_agents]
gjc = "gjc"

[[agents.gjc.status_rules]]
status = "waiting"
contains = "(y/n)"

[[agents.gjc.status_rules]]
status = "running"
regex = "esc to interrupt|thinking"
```

Ordered rules, `status` + exactly one of `contains` (case-insensitive substring) or `regex` (Rust regex, as written), evaluated against the ANSI-stripped pane snapshot the built-in detectors already consume. First match wins; no match reports `idle`. This is the config-shaped subset of the plugin design's Tier 0 status rules (D7, #2096) — if/when the plugin status registry lands it can subsume the same rule shape.

Design notes:

- Rules compile once into a process-global registry (`tmux::status_rules`), installed by `profile_config::resolve_config` — the status poll hot path deliberately never loads config (same reason `Instance.detect_as` is resolved at build time). `aoe status` gets an explicit resolve since it previously loaded no config at all.
- Rules outrank an `agent_detect_as` alias (an agent with rules uses them even if an alias is configured) and a built-in detector of the same name (explicit user override).
- Malformed rules (no matcher, both matchers, invalid regex) are skipped with a `tracing` warning; an agent whose rules all fail to compile behaves as if none were configured.
- Hook-based detection is untouched: rules only participate in the pane fallback path, which is the only path a hookless custom agent ever reaches.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the new behavior is exercised end-to-end at the unit seam it lives behind — `detect_status_from_content` dispatch (rules vs built-in vs unknown-tool), registry install/replace, rule compilation edge cases, `detect_as` precedence, and config TOML round-trip are all covered in `src/tmux/status_rules.rs` and `src/session/config.rs` tests. An e2e run would additionally need a live tmux pane running a fake agent only to re-test the same dispatch line; happy to add one if you'd like.

Test details: `cargo test` on Linux — 4290 passed, 2 failed: `delete_branch_reaps_lingering_locked_worktree` and `purge_recovers_when_project_path_diverged_and_locked_entry_survives`, which fail identically on unmodified `origin/main` in my environment (git 2.34.1 worktree branch-delete behavior), i.e. pre-existing and unrelated. `cargo fmt --check` and `cargo clippy` clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude (agent harness) — investigation, implementation, and this PR text via back-and-forth; the problem report, measurements, design decisions, and review are mine.

**Any Additional AI Details you'd like to share:**
Same setup as issue #3137. I (the human) reviewed the full diff and ran the verification myself.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `agents.<name>.status_rules` for custom agent status detection.
- Added ordered, case-insensitive `contains` and Rust `regex` matchers.
- Applied rules to ANSI-stripped pane content, with `idle` as the fallback.
- Scoped rules to profiles and resolved them before status polling and session commands.
- Kept hook-based detection separate from pane-based rule detection.
- Added warnings for invalid rules and rules that shadow built-in detectors.
- Added documentation and tests for matching, precedence, profile isolation, dispatch, and TOML round-tripping.

## Benefits

Custom agents can report accurate statuses from pane output without changes to built-in detectors or hook-based detection. Profile isolation prevents configuration from affecting unrelated profiles.

## Potential enhancements

- Improve diagnostics for skipped rules and unmatched content.
- Add more matcher types or configurable regex options.
- Add broader integration coverage for profile-specific polling and session commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->