### PR TITLE
feat(acp): route MiniMax models via Anthropic-compatible endpoint

### DIFF
--- a/acp-worker/aoe-agent/src/index.ts
+++ b/acp-worker/aoe-agent/src/index.ts
@@ -17,13 +17,22 @@
 import * as acp from "@agentclientprotocol/sdk";
 import { Readable, Writable } from "node:stream";
 import { streamText, tool, stepCountIs, type ModelMessage } from "ai";
-import { anthropic } from "@ai-sdk/anthropic";
+import { anthropic, createAnthropic } from "@ai-sdk/anthropic";
 import { openai } from "@ai-sdk/openai";
 import { google } from "@ai-sdk/google";
 import { z } from "zod";
 import { appendTurn, loadTranscript } from "./transcript.ts";
 
 const DEFAULT_MODEL = "claude-opus-4-7";
+
+// MiniMax exposes an Anthropic-compatible Messages endpoint. Default to the
+// global region and let operators point at the CN region (or any other proxy)
+// via AOE_MINIMAX_BASE_URL. The API key is read from MINIMAX_API_KEY so it
+// stays independent of the Anthropic credential.
+const minimax = createAnthropic({
+  baseURL: process.env.AOE_MINIMAX_BASE_URL ?? "https://api.minimax.io/anthropic",
+  apiKey: process.env.MINIMAX_API_KEY,
+});
 
 interface SessionState {
   pendingPrompt: AbortController | null;
@@ -288,7 +297,7 @@ function serialiseToolOutput(output: unknown): Record<string, unknown> {
   return { value: output };
 }
 
-function pickModel(modelId: string) {
+export function pickModel(modelId: string) {
   if (modelId.startsWith("claude-") || modelId.startsWith("anthropic:")) {
     return anthropic(modelId.replace(/^anthropic:/, ""));
   }
@@ -297,6 +306,9 @@ function pickModel(modelId: string) {
   }
   if (modelId.startsWith("gemini-") || modelId.startsWith("google:")) {
     return google(modelId.replace(/^google:/, ""));
+  }
+  if (modelId.startsWith("MiniMax-") || modelId.startsWith("minimax:")) {
+    return minimax(modelId.replace(/^minimax:/, ""));
   }
   return anthropic(modelId);
 }
@@ -374,4 +386,8 @@ function main() {
   process.on("SIGINT", () => process.exit(0));
 }
 
-main();
+// Only start the ACP server when this file is the process entry point so
+// that tests can import pickModel without triggering main().
+if (process.argv[1] && process.argv[1].endsWith("src/index.ts")) {
+  main();
+}

--- a/acp-worker/aoe-agent/test/pick-model.test.ts
+++ b/acp-worker/aoe-agent/test/pick-model.test.ts
@@ -1,0 +1,29 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pickModel } from "../src/index.ts";
+
+test("routes MiniMax- prefixed ids to the MiniMax provider", () => {
+  const model = pickModel("MiniMax-M3");
+  assert.ok(model, "pickModel should return a model for MiniMax-M3");
+  assert.equal(
+    (model as unknown as { provider: string }).provider,
+    "anthropic.messages",
+    "MiniMax models should use the Anthropic-compatible provider",
+  );
+});
+
+test("routes minimax: prefixed ids and strips the prefix", () => {
+  const model = pickModel("minimax:MiniMax-M2.7");
+  assert.ok(model, "pickModel should return a model for minimax:MiniMax-M2.7");
+  assert.equal(
+    (model as unknown as { provider: string }).provider,
+    "anthropic.messages",
+    "minimax: prefix should route to the Anthropic-compatible provider",
+  );
+});
+
+test("still routes other providers unchanged", () => {
+  assert.ok(pickModel("claude-opus-4-7"));
+  assert.ok(pickModel("gpt-4o"));
+  assert.ok(pickModel("gemini-2.0-flash"));
+});


### PR DESCRIPTION
Reason: The bundled ACP agent's pickModel only routed Claude/Anthropic, OpenAI, and Gemini prefixes; MiniMax models and their global/CN endpoints were absent.

## Changes

- Add a MiniMax provider via `createAnthropic` using the Anthropic-compatible Messages endpoint (`https://api.minimax.io/anthropic` by default).
- Route `MiniMax-` and `minimax:` model-id prefixes to the MiniMax provider in `pickModel`, matching the existing prefix-dispatch pattern.
- Allow operators to override the base URL through `AOE_MINIMAX_BASE_URL` (e.g. to point at the CN endpoint `https://api.minimaxi.com/anthropic`) and supply the API key through `MINIMAX_API_KEY`.
- Export `pickModel` and guard the `main()` entry-point call so the module can be imported by tests without starting the ACP server.

## Checks

- `npx tsx --test test/*.ts` — 8 tests pass (5 transcript + 3 pick-model).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added MiniMax model support through its Anthropic-compatible API.
- Added configurable MiniMax endpoint and API key handling.
- Updated model routing for `MiniMax-` and `minimax:` identifiers.
- Exported model selection logic and made startup test-friendly.
- Added tests covering MiniMax routing and existing providers.

## Benefits

Enables MiniMax models in the bundled ACP agent while preserving existing provider behavior and improving testability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->