### PR TITLE
feat(tui): show every tmux pane in the session preview

### DIFF
--- a/docs/guides/live-mode.md
+++ b/docs/guides/live-mode.md
@@ -91,6 +91,24 @@ agent's history without leaving live mode or forwarding the keys. Bare
 `PageUp` / `PageDown` still pass through to the agent, so agents that
 page their own UI keep working.
 
+## Split windows
+
+If you split the session's tmux window by hand (`Ctrl+B %`, `Ctrl+B "`), or
+an agent splits it for you (a Claude Code agent team spawns one pane per
+teammate), the preview composites every pane onto the window grid with
+borders in the gaps, so nothing is hidden.
+
+Two things change while a window is split:
+
+- **Scrolling history is unavailable.** Panes keep independent scrollbacks
+  with no coherent way to stack them, so the composite covers the visible
+  window only and `Shift+PageUp` has nothing to scroll into. Close the extra
+  pane and history comes back.
+- **Input still goes to the first pane.** Keystrokes, clicks, and the scroll
+  wheel all reach the agent's own pane regardless of which pane you split
+  off, so a wheel or click aimed at a neighbouring pane does nothing. Attach
+  to the session to interact with the other panes.
+
 ## Inserting newlines
 
 `Shift+Enter` inserts a newline into the agent's input box on

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -1162,6 +1162,7 @@ mod tests {
             mouse_sgr: false,
             mouse_all: false,
             position_reliable: true,
+            composite_pane0: None,
         };
         let json = frame_json("hello\nworld", Some(&cursor));
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -1190,6 +1191,7 @@ mod tests {
             mouse_sgr: false,
             mouse_all: false,
             position_reliable: true,
+            composite_pane0: None,
         };
         let v: serde_json::Value = serde_json::from_str(&frame_json("x", Some(&cursor))).unwrap();
         assert_eq!(v["altScreen"], true);
@@ -1211,6 +1213,7 @@ mod tests {
             mouse_sgr: false,
             mouse_all: false,
             position_reliable: true,
+            composite_pane0: None,
         };
         let v: serde_json::Value = serde_json::from_str(&frame_json("x", Some(&cursor))).unwrap();
         assert!(v["cursor"].is_null());

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -5185,16 +5185,9 @@ impl Instance {
         self.update_status_with_metadata(None);
     }
 
-    pub fn capture_output(&self, lines: usize) -> Result<String> {
-        // capture-pane has no size parameters: the pane is captured at
-        // the window's own dimensions. (A previous *_with_size variant
-        // accepted width/height and silently ignored them.)
-        self.tmux_session()?.capture_pane(lines)
-    }
-
-    /// Like [`capture_output`](Self::capture_output) but with the window's
-    /// other panes composited in, for the passive preview. Costs the same
-    /// single fork when the session has not been split.
+    /// Capture the session's window for the preview, with any panes the user
+    /// split off composited in. `capture-pane` has no size parameters: the
+    /// window is captured at its own dimensions.
     pub fn capture_output_composited(&self, lines: usize) -> Result<String> {
         self.tmux_session()?.capture_window_composited(lines)
     }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -5191,6 +5191,13 @@ impl Instance {
         // accepted width/height and silently ignored them.)
         self.tmux_session()?.capture_pane(lines)
     }
+
+    /// Like [`capture_output`](Self::capture_output) but with the window's
+    /// other panes composited in, for the passive preview. Costs the same
+    /// single fork when the session has not been split.
+    pub fn capture_output_composited(&self, lines: usize) -> Result<String> {
+        self.tmux_session()?.capture_window_composited(lines)
+    }
 }
 
 fn generate_id() -> String {

--- a/src/tmux/composite.rs
+++ b/src/tmux/composite.rs
@@ -55,6 +55,53 @@ pub(crate) struct CapturedPane {
     pub rows: Vec<String>,
 }
 
+/// A window's dimensions and every pane's rectangle plus captured rows.
+///
+/// Held as a unit so the live preview can cache one across frames: the panes
+/// the user is only *watching* refresh on a lazy cadence, while pane 0 (the
+/// one receiving input, whose latency is the only one that can be felt) is
+/// re-rendered every frame from its VT grid.
+pub(crate) struct WindowLayout {
+    pub window_width: u16,
+    pub window_height: u16,
+    pub panes: Vec<CapturedPane>,
+}
+
+impl WindowLayout {
+    pub(crate) fn composite(&self) -> String {
+        composite_window(self.window_width, self.window_height, &self.panes)
+    }
+
+    /// The first pane's rectangle, which tmux guarantees sits at the window
+    /// origin: pane indices follow layout order, so index 0 is the top-left
+    /// pane, and closing it renumbers whichever pane takes that corner. That
+    /// is what lets a VT grid's cursor be painted onto the composite with no
+    /// coordinate translation.
+    pub(crate) fn first_pane(&self) -> Option<PaneGeom> {
+        self.panes.first().map(|p| p.geom)
+    }
+
+    /// Composite with the first pane's rows swapped for `rows`, for the live
+    /// path's fresh VT-grid frame over a cached layout.
+    pub(crate) fn composite_with_first_pane_rows(&self, rows: &[String]) -> String {
+        let Some(first) = self.panes.first() else {
+            return self.composite();
+        };
+        let mut panes: Vec<CapturedPane> = Vec::with_capacity(self.panes.len());
+        panes.push(CapturedPane {
+            geom: first.geom,
+            rows: rows.to_vec(),
+        });
+        for pane in &self.panes[1..] {
+            panes.push(CapturedPane {
+                geom: pane.geom,
+                rows: pane.rows.clone(),
+            });
+        }
+        composite_window(self.window_width, self.window_height, &panes)
+    }
+}
+
 /// Border glyphs. tmux draws proper tee/cross junctions; a preview only needs
 /// the two edges, so a full-width gap row is drawn as an unbroken rule rather
 /// than tracking which columns carry a vertical border through it.
@@ -213,6 +260,55 @@ mod tests {
             pane(4, 0, 3, 2, &["xyz", "uvw"]),
         ];
         assert_eq!(composite_window(7, 2, &panes), "abc│xyz\n   │uvw");
+    }
+
+    fn layout(w: u16, h: u16, panes: Vec<CapturedPane>) -> WindowLayout {
+        WindowLayout {
+            window_width: w,
+            window_height: h,
+            panes,
+        }
+    }
+
+    #[test]
+    fn first_pane_is_the_one_at_the_window_origin() {
+        // tmux orders pane indices by layout, so index 0 is the top-left pane.
+        // The live path relies on this to paint pane 0's cursor onto the
+        // composite without translating its coordinates.
+        let l = layout(
+            9,
+            1,
+            vec![pane(0, 0, 4, 1, &["left"]), pane(5, 0, 4, 1, &["rght"])],
+        );
+        let first = l.first_pane().expect("a first pane");
+        assert_eq!((first.left, first.top), (0, 0));
+    }
+
+    #[test]
+    fn swapping_the_first_pane_rows_leaves_the_others_alone() {
+        // The live path's whole trick: a cached layout re-rendered with only
+        // pane 0 refreshed from its VT grid.
+        let l = layout(
+            9,
+            2,
+            vec![
+                pane(0, 0, 4, 2, &["old1", "old2"]),
+                pane(5, 0, 4, 2, &["keep", "same"]),
+            ],
+        );
+        let fresh = vec!["new1".to_string(), "new2".to_string()];
+        assert_eq!(
+            l.composite_with_first_pane_rows(&fresh),
+            "new1│keep\nnew2│same"
+        );
+        // The cached layout is not consumed: the next frame swaps again.
+        assert_eq!(l.composite(), "old1│keep\nold2│same");
+    }
+
+    #[test]
+    fn swapping_rows_on_an_empty_layout_is_a_no_op() {
+        let l = layout(3, 1, vec![]);
+        assert_eq!(l.composite_with_first_pane_rows(&["x".to_string()]), "");
     }
 
     #[test]

--- a/src/tmux/composite.rs
+++ b/src/tmux/composite.rs
@@ -43,6 +43,21 @@ impl PaneGeom {
         row >= self.top && row < self.top.saturating_add(self.height)
     }
 
+    /// Whether two pane rectangles share any cell.
+    ///
+    /// Panes in a normal window tile the grid, but a zoomed pane (`C-b z`) is
+    /// reported at the window's full rectangle while its neighbours keep their
+    /// own, so they overlap. [`composite_window`]'s walk assumes a tiling, so
+    /// [`crate::tmux::Session::capture_window_layout`] uses this to drop panes it
+    /// cannot lay out rather than painting a scrambled frame.
+    pub(crate) fn overlaps(&self, other: &Self) -> bool {
+        let x_overlap = self.left < other.left.saturating_add(other.width)
+            && other.left < self.left.saturating_add(self.width);
+        let y_overlap = self.top < other.top.saturating_add(other.height)
+            && other.top < self.top.saturating_add(self.height);
+        x_overlap && y_overlap
+    }
+
     fn covers(&self, row: u16, col: u16) -> bool {
         self.covers_row(row) && col >= self.left && col < self.left.saturating_add(self.width)
     }
@@ -142,10 +157,21 @@ const SGR_RESET: &str = "\x1b[0m";
 /// than tracking which columns carry a vertical border through it.
 const BORDER_VERTICAL: char = '│';
 const BORDER_HORIZONTAL: char = '─';
+/// Where a horizontal and a vertical rule cross. Reached only when no pane
+/// touches the cell orthogonally but one touches it diagonally.
+const BORDER_CROSS: char = '┼';
 
 /// Lay `panes` back onto a `window_width` x `window_height` grid and return the
-/// rows joined by `\n`, ready to be handed to the preview cache exactly like a
+/// rows, each terminated by `\n`, ready to be handed to the preview cache like a
 /// single-pane `capture-pane` result.
+///
+/// Every row is TERMINATED rather than joined, matching `capture-pane`, so the
+/// result always counts `window_height` lines. Joining instead lost the last row
+/// whenever it was blank (a stacked split with an idle shell underneath), because
+/// `str::lines` and the renderer's ANSI parser both drop a trailing empty segment.
+/// The cursor is rebased onto `window_height`, so a short count painted it a row
+/// above the text, and only for some splits, since a side-by-side border glyph
+/// makes the last row non-empty.
 ///
 /// Walks each window row left to right, emitting a pane's row whole whenever
 /// the cursor reaches that pane's left edge and a border glyph otherwise. Rows
@@ -163,27 +189,31 @@ pub(crate) fn composite_window(
 ) -> String {
     let mut out = String::new();
     for row in 0..window_height {
-        if row > 0 {
-            out.push('\n');
-        }
         // An unclaimed cell is a border only where it actually separates two
         // panes, and which glyph depends on the direction it separates them
         // in: a pane directly above or below makes it part of a horizontal
         // rule, a pane to the left or right makes it part of a vertical one.
         // A cell with no pane on any side is void (the dead corner beside a
-        // short pane) and stays blank rather than drawing a border to nowhere.
-        // Genuine cross junctions resolve to the horizontal rule; tmux would
-        // draw a tee there, which a preview does not need.
+        // short pane) and stays blank rather than drawing a border to nowhere,
+        // UNLESS a pane touches it diagonally, which only happens where a
+        // horizontal and a vertical rule cross. Those cells used to render as a
+        // hole in the middle of an otherwise unbroken rule.
         let covered = |r: u16, c: u16| panes.iter().any(|p| p.geom.covers(r, c));
         let gap_fill = |col: u16| -> char {
-            if row.checked_sub(1).is_some_and(|r| covered(r, col))
-                || covered(row.saturating_add(1), col)
-            {
+            let up = row.checked_sub(1);
+            let left = col.checked_sub(1);
+            let down = row.saturating_add(1);
+            let right = col.saturating_add(1);
+            if up.is_some_and(|r| covered(r, col)) || covered(down, col) {
                 BORDER_HORIZONTAL
-            } else if col.checked_sub(1).is_some_and(|c| covered(row, c))
-                || covered(row, col.saturating_add(1))
-            {
+            } else if left.is_some_and(|c| covered(row, c)) || covered(row, right) {
                 BORDER_VERTICAL
+            } else if up.zip(left).is_some_and(|(r, c)| covered(r, c))
+                || up.is_some_and(|r| covered(r, right))
+                || left.is_some_and(|c| covered(down, c))
+                || covered(down, right)
+            {
+                BORDER_CROSS
             } else {
                 ' '
             }
@@ -191,6 +221,11 @@ pub(crate) fn composite_window(
 
         let mut line = String::new();
         let mut col = 0u16;
+        // Whether the last thing written was pane content, whose SGR state may
+        // still be live. `capture_rows_padded` only resets when it actually pads,
+        // so a pane row whose fill runs to its own right edge leaves the colour
+        // set and would paint the border glyph beside it in that background.
+        let mut sgr_live = false;
         while col < window_width {
             let hit = panes
                 .iter()
@@ -199,6 +234,10 @@ pub(crate) fn composite_window(
                 Some(pane) if pane.geom.width > 0 => {
                     if let Some(text) = pane.rows.get((row - pane.geom.top) as usize) {
                         line.push_str(text);
+                        // A row that already ends in the padding reset needs no
+                        // second one; only a fill running to the pane's own right
+                        // edge leaves the colour set.
+                        sgr_live = text.contains('\x1b') && !text.ends_with(SGR_RESET);
                     } else {
                         // Short capture (pane resized mid-frame): pad rather
                         // than shift every pane to its right.
@@ -207,12 +246,17 @@ pub(crate) fn composite_window(
                     col = col.saturating_add(pane.geom.width);
                 }
                 _ => {
+                    if sgr_live {
+                        line.push_str(SGR_RESET);
+                        sgr_live = false;
+                    }
                     line.push(gap_fill(col));
                     col = col.saturating_add(1);
                 }
             }
         }
         out.push_str(trim_padding(&line));
+        out.push('\n');
     }
     out
 }
@@ -252,7 +296,7 @@ mod tests {
     #[test]
     fn single_pane_fills_the_window_unchanged() {
         let panes = [pane(0, 0, 5, 2, &["hello", "world"])];
-        assert_eq!(composite_window(5, 2, &panes), "hello\nworld");
+        assert_eq!(composite_window(5, 2, &panes), "hello\nworld\n");
     }
 
     #[test]
@@ -262,14 +306,17 @@ mod tests {
             pane(0, 0, 5, 2, &["aaaaa", "bbbbb"]),
             pane(6, 0, 5, 2, &["ccccc", "ddddd"]),
         ];
-        assert_eq!(composite_window(11, 2, &panes), "aaaaa│ccccc\nbbbbb│ddddd");
+        assert_eq!(
+            composite_window(11, 2, &panes),
+            "aaaaa│ccccc\nbbbbb│ddddd\n"
+        );
     }
 
     #[test]
     fn stacked_panes_are_joined_by_a_horizontal_border() {
         // `C-b "`: the row between the panes belongs to no pane.
         let panes = [pane(0, 0, 4, 1, &["topp"]), pane(0, 2, 4, 1, &["botm"])];
-        assert_eq!(composite_window(4, 3, &panes), "topp\n────\nbotm");
+        assert_eq!(composite_window(4, 3, &panes), "topp\n────\nbotm\n");
     }
 
     #[test]
@@ -281,7 +328,7 @@ mod tests {
             pane(0, 0, 3, 1, &["abc"]),
             pane(4, 0, 3, 2, &["xyz", "uvw"]),
         ];
-        assert_eq!(composite_window(7, 2, &panes), "abc│xyz\n───│uvw");
+        assert_eq!(composite_window(7, 2, &panes), "abc│xyz\n───│uvw\n");
     }
 
     #[test]
@@ -292,7 +339,7 @@ mod tests {
             pane(0, 0, 3, 2, &["abc"]),
             pane(4, 0, 3, 2, &["xyz", "uvw"]),
         ];
-        assert_eq!(composite_window(7, 2, &panes), "abc│xyz\n   │uvw");
+        assert_eq!(composite_window(7, 2, &panes), "abc│xyz\n   │uvw\n");
     }
 
     fn layout(w: u16, h: u16, panes: Vec<CapturedPane>) -> WindowLayout {
@@ -332,16 +379,129 @@ mod tests {
         let fresh = vec!["new1".to_string(), "new2".to_string()];
         assert_eq!(
             l.composite_with_first_pane_rows(&fresh),
-            "new1│keep\nnew2│same"
+            "new1│keep\nnew2│same\n"
         );
         // The cached layout is not consumed: the next frame swaps again.
-        assert_eq!(l.composite(), "old1│keep\nold2│same");
+        assert_eq!(l.composite(), "old1│keep\nold2│same\n");
+    }
+
+    /// A composite must always count `window_height` lines, whatever the bottom
+    /// row holds. The cursor is rebased onto `window_height`, so a row lost off
+    /// the bottom paints it one row too high, and a blank bottom row is the
+    /// common case (a stacked split with an idle shell underneath).
+    #[test]
+    fn every_row_is_terminated_so_the_line_count_matches_the_window() {
+        for (label, panes) in [
+            ("blank bottom row", vec![pane(0, 0, 4, 1, &["top."])]),
+            (
+                "content on every row",
+                vec![pane(0, 0, 4, 3, &["r0..", "r1..", "r2.."])],
+            ),
+            ("no panes at all", vec![]),
+        ] {
+            let out = composite_window(4, 3, &panes);
+            assert_eq!(out.lines().count(), 3, "{label}: lines() short");
+            assert!(out.ends_with('\n'), "{label}: last row not terminated");
+        }
+    }
+
+    /// A zoomed pane (`C-b z`) is reported at the window's full rectangle while
+    /// its neighbours keep theirs, so the rectangles OVERLAP and the walk's
+    /// tiling assumption breaks: it painted one pane then filled the rest of
+    /// every row with border glyphs, hiding the zoomed pane entirely. The capture
+    /// side drops overlapping panes; this pins the geometry test it relies on.
+    #[test]
+    fn overlapping_rectangles_are_detected() {
+        // The real measured zoom layout: 40x8 window split at column 20, then
+        // pane 1 zoomed to the full window.
+        let unzoomed_0 = PaneGeom {
+            left: 0,
+            top: 0,
+            width: 20,
+            height: 8,
+        };
+        let unzoomed_1 = PaneGeom {
+            left: 21,
+            top: 0,
+            width: 19,
+            height: 8,
+        };
+        let zoomed_1 = PaneGeom {
+            left: 0,
+            top: 0,
+            width: 40,
+            height: 8,
+        };
+        assert!(
+            !unzoomed_0.overlaps(&unzoomed_1),
+            "a normal split tiles and must not be dropped"
+        );
+        assert!(unzoomed_0.overlaps(&zoomed_1), "zoomed pane must be caught");
+        assert!(zoomed_1.overlaps(&unzoomed_0), "overlap is symmetric");
+        // Stacked panes separated by a rule row also tile.
+        let top = PaneGeom {
+            left: 0,
+            top: 0,
+            width: 9,
+            height: 1,
+        };
+        let bottom = PaneGeom {
+            left: 0,
+            top: 2,
+            width: 9,
+            height: 1,
+        };
+        assert!(!top.overlaps(&bottom));
+        // A zero-width pane touches nothing.
+        let empty = PaneGeom {
+            left: 0,
+            top: 0,
+            width: 0,
+            height: 8,
+        };
+        assert!(!empty.overlaps(&unzoomed_0));
+    }
+
+    /// Where a horizontal and a vertical rule cross, no pane touches the cell
+    /// orthogonally, so it used to render as a blank hole in the middle of an
+    /// otherwise unbroken rule. A pane on the diagonal marks it as a junction.
+    #[test]
+    fn a_rule_crossing_draws_a_junction_not_a_hole() {
+        // Four panes in a 2x2 grid, rules at row 1 and column 4.
+        let panes = [
+            pane(0, 0, 4, 1, &["tl.."]),
+            pane(5, 0, 4, 1, &["tr.."]),
+            pane(0, 2, 4, 1, &["bl.."]),
+            pane(5, 2, 4, 1, &["br.."]),
+        ];
+        let out = composite_window(9, 3, &panes);
+        let rule = out.lines().nth(1).expect("rule row");
+        assert_eq!(rule, "────┼────", "cross cell should be a junction");
+    }
+
+    /// The dead corner beside a SHORT pane has no pane on any side and no pane
+    /// on the diagonal either, so it must stay blank rather than being promoted
+    /// to a junction by the crossing rule above.
+    #[test]
+    fn a_dead_corner_stays_blank() {
+        // A one-row pane on the left, a three-row pane on the right. Rows 1-2 of
+        // the left column are void.
+        let panes = [
+            pane(0, 0, 3, 1, &["abc"]),
+            pane(4, 0, 3, 3, &["x", "y", "z"]),
+        ];
+        let out = composite_window(7, 3, &panes);
+        let last = out.lines().nth(2).expect("row 2");
+        assert!(
+            !last.contains('┼'),
+            "void corner became a junction: {last:?}"
+        );
     }
 
     #[test]
     fn swapping_rows_on_an_empty_layout_is_a_no_op() {
         let l = layout(3, 1, vec![]);
-        assert_eq!(l.composite_with_first_pane_rows(&["x".to_string()]), "");
+        assert_eq!(l.composite_with_first_pane_rows(&["x".to_string()]), "\n");
     }
 
     #[test]
@@ -357,7 +517,7 @@ mod tests {
         ];
         assert_eq!(
             composite_window(9, 3, &panes),
-            "top1│rgt1\n────│rgt2\nbot1│rgt3"
+            "top1│rgt1\n────│rgt2\nbot1│rgt3\n"
         );
     }
 
@@ -368,7 +528,7 @@ mod tests {
         let right = "\x1b[0m\x1b[32mgrn\x1b[0m";
         let panes = [pane(0, 0, 3, 1, &[left]), pane(4, 0, 3, 1, &[right])];
         let out = composite_window(7, 1, &panes);
-        assert_eq!(out, format!("{left}│{right}"));
+        assert_eq!(out, format!("{left}│{right}\n"));
     }
 
     #[test]
@@ -377,13 +537,13 @@ mod tests {
         // must still produce a full-width row instead of looping or panicking.
         // Only the column abutting the pane reads as a border; the rest is void.
         let panes = [pane(2, 0, 3, 1, &["xyz"])];
-        assert_eq!(composite_window(5, 1, &panes), " │xyz");
+        assert_eq!(composite_window(5, 1, &panes), " │xyz\n");
     }
 
     #[test]
     fn a_zero_width_pane_cannot_stall_the_walk() {
         let panes = [pane(0, 0, 0, 1, &[""]), pane(1, 0, 2, 1, &["ok"])];
-        assert_eq!(composite_window(3, 1, &panes), "│ok");
+        assert_eq!(composite_window(3, 1, &panes), "│ok\n");
     }
 
     #[test]
@@ -394,7 +554,7 @@ mod tests {
         let filled = format!("ab{}  ", "\x1b[44m");
         let panes = [pane(0, 0, 2, 1, &["xy"]), pane(3, 0, 4, 1, &[&filled])];
         let out = composite_window(7, 1, &panes);
-        assert_eq!(out, format!("xy│{filled}"), "styled fill was trimmed");
+        assert_eq!(out, format!("xy│{filled}\n"), "styled fill was trimmed");
     }
 
     #[test]
@@ -403,7 +563,7 @@ mod tests {
         // Both go, since nothing is colouring them.
         let padded = format!("ab{}  ", SGR_RESET);
         let panes = [pane(0, 0, 2, 1, &["xy"]), pane(3, 0, 4, 1, &[&padded])];
-        assert_eq!(composite_window(7, 1, &panes), "xy│ab");
+        assert_eq!(composite_window(7, 1, &panes), "xy│ab\n");
     }
 
     #[test]
@@ -427,6 +587,6 @@ mod tests {
     fn no_panes_renders_a_blank_grid() {
         // Nothing to separate, so nothing to draw: borders only appear where
         // they divide real panes.
-        assert_eq!(composite_window(3, 2, &[]), "\n");
+        assert_eq!(composite_window(3, 2, &[]), "\n\n");
     }
 }

--- a/src/tmux/composite.rs
+++ b/src/tmux/composite.rs
@@ -102,6 +102,41 @@ impl WindowLayout {
     }
 }
 
+/// Drop a composed row's trailing padding, which buys nothing and only risks
+/// the renderer wrapping a row that is exactly the viewport width.
+///
+/// Trailing spaces are only padding when nothing is colouring them. The
+/// rightmost pane's last row may legitimately end in a background fill running
+/// to the window edge (a status bar, a selection), which arrives here as an SGR
+/// followed by spaces; blanket-trimming those would strip the cells while
+/// leaving the escape, silently shortening the fill.
+/// [`crate::tmux::vt::capture_rows_padded`] treats a styled blank as content
+/// for the same reason, so this keeps the two halves of the pipeline agreeing.
+///
+/// Padding this module and `capture_rows_padded` append is always introduced by
+/// an explicit reset, so a reset immediately before the spaces is the signal
+/// that they are safe to drop (along with the now-pointless reset). A row of
+/// bare spaces carrying no escapes at all is a blank row and trims to nothing.
+fn trim_padding(line: &str) -> &str {
+    let trimmed = line.trim_end_matches(' ');
+    if trimmed.len() == line.len() {
+        return line;
+    }
+    if let Some(rest) = trimmed.strip_suffix(SGR_RESET) {
+        return rest;
+    }
+    // Unstyled blanks: no escape anywhere, so there is nothing to preserve.
+    if !trimmed.contains('\x1b') {
+        return trimmed;
+    }
+    // Spaces under a live SGR: a coloured fill, not padding.
+    line
+}
+
+/// The reset [`crate::tmux::vt::capture_rows_padded`] emits before padding a row
+/// out to its pane's width.
+const SGR_RESET: &str = "\x1b[0m";
+
 /// Border glyphs. tmux draws proper tee/cross junctions; a preview only needs
 /// the two edges, so a full-width gap row is drawn as an unbroken rule rather
 /// than tracking which columns carry a vertical border through it.
@@ -177,9 +212,7 @@ pub(crate) fn composite_window(
                 }
             }
         }
-        // Trailing padding buys nothing and only risks the renderer wrapping a
-        // row that is exactly the viewport width. Escapes are left alone.
-        out.push_str(line.trim_end_matches(' '));
+        out.push_str(trim_padding(&line));
     }
     out
 }
@@ -351,6 +384,43 @@ mod tests {
     fn a_zero_width_pane_cannot_stall_the_walk() {
         let panes = [pane(0, 0, 0, 1, &[""]), pane(1, 0, 2, 1, &["ok"])];
         assert_eq!(composite_window(3, 1, &panes), "│ok");
+    }
+
+    #[test]
+    fn a_styled_fill_running_to_the_window_edge_survives_the_trim() {
+        // The rightmost pane ends in a background fill (a status bar). Blanket
+        // trimming trailing spaces would strip the coloured cells and leave the
+        // escape behind, shortening the fill.
+        let filled = format!("ab{}  ", "\x1b[44m");
+        let panes = [pane(0, 0, 2, 1, &["xy"]), pane(3, 0, 4, 1, &[&filled])];
+        let out = composite_window(7, 1, &panes);
+        assert_eq!(out, format!("xy│{filled}"), "styled fill was trimmed");
+    }
+
+    #[test]
+    fn reset_prefixed_padding_is_still_trimmed() {
+        // What `capture_rows_padded` appends: an explicit reset, then spaces.
+        // Both go, since nothing is colouring them.
+        let padded = format!("ab{}  ", SGR_RESET);
+        let panes = [pane(0, 0, 2, 1, &["xy"]), pane(3, 0, 4, 1, &[&padded])];
+        assert_eq!(composite_window(7, 1, &panes), "xy│ab");
+    }
+
+    #[test]
+    fn trim_padding_handles_each_tail_shape() {
+        assert_eq!(trim_padding("abc"), "abc", "no trailing spaces: untouched");
+        assert_eq!(trim_padding("abc   "), "abc", "bare spaces: trimmed");
+        assert_eq!(trim_padding("     "), "", "blank row: trims to nothing");
+        assert_eq!(
+            trim_padding("\x1b[31mred\x1b[0m   "),
+            "\x1b[31mred",
+            "reset-prefixed padding: reset and spaces both dropped"
+        );
+        assert_eq!(
+            trim_padding("\x1b[44m   "),
+            "\x1b[44m   ",
+            "spaces under a live SGR: preserved"
+        );
     }
 
     #[test]

--- a/src/tmux/composite.rs
+++ b/src/tmux/composite.rs
@@ -1,0 +1,266 @@
+//! Splice a tmux window's panes into one screen-shaped snapshot.
+//!
+//! `capture-pane` is per-pane and tmux has no command that returns a window
+//! with its panes composited, so the preview historically showed only the
+//! pinned `^.0` pane and a user's split was invisible (see
+//! [`crate::tmux::Session::capture_window_composited`] for the capture side).
+//! This module is the pure half: given each pane's geometry and its captured
+//! rows, lay them back out on the window grid and draw tmux-style borders in
+//! the gaps between them.
+//!
+//! Compositing is read-only and changes nothing about input routing, which
+//! stays pinned to `^.0` (#435, #488).
+
+/// One pane's rectangle within its window, from
+/// `#{pane_left} #{pane_top} #{pane_width} #{pane_height}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PaneGeom {
+    pub left: u16,
+    pub top: u16,
+    pub width: u16,
+    pub height: u16,
+}
+
+impl PaneGeom {
+    /// Parse the four space-separated fields tmux emits for a pane's
+    /// rectangle. Returns `None` for a malformed line so a single unparseable
+    /// pane degrades that pane to border fill rather than failing the frame.
+    pub(crate) fn parse(line: &str) -> Option<Self> {
+        let mut f = line.split_whitespace();
+        let left = f.next()?.parse().ok()?;
+        let top = f.next()?.parse().ok()?;
+        let width = f.next()?.parse().ok()?;
+        let height = f.next()?.parse().ok()?;
+        Some(Self {
+            left,
+            top,
+            width,
+            height,
+        })
+    }
+
+    fn covers_row(&self, row: u16) -> bool {
+        row >= self.top && row < self.top.saturating_add(self.height)
+    }
+
+    fn covers(&self, row: u16, col: u16) -> bool {
+        self.covers_row(row) && col >= self.left && col < self.left.saturating_add(self.width)
+    }
+}
+
+/// A pane's rectangle plus its rows, each already padded to `geom.width`
+/// display columns by [`crate::tmux::vt::capture_rows_padded`].
+pub(crate) struct CapturedPane {
+    pub geom: PaneGeom,
+    pub rows: Vec<String>,
+}
+
+/// Border glyphs. tmux draws proper tee/cross junctions; a preview only needs
+/// the two edges, so a full-width gap row is drawn as an unbroken rule rather
+/// than tracking which columns carry a vertical border through it.
+const BORDER_VERTICAL: char = '│';
+const BORDER_HORIZONTAL: char = '─';
+
+/// Lay `panes` back onto a `window_width` x `window_height` grid and return the
+/// rows joined by `\n`, ready to be handed to the preview cache exactly like a
+/// single-pane `capture-pane` result.
+///
+/// Walks each window row left to right, emitting a pane's row whole whenever
+/// the cursor reaches that pane's left edge and a border glyph otherwise. Rows
+/// are emitted whole, never sliced at a column, which is what keeps the
+/// ANSI-laden content correct: slicing a styled row at a display column would
+/// mean parsing SGR state mid-string.
+///
+/// A column the walk cannot attribute to any pane advances by one and is
+/// filled, so a layout this function does not understand degrades to border
+/// fill instead of panicking or dropping the frame.
+pub(crate) fn composite_window(
+    window_width: u16,
+    window_height: u16,
+    panes: &[CapturedPane],
+) -> String {
+    let mut out = String::new();
+    for row in 0..window_height {
+        if row > 0 {
+            out.push('\n');
+        }
+        // An unclaimed cell is a border only where it actually separates two
+        // panes, and which glyph depends on the direction it separates them
+        // in: a pane directly above or below makes it part of a horizontal
+        // rule, a pane to the left or right makes it part of a vertical one.
+        // A cell with no pane on any side is void (the dead corner beside a
+        // short pane) and stays blank rather than drawing a border to nowhere.
+        // Genuine cross junctions resolve to the horizontal rule; tmux would
+        // draw a tee there, which a preview does not need.
+        let covered = |r: u16, c: u16| panes.iter().any(|p| p.geom.covers(r, c));
+        let gap_fill = |col: u16| -> char {
+            if row.checked_sub(1).is_some_and(|r| covered(r, col))
+                || covered(row.saturating_add(1), col)
+            {
+                BORDER_HORIZONTAL
+            } else if col.checked_sub(1).is_some_and(|c| covered(row, c))
+                || covered(row, col.saturating_add(1))
+            {
+                BORDER_VERTICAL
+            } else {
+                ' '
+            }
+        };
+
+        let mut line = String::new();
+        let mut col = 0u16;
+        while col < window_width {
+            let hit = panes
+                .iter()
+                .find(|p| p.geom.left == col && p.geom.covers_row(row));
+            match hit {
+                Some(pane) if pane.geom.width > 0 => {
+                    if let Some(text) = pane.rows.get((row - pane.geom.top) as usize) {
+                        line.push_str(text);
+                    } else {
+                        // Short capture (pane resized mid-frame): pad rather
+                        // than shift every pane to its right.
+                        line.extend(std::iter::repeat_n(' ', pane.geom.width as usize));
+                    }
+                    col = col.saturating_add(pane.geom.width);
+                }
+                _ => {
+                    line.push(gap_fill(col));
+                    col = col.saturating_add(1);
+                }
+            }
+        }
+        // Trailing padding buys nothing and only risks the renderer wrapping a
+        // row that is exactly the viewport width. Escapes are left alone.
+        out.push_str(line.trim_end_matches(' '));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pane(left: u16, top: u16, width: u16, height: u16, rows: &[&str]) -> CapturedPane {
+        CapturedPane {
+            geom: PaneGeom {
+                left,
+                top,
+                width,
+                height,
+            },
+            rows: rows.iter().map(|r| r.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn parses_a_geometry_line() {
+        assert_eq!(
+            PaneGeom::parse("0 0 80 24"),
+            Some(PaneGeom {
+                left: 0,
+                top: 0,
+                width: 80,
+                height: 24
+            })
+        );
+        assert_eq!(PaneGeom::parse("0 0 80"), None);
+        assert_eq!(PaneGeom::parse("a b c d"), None);
+        assert_eq!(PaneGeom::parse(""), None);
+    }
+
+    #[test]
+    fn single_pane_fills_the_window_unchanged() {
+        let panes = [pane(0, 0, 5, 2, &["hello", "world"])];
+        assert_eq!(composite_window(5, 2, &panes), "hello\nworld");
+    }
+
+    #[test]
+    fn side_by_side_panes_are_joined_by_a_vertical_border() {
+        // `C-b %`: two panes split at column 5, tmux's border occupying it.
+        let panes = [
+            pane(0, 0, 5, 2, &["aaaaa", "bbbbb"]),
+            pane(6, 0, 5, 2, &["ccccc", "ddddd"]),
+        ];
+        assert_eq!(composite_window(11, 2, &panes), "aaaaa│ccccc\nbbbbb│ddddd");
+    }
+
+    #[test]
+    fn stacked_panes_are_joined_by_a_horizontal_border() {
+        // `C-b "`: the row between the panes belongs to no pane.
+        let panes = [pane(0, 0, 4, 1, &["topp"]), pane(0, 2, 4, 1, &["botm"])];
+        assert_eq!(composite_window(4, 3, &panes), "topp\n────\nbotm");
+    }
+
+    #[test]
+    fn a_pane_shorter_than_its_neighbour_pads_rather_than_shifting() {
+        // The right pane spans both rows; the left only the first. Row 1 must
+        // still start the right pane at the same column, and the space the
+        // short pane vacated reads as the rule tmux would draw beneath it.
+        let panes = [
+            pane(0, 0, 3, 1, &["abc"]),
+            pane(4, 0, 3, 2, &["xyz", "uvw"]),
+        ];
+        assert_eq!(composite_window(7, 2, &panes), "abc│xyz\n───│uvw");
+    }
+
+    #[test]
+    fn a_row_missing_from_a_capture_pads_its_width() {
+        // Pane claims two rows but the capture came back with one (a resize
+        // raced the frame). The neighbour must not slide left.
+        let panes = [
+            pane(0, 0, 3, 2, &["abc"]),
+            pane(4, 0, 3, 2, &["xyz", "uvw"]),
+        ];
+        assert_eq!(composite_window(7, 2, &panes), "abc│xyz\n   │uvw");
+    }
+
+    #[test]
+    fn a_left_column_split_in_two_draws_a_rule_between_its_panes() {
+        // The layout `C-b %` then `C-b "` produces: a tall pane down the right
+        // side, and the left column split into two stacked panes. The rule
+        // between the stacked pair must stop at the vertical border rather
+        // than running through it or vanishing.
+        let panes = [
+            pane(0, 0, 4, 1, &["top1"]),
+            pane(0, 2, 4, 1, &["bot1"]),
+            pane(5, 0, 4, 3, &["rgt1", "rgt2", "rgt3"]),
+        ];
+        assert_eq!(
+            composite_window(9, 3, &panes),
+            "top1│rgt1\n────│rgt2\nbot1│rgt3"
+        );
+    }
+
+    #[test]
+    fn ansi_rows_are_spliced_without_being_cut() {
+        // A styled row must arrive at the seam intact, escapes and all.
+        let left = "\x1b[0m\x1b[31mred\x1b[0m";
+        let right = "\x1b[0m\x1b[32mgrn\x1b[0m";
+        let panes = [pane(0, 0, 3, 1, &[left]), pane(4, 0, 3, 1, &[right])];
+        let out = composite_window(7, 1, &panes);
+        assert_eq!(out, format!("{left}│{right}"));
+    }
+
+    #[test]
+    fn an_unclaimed_column_degrades_to_border_fill() {
+        // A layout the walk cannot attribute (pane starts at 2, nothing at 0)
+        // must still produce a full-width row instead of looping or panicking.
+        // Only the column abutting the pane reads as a border; the rest is void.
+        let panes = [pane(2, 0, 3, 1, &["xyz"])];
+        assert_eq!(composite_window(5, 1, &panes), " │xyz");
+    }
+
+    #[test]
+    fn a_zero_width_pane_cannot_stall_the_walk() {
+        let panes = [pane(0, 0, 0, 1, &[""]), pane(1, 0, 2, 1, &["ok"])];
+        assert_eq!(composite_window(3, 1, &panes), "│ok");
+    }
+
+    #[test]
+    fn no_panes_renders_a_blank_grid() {
+        // Nothing to separate, so nothing to draw: borders only appear where
+        // they divide real panes.
+        assert_eq!(composite_window(3, 2, &[]), "\n");
+    }
+}

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -1,5 +1,6 @@
 //! tmux integration module
 
+pub(crate) mod composite;
 pub(crate) mod env;
 mod session;
 pub mod status_bar;

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -122,6 +122,11 @@ pub struct PaneCursor {
     pub position_reliable: bool,
 }
 
+/// tmux format line every cursor probe requests, parsed by
+/// [`PaneCursor::parse`]. Shared so the plain capture and the composited one
+/// cannot drift into asking for different fields.
+const CURSOR_FMT: &str = "#{cursor_x} #{cursor_y} #{cursor_flag} #{pane_height} #{history_size} #{pane_width} #{alternate_on} #{mouse_any_flag} #{mouse_sgr_flag} #{mouse_all_flag}";
+
 impl PaneCursor {
     /// Parse the single space-separated line emitted by the
     /// `#{cursor_x} #{cursor_y} #{cursor_flag} #{pane_height}
@@ -225,6 +230,22 @@ fn parse_pane_segments(raw: &str, sentinel: &str) -> Vec<CapturedPane> {
     }
     flush(&mut panes, current.take());
     panes
+}
+
+/// Flag a cursor's POSITION as untrustworthy while keeping its always-valid
+/// mode flags, for the composite paths that fall through to a scrollback-bearing
+/// pane-0 capture.
+///
+/// [`Session::capture_pane_with_cursor`] earns the right to trust a position by
+/// probing twice around its capture and comparing; a single probe against
+/// content that includes scrollback has no such evidence, so the render skips
+/// painting rather than risk the row-drift bug while the wheel forward (which
+/// reads only the mode flags) keeps working.
+fn unreliable_position(cursor: Option<PaneCursor>) -> Option<PaneCursor> {
+    cursor.map(|c| PaneCursor {
+        position_reliable: false,
+        ..c
+    })
 }
 
 /// A delta beyond this many rows between a window and its pane is a multi-pane
@@ -564,8 +585,36 @@ impl Session {
     /// so this reads as "a split window doesn't scroll back" rather than
     /// misbehaving.
     pub fn capture_window_composited(&self, lines: usize) -> Result<String> {
+        Ok(self.capture_window_composited_with_cursor(lines)?.0)
+    }
+
+    /// [`capture_window_composited`](Self::capture_window_composited) plus pane
+    /// 0's cursor, for the live preview.
+    ///
+    /// Pane 0 owns the cursor because it is the pane that receives input, and
+    /// tmux puts it at the window origin, so its coordinates index the
+    /// composite untranslated. The probe targets `^.0` explicitly rather than
+    /// the window, whose format fields would resolve against whichever pane the
+    /// user happens to have selected.
+    ///
+    /// On a composite the cursor is rebased onto the window's dimensions: the
+    /// renderer anchors it by `pane_height` against the painted line count,
+    /// which is now the whole window rather than one pane.
+    pub fn capture_window_composited_with_cursor(
+        &self,
+        lines: usize,
+    ) -> Result<(String, Option<PaneCursor>)> {
+        /// Gates the window-dimensions line. A chained `display-message` can
+        /// silently produce nothing while the invocation still exits 0 (the
+        /// same hazard `is_probe_line` guards in the vt seed path), and without
+        /// a sentinel the capture's first row would be mistaken for the header
+        /// and dropped from the fallback content.
+        const WINDOW_SENTINEL: &str = "@@aoe-win@@";
+        /// Gates the cursor line, for the same reason.
+        const CURSOR_SENTINEL: &str = "@@aoe-cur@@";
+
         if !self.exists() {
-            return Ok(String::new());
+            return Ok((String::new(), None));
         }
 
         let window = format!("{}:^", self.name);
@@ -577,7 +626,16 @@ impl Session {
                 "-t",
                 &window,
                 "-F",
-                "#{window_panes} #{window_width} #{window_height}",
+                &format!(
+                    "{WINDOW_SENTINEL} #{{window_panes}} #{{window_width}} #{{window_height}}"
+                ),
+                ";",
+                "display-message",
+                "-p",
+                "-t",
+                &pane0,
+                "-F",
+                &format!("{CURSOR_SENTINEL} {CURSOR_FMT}"),
                 ";",
                 "capture-pane",
                 "-t",
@@ -590,30 +648,61 @@ impl Session {
             .output()?;
 
         if !output.status.success() {
-            return Ok(String::new());
+            return Ok((String::new(), None));
         }
 
+        // Consume the sentinel-tagged preamble line by line; the first line
+        // that carries neither sentinel is where the capture starts. Either
+        // probe going missing costs only its own information, never a row of
+        // pane content.
         let raw = String::from_utf8_lossy(&output.stdout);
-        let mut parts = raw.splitn(2, '\n');
-        let header = parts.next().unwrap_or("");
-        let pane0_content = parts.next().unwrap_or("").to_string();
+        let mut rest: &str = &raw;
+        let mut dims: Option<(u16, u16, u16)> = None;
+        let mut cursor: Option<PaneCursor> = None;
+        while let Some((line, tail)) = rest.split_once('\n') {
+            if let Some(fields) = line.strip_prefix(WINDOW_SENTINEL) {
+                let mut f = fields.split_whitespace();
+                dims = match (f.next(), f.next(), f.next()) {
+                    (Some(c), Some(w), Some(h)) => {
+                        match (c.parse().ok(), w.parse().ok(), h.parse().ok()) {
+                            (Some(c), Some(w), Some(h)) => Some((c, w, h)),
+                            _ => None,
+                        }
+                    }
+                    _ => None,
+                };
+            } else if let Some(fields) = line.strip_prefix(CURSOR_SENTINEL) {
+                cursor = PaneCursor::parse(fields.trim());
+            } else {
+                break;
+            }
+            rest = tail;
+        }
+        let pane0_content = rest.to_string();
 
-        let mut fields = header.split_whitespace();
-        let count: u16 = fields.next().and_then(|f| f.parse().ok()).unwrap_or(1);
-        let window_width: u16 = fields.next().and_then(|f| f.parse().ok()).unwrap_or(0);
-        let window_height: u16 = fields.next().and_then(|f| f.parse().ok()).unwrap_or(0);
-
+        let Some((count, window_width, window_height)) = dims else {
+            return Ok((pane0_content, unreliable_position(cursor)));
+        };
         if count <= 1 || window_width == 0 || window_height == 0 {
-            return Ok(pane0_content);
+            return Ok((pane0_content, unreliable_position(cursor)));
         }
 
         // Any failure in the split path (fork error, unparseable layout) falls
         // back to the pane-0 bytes already in hand, so a composite that cannot
         // be built is never worse than the old single-pane preview.
-        Ok(self
-            .capture_window_layout(count)
-            .map(|layout| layout.composite())
-            .unwrap_or(pane0_content))
+        let Some(layout) = self.capture_window_layout(count) else {
+            return Ok((pane0_content, unreliable_position(cursor)));
+        };
+        // The composite is the visible window with no scrollback, so the row a
+        // single probe reported cannot have drifted underneath it, and the
+        // position stands.
+        let cursor = cursor.map(|mut c| {
+            c.pane_height = layout.window_height;
+            c.pane_width = layout.window_width;
+            c.history_size = 0;
+            c
+        });
+        Ok((layout.composite(), cursor))
     }
 
     /// Second fork of [`capture_window_composited`](Self::capture_window_composited):
@@ -627,7 +716,7 @@ impl Session {
     ///
     /// Returned rather than composited on the spot so the live preview can
     /// cache a layout across frames and re-render only pane 0 from its VT grid
-    /// (see [`WindowLayout::with_first_pane_rows`]).
+    /// (see [`WindowLayout::composite_with_first_pane_rows`]).
     pub(crate) fn capture_window_layout(&self, count: u16) -> Option<WindowLayout> {
         /// Marks the start of each pane's segment in the chained output. Pane
         /// content could in principle contain this line, which would split one
@@ -737,8 +826,7 @@ impl Session {
 
         let target = format!("{}:^.0", self.name);
         let start = format!("-{}", lines);
-        const HEADER_FMT: &str =
-            "#{cursor_x} #{cursor_y} #{cursor_flag} #{pane_height} #{history_size} #{pane_width} #{alternate_on} #{mouse_any_flag} #{mouse_sgr_flag} #{mouse_all_flag}";
+        const HEADER_FMT: &str = CURSOR_FMT;
         let output = crate::tmux::tmux_command()
             .args([
                 "display-message",
@@ -2395,6 +2483,94 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// A composited capture must return the pane's cursor, and on an unsplit
+    /// window it must return the same bytes and cursor mode flags the plain
+    /// cursor-bearing capture does.
+    ///
+    /// The cursor matters because this is live-send's transport whenever no VT
+    /// channel is available: without it a split preview loses both its painted
+    /// cursor and the alternate-screen / mouse flags the wheel forward reads.
+    #[test]
+    #[serial_test::serial]
+    fn composited_capture_carries_the_pane_cursor() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let guard = TmuxTestSession::new("aoe_test_composite_cursor");
+        let session_name = guard.name().to_string();
+        crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &session_name,
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sh -c 'echo ALPHA; sleep 30'",
+            ])
+            .output()
+            .expect("tmux new-session");
+        crate::tmux::tmux_command()
+            .args(["set-option", "-t", &session_name, "pane-base-index", "0"])
+            .output()
+            .expect("tmux set-option pane-base-index");
+        std::thread::sleep(std::time::Duration::from_millis(300));
+
+        let session = Session {
+            name: session_name.clone(),
+        };
+        let (content, cursor) = session
+            .capture_window_composited_with_cursor(20)
+            .expect("composited capture");
+        let plain = session.capture_pane(20).expect("capture_pane");
+        assert_eq!(
+            content, plain,
+            "unsplit window must still pass pane bytes through untouched"
+        );
+        assert!(
+            content.contains("ALPHA"),
+            "first captured row went missing: {content:?}"
+        );
+        let cursor = cursor.expect("a cursor for a live pane");
+        assert_eq!(cursor.pane_width, 80, "cursor carries the pane geometry");
+
+        // Now split, and the cursor must be rebased onto the window so the
+        // renderer's `pane_height` anchoring still lines up with the composite.
+        crate::tmux::tmux_command()
+            .args([
+                "split-window",
+                "-h",
+                "-t",
+                &session_name,
+                "sh -c 'echo BRAVO; sleep 30'",
+            ])
+            .output()
+            .expect("tmux split-window");
+        std::thread::sleep(std::time::Duration::from_millis(400));
+
+        let (content, cursor) = session
+            .capture_window_composited_with_cursor(20)
+            .expect("composited capture");
+        assert!(content.contains("ALPHA") && content.contains("BRAVO"));
+        let cursor = cursor.expect("a cursor for the split window");
+        assert_eq!(
+            cursor.pane_width, 80,
+            "rebased onto the window, not pane 0 (which is now ~39 wide)"
+        );
+        assert_eq!(
+            cursor.history_size, 0,
+            "a composite has no scrollback to advertise"
+        );
+        assert!(
+            cursor.position_reliable,
+            "visible-only composite cannot have drifted"
+        );
     }
 
     /// The two composite transports must agree byte for byte on a static

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -598,6 +598,10 @@ impl Session {
     /// and that one is chained so it stays a single `tmux` invocation no matter
     /// how many panes there are.
     ///
+    /// A zoomed pane (`C-b z`) is treated as unsplit and takes the same
+    /// single-pane path, because tmux reports zoomed panes at overlapping
+    /// rectangles that the compositor cannot tile.
+    ///
     /// Splits lose scrollback: panes have independent histories, so there is no
     /// coherent way to stack them, and the composite covers the visible window
     /// only. The preview's scroll offset clamps itself to the shorter capture,
@@ -646,7 +650,7 @@ impl Session {
                 &window,
                 "-F",
                 &format!(
-                    "{WINDOW_SENTINEL} #{{window_panes}} #{{window_width}} #{{window_height}}"
+                    "{WINDOW_SENTINEL} #{{window_panes}} #{{window_width}} #{{window_height}} #{{window_zoomed_flag}}"
                 ),
                 ";",
                 "display-message",
@@ -677,6 +681,7 @@ impl Session {
         let raw = String::from_utf8_lossy(&output.stdout);
         let mut rest: &str = &raw;
         let mut dims: Option<(u16, u16, u16)> = None;
+        let mut zoomed = false;
         let mut cursor: Option<PaneCursor> = None;
         while let Some((line, tail)) = rest.split_once('\n') {
             if let Some(fields) = line.strip_prefix(WINDOW_SENTINEL) {
@@ -690,6 +695,9 @@ impl Session {
                     }
                     _ => None,
                 };
+                // Absent (older tmux, or a truncated line) reads as not zoomed,
+                // which keeps the composite path rather than disabling it.
+                zoomed = f.next().is_some_and(|z| z != "0");
             } else if let Some(fields) = line.strip_prefix(CURSOR_SENTINEL) {
                 cursor = PaneCursor::parse(fields.trim());
             } else {
@@ -703,6 +711,17 @@ impl Session {
             return Ok((pane0_content, unreliable_position(cursor)));
         };
         if count <= 1 || window_width == 0 || window_height == 0 {
+            return Ok((pane0_content, unreliable_position(cursor)));
+        }
+        // A zoomed pane (`C-b z`) keeps `window_panes` at its real count but
+        // reports every pane at the window's full rectangle, so the panes
+        // OVERLAP. The compositor's walk assumes a tiling, and handed overlap it
+        // paints one pane and fills the rest of the row with border glyphs,
+        // hiding the zoomed pane's content, which is the only thing the user is
+        // looking at in tmux. Treat zoomed as unsplit: pane 0's bytes are already
+        // in hand, scrollback included, which is what the preview showed before
+        // compositing existed.
+        if zoomed {
             return Ok((pane0_content, unreliable_position(cursor)));
         }
 
@@ -792,10 +811,23 @@ impl Session {
             return None;
         }
 
-        let panes = parse_pane_segments(rest, SENTINEL);
+        let mut panes = parse_pane_segments(rest, SENTINEL);
         if panes.is_empty() {
             return None;
         }
+        // Backstop for the zoom guard in `capture_window_composited_with_cursor`
+        // and `probe_pane_count`: if any overlapping layout still reaches here,
+        // keep the first pane of each overlapping set rather than handing the
+        // compositor a non-tiling layout it would paint as border garbage. Pane 0
+        // comes first, so the pane that survives is always the one receiving
+        // input, and the frame degrades to "pane 0 plus empty space".
+        let mut kept: Vec<CapturedPane> = Vec::with_capacity(panes.len());
+        for pane in panes.drain(..) {
+            if !kept.iter().any(|k| k.geom.overlaps(&pane.geom)) {
+                kept.push(pane);
+            }
+        }
+        let panes = kept;
         Some(WindowLayout {
             window_width,
             window_height,
@@ -2458,6 +2490,132 @@ mod tests {
         assert!(
             seam_row.contains("BRAVO"),
             "panes should share a row, not stack:\n{seam_row:?}"
+        );
+    }
+
+    /// `C-b z` keeps `window_panes` at its real count while reporting every pane
+    /// at the window's FULL rectangle, so the rectangles overlap and the
+    /// compositor's tiling assumption breaks. Compositing that painted pane 0 at
+    /// its unzoomed width and filled the rest of every row with `─`, hiding the
+    /// zoomed pane, which is the only thing the user sees in tmux. The frame was
+    /// strictly worse than the pane-0-only preview it replaced, and permanently
+    /// so, since nothing self-heals a zoom.
+    ///
+    /// Zoomed must therefore be treated as unsplit, byte-for-byte identical to
+    /// the plain capture.
+    #[test]
+    #[serial_test::serial]
+    fn a_zoomed_pane_falls_back_to_the_plain_capture() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let guard = TmuxTestSession::new("aoe_test_composite_zoom");
+        let session = start_composite_session(guard.name(), 40, 8, "sh -c 'echo ALPHA; sleep 30'");
+        wait_for_pane_text(&session, "ALPHA");
+        split_composite_session(&session, "sh -c 'echo BRAVO; sleep 30'");
+        wait_for_composite_text(&session, "BRAVO");
+
+        // Control: unzoomed, both panes, and one line per window row.
+        let unzoomed = session
+            .capture_window_composited(10)
+            .expect("composite unzoomed");
+        assert!(
+            unzoomed.contains("ALPHA") && unzoomed.contains("BRAVO"),
+            "control: split should composite both panes:\n{unzoomed}"
+        );
+
+        let zoom = crate::tmux::tmux_command()
+            .args(["resize-pane", "-Z", "-t", &format!("{}:^.1", session.name)])
+            .status()
+            .expect("tmux resize-pane -Z");
+        assert!(zoom.success(), "zoom must land or this tests nothing");
+        assert_eq!(
+            String::from_utf8_lossy(
+                &crate::tmux::tmux_command()
+                    .args([
+                        "display-message",
+                        "-p",
+                        "-t",
+                        &format!("{}:^", session.name),
+                        "-F",
+                        "#{window_zoomed_flag}",
+                    ])
+                    .output()
+                    .expect("zoom probe")
+                    .stdout
+            )
+            .trim(),
+            "1",
+            "tmux did not report the window as zoomed"
+        );
+
+        let zoomed = session
+            .capture_window_composited(10)
+            .expect("composite zoomed");
+        assert!(
+            !zoomed.contains('─') && !zoomed.contains('│'),
+            "zoomed frame painted border fill over the window:\n{zoomed}"
+        );
+        assert_eq!(
+            zoomed,
+            session.capture_pane(10).expect("plain capture"),
+            "zoomed must be byte-identical to the pane-0 capture"
+        );
+
+        // Unzooming restores the composite rather than latching the fallback.
+        assert!(crate::tmux::tmux_command()
+            .args(["resize-pane", "-Z", "-t", &format!("{}:^.1", session.name)])
+            .status()
+            .expect("tmux unzoom")
+            .success());
+        let restored = session
+            .capture_window_composited(10)
+            .expect("composite after unzoom");
+        assert!(
+            restored.contains("ALPHA") && restored.contains("BRAVO"),
+            "unzoom did not restore the composite:\n{restored}"
+        );
+    }
+
+    /// A composited capture must carry one line per window row. It is handed to
+    /// the preview cache like a `capture-pane` result and the cursor is rebased
+    /// onto `window_height`, so a row lost off the bottom paints the cursor one
+    /// row too high. A stacked split with an idle shell underneath is the case
+    /// that produced it: the bottom row is blank, and joining rows rather than
+    /// terminating them let the renderer drop it.
+    #[test]
+    #[serial_test::serial]
+    fn a_stacked_split_composites_one_line_per_window_row() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let guard = TmuxTestSession::new("aoe_test_composite_rows");
+        let session = start_composite_session(guard.name(), 30, 10, "sh -c 'echo ALPHA; sleep 30'");
+        wait_for_pane_text(&session, "ALPHA");
+        // `C-b "`: stacked, so the bottom pane's last row is blank.
+        let split = crate::tmux::tmux_command()
+            .args([
+                "split-window",
+                "-v",
+                "-t",
+                &session.name,
+                "sh -c 'sleep 30'",
+            ])
+            .status()
+            .expect("tmux split-window -v");
+        assert!(split.success(), "failed to split {}", session.name);
+        refresh_session_cache();
+        wait_for_composite_text(&session, "ALPHA");
+
+        let composited = session.capture_window_composited(10).expect("composite");
+        assert_eq!(
+            composited.lines().count(),
+            10,
+            "composite must be window_height lines:\n{composited}"
         );
     }
 

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use super::{
+    composite::{composite_window, CapturedPane, PaneGeom},
     probe_session_existence, refresh_session_cache,
     utils::{
         append_clipboard_passthrough_args, append_mouse_on_args, append_pane_base_index_args,
@@ -188,6 +189,42 @@ fn merge_cursor_probes(
         }
         _ => None,
     }
+}
+
+/// Split the chained multi-pane capture into one [`CapturedPane`] per pane.
+///
+/// The output is a flat byte stream of `<sentinel + geometry>` lines each
+/// followed by that pane's `capture-pane` rows, so the sentinel is the only
+/// frame marker. A pane whose geometry line does not parse is dropped rather
+/// than shifting every later pane's content onto the wrong rectangle.
+fn parse_pane_segments(raw: &str, sentinel: &str) -> Vec<CapturedPane> {
+    let mut panes: Vec<CapturedPane> = Vec::new();
+    let mut current: Option<(PaneGeom, Vec<&str>)> = None;
+
+    let flush = |panes: &mut Vec<CapturedPane>, entry: Option<(PaneGeom, Vec<&str>)>| {
+        if let Some((geom, lines)) = entry {
+            let body = lines.join("\n");
+            panes.push(CapturedPane {
+                rows: crate::tmux::vt::capture_rows_padded(
+                    body.as_bytes(),
+                    geom.width,
+                    geom.height,
+                ),
+                geom,
+            });
+        }
+    };
+
+    for line in raw.lines() {
+        if let Some(rest) = line.strip_prefix(sentinel) {
+            flush(&mut panes, current.take());
+            current = PaneGeom::parse(rest).map(|geom| (geom, Vec::new()));
+        } else if let Some((_, lines)) = current.as_mut() {
+            lines.push(line);
+        }
+    }
+    flush(&mut panes, current.take());
+    panes
 }
 
 /// A delta beyond this many rows between a window and its pane is a multi-pane
@@ -502,6 +539,135 @@ impl Session {
         } else {
             Ok(String::new())
         }
+    }
+
+    /// Capture the whole first window, panes composited, for the passive
+    /// preview.
+    ///
+    /// [`capture_pane`](Self::capture_pane) shows `^.0` and nothing else, so a
+    /// user who splits the window watches aoe go blind to everything but the
+    /// agent's own pane. This reads every pane and lays them back out on the
+    /// window grid. Input is untouched and still pinned to `^.0` (#435, #488):
+    /// compositing is read-only, so the mis-targeted-keystroke class of bug
+    /// that the pin exists to prevent cannot arise here.
+    ///
+    /// The single-pane case, which is almost every session, costs the same one
+    /// fork as before: the pane count rides along as a header on the capture
+    /// that was already being taken, and its bytes are returned verbatim
+    /// (scrollback and all). Only a genuinely split window pays a second fork,
+    /// and that one is chained so it stays a single `tmux` invocation no matter
+    /// how many panes there are.
+    ///
+    /// Splits lose scrollback: panes have independent histories, so there is no
+    /// coherent way to stack them, and the composite covers the visible window
+    /// only. The preview's scroll offset clamps itself to the shorter capture,
+    /// so this reads as "a split window doesn't scroll back" rather than
+    /// misbehaving.
+    pub fn capture_window_composited(&self, lines: usize) -> Result<String> {
+        if !self.exists() {
+            return Ok(String::new());
+        }
+
+        let window = format!("{}:^", self.name);
+        let pane0 = format!("{}:^.0", self.name);
+        let output = crate::tmux::tmux_command()
+            .args([
+                "display-message",
+                "-p",
+                "-t",
+                &window,
+                "-F",
+                "#{window_panes} #{window_width} #{window_height}",
+                ";",
+                "capture-pane",
+                "-t",
+                &pane0,
+                "-p",
+                "-e",
+                "-S",
+                &format!("-{}", lines),
+            ])
+            .output()?;
+
+        if !output.status.success() {
+            return Ok(String::new());
+        }
+
+        let raw = String::from_utf8_lossy(&output.stdout);
+        let mut parts = raw.splitn(2, '\n');
+        let header = parts.next().unwrap_or("");
+        let pane0_content = parts.next().unwrap_or("").to_string();
+
+        let mut fields = header.split_whitespace();
+        let count: u16 = fields.next().and_then(|f| f.parse().ok()).unwrap_or(1);
+        let window_width: u16 = fields.next().and_then(|f| f.parse().ok()).unwrap_or(0);
+        let window_height: u16 = fields.next().and_then(|f| f.parse().ok()).unwrap_or(0);
+
+        if count <= 1 || window_width == 0 || window_height == 0 {
+            return Ok(pane0_content);
+        }
+
+        // Any failure in the split path (fork error, unparseable layout) falls
+        // back to the pane-0 bytes already in hand, so a composite that cannot
+        // be built is never worse than the old single-pane preview.
+        Ok(self
+            .capture_split_window(count, window_width, window_height)
+            .unwrap_or(pane0_content))
+    }
+
+    /// Second fork of [`capture_window_composited`](Self::capture_window_composited):
+    /// geometry plus visible capture for each of `count` panes, chained into one
+    /// `tmux` invocation, spliced by [`composite_window`].
+    ///
+    /// Pane indices are contiguous from 0 within a window (tmux renumbers them
+    /// as the layout changes, unlike window indices) and `pane-base-index` is
+    /// forced to 0 when the session is created, so `^.0..^.{count-1}` addresses
+    /// every pane without a prior `list-panes` round trip.
+    fn capture_split_window(
+        &self,
+        count: u16,
+        window_width: u16,
+        window_height: u16,
+    ) -> Option<String> {
+        /// Marks the start of each pane's segment in the chained output. Pane
+        /// content could in principle contain this line, which would split one
+        /// pane's rows in two; the cost is a single garbled preview frame, and
+        /// the string is unusual enough to make that a non-event.
+        const SENTINEL: &str = "@@aoe-pane@@";
+
+        let mut args: Vec<String> = Vec::new();
+        for i in 0..count {
+            let target = format!("{}:^.{}", self.name, i);
+            if !args.is_empty() {
+                args.push(";".to_string());
+            }
+            args.extend([
+                "display-message".to_string(),
+                "-p".to_string(),
+                "-t".to_string(),
+                target.clone(),
+                "-F".to_string(),
+                format!("{SENTINEL} #{{pane_left}} #{{pane_top}} #{{pane_width}} #{{pane_height}}"),
+                ";".to_string(),
+                "capture-pane".to_string(),
+                "-t".to_string(),
+                target,
+                "-p".to_string(),
+                "-e".to_string(),
+            ]);
+        }
+
+        let output = crate::tmux::tmux_command().args(&args).output().ok()?;
+        if !output.status.success() {
+            return None;
+        }
+
+        let raw = String::from_utf8_lossy(&output.stdout);
+        let panes = parse_pane_segments(&raw, SENTINEL);
+        if panes.is_empty() {
+            return None;
+        }
+        Some(composite_window(window_width, window_height, &panes))
     }
 
     /// Capture the pane's full scrollback (from session start) with wrapped
@@ -1220,6 +1386,40 @@ mod tests {
         assert_eq!(chrome_rows(40, 18), 0, "split layout is not chrome");
         // Degenerate: pane taller than window can't underflow.
         assert_eq!(chrome_rows(10, 20), 0, "saturating, no panic");
+    }
+
+    #[test]
+    fn pane_segments_split_the_chained_capture_by_sentinel() {
+        // Shape of the chained fork's stdout: a geometry line per pane, each
+        // followed by that pane's rows.
+        let raw = "@@s@@ 0 0 6 2\nleft1\nleft2\n@@s@@ 7 0 6 2\nright1\nright2\n";
+        let panes = parse_pane_segments(raw, "@@s@@");
+        assert_eq!(panes.len(), 2);
+        assert_eq!(panes[0].geom.left, 0);
+        assert_eq!(panes[1].geom.left, 7);
+        // Rows come back padded to the pane's width, which is what lets the
+        // compositor concatenate them without measuring.
+        assert_eq!(panes[0].rows.len(), 2);
+        assert!(panes[0].rows[0].contains("left1"));
+        assert!(panes[1].rows[1].contains("right2"));
+    }
+
+    #[test]
+    fn pane_segments_drop_a_pane_with_unparseable_geometry() {
+        // A bad geometry line must not push its rows onto the next pane's
+        // rectangle; the pane is dropped and the rest still parse.
+        let raw = "@@s@@ bogus\norphan\n@@s@@ 0 0 4 1\nkeep\n";
+        let panes = parse_pane_segments(raw, "@@s@@");
+        assert_eq!(panes.len(), 1);
+        assert_eq!(panes[0].geom.width, 4);
+        assert!(panes[0].rows[0].contains("keep"));
+    }
+
+    #[test]
+    fn pane_segments_are_empty_when_no_sentinel_appears() {
+        // A tmux that emitted nothing recognisable must yield no panes, so the
+        // caller falls back to its already-captured pane-0 bytes.
+        assert!(parse_pane_segments("just some output\n", "@@s@@").is_empty());
     }
 
     #[test]
@@ -1970,6 +2170,125 @@ mod tests {
         assert!(
             !session.is_pane_running_shell(),
             "is_pane_running_shell should check first window (sleep), not active window (sh)"
+        );
+    }
+
+    /// An unsplit window must composite to exactly what `capture_pane`
+    /// returns, so the overwhelmingly common case is provably unchanged.
+    #[test]
+    #[serial_test::serial]
+    fn composited_capture_matches_capture_pane_when_unsplit() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let guard = TmuxTestSession::new("aoe_test_composite_single");
+        let session_name = guard.name().to_string();
+        let output = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &session_name,
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sh -c 'echo ALPHA; sleep 30'",
+            ])
+            .output()
+            .expect("tmux new-session");
+        assert!(output.status.success());
+        std::thread::sleep(std::time::Duration::from_millis(300));
+
+        let session = Session {
+            name: session_name.clone(),
+        };
+        let plain = session.capture_pane(10).expect("capture_pane");
+        let composited = session
+            .capture_window_composited(10)
+            .expect("capture_window_composited");
+        assert!(plain.contains("ALPHA"), "control capture empty: {plain:?}");
+        assert_eq!(
+            composited, plain,
+            "an unsplit window must pass the pane bytes through untouched"
+        );
+    }
+
+    /// The point of the feature: a pane the user split off by hand shows up in
+    /// the preview instead of being invisible.
+    #[test]
+    #[serial_test::serial]
+    fn composited_capture_includes_a_split_off_pane() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let guard = TmuxTestSession::new("aoe_test_composite_split");
+        let session_name = guard.name().to_string();
+        let output = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &session_name,
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sh -c 'echo ALPHA; sleep 30'",
+            ])
+            .output()
+            .expect("tmux new-session");
+        assert!(output.status.success());
+        crate::tmux::tmux_command()
+            .args(["set-option", "-t", &session_name, "pane-base-index", "0"])
+            .output()
+            .expect("tmux set-option pane-base-index");
+
+        // `C-b %`: a second pane beside the first. Selecting it also proves
+        // the composite does not depend on which pane is active.
+        let output = crate::tmux::tmux_command()
+            .args([
+                "split-window",
+                "-h",
+                "-t",
+                &session_name,
+                "sh -c 'echo BRAVO; sleep 30'",
+            ])
+            .output()
+            .expect("tmux split-window");
+        assert!(output.status.success());
+        std::thread::sleep(std::time::Duration::from_millis(400));
+
+        let session = Session {
+            name: session_name.clone(),
+        };
+        let plain = session.capture_pane(10).expect("capture_pane");
+        let composited = session
+            .capture_window_composited(10)
+            .expect("capture_window_composited");
+
+        // The old behaviour: pane 0 only, split pane invisible.
+        assert!(plain.contains("ALPHA"));
+        assert!(
+            !plain.contains("BRAVO"),
+            "control: capture_pane should not see the split pane"
+        );
+        // The new behaviour: both panes, side by side on the same rows.
+        assert!(
+            composited.contains("ALPHA") && composited.contains("BRAVO"),
+            "composite missed a pane:\n{composited}"
+        );
+        let seam_row = composited
+            .lines()
+            .find(|l| l.contains("ALPHA"))
+            .expect("row with ALPHA");
+        assert!(
+            seam_row.contains("BRAVO"),
+            "panes should share a row, not stack:\n{seam_row:?}"
         );
     }
 

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -1455,6 +1455,90 @@ mod tests {
             .unwrap_or(false)
     }
 
+    /// Create a detached session for the composite tests, applying the guards
+    /// the rest of this module treats as mandatory:
+    ///
+    /// * `pane-base-index 0` chained into the create, so the `^.0` targets
+    ///   these paths use resolve on a host that sets `pane-base-index 1`
+    ///   globally (#488, #2231).
+    /// * [`refresh_session_cache`] afterwards, because every capture entry point
+    ///   is `exists()`-gated and a cache refreshed concurrently by another test
+    ///   would make the call a silent `Ok("")` rather than a visible failure.
+    fn start_composite_session(name: &str, cols: u16, rows: u16, cmd: &str) -> Session {
+        let status = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                name,
+                "-x",
+                &cols.to_string(),
+                "-y",
+                &rows.to_string(),
+                cmd,
+                ";",
+                "set-option",
+                "-t",
+                name,
+                "pane-base-index",
+                "0",
+            ])
+            .status()
+            .expect("tmux new-session");
+        assert!(status.success(), "failed to create {name}");
+        refresh_session_cache();
+        Session::from_name(name)
+    }
+
+    /// Split `session` horizontally and refresh the cache, mirroring
+    /// [`start_composite_session`]'s guards for the second pane.
+    fn split_composite_session(session: &Session, cmd: &str) {
+        let status = crate::tmux::tmux_command()
+            .args(["split-window", "-h", "-t", &session.name, cmd])
+            .status()
+            .expect("tmux split-window");
+        assert!(status.success(), "failed to split {}", session.name);
+        refresh_session_cache();
+    }
+
+    /// Poll until the pane has painted `needle`. A fixed sleep is flaky under
+    /// parallel suite load: the shell must spawn and the command run before a
+    /// capture sees anything. Mirrors
+    /// `capture_pane_with_cursor_returns_content_and_cursor`.
+    fn wait_for_pane_text(session: &Session, needle: &str) {
+        for _ in 0..50 {
+            if session
+                .capture_pane(20)
+                .map(|c| c.contains(needle))
+                .unwrap_or(false)
+            {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        panic!(
+            "pane {} never painted {needle:?}; last capture: {:?}",
+            session.name,
+            session.capture_pane(20)
+        );
+    }
+
+    /// Poll until the composited capture contains `needle`, for the panes a
+    /// plain `capture_pane` cannot see.
+    fn wait_for_composite_text(session: &Session, needle: &str) {
+        for _ in 0..50 {
+            if session
+                .capture_window_composited(20)
+                .map(|c| c.contains(needle))
+                .unwrap_or(false)
+            {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        panic!("composite for {} never painted {needle:?}", session.name);
+    }
+
     #[test]
     fn raw_byte_batches_chunks_and_preserves_order() {
         let payload: Vec<u8> = (0..=255u8)
@@ -2293,27 +2377,9 @@ mod tests {
         }
 
         let guard = TmuxTestSession::new("aoe_test_composite_single");
-        let session_name = guard.name().to_string();
-        let output = crate::tmux::tmux_command()
-            .args([
-                "new-session",
-                "-d",
-                "-s",
-                &session_name,
-                "-x",
-                "80",
-                "-y",
-                "24",
-                "sh -c 'echo ALPHA; sleep 30'",
-            ])
-            .output()
-            .expect("tmux new-session");
-        assert!(output.status.success());
-        std::thread::sleep(std::time::Duration::from_millis(300));
+        let session = start_composite_session(guard.name(), 80, 24, "sh -c 'echo ALPHA; sleep 30'");
+        wait_for_pane_text(&session, "ALPHA");
 
-        let session = Session {
-            name: session_name.clone(),
-        };
         let plain = session.capture_pane(10).expect("capture_pane");
         let composited = session
             .capture_window_composited(10)
@@ -2336,45 +2402,12 @@ mod tests {
         }
 
         let guard = TmuxTestSession::new("aoe_test_composite_split");
-        let session_name = guard.name().to_string();
-        let output = crate::tmux::tmux_command()
-            .args([
-                "new-session",
-                "-d",
-                "-s",
-                &session_name,
-                "-x",
-                "80",
-                "-y",
-                "24",
-                "sh -c 'echo ALPHA; sleep 30'",
-            ])
-            .output()
-            .expect("tmux new-session");
-        assert!(output.status.success());
-        crate::tmux::tmux_command()
-            .args(["set-option", "-t", &session_name, "pane-base-index", "0"])
-            .output()
-            .expect("tmux set-option pane-base-index");
+        let session = start_composite_session(guard.name(), 80, 24, "sh -c 'echo ALPHA; sleep 30'");
+        wait_for_pane_text(&session, "ALPHA");
+        // `C-b %`: a second pane beside the first.
+        split_composite_session(&session, "sh -c 'echo BRAVO; sleep 30'");
+        wait_for_composite_text(&session, "BRAVO");
 
-        // `C-b %`: a second pane beside the first. Selecting it also proves
-        // the composite does not depend on which pane is active.
-        let output = crate::tmux::tmux_command()
-            .args([
-                "split-window",
-                "-h",
-                "-t",
-                &session_name,
-                "sh -c 'echo BRAVO; sleep 30'",
-            ])
-            .output()
-            .expect("tmux split-window");
-        assert!(output.status.success());
-        std::thread::sleep(std::time::Duration::from_millis(400));
-
-        let session = Session {
-            name: session_name.clone(),
-        };
         let plain = session.capture_pane(10).expect("capture_pane");
         let composited = session
             .capture_window_composited(10)
@@ -2413,46 +2446,15 @@ mod tests {
         }
 
         let guard = TmuxTestSession::new("aoe_test_layout_order");
-        let session_name = guard.name().to_string();
-        let output = crate::tmux::tmux_command()
-            .args([
-                "new-session",
-                "-d",
-                "-s",
-                &session_name,
-                "-x",
-                "80",
-                "-y",
-                "24",
-                "sh -c 'echo ALPHA; sleep 30'",
-            ])
-            .output()
-            .expect("tmux new-session");
-        assert!(output.status.success());
-        crate::tmux::tmux_command()
-            .args(["set-option", "-t", &session_name, "pane-base-index", "0"])
-            .output()
-            .expect("tmux set-option pane-base-index");
-        crate::tmux::tmux_command()
-            .args([
-                "split-window",
-                "-h",
-                "-t",
-                &session_name,
-                "sh -c 'echo BRAVO; sleep 30'",
-            ])
-            .output()
-            .expect("tmux split-window");
+        let session = start_composite_session(guard.name(), 80, 24, "sh -c 'echo ALPHA; sleep 30'");
+        wait_for_pane_text(&session, "ALPHA");
+        split_composite_session(&session, "sh -c 'echo BRAVO; sleep 30'");
+        wait_for_composite_text(&session, "BRAVO");
         // Make the SECOND pane active: pane 0 must still come back first.
         crate::tmux::tmux_command()
-            .args(["select-pane", "-t", &format!("{session_name}:^.1")])
+            .args(["select-pane", "-t", &format!("{}:^.1", session.name)])
             .output()
             .expect("tmux select-pane");
-        std::thread::sleep(std::time::Duration::from_millis(400));
-
-        let session = Session {
-            name: session_name.clone(),
-        };
         let layout = session
             .capture_window_layout(2)
             .expect("layout for a split window");
@@ -2501,30 +2503,9 @@ mod tests {
         }
 
         let guard = TmuxTestSession::new("aoe_test_composite_cursor");
-        let session_name = guard.name().to_string();
-        crate::tmux::tmux_command()
-            .args([
-                "new-session",
-                "-d",
-                "-s",
-                &session_name,
-                "-x",
-                "80",
-                "-y",
-                "24",
-                "sh -c 'echo ALPHA; sleep 30'",
-            ])
-            .output()
-            .expect("tmux new-session");
-        crate::tmux::tmux_command()
-            .args(["set-option", "-t", &session_name, "pane-base-index", "0"])
-            .output()
-            .expect("tmux set-option pane-base-index");
-        std::thread::sleep(std::time::Duration::from_millis(300));
+        let session = start_composite_session(guard.name(), 80, 24, "sh -c 'echo ALPHA; sleep 30'");
+        wait_for_pane_text(&session, "ALPHA");
 
-        let session = Session {
-            name: session_name.clone(),
-        };
         let (content, cursor) = session
             .capture_window_composited_with_cursor(20)
             .expect("composited capture");
@@ -2542,17 +2523,8 @@ mod tests {
 
         // Now split, and the cursor must be rebased onto the window so the
         // renderer's `pane_height` anchoring still lines up with the composite.
-        crate::tmux::tmux_command()
-            .args([
-                "split-window",
-                "-h",
-                "-t",
-                &session_name,
-                "sh -c 'echo BRAVO; sleep 30'",
-            ])
-            .output()
-            .expect("tmux split-window");
-        std::thread::sleep(std::time::Duration::from_millis(400));
+        split_composite_session(&session, "sh -c 'echo BRAVO; sleep 30'");
+        wait_for_composite_text(&session, "BRAVO");
 
         let (content, cursor) = session
             .capture_window_composited_with_cursor(20)
@@ -2592,40 +2564,11 @@ mod tests {
         }
 
         let guard = TmuxTestSession::new("aoe_test_composite_agree");
-        let session_name = guard.name().to_string();
-        crate::tmux::tmux_command()
-            .args([
-                "new-session",
-                "-d",
-                "-s",
-                &session_name,
-                "-x",
-                "80",
-                "-y",
-                "24",
-                "sh -c 'echo ALPHA; sleep 30'",
-            ])
-            .output()
-            .expect("tmux new-session");
-        crate::tmux::tmux_command()
-            .args(["set-option", "-t", &session_name, "pane-base-index", "0"])
-            .output()
-            .expect("tmux set-option pane-base-index");
-        crate::tmux::tmux_command()
-            .args([
-                "split-window",
-                "-h",
-                "-t",
-                &session_name,
-                "sh -c 'echo BRAVO; sleep 30'",
-            ])
-            .output()
-            .expect("tmux split-window");
-        std::thread::sleep(std::time::Duration::from_millis(400));
+        let session = start_composite_session(guard.name(), 80, 24, "sh -c 'echo ALPHA; sleep 30'");
+        wait_for_pane_text(&session, "ALPHA");
+        split_composite_session(&session, "sh -c 'echo BRAVO; sleep 30'");
+        wait_for_composite_text(&session, "BRAVO");
 
-        let session = Session {
-            name: session_name.clone(),
-        };
         // Passive fallback: one fork per pane, composited on the spot.
         let fallback = session
             .capture_window_composited(24)

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -120,6 +120,22 @@ pub struct PaneCursor {
     /// works while an agent streams. `parse` sets it `true`; only the
     /// cross-probe check downgrades it.
     pub position_reliable: bool,
+    /// Pane 0's `(width, height)` within a COMPOSITED preview, or `None` when
+    /// the preview shows a single pane.
+    ///
+    /// Mouse forwarding maps the hovered cell into the previewed app's
+    /// coordinate space by treating the preview rect as the pane, which holds
+    /// while the two describe the same rectangle. A composite makes the rect the
+    /// whole window, so a pointer over a neighbouring pane maps to a column past
+    /// pane 0's right edge and is reported to the agent as though its own pane
+    /// were that wide. Pane 0 is the only pane that receives input (#435, #488),
+    /// so this carries its extent and the forward clamps to it, dropping events
+    /// that land outside.
+    ///
+    /// Only the extent is needed, never the origin: tmux keeps pane 0 at the
+    /// window origin, because pane indices follow layout order and closing pane
+    /// 0 renumbers whichever pane takes that corner.
+    pub composite_pane0: Option<(u16, u16)>,
 }
 
 /// tmux format line every cursor probe requests, parsed by
@@ -161,6 +177,9 @@ impl PaneCursor {
             // cross-probe check in `capture_pane_with_cursor` is the only
             // thing that downgrades this.
             position_reliable: true,
+            // A probe describes one pane. The composited paths overwrite this
+            // once they know the window really is split.
+            composite_pane0: None,
         })
     }
 }
@@ -700,6 +719,10 @@ impl Session {
             c.pane_height = layout.window_height;
             c.pane_width = layout.window_width;
             c.history_size = 0;
+            // Rebasing the frame onto the window is what the renderer needs, but
+            // it also erases the only record of how wide the input pane is, which
+            // mouse forwarding maps into. Carry pane 0's extent alongside.
+            c.composite_pane0 = layout.first_pane().map(|p| (p.width, p.height));
             c
         });
         Ok((layout.composite(), cursor))
@@ -1656,6 +1679,7 @@ mod tests {
                 mouse_sgr: true,
                 mouse_all: true,
                 position_reliable: true,
+                composite_pane0: None,
             }
         );
         // Legacy mouse (tracking on, SGR off) parses with mouse_sgr false.

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use super::{
-    composite::{composite_window, CapturedPane, PaneGeom},
+    composite::{CapturedPane, PaneGeom, WindowLayout},
     probe_session_existence, refresh_session_cache,
     utils::{
         append_clipboard_passthrough_args, append_mouse_on_args, append_pane_base_index_args,
@@ -611,36 +611,44 @@ impl Session {
         // back to the pane-0 bytes already in hand, so a composite that cannot
         // be built is never worse than the old single-pane preview.
         Ok(self
-            .capture_split_window(count, window_width, window_height)
+            .capture_window_layout(count)
+            .map(|layout| layout.composite())
             .unwrap_or(pane0_content))
     }
 
     /// Second fork of [`capture_window_composited`](Self::capture_window_composited):
-    /// geometry plus visible capture for each of `count` panes, chained into one
-    /// `tmux` invocation, spliced by [`composite_window`].
+    /// window dimensions plus geometry and visible capture for each of `count`
+    /// panes, chained into one `tmux` invocation.
     ///
     /// Pane indices are contiguous from 0 within a window (tmux renumbers them
     /// as the layout changes, unlike window indices) and `pane-base-index` is
     /// forced to 0 when the session is created, so `^.0..^.{count-1}` addresses
     /// every pane without a prior `list-panes` round trip.
-    fn capture_split_window(
-        &self,
-        count: u16,
-        window_width: u16,
-        window_height: u16,
-    ) -> Option<String> {
+    ///
+    /// Returned rather than composited on the spot so the live preview can
+    /// cache a layout across frames and re-render only pane 0 from its VT grid
+    /// (see [`WindowLayout::with_first_pane_rows`]).
+    pub(crate) fn capture_window_layout(&self, count: u16) -> Option<WindowLayout> {
         /// Marks the start of each pane's segment in the chained output. Pane
         /// content could in principle contain this line, which would split one
         /// pane's rows in two; the cost is a single garbled preview frame, and
         /// the string is unusual enough to make that a non-event.
         const SENTINEL: &str = "@@aoe-pane@@";
+        /// Leading line carrying the window's own dimensions, so a cached
+        /// layout is self-contained and needs no separate probe.
+        const WINDOW_SENTINEL: &str = "@@aoe-win@@";
 
-        let mut args: Vec<String> = Vec::new();
+        let mut args: Vec<String> = vec![
+            "display-message".to_string(),
+            "-p".to_string(),
+            "-t".to_string(),
+            format!("{}:^", self.name),
+            "-F".to_string(),
+            format!("{WINDOW_SENTINEL} #{{window_width}} #{{window_height}}"),
+        ];
         for i in 0..count {
             let target = format!("{}:^.{}", self.name, i);
-            if !args.is_empty() {
-                args.push(";".to_string());
-            }
+            args.push(";".to_string());
             args.extend([
                 "display-message".to_string(),
                 "-p".to_string(),
@@ -663,11 +671,24 @@ impl Session {
         }
 
         let raw = String::from_utf8_lossy(&output.stdout);
-        let panes = parse_pane_segments(&raw, SENTINEL);
+        let (header, rest) = raw.split_once('\n')?;
+        let dims = header.strip_prefix(WINDOW_SENTINEL)?;
+        let mut fields = dims.split_whitespace();
+        let window_width: u16 = fields.next().and_then(|f| f.parse().ok())?;
+        let window_height: u16 = fields.next().and_then(|f| f.parse().ok())?;
+        if window_width == 0 || window_height == 0 {
+            return None;
+        }
+
+        let panes = parse_pane_segments(rest, SENTINEL);
         if panes.is_empty() {
             return None;
         }
-        Some(composite_window(window_width, window_height, &panes))
+        Some(WindowLayout {
+            window_width,
+            window_height,
+            panes,
+        })
     }
 
     /// Capture the pane's full scrollback (from session start) with wrapped
@@ -2289,6 +2310,164 @@ mod tests {
         assert!(
             seam_row.contains("BRAVO"),
             "panes should share a row, not stack:\n{seam_row:?}"
+        );
+    }
+
+    /// The live path caches a layout and re-renders only pane 0 from its VT
+    /// grid, so the layout must come back with pane 0 first, at the window
+    /// origin, and with rectangles that tile the real window.
+    #[test]
+    #[serial_test::serial]
+    fn captured_layout_puts_pane_zero_first_at_the_origin() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let guard = TmuxTestSession::new("aoe_test_layout_order");
+        let session_name = guard.name().to_string();
+        let output = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &session_name,
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sh -c 'echo ALPHA; sleep 30'",
+            ])
+            .output()
+            .expect("tmux new-session");
+        assert!(output.status.success());
+        crate::tmux::tmux_command()
+            .args(["set-option", "-t", &session_name, "pane-base-index", "0"])
+            .output()
+            .expect("tmux set-option pane-base-index");
+        crate::tmux::tmux_command()
+            .args([
+                "split-window",
+                "-h",
+                "-t",
+                &session_name,
+                "sh -c 'echo BRAVO; sleep 30'",
+            ])
+            .output()
+            .expect("tmux split-window");
+        // Make the SECOND pane active: pane 0 must still come back first.
+        crate::tmux::tmux_command()
+            .args(["select-pane", "-t", &format!("{session_name}:^.1")])
+            .output()
+            .expect("tmux select-pane");
+        std::thread::sleep(std::time::Duration::from_millis(400));
+
+        let session = Session {
+            name: session_name.clone(),
+        };
+        let layout = session
+            .capture_window_layout(2)
+            .expect("layout for a split window");
+        assert_eq!(layout.panes.len(), 2);
+        assert_eq!(layout.window_width, 80);
+        let first = layout.first_pane().expect("first pane");
+        assert_eq!(
+            (first.left, first.top),
+            (0, 0),
+            "pane 0 must sit at the window origin for the cursor math to hold"
+        );
+        // Pane 0 is the agent's, even though pane 1 is the active one.
+        assert!(
+            layout.panes[0].rows.iter().any(|r| r.contains("ALPHA")),
+            "pane 0 rows: {:?}",
+            layout.panes[0].rows
+        );
+        assert!(layout.panes[1].rows.iter().any(|r| r.contains("BRAVO")));
+        // Every row is padded to its own pane's width, which is what lets the
+        // compositor concatenate them.
+        for (i, pane) in layout.panes.iter().enumerate() {
+            for row in &pane.rows {
+                assert_eq!(
+                    crate::tmux::utils::strip_ansi(row).chars().count(),
+                    pane.geom.width as usize,
+                    "pane {i} row not padded to {}: {row:?}",
+                    pane.geom.width
+                );
+            }
+        }
+    }
+
+    /// The two composite transports must agree byte for byte on a static
+    /// window.
+    ///
+    /// The live path renders a cached layout with pane 0 swapped for its VT
+    /// grid rows, while the passive fallback re-forks every pane. Any
+    /// divergence in shape between them shows up as the preview flickering
+    /// between two renderings as one path takes over from the other, which is
+    /// exactly the bug that shipped when the fallback still captured pane 0
+    /// alone: the split was visible for one frame after each keystroke and
+    /// vanished during idle.
+    #[test]
+    #[serial_test::serial]
+    fn both_composite_transports_agree_on_a_static_window() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let guard = TmuxTestSession::new("aoe_test_composite_agree");
+        let session_name = guard.name().to_string();
+        crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &session_name,
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sh -c 'echo ALPHA; sleep 30'",
+            ])
+            .output()
+            .expect("tmux new-session");
+        crate::tmux::tmux_command()
+            .args(["set-option", "-t", &session_name, "pane-base-index", "0"])
+            .output()
+            .expect("tmux set-option pane-base-index");
+        crate::tmux::tmux_command()
+            .args([
+                "split-window",
+                "-h",
+                "-t",
+                &session_name,
+                "sh -c 'echo BRAVO; sleep 30'",
+            ])
+            .output()
+            .expect("tmux split-window");
+        std::thread::sleep(std::time::Duration::from_millis(400));
+
+        let session = Session {
+            name: session_name.clone(),
+        };
+        // Passive fallback: one fork per pane, composited on the spot.
+        let fallback = session
+            .capture_window_composited(24)
+            .expect("capture_window_composited");
+        let layout = session.capture_window_layout(2).expect("layout");
+        // Live path, minus the grid: swapping pane 0's own captured rows back
+        // in must be a no-op, which is what makes the swap safe to do with
+        // fresher rows every frame.
+        let swapped = layout.composite_with_first_pane_rows(&layout.panes[0].rows.clone());
+
+        assert_eq!(
+            fallback,
+            layout.composite(),
+            "fork-per-frame and cached-layout renderings diverged"
+        );
+        assert_eq!(
+            fallback, swapped,
+            "swapping pane 0's rows for identical rows changed the frame"
         );
     }
 

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -1506,37 +1506,40 @@ mod tests {
     /// capture sees anything. Mirrors
     /// `capture_pane_with_cursor_returns_content_and_cursor`.
     fn wait_for_pane_text(session: &Session, needle: &str) {
-        for _ in 0..50 {
-            if session
-                .capture_pane(20)
-                .map(|c| c.contains(needle))
-                .unwrap_or(false)
-            {
-                return;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(100));
-        }
-        panic!(
-            "pane {} never painted {needle:?}; last capture: {:?}",
-            session.name,
-            session.capture_pane(20)
-        );
+        wait_for_text(session, needle, "pane", |s| s.capture_pane(20));
     }
 
     /// Poll until the composited capture contains `needle`, for the panes a
     /// plain `capture_pane` cannot see.
     fn wait_for_composite_text(session: &Session, needle: &str) {
+        wait_for_text(session, needle, "composite", |s| {
+            s.capture_window_composited(20)
+        });
+    }
+
+    /// Shared poll loop. Reports the LAST OBSERVED capture on timeout rather
+    /// than taking a fresh one, which is the thing you want when this trips in
+    /// CI: a re-capture at panic time can show different content than the poll
+    /// ever saw, which sends the reader chasing the wrong thing.
+    fn wait_for_text(
+        session: &Session,
+        needle: &str,
+        what: &str,
+        capture: impl Fn(&Session) -> Result<String>,
+    ) {
+        let mut last = None;
         for _ in 0..50 {
-            if session
-                .capture_window_composited(20)
-                .map(|c| c.contains(needle))
-                .unwrap_or(false)
-            {
+            let seen = capture(session).unwrap_or_default();
+            if seen.contains(needle) {
                 return;
             }
+            last = Some(seen);
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
-        panic!("composite for {} never painted {needle:?}", session.name);
+        panic!(
+            "{what} for {} never painted {needle:?}; last seen: {last:?}",
+            session.name
+        );
     }
 
     #[test]
@@ -2450,11 +2453,34 @@ mod tests {
         wait_for_pane_text(&session, "ALPHA");
         split_composite_session(&session, "sh -c 'echo BRAVO; sleep 30'");
         wait_for_composite_text(&session, "BRAVO");
-        // Make the SECOND pane active: pane 0 must still come back first.
-        crate::tmux::tmux_command()
+        // Make the SECOND pane active: pane 0 must still come back first. The
+        // select must be asserted, or a failure leaves pane 0 active and the
+        // assertions below pass for the boring reason, silently retiring the
+        // premise this test exists to check.
+        let selected = crate::tmux::tmux_command()
             .args(["select-pane", "-t", &format!("{}:^.1", session.name)])
             .output()
             .expect("tmux select-pane");
+        assert!(
+            selected.status.success(),
+            "select-pane must land, or this degrades to the pane-0-already-active case"
+        );
+        let active = crate::tmux::tmux_command()
+            .args([
+                "display-message",
+                "-p",
+                "-t",
+                &format!("{}:^", session.name),
+                "-F",
+                "#{pane_index}",
+            ])
+            .output()
+            .expect("tmux display-message");
+        assert_eq!(
+            String::from_utf8_lossy(&active.stdout).trim(),
+            "1",
+            "pane 1 should be the active pane before the layout is captured"
+        );
         let layout = session
             .capture_window_layout(2)
             .expect("layout for a split window");

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -235,12 +235,6 @@ impl PairedTerminal {
         }
         super::Session::from_name(&self.name).capture_window_composited(lines)
     }
-
-    fn capture_pane(&self, lines: usize) -> Result<String> {
-        // Shared with the agent session / web live view paths: same
-        // `^.0` targeting and trailing-blank preservation semantics.
-        super::Session::from_name(&self.name).capture_pane(lines)
-    }
 }
 
 pub struct TerminalSession {
@@ -303,12 +297,8 @@ impl TerminalSession {
         self.inner.attach()
     }
 
-    pub fn capture_pane(&self, lines: usize) -> Result<String> {
-        self.inner.capture_pane(lines)
-    }
-
-    /// Passive-preview capture with the window's other panes composited in;
-    /// see [`super::Session::capture_window_composited`].
+    /// Preview capture with the window's other panes composited in; see
+    /// [`super::Session::capture_window_composited`].
     pub fn capture_window_composited(&self, lines: usize) -> Result<String> {
         self.inner.capture_window_composited(lines)
     }
@@ -372,12 +362,8 @@ impl ContainerTerminalSession {
         self.inner.attach()
     }
 
-    pub fn capture_pane(&self, lines: usize) -> Result<String> {
-        self.inner.capture_pane(lines)
-    }
-
-    /// Passive-preview capture with the window's other panes composited in;
-    /// see [`super::Session::capture_window_composited`].
+    /// Preview capture with the window's other panes composited in; see
+    /// [`super::Session::capture_window_composited`].
     pub fn capture_window_composited(&self, lines: usize) -> Result<String> {
         self.inner.capture_window_composited(lines)
     }

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -229,6 +229,13 @@ impl PairedTerminal {
         Ok(())
     }
 
+    fn capture_window_composited(&self, lines: usize) -> Result<String> {
+        if !self.exists() {
+            return Ok(String::new());
+        }
+        super::Session::from_name(&self.name).capture_window_composited(lines)
+    }
+
     fn capture_pane(&self, lines: usize) -> Result<String> {
         // Shared with the agent session / web live view paths: same
         // `^.0` targeting and trailing-blank preservation semantics.
@@ -299,6 +306,12 @@ impl TerminalSession {
     pub fn capture_pane(&self, lines: usize) -> Result<String> {
         self.inner.capture_pane(lines)
     }
+
+    /// Passive-preview capture with the window's other panes composited in;
+    /// see [`super::Session::capture_window_composited`].
+    pub fn capture_window_composited(&self, lines: usize) -> Result<String> {
+        self.inner.capture_window_composited(lines)
+    }
 }
 
 /// Container terminal session for sandboxed sessions.
@@ -361,6 +374,12 @@ impl ContainerTerminalSession {
 
     pub fn capture_pane(&self, lines: usize) -> Result<String> {
         self.inner.capture_pane(lines)
+    }
+
+    /// Passive-preview capture with the window's other panes composited in;
+    /// see [`super::Session::capture_window_composited`].
+    pub fn capture_window_composited(&self, lines: usize) -> Result<String> {
+        self.inner.capture_window_composited(lines)
     }
 }
 

--- a/src/tmux/tool_session.rs
+++ b/src/tmux/tool_session.rs
@@ -172,6 +172,12 @@ impl ToolSession {
         super::Session::from_name(&self.name).capture_pane(lines)
     }
 
+    /// Passive-preview capture with the window's other panes composited in;
+    /// see [`super::Session::capture_window_composited`].
+    pub fn capture_window_composited(&self, lines: usize) -> Result<String> {
+        super::Session::from_name(&self.name).capture_window_composited(lines)
+    }
+
     fn get_pane_pid(&self) -> Option<u32> {
         process::get_pane_pid(&self.name)
     }

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -818,17 +818,20 @@ fn row_to_ansi(screen: &vt100::Screen, row: u16, cols: u16) -> String {
 /// counts as content: it is drawn as a coloured space, exactly as a mid-row
 /// styled blank already is.
 ///
-/// The count is in display columns, not cells: the loop below advances past a
-/// wide glyph's continuation cell, so a row ending in a wide char reports the
-/// two columns it actually occupies.
+/// The count is in display COLUMNS, not cells, so a trailing wide glyph
+/// contributes both of the columns it occupies. Its continuation cell carries no
+/// contents and, unstyled, no style either, so advancing by one per occupied
+/// cell would under-count by one and leave
+/// [`capture_rows_padded`] appending a space to a row that already fills its
+/// pane, shifting every pane to its right by a column.
 fn row_last_col(screen: &vt100::Screen, row: u16, cols: u16) -> u16 {
     let mut last = 0u16;
     for col in 0..cols {
-        if screen
-            .cell(row, col)
-            .is_some_and(|cell| cell.has_contents() || cell_has_style(cell))
-        {
-            last = col + 1;
+        if let Some(cell) = screen.cell(row, col) {
+            if cell.has_contents() || cell_has_style(cell) {
+                let width = if cell.is_wide() { 2 } else { 1 };
+                last = col.saturating_add(width).min(cols);
+            }
         }
     }
     last
@@ -1697,8 +1700,11 @@ mod tests {
     }
 
     /// Display columns a row occupies once its escape sequences are removed.
+    /// Measured as width, not `chars().count()`, so a wide glyph is counted as
+    /// the two columns it actually paints.
     fn visible_width(row: &str) -> usize {
-        crate::tmux::utils::strip_ansi(row).chars().count()
+        use unicode_width::UnicodeWidthStr;
+        UnicodeWidthStr::width(crate::tmux::utils::strip_ansi(row).as_str())
     }
 
     #[test]
@@ -1739,6 +1745,37 @@ mod tests {
             "padding not reset: {:?}",
             rows[0]
         );
+    }
+
+    #[test]
+    fn capture_rows_padded_counts_a_trailing_wide_glyph_as_two_columns() {
+        // A wide glyph's continuation cell holds no contents and, unstyled, no
+        // style, so counting one column per occupied cell under-counts the row
+        // by one. The padding step then appended a space to a row that already
+        // filled its pane, making it `cols + 1` wide and shifting every pane to
+        // its right by a column.
+        let rows = capture_rows_padded("ab漢".as_bytes(), 4, 1);
+        assert_eq!(
+            visible_width(&rows[0]),
+            4,
+            "row should exactly fill the pane: {:?}",
+            rows[0]
+        );
+        assert!(
+            !rows[0].ends_with(' '),
+            "no padding belongs on a row that already fills its width: {:?}",
+            rows[0]
+        );
+
+        // The same glyph with room to spare still pads, to the right total.
+        let rows = capture_rows_padded("ab漢".as_bytes(), 7, 1);
+        assert_eq!(visible_width(&rows[0]), 7, "{:?}", rows[0]);
+
+        // A wide glyph split by the pane edge cannot push the count past `cols`.
+        let rows = capture_rows_padded("abc漢".as_bytes(), 4, 2);
+        for (i, r) in rows.iter().enumerate() {
+            assert_eq!(visible_width(r), 4, "row {i}: {r:?}");
+        }
     }
 
     #[test]

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -724,6 +724,9 @@ fn cursor_from_screen(screen: &vt100::Screen, rows: u16, cols: u16) -> PaneCurso
         // Authoritative: the cursor is read straight from the owned grid, not
         // probed against a racing capture, so it is always trustworthy.
         position_reliable: true,
+        // The grid is pane 0's alone. `capture_composited_over_grid` sets this
+        // when it splices that grid into a composited window.
+        composite_pane0: None,
     }
 }
 

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -1526,6 +1526,53 @@ impl VtChannel {
         (content, Some(cursor))
     }
 
+    /// Sample the VISIBLE grid as `want_rows` rows padded to `want_cols`
+    /// display columns, for splicing this pane into a composited window.
+    ///
+    /// Unlike [`sample`](Self::sample) this never reaches into scrollback: a
+    /// composite shows the live window only, since panes have independent
+    /// histories with no coherent way to stack them.
+    ///
+    /// `want_cols` / `want_rows` come from tmux's view of the pane, which can
+    /// briefly disagree with the grid mid-resize. Padding and truncating to the
+    /// requested rectangle keeps that frame merely stale instead of shifting
+    /// every pane to its right.
+    pub(crate) fn sample_rows_padded(
+        &self,
+        want_cols: u16,
+        want_rows: u16,
+    ) -> Option<(Vec<String>, PaneCursor)> {
+        self.reconcile_size();
+        self.refresh_owner_heartbeat();
+        let cols = self.cols.load(Ordering::Relaxed);
+        let rows = self.rows.load(Ordering::Relaxed);
+        let want_cols = want_cols.max(1);
+        let want_rows = want_rows.max(1);
+
+        let p = self.parser.lock().ok()?;
+        let screen = p.screen();
+        let readable_cols = cols.min(want_cols);
+        let out = (0..want_rows)
+            .map(|row| {
+                if row >= rows {
+                    // Grid shorter than tmux says the pane is: blank filler
+                    // rather than a row borrowed from somewhere else.
+                    return " ".repeat(want_cols as usize);
+                }
+                let last = row_last_col(screen, row, readable_cols);
+                let mut line = row_to_ansi_upto(screen, row, last);
+                if last < want_cols {
+                    line.push_str("\x1b[0m");
+                    line.extend(std::iter::repeat_n(' ', (want_cols - last) as usize));
+                }
+                line
+            })
+            .collect();
+        let cursor = cursor_from_screen(screen, rows, cols);
+        drop(p);
+        Some((out, cursor))
+    }
+
     /// Whether the forwarder is connected and the reader loop is running. A
     /// channel that never connected, or whose pipe has since closed, reports
     /// `false` so input and capture fall back to the legacy tmux path instead
@@ -1981,6 +2028,58 @@ mod tests {
             last_owner_hb: Mutex::new(Instant::now()),
         });
         (ch, alive)
+    }
+
+    #[test]
+    fn sample_rows_padded_renders_the_visible_grid_at_the_requested_rectangle() {
+        // The live composite asks for pane 0's rectangle as tmux reports it,
+        // which can differ from the grid's own size mid-resize. Every returned
+        // row must occupy exactly the requested width, and there must be
+        // exactly the requested number of them, or the panes spliced to the
+        // right of this one shift.
+        let name = format!("aoe_test_vt_padded_{}", std::process::id());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (ch, _alive) = dummy_channel(&name, dir.path());
+        // Grid is 4 rows x 20 cols (see `dummy_channel`).
+        ch.parser
+            .lock()
+            .unwrap()
+            .process(b"hello\r\nworld\r\n\x1b[41mfilled");
+
+        // Exact rectangle.
+        let (rows, cursor) = ch.sample_rows_padded(20, 4).expect("sample");
+        assert_eq!(rows.len(), 4);
+        for (i, r) in rows.iter().enumerate() {
+            assert_eq!(
+                crate::tmux::utils::strip_ansi(r).chars().count(),
+                20,
+                "row {i} not padded to width: {r:?}"
+            );
+        }
+        assert!(crate::tmux::utils::strip_ansi(&rows[0]).starts_with("hello"));
+        assert!(crate::tmux::utils::strip_ansi(&rows[1]).starts_with("world"));
+        // Cursor comes straight off the grid and is always trustworthy.
+        assert!(cursor.position_reliable);
+
+        // Narrower and shorter than the grid: truncate, never overflow.
+        let (rows, _) = ch.sample_rows_padded(6, 2).expect("sample");
+        assert_eq!(rows.len(), 2);
+        for r in &rows {
+            assert_eq!(crate::tmux::utils::strip_ansi(r).chars().count(), 6);
+        }
+
+        // Taller than the grid (tmux says the pane grew before the grid caught
+        // up): the extra rows are blank filler at the right width, not rows
+        // borrowed from elsewhere.
+        let (rows, _) = ch.sample_rows_padded(10, 6).expect("sample");
+        assert_eq!(rows.len(), 6);
+        for (i, r) in rows.iter().enumerate() {
+            let plain = crate::tmux::utils::strip_ansi(r);
+            assert_eq!(plain.chars().count(), 10, "row {i}: {r:?}");
+            if i >= 4 {
+                assert!(plain.trim().is_empty(), "row {i} should be filler: {r:?}");
+            }
+        }
     }
 
     #[test]

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -807,11 +807,21 @@ fn cell_sgr(cell: &vt100::Cell) -> String {
 /// with their spaces stripped (#2433 regression). Emitting literal spaces keeps
 /// the column layout intact while preserving colour and intensity.
 fn row_to_ansi(screen: &vt100::Screen, row: u16, cols: u16) -> String {
-    // Trim trailing *unstyled* blank cells, mirroring `capture-pane`'s
-    // trailing-space trim, so a row never carries a full width of padding into
-    // ratatui's wrapper. A trailing blank that carries styling (a background
-    // fill running to the edge) is kept: it is drawn as a coloured space below,
-    // exactly as a mid-row styled blank already is.
+    let last = row_last_col(screen, row, cols);
+    row_to_ansi_upto(screen, row, last)
+}
+
+/// Columns of `row` that carry content, i.e. the trim point past which only
+/// *unstyled* blank cells remain. Mirrors `capture-pane`'s trailing-space trim
+/// so a row never carries a full width of padding into ratatui's wrapper. A
+/// trailing blank that carries styling (a background fill running to the edge)
+/// counts as content: it is drawn as a coloured space, exactly as a mid-row
+/// styled blank already is.
+///
+/// The count is in display columns, not cells: the loop below advances past a
+/// wide glyph's continuation cell, so a row ending in a wide char reports the
+/// two columns it actually occupies.
+fn row_last_col(screen: &vt100::Screen, row: u16, cols: u16) -> u16 {
     let mut last = 0u16;
     for col in 0..cols {
         if screen
@@ -821,7 +831,13 @@ fn row_to_ansi(screen: &vt100::Screen, row: u16, cols: u16) -> String {
             last = col + 1;
         }
     }
+    last
+}
 
+/// Serialise columns `0..last` of `row`. Split out of [`row_to_ansi`] so the
+/// pane compositor can ask for a row rendered to its pane's full width rather
+/// than to the trim point.
+fn row_to_ansi_upto(screen: &vt100::Screen, row: u16, last: u16) -> String {
     let mut out = String::new();
     let mut cur_sgr: Option<String> = None;
     let mut col = 0u16;
@@ -853,6 +869,48 @@ fn row_to_ansi(screen: &vt100::Screen, row: u16, cols: u16) -> String {
         col += if cell.is_wide() { 2 } else { 1 };
     }
     out
+}
+
+/// Render `raw` (one pane's `capture-pane -e -p` output) as exactly `rows`
+/// ANSI rows, each padded with spaces to `cols` display columns.
+///
+/// The compositor splices panes side by side by *concatenating* their rows, so
+/// unlike the single-pane preview path every row must occupy its pane's full
+/// width: a trimmed row would let the next pane's first column slide left into
+/// the gap. Going through a `vt100::Parser` rather than splitting the bytes on
+/// newlines is what makes that safe, because a row's escape sequences are
+/// resolved into cells before they are re-serialised, so no SGR state can leak
+/// across a pane boundary into its neighbour.
+pub(crate) fn capture_rows_padded(raw: &[u8], cols: u16, rows: u16) -> Vec<String> {
+    let cols = cols.max(1);
+    let rows = rows.max(1);
+    // Parse at two rows minimum, then read back only the pane's real height.
+    // vt100 0.16 underflows (panics) whenever content wraps on a ONE-row grid,
+    // regardless of scrollback, and `resize-pane -y 1` makes that a layout a
+    // user can actually produce. Captured content is already wrapped to the
+    // pane's width so it normally fits exactly; this keeps a stale geometry
+    // (the pane resized between the probe and the capture) from taking down
+    // the render thread.
+    let mut parser = vt100::Parser::new(rows.max(2), cols, 0);
+    // `capture-pane` joins rows with a bare LF, which staircases each row off
+    // the previous one's end column unless it is promoted to CRLF first (the
+    // same seeding fix the live channel applies).
+    parser.process(&lf_to_crlf(strip_trailing_row_terminator(raw)));
+
+    let screen = parser.screen();
+    (0..rows)
+        .map(|row| {
+            let last = row_last_col(screen, row, cols);
+            let mut out = row_to_ansi_upto(screen, row, last);
+            if last < cols {
+                // Reset before padding so a styled final cell (a background
+                // fill) does not bleed its colour across the gap.
+                out.push_str("\x1b[0m");
+                out.extend(std::iter::repeat_n(' ', (cols - last) as usize));
+            }
+            out
+        })
+        .collect()
 }
 
 /// Assemble the last `max_lines` rows of (scrollback + visible screen) as
@@ -1589,6 +1647,69 @@ mod tests {
             !content.contains("\x1b[10C") && !content.contains("\x1b[C"),
             "cursor-forward escape leaked:\n{content:?}"
         );
+    }
+
+    /// Display columns a row occupies once its escape sequences are removed.
+    fn visible_width(row: &str) -> usize {
+        crate::tmux::utils::strip_ansi(row).chars().count()
+    }
+
+    #[test]
+    fn capture_rows_padded_fills_every_row_to_the_pane_width() {
+        // The compositor concatenates rows to splice panes side by side, so a
+        // short row must be padded or the next pane slides left into the gap.
+        let rows = capture_rows_padded(b"ab\nlonger\n", 8, 3);
+        assert_eq!(rows.len(), 3, "one entry per pane row, blanks included");
+        for (i, row) in rows.iter().enumerate() {
+            assert_eq!(visible_width(row), 8, "row {i} not padded: {row:?}");
+        }
+        assert!(rows[0].contains("ab"));
+        assert!(rows[1].contains("longer"));
+    }
+
+    #[test]
+    fn capture_rows_padded_unstaircases_bare_lf_input() {
+        // Same hazard `lf_to_crlf` fixes for the live seed: `capture-pane`
+        // joins rows with a bare LF, which would staircase each pane row off
+        // the previous one's end column.
+        let rows = capture_rows_padded(b"line-1\nline-2\n", 10, 2);
+        let plain: Vec<String> = rows
+            .iter()
+            .map(|r| crate::tmux::utils::strip_ansi(r))
+            .collect();
+        assert_eq!(plain[0].trim_end(), "line-1");
+        assert_eq!(plain[1].trim_end(), "line-2", "row 1 staircased");
+    }
+
+    #[test]
+    fn capture_rows_padded_resets_style_before_padding() {
+        // A row ending in a background fill must not bleed that colour across
+        // the border into the pane beside it.
+        let rows = capture_rows_padded(b"\x1b[41mred", 8, 1);
+        assert_eq!(visible_width(&rows[0]), 8);
+        assert!(
+            rows[0].ends_with("\x1b[0m     "),
+            "padding not reset: {:?}",
+            rows[0]
+        );
+    }
+
+    #[test]
+    fn capture_rows_padded_survives_a_one_row_pane_that_wraps() {
+        // `resize-pane -y 1` is a real layout, and vt100 panics on a wrapping
+        // one-row grid, so this must come back with a single padded row.
+        let rows = capture_rows_padded(b"keep", 3, 1);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(visible_width(&rows[0]), 3);
+    }
+
+    #[test]
+    fn capture_rows_padded_truncates_content_wider_than_the_pane() {
+        // Content wider than the pane wraps inside the parser rather than
+        // overflowing the row and shifting the neighbour.
+        let rows = capture_rows_padded(b"abcdefgh", 4, 2);
+        assert_eq!(visible_width(&rows[0]), 4);
+        assert_eq!(visible_width(&rows[1]), 4);
     }
 
     #[test]

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -203,6 +203,62 @@ fn split_bracketed_paste(text: &str) -> Vec<live_send::TmuxKey> {
     vec![live_send::TmuxKey::HexBytes(bytes)]
 }
 
+/// The rectangle mouse coordinates are mapped into, or `None` when the pointer
+/// is not over the pane that receives input.
+///
+/// Normally the previewed pane is sized to the preview output rect, so the rect
+/// IS the pane. On a composited preview (the user split the window) the rect is
+/// the whole window while input still goes to pane 0 alone (#435, #488), so the
+/// pane-0 sub-rectangle is the right target: mapping against the full rect would
+/// report a column past pane 0's right edge to the agent as though its own pane
+/// were window-wide. A pointer outside pane 0 has no meaningful coordinate to
+/// report at all, so it is dropped rather than clamped to the nearest edge,
+/// which would otherwise synthesise a click or hover on pane 0's border.
+///
+/// Pane 0 sits at the window origin, so the sub-rectangle shares the preview's
+/// top-left corner and only its extent differs.
+fn mouse_target_rect(
+    cursor: &crate::tmux::PaneCursor,
+    pane: ratatui::layout::Rect,
+    col: u16,
+    row: u16,
+) -> Option<ratatui::layout::Rect> {
+    // Unsplit: the rect IS the pane, and containment stays the caller's business
+    // (`hit_preview` gates the press) with `map_pane_cell` clamping the rest, so
+    // this must not start rejecting cells that used to clamp.
+    if cursor.composite_pane0.is_none() {
+        return Some(pane);
+    }
+    let pane0 = mouse_pane_rect(cursor, pane);
+    let inside = col >= pane0.x
+        && col < pane0.x.saturating_add(pane0.width)
+        && row >= pane0.y
+        && row < pane0.y.saturating_add(pane0.height);
+    inside.then_some(pane0)
+}
+
+/// The input pane's rectangle within the preview, with no containment test:
+/// pane 0's sub-rectangle on a composited preview, else the whole preview rect.
+///
+/// Split from [`mouse_target_rect`] for the mid-gesture case. A drag or release
+/// is deliberately not position-gated so a gesture that began on pane 0 still
+/// completes, and those events need a clamped coordinate even after the pointer
+/// has wandered off pane 0.
+fn mouse_pane_rect(
+    cursor: &crate::tmux::PaneCursor,
+    pane: ratatui::layout::Rect,
+) -> ratatui::layout::Rect {
+    match cursor.composite_pane0 {
+        Some((width, height)) => ratatui::layout::Rect {
+            x: pane.x,
+            y: pane.y,
+            width: width.min(pane.width),
+            height: height.min(pane.height),
+        },
+        None => pane,
+    }
+}
+
 /// Map a hovered screen cell `(col, row)` into a forwarded app's 1-based
 /// mouse coordinate space, relative to its pane `pane` (the live-send target
 /// is sized to the preview output rect, so this maps directly), clamped
@@ -290,8 +346,9 @@ fn hover_forward_bytes(
     col: u16,
     row: u16,
 ) -> Option<Vec<u8>> {
+    let target = mouse_target_rect(cursor, pane, col, row)?;
     (cursor.alternate_on && cursor.mouse_all)
-        .then(|| mouse_event_bytes(3, false, true, cursor.mouse_sgr, pane, col, row))
+        .then(|| mouse_event_bytes(3, false, true, cursor.mouse_sgr, target, col, row))
 }
 
 /// Page presses delivered per wheel notch for a no-mouse full-screen app.
@@ -315,11 +372,15 @@ fn wheel_forward_key(
     if !cursor.alternate_on {
         return None;
     }
+    // Outside pane 0 on a composited preview there is nothing to drive: the
+    // pointer is over a pane that receives no input, and paging pane 0 because
+    // the wheel turned somewhere else would be a scroll the user did not aim.
+    let target = mouse_target_rect(cursor, pane, col, row)?;
     if cursor.mouse_tracking {
         Some(live_send::TmuxKey::HexBytes(wheel_mouse_bytes(
             up,
             cursor.mouse_sgr,
-            pane,
+            target,
             col,
             row,
         )))
@@ -4401,13 +4462,23 @@ impl HomeView {
             self.mouse_forward_btn = None;
             return false;
         };
+        // On a composited preview only pane 0 takes input, so a PRESS outside it
+        // must not open a gesture: the pointer is over a pane the agent does not
+        // own, and forwarding would report the click at a clamped cell pane 0
+        // never saw. Drags and releases stay ungated so a gesture that began on
+        // pane 0 still completes.
+        let press = !release && !motion;
+        if press && mouse_target_rect(&cursor, self.preview_text_view.pane, col, row).is_none() {
+            self.mouse_forward_btn = None;
+            return false;
+        }
         self.mouse_forward_btn = if release { None } else { Some(base_button) };
         let bytes = mouse_event_bytes(
             base_button,
             release,
             motion,
             cursor.mouse_sgr,
-            self.preview_text_view.pane,
+            mouse_pane_rect(&cursor, self.preview_text_view.pane),
             col,
             row,
         );
@@ -6777,6 +6848,7 @@ mod tests {
             mouse_sgr,
             mouse_all: false,
             position_reliable: true,
+            composite_pane0: None,
         }
     }
 
@@ -6811,6 +6883,75 @@ mod tests {
         let mut normal = cursor_for(false, true, true);
         normal.mouse_all = true;
         assert_eq!(hover_forward_bytes(&normal, pane, 10, 5), None);
+    }
+
+    /// On a composited preview the rect is the whole window while input still
+    /// goes to pane 0 alone, so a pointer over a neighbouring pane must not be
+    /// mapped against the full rect: that reported a column past pane 0's right
+    /// edge to the agent as though its own pane were window-wide.
+    #[test]
+    fn composited_preview_maps_the_mouse_into_pane_zero_only() {
+        use ratatui::layout::Rect;
+        // An 80x24 preview showing a window split at column 40.
+        let pane = Rect::new(0, 0, 80, 24);
+        let mut split = cursor_for(true, true, true);
+        split.mouse_all = true;
+        split.composite_pane0 = Some((40, 24));
+
+        // Inside pane 0: maps as before, 1-based.
+        assert_eq!(
+            hover_forward_bytes(&split, pane, 10, 5).as_deref(),
+            Some(b"\x1b[<35;11;6M".as_slice())
+        );
+        // Over the neighbour: dropped, not clamped to pane 0's border, which
+        // would synthesise a hover on a cell the pointer never touched.
+        assert_eq!(hover_forward_bytes(&split, pane, 60, 5), None);
+        assert_eq!(wheel_forward_key(&split, true, pane, 60, 5), None);
+        // The last column of pane 0 is still inside it; the first past it is not.
+        assert!(hover_forward_bytes(&split, pane, 39, 5).is_some());
+        assert_eq!(hover_forward_bytes(&split, pane, 40, 5), None);
+
+        // A no-mouse full-screen agent gets no page key from a wheel aimed at
+        // the neighbour either, but keeps it over pane 0.
+        let mut no_mouse = cursor_for(true, false, false);
+        no_mouse.composite_pane0 = Some((40, 24));
+        assert_eq!(wheel_forward_key(&no_mouse, true, pane, 60, 5), None);
+        assert!(wheel_forward_key(&no_mouse, true, pane, 10, 5).is_some());
+
+        // Unsplit is unchanged: no composite extent, so the whole rect maps.
+        let unsplit = {
+            let mut c = cursor_for(true, true, true);
+            c.mouse_all = true;
+            c
+        };
+        assert_eq!(
+            hover_forward_bytes(&unsplit, pane, 60, 5).as_deref(),
+            Some(b"\x1b[<35;61;6M".as_slice())
+        );
+        // And an unsplit cell OUTSIDE the rect must still CLAMP, not drop. The
+        // press is gated by `hit_preview`, and these helpers have always relied
+        // on `map_pane_cell` to clamp whatever reaches them, so adding the
+        // pane-0 containment test must not leak into the single-pane path.
+        assert_eq!(
+            hover_forward_bytes(&unsplit, pane, 999, 999).as_deref(),
+            Some(b"\x1b[<35;80;24M".as_slice()),
+            "unsplit coordinates clamp to the rect, they do not get dropped"
+        );
+    }
+
+    /// A pane 0 extent larger than the preview rect (the window is bigger than
+    /// the area it is being shown in, e.g. an attached client keeping its own
+    /// size) must clamp to the rect rather than admitting cells outside it.
+    #[test]
+    fn composite_pane_rect_clamps_to_the_preview() {
+        use ratatui::layout::Rect;
+        let pane = Rect::new(2, 3, 20, 10);
+        let mut cursor = cursor_for(true, true, true);
+        cursor.composite_pane0 = Some((999, 999));
+        assert_eq!(mouse_pane_rect(&cursor, pane), pane);
+        // And the origin is honoured: a cell above/left of the rect is outside.
+        assert_eq!(mouse_target_rect(&cursor, pane, 1, 3), None);
+        assert!(mouse_target_rect(&cursor, pane, 2, 3).is_some());
     }
 
     /// The fix for #2407: a full-screen pane with no mouse tracking must

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -914,6 +914,9 @@ fn capture_composited_over_grid(
     // A composite carries no scrollback (panes have independent histories), so
     // the preview must not advertise any to scroll into.
     cursor.history_size = 0;
+    // Rebasing onto the window erases how wide the input pane is, which mouse
+    // forwarding maps into; carry pane 0's extent so it can clamp.
+    cursor.composite_pane0 = Some((first.width, first.height));
     (
         Some(layout.composite_with_first_pane_rows(&rows)),
         Some(cursor),

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -793,32 +793,53 @@ impl Drop for LiveCaptureWorker {
     }
 }
 
-/// How often the worker re-asks how many panes its target window has. The
-/// answer only changes when the user splits or closes a pane by hand, so a
-/// lazy cadence is plenty; it costs one tiny `display-message` fork on the one
-/// pane currently being previewed, and only outside live mode.
-const PANE_COUNT_PROBE_MS: u64 = 2_000;
+/// How often the worker re-asks how many panes its target window has, and
+/// whether one is zoomed. The answer only changes when the user splits, closes,
+/// or zooms a pane by hand, so a lazy cadence is enough; it costs one tiny
+/// `display-message` fork on the previewed pane, in live mode as well as out of
+/// it (a mid-session split has to be noticed either way).
+///
+/// This bounds a visible transient rather than only a cost. The render-thread
+/// fallback probes `window_panes` in the SAME fork as its capture, so it composites
+/// as soon as the user splits, while the worker keeps publishing single-pane
+/// frames until this elapses; the preview alternates between the two until they
+/// agree. One second keeps that wobble short without putting the probe anywhere
+/// near per-frame. `VtChannel::sample` already forks `pane_size` about once a
+/// second, so this roughly doubles a cost that was already there rather than
+/// introducing one.
+const PANE_COUNT_PROBE_MS: u64 = 1_000;
 
 /// How many panes the worker's target window has, for deciding whether the
-/// passive preview needs the composite path. Returns 1 on any failure, which
-/// keeps the caller on the cheap single-pane transport.
+/// preview needs the composite path. Returns 1 on any failure, which keeps the
+/// caller on the cheap single-pane transport.
+///
+/// A zoomed pane (`C-b z`) also reports 1: tmux keeps `window_panes` at its real
+/// count while reporting every pane at the window's full rectangle, so the panes
+/// overlap and the compositor's tiling assumption does not hold. Compositing
+/// there hides the zoomed pane behind border fill, so the single-pane transport
+/// is both cheaper and more correct.
 fn probe_pane_count(name: &str) -> u16 {
-    crate::tmux::tmux_command()
+    let out = crate::tmux::tmux_command()
         .args([
             "display-message",
             "-p",
             "-t",
             &format!("{name}:^"),
             "-F",
-            "#{window_panes}",
+            "#{window_panes} #{window_zoomed_flag}",
         ])
         .output()
         .ok()
         .filter(|o| o.status.success())
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .and_then(|s| s.trim().parse().ok())
-        .unwrap_or(1)
-        .max(1)
+        .and_then(|o| String::from_utf8(o.stdout).ok());
+    let Some(out) = out else { return 1 };
+    let mut fields = out.split_whitespace();
+    let count: u16 = fields.next().and_then(|f| f.parse().ok()).unwrap_or(1);
+    // Absent (older tmux, or a truncated line) reads as not zoomed.
+    if fields.next().is_some_and(|z| z != "0") {
+        return 1;
+    }
+    count.max(1)
 }
 
 /// Capture transport for a split window: every pane laid back out on the window
@@ -996,9 +1017,11 @@ impl LiveCaptureWorker {
             #[cfg(unix)]
             let mut last_vt_arm: Option<std::time::Instant> = None;
             // Panes in the target window, refreshed on the lazy
-            // `PANE_COUNT_PROBE_MS` cadence. Starts at 1 so the first cycle
-            // takes the cheap path; a user's split shows up within a couple of
-            // seconds. Reset on retarget so a probe runs for the new pane.
+            // `PANE_COUNT_PROBE_MS` cadence. The seed only covers the window
+            // between arming and the first probe, which runs on the first cycle
+            // (`last_pane_probe` starts unset), so an already-split window
+            // composites immediately rather than showing one pane first. Reset on
+            // retarget so a probe runs for the new pane.
             let mut pane_count: u16 = 1;
             let mut last_pane_probe: Option<std::time::Instant> = None;
             // Window geometry plus the captured rows of every pane, reused

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -858,10 +858,20 @@ const COMPOSITE_LAYOUT_MS: u64 = 300;
 /// speed); every other pane comes from `cache`, re-captured on the
 /// [`COMPOSITE_LAYOUT_MS`] cadence. Falls back to the all-panes fork whenever
 /// there is no usable layout or the grid cannot be read.
+///
+/// `last_pane_probe` is reset whenever the layout capture fails, which is the
+/// signal that `pane_count` has gone stale: the chained capture addresses
+/// `^.0..^.{pane_count-1}`, so a pane the user closed since the last probe makes
+/// tmux exit non-zero (`can't find pane: N`) for the whole invocation. Without
+/// that reset the count would stay wrong until [`PANE_COUNT_PROBE_MS`] elapsed,
+/// and because the cache is only stamped on success the failing fork would be
+/// retried every frame while the preview kept compositing a ghost of the closed
+/// pane from the stale rectangles.
 fn capture_composited_over_grid(
     name: &str,
     channel: &crate::tmux::vt::VtChannel,
     cache: &mut Option<(std::time::Instant, crate::tmux::composite::WindowLayout)>,
+    last_pane_probe: &mut Option<std::time::Instant>,
     pane_count: u16,
     lines: usize,
     forward_empty: bool,
@@ -870,10 +880,17 @@ fn capture_composited_over_grid(
         at.elapsed() >= std::time::Duration::from_millis(COMPOSITE_LAYOUT_MS)
     });
     if stale {
-        if let Some(layout) =
-            crate::tmux::Session::from_name(name).capture_window_layout(pane_count)
-        {
-            *cache = Some((std::time::Instant::now(), layout));
+        match crate::tmux::Session::from_name(name).capture_window_layout(pane_count) {
+            Some(layout) => *cache = Some((std::time::Instant::now(), layout)),
+            // The window is no longer the one these rectangles describe. Drop
+            // them rather than compositing a pane that is gone, force a count
+            // re-probe on the next cycle, and let the fallback below carry this
+            // frame: it probes `window_panes` in the same fork as its capture,
+            // so it is correct no matter how stale the count had become.
+            None => {
+                *cache = None;
+                *last_pane_probe = None;
+            }
         }
     }
 
@@ -1111,6 +1128,7 @@ impl LiveCaptureWorker {
                                         &name,
                                         v,
                                         &mut composite_layout,
+                                        &mut last_pane_probe,
                                         pane_count,
                                         lines,
                                         forward_empty,

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -782,12 +782,6 @@ pub(in crate::tui) struct LiveCaptureWorker {
     /// down an armed channel (disabling its `pipe-pane`) and falls back to
     /// the capture path in place, no restart needed.
     vt_enabled: std::sync::Arc<std::sync::atomic::AtomicBool>,
-    /// Whether live-send is attached to the pane this worker is capturing.
-    /// Set alongside the cadence by `set_live`. Gates the split-window
-    /// composite: a passive preview shows every pane the user has split off,
-    /// but live mode stays on the single pinned `^.0` pane, which is the one
-    /// that receives input and owns the cursor being painted.
-    live: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl Drop for LiveCaptureWorker {
@@ -846,6 +840,67 @@ fn capture_composited(
     }
 }
 
+/// How long a cached window layout serves the composite before the panes
+/// around pane 0 are re-captured.
+///
+/// Only pane 0 receives input, so only its latency can be felt; the panes
+/// beside it are being watched, not driven. Refreshing them at this cadence
+/// while pane 0 comes from its VT grid every frame keeps echo latency
+/// identical to an unsplit session, at roughly three forks a second instead of
+/// one per frame.
+const COMPOSITE_LAYOUT_MS: u64 = 300;
+
+/// Composite transport for a split window with a live VT channel on pane 0.
+///
+/// Pane 0's rows come from the grid every call (so typing echoes at full
+/// speed); every other pane comes from `cache`, re-captured on the
+/// [`COMPOSITE_LAYOUT_MS`] cadence. Falls back to the all-panes fork whenever
+/// there is no usable layout or the grid cannot be read.
+fn capture_composited_over_grid(
+    name: &str,
+    channel: &crate::tmux::vt::VtChannel,
+    cache: &mut Option<(std::time::Instant, crate::tmux::composite::WindowLayout)>,
+    pane_count: u16,
+    lines: usize,
+    forward_empty: bool,
+) -> (Option<String>, Option<crate::tmux::PaneCursor>) {
+    let stale = cache.as_ref().is_none_or(|(at, _)| {
+        at.elapsed() >= std::time::Duration::from_millis(COMPOSITE_LAYOUT_MS)
+    });
+    if stale {
+        if let Some(layout) =
+            crate::tmux::Session::from_name(name).capture_window_layout(pane_count)
+        {
+            *cache = Some((std::time::Instant::now(), layout));
+        }
+    }
+
+    let Some((_, layout)) = cache.as_ref() else {
+        return capture_composited(name, lines, forward_empty);
+    };
+    let Some(first) = layout.first_pane() else {
+        return capture_composited(name, lines, forward_empty);
+    };
+    let Some((rows, mut cursor)) = channel.sample_rows_padded(first.width, first.height) else {
+        return capture_composited(name, lines, forward_empty);
+    };
+
+    // The cursor is pane 0's, and tmux puts pane 0 at the window origin, so its
+    // coordinates already index the composite with no translation. What must be
+    // restated is the frame it is measured against: the renderer anchors the
+    // cursor by `pane_height` against the painted line count, which is now the
+    // whole window rather than one pane.
+    cursor.pane_height = layout.window_height;
+    cursor.pane_width = layout.window_width;
+    // A composite carries no scrollback (panes have independent histories), so
+    // the preview must not advertise any to scroll into.
+    cursor.history_size = 0;
+    (
+        Some(layout.composite_with_first_pane_rows(&rows)),
+        Some(cursor),
+    )
+}
+
 /// The default capture transport: one `capture-pane` fork that folds in the
 /// cursor probe. Shared by the worker's non-VT path on all platforms.
 fn capture_via_tmux(
@@ -878,8 +933,6 @@ impl LiveCaptureWorker {
         // `[tmux] vt_live` value right after spawn (and on every config
         // refresh), so the worker itself never touches the config file.
         let vt_enabled = Arc::new(AtomicBool::new(true));
-        let live = Arc::new(AtomicBool::new(false));
-        let live_cell = live.clone();
         let lines_cell = capture_lines.clone();
         let target_cell = target.clone();
         let slot = latest.clone();
@@ -926,6 +979,14 @@ impl LiveCaptureWorker {
             // seconds. Reset on retarget so a probe runs for the new pane.
             let mut pane_count: u16 = 1;
             let mut last_pane_probe: Option<std::time::Instant> = None;
+            // Window geometry plus the captured rows of every pane, reused
+            // across frames while pane 0 is re-rendered from its VT grid.
+            // Dropped on retarget and whenever the pane count changes, since
+            // the cached rectangles then describe a layout that is gone.
+            let mut composite_layout: Option<(
+                std::time::Instant,
+                crate::tmux::composite::WindowLayout,
+            )> = None;
             while !stop_flag.load(Ordering::Relaxed) {
                 let lines = lines_cell.load(Ordering::Relaxed);
                 // Read the target without holding the lock across the fork:
@@ -961,6 +1022,7 @@ impl LiveCaptureWorker {
                     }
                     pane_count = 1;
                     last_pane_probe = None;
+                    composite_layout = None;
                 }
                 // `[tmux] vt_live`, re-read every cycle. Toggling off while a
                 // channel is armed tears it down (disabling its `pipe-pane`);
@@ -977,25 +1039,27 @@ impl LiveCaptureWorker {
                 }
                 if lines > 0 && !name.is_empty() {
                     let forward_empty = forward_empty_cell.load(Ordering::Relaxed);
-                    // Outside live mode, keep a lazy count of the target
-                    // window's panes so a hand-made split stops being
-                    // invisible. Live mode never composites, so it never pays
-                    // for the probe either.
-                    let is_live = live_cell.load(Ordering::Relaxed);
-                    if !is_live
-                        && last_pane_probe.is_none_or(|t| {
-                            t.elapsed() >= std::time::Duration::from_millis(PANE_COUNT_PROBE_MS)
-                        })
-                    {
+                    // Keep a lazy count of the target window's panes so a
+                    // hand-made split stops being invisible. One tiny fork
+                    // every couple of seconds on the single previewed pane.
+                    if last_pane_probe.is_none_or(|t| {
+                        t.elapsed() >= std::time::Duration::from_millis(PANE_COUNT_PROBE_MS)
+                    }) {
                         last_pane_probe = Some(std::time::Instant::now());
-                        pane_count = probe_pane_count(&name);
+                        let seen = probe_pane_count(&name);
+                        if seen != pane_count {
+                            // Layout changed under us; the cached rectangles no
+                            // longer describe this window.
+                            composite_layout = None;
+                            pane_count = seen;
+                        }
                     }
-                    // A split window's passive preview goes through the
-                    // compositor, which reads every pane. That bypasses the VT
-                    // grid (a channel mirrors one pane only), so the cost lands
-                    // exclusively on split windows; an unsplit session keeps the
-                    // fork-free steady state untouched.
-                    let composite = !is_live && pane_count > 1;
+                    // A split window renders through the compositor in BOTH
+                    // passive and live mode. With a VT channel armed the split
+                    // costs no more per frame than an unsplit session: pane 0
+                    // still comes from the grid, and only the panes beside it
+                    // are re-captured, on their own slower cadence.
+                    let composite = pane_count > 1;
                     // An OSC 52 clipboard write the displayed agent emitted
                     // since the last cycle (VT path only). Published below
                     // under the same retarget guard as the cursor.
@@ -1014,14 +1078,7 @@ impl LiveCaptureWorker {
                     // hold the last-good frame (drop it); forward panes
                     // (terminals) surface empty so stale text clears.
                     #[cfg(unix)]
-                    let (capture, cursor_now) = if composite {
-                        // Drop any armed channel: it mirrors `^.0` alone, and
-                        // holding it would keep the exclusive `pipe-pane` slot
-                        // from a viewer that can actually use it.
-                        vt_source = None;
-                        last_vt_arm = None;
-                        capture_composited(&name, lines, forward_empty)
-                    } else if vt_enabled {
+                    let (capture, cursor_now) = if vt_enabled {
                         if vt_source.is_none()
                             && last_vt_arm.is_none_or(|t| t.elapsed() >= VT_REARM_INTERVAL)
                         {
@@ -1046,12 +1103,28 @@ impl LiveCaptureWorker {
                         }
                         match vt_source.as_ref() {
                             Some(v) => {
-                                let (content, cur) = v.sample(lines);
                                 clipboard_now = v.take_clipboard();
-                                (Some(content), cur)
+                                if composite {
+                                    capture_composited_over_grid(
+                                        &name,
+                                        v,
+                                        &mut composite_layout,
+                                        pane_count,
+                                        lines,
+                                        forward_empty,
+                                    )
+                                } else {
+                                    let (content, cur) = v.sample(lines);
+                                    (Some(content), cur)
+                                }
                             }
+                            // No grid for pane 0, so every pane comes from the
+                            // fork instead.
+                            None if composite => capture_composited(&name, lines, forward_empty),
                             None => capture_via_tmux(&name, lines, forward_empty),
                         }
+                    } else if composite {
+                        capture_composited(&name, lines, forward_empty)
                     } else {
                         capture_via_tmux(&name, lines, forward_empty)
                     };
@@ -1209,7 +1282,6 @@ impl LiveCaptureWorker {
             cursor,
             clipboard,
             vt_enabled,
-            live,
         }
     }
 
@@ -1298,7 +1370,6 @@ impl LiveCaptureWorker {
     /// cycle now (the passive wheel forward reads it), and the render only
     /// paints it under live-send, so a backgrounded preview never shows one.
     pub(in crate::tui) fn set_live(&self, live: bool) {
-        self.live.store(live, std::sync::atomic::Ordering::Relaxed);
         let ms = if live {
             LIVE_CAPTURE_INTERVAL_FAST_MS
         } else {

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -821,20 +821,22 @@ fn probe_pane_count(name: &str) -> u16 {
         .max(1)
 }
 
-/// Capture transport for a split window's passive preview: every pane, laid
-/// back out on the window grid.
+/// Capture transport for a split window: every pane laid back out on the window
+/// grid, plus pane 0's cursor.
 ///
-/// Publishes no cursor. The composite has no single meaningful cursor (each
-/// pane has its own), and the render only paints one under live-send, which
-/// this path never runs in.
+/// The cursor rides along because this path also serves live-send whenever no VT
+/// channel is available (arming failed, `[tmux] vt_live` off, non-unix).
+/// Dropping it there would cost a split preview its painted cursor and, worse,
+/// the alternate-screen and mouse-mode flags the wheel forward reads to decide
+/// how to scroll a full-screen agent.
 fn capture_composited(
     name: &str,
     lines: usize,
     forward_empty: bool,
 ) -> (Option<String>, Option<crate::tmux::PaneCursor>) {
     let session = crate::tmux::Session::from_name(name);
-    match session.capture_window_composited(lines) {
-        Ok(content) => (Some(content), None),
+    match session.capture_window_composited_with_cursor(lines) {
+        Ok((content, cursor)) => (Some(content), cursor),
         Err(_) if forward_empty => (Some(String::new()), None),
         Err(_) => (None, None),
     }

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -782,6 +782,12 @@ pub(in crate::tui) struct LiveCaptureWorker {
     /// down an armed channel (disabling its `pipe-pane`) and falls back to
     /// the capture path in place, no restart needed.
     vt_enabled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Whether live-send is attached to the pane this worker is capturing.
+    /// Set alongside the cadence by `set_live`. Gates the split-window
+    /// composite: a passive preview shows every pane the user has split off,
+    /// but live mode stays on the single pinned `^.0` pane, which is the one
+    /// that receives input and owns the cursor being painted.
+    live: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl Drop for LiveCaptureWorker {
@@ -790,6 +796,53 @@ impl Drop for LiveCaptureWorker {
         // Wake the worker so it sees `stop` and exits now rather than after
         // its current inter-capture sleep.
         self.nudge();
+    }
+}
+
+/// How often the worker re-asks how many panes its target window has. The
+/// answer only changes when the user splits or closes a pane by hand, so a
+/// lazy cadence is plenty; it costs one tiny `display-message` fork on the one
+/// pane currently being previewed, and only outside live mode.
+const PANE_COUNT_PROBE_MS: u64 = 2_000;
+
+/// How many panes the worker's target window has, for deciding whether the
+/// passive preview needs the composite path. Returns 1 on any failure, which
+/// keeps the caller on the cheap single-pane transport.
+fn probe_pane_count(name: &str) -> u16 {
+    crate::tmux::tmux_command()
+        .args([
+            "display-message",
+            "-p",
+            "-t",
+            &format!("{name}:^"),
+            "-F",
+            "#{window_panes}",
+        ])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(1)
+        .max(1)
+}
+
+/// Capture transport for a split window's passive preview: every pane, laid
+/// back out on the window grid.
+///
+/// Publishes no cursor. The composite has no single meaningful cursor (each
+/// pane has its own), and the render only paints one under live-send, which
+/// this path never runs in.
+fn capture_composited(
+    name: &str,
+    lines: usize,
+    forward_empty: bool,
+) -> (Option<String>, Option<crate::tmux::PaneCursor>) {
+    let session = crate::tmux::Session::from_name(name);
+    match session.capture_window_composited(lines) {
+        Ok(content) => (Some(content), None),
+        Err(_) if forward_empty => (Some(String::new()), None),
+        Err(_) => (None, None),
     }
 }
 
@@ -825,6 +878,8 @@ impl LiveCaptureWorker {
         // `[tmux] vt_live` value right after spawn (and on every config
         // refresh), so the worker itself never touches the config file.
         let vt_enabled = Arc::new(AtomicBool::new(true));
+        let live = Arc::new(AtomicBool::new(false));
+        let live_cell = live.clone();
         let lines_cell = capture_lines.clone();
         let target_cell = target.clone();
         let slot = latest.clone();
@@ -865,6 +920,12 @@ impl LiveCaptureWorker {
             // panes. Reset on target change so a new pane arms immediately.
             #[cfg(unix)]
             let mut last_vt_arm: Option<std::time::Instant> = None;
+            // Panes in the target window, refreshed on the lazy
+            // `PANE_COUNT_PROBE_MS` cadence. Starts at 1 so the first cycle
+            // takes the cheap path; a user's split shows up within a couple of
+            // seconds. Reset on retarget so a probe runs for the new pane.
+            let mut pane_count: u16 = 1;
+            let mut last_pane_probe: Option<std::time::Instant> = None;
             while !stop_flag.load(Ordering::Relaxed) {
                 let lines = lines_cell.load(Ordering::Relaxed);
                 // Read the target without holding the lock across the fork:
@@ -898,6 +959,8 @@ impl LiveCaptureWorker {
                         vt_source = None;
                         last_vt_arm = None;
                     }
+                    pane_count = 1;
+                    last_pane_probe = None;
                 }
                 // `[tmux] vt_live`, re-read every cycle. Toggling off while a
                 // channel is armed tears it down (disabling its `pipe-pane`);
@@ -914,6 +977,25 @@ impl LiveCaptureWorker {
                 }
                 if lines > 0 && !name.is_empty() {
                     let forward_empty = forward_empty_cell.load(Ordering::Relaxed);
+                    // Outside live mode, keep a lazy count of the target
+                    // window's panes so a hand-made split stops being
+                    // invisible. Live mode never composites, so it never pays
+                    // for the probe either.
+                    let is_live = live_cell.load(Ordering::Relaxed);
+                    if !is_live
+                        && last_pane_probe.is_none_or(|t| {
+                            t.elapsed() >= std::time::Duration::from_millis(PANE_COUNT_PROBE_MS)
+                        })
+                    {
+                        last_pane_probe = Some(std::time::Instant::now());
+                        pane_count = probe_pane_count(&name);
+                    }
+                    // A split window's passive preview goes through the
+                    // compositor, which reads every pane. That bypasses the VT
+                    // grid (a channel mirrors one pane only), so the cost lands
+                    // exclusively on split windows; an unsplit session keeps the
+                    // fork-free steady state untouched.
+                    let composite = !is_live && pane_count > 1;
                     // An OSC 52 clipboard write the displayed agent emitted
                     // since the last cycle (VT path only). Published below
                     // under the same retarget guard as the cursor.
@@ -932,7 +1014,14 @@ impl LiveCaptureWorker {
                     // hold the last-good frame (drop it); forward panes
                     // (terminals) surface empty so stale text clears.
                     #[cfg(unix)]
-                    let (capture, cursor_now) = if vt_enabled {
+                    let (capture, cursor_now) = if composite {
+                        // Drop any armed channel: it mirrors `^.0` alone, and
+                        // holding it would keep the exclusive `pipe-pane` slot
+                        // from a viewer that can actually use it.
+                        vt_source = None;
+                        last_vt_arm = None;
+                        capture_composited(&name, lines, forward_empty)
+                    } else if vt_enabled {
                         if vt_source.is_none()
                             && last_vt_arm.is_none_or(|t| t.elapsed() >= VT_REARM_INTERVAL)
                         {
@@ -967,7 +1056,11 @@ impl LiveCaptureWorker {
                         capture_via_tmux(&name, lines, forward_empty)
                     };
                     #[cfg(not(unix))]
-                    let (capture, cursor_now) = capture_via_tmux(&name, lines, forward_empty);
+                    let (capture, cursor_now) = if composite {
+                        capture_composited(&name, lines, forward_empty)
+                    } else {
+                        capture_via_tmux(&name, lines, forward_empty)
+                    };
                     // Chunk-arrival timing for the repaint-quiescence debounce,
                     // only when sampling a live VT grid. `None` on the
                     // capture-pane fallback and non-unix, which leaves pacing to
@@ -1116,6 +1209,7 @@ impl LiveCaptureWorker {
             cursor,
             clipboard,
             vt_enabled,
+            live,
         }
     }
 
@@ -1204,6 +1298,7 @@ impl LiveCaptureWorker {
     /// cycle now (the passive wheel forward reads it), and the render only
     /// paints it under live-send, so a backgrounded preview never shows one.
     pub(in crate::tui) fn set_live(&self, live: bool) {
+        self.live.store(live, std::sync::atomic::Ordering::Relaxed);
         let ms = if live {
             LIVE_CAPTURE_INTERVAL_FAST_MS
         } else {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2224,9 +2224,17 @@ impl HomeView {
                 // always overwrite, falling back to an empty body (the same
                 // "session looks gone" signal the non-live path uses).
                 let same_session = s.preview_cache.session_id.as_deref() == Some(id);
-                let fork_capture = s
-                    .get_instance(id)
-                    .and_then(|inst| inst.capture_output(capture_lines).ok());
+                // Outside live mode the preview shows the whole window, panes
+                // and all; live mode stays on the pinned `^.0` pane so this
+                // cold-start frame matches what the worker will publish next
+                // instead of flickering between the two shapes.
+                let fork_capture = s.get_instance(id).and_then(|inst| {
+                    if in_live {
+                        inst.capture_output(capture_lines).ok()
+                    } else {
+                        inst.capture_output_composited(capture_lines).ok()
+                    }
+                });
                 if in_live {
                     match fork_capture {
                         Some(content) if !content.is_empty() => Some(content),
@@ -2259,9 +2267,19 @@ impl HomeView {
             false,
             |s| &mut s.terminal_preview_cache,
             |s, id, capture_lines| {
+                let in_live = s
+                    .live_send
+                    .as_ref()
+                    .is_some_and(|st| st.target == live_send::LiveSendTarget::Terminal);
                 s.get_instance(id).map(|inst| {
                     inst.terminal_tmux_session()
-                        .and_then(|sess| sess.capture_pane(capture_lines))
+                        .and_then(|sess| {
+                            if in_live {
+                                sess.capture_pane(capture_lines)
+                            } else {
+                                sess.capture_window_composited(capture_lines)
+                            }
+                        })
                         .unwrap_or_default()
                 })
             },
@@ -2288,9 +2306,19 @@ impl HomeView {
             false,
             |s| &mut s.container_terminal_preview_cache,
             |s, id, capture_lines| {
+                let in_live = s
+                    .live_send
+                    .as_ref()
+                    .is_some_and(|st| st.target == live_send::LiveSendTarget::ContainerTerminal);
                 s.get_instance(id).map(|inst| {
                     inst.container_terminal_tmux_session()
-                        .and_then(|sess| sess.capture_pane(capture_lines))
+                        .and_then(|sess| {
+                            if in_live {
+                                sess.capture_pane(capture_lines)
+                            } else {
+                                sess.capture_window_composited(capture_lines)
+                            }
+                        })
                         .unwrap_or_default()
                 })
             },
@@ -2322,10 +2350,17 @@ impl HomeView {
             false,
             |s| &mut s.tool_preview_cache,
             |s, id, capture_lines| {
+                let in_live = s.live_send.as_ref().is_some_and(|st| {
+                    st.target == live_send::LiveSendTarget::Tool(tool_name.to_string())
+                });
                 s.get_instance(id).map(|inst| {
-                    crate::tmux::ToolSession::new(&inst.id, &inst.title, tool_name)
-                        .capture_pane(capture_lines)
-                        .unwrap_or_default()
+                    let sess = crate::tmux::ToolSession::new(&inst.id, &inst.title, tool_name);
+                    if in_live {
+                        sess.capture_pane(capture_lines)
+                    } else {
+                        sess.capture_window_composited(capture_lines)
+                    }
+                    .unwrap_or_default()
                 })
             },
         );

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2224,17 +2224,16 @@ impl HomeView {
                 // always overwrite, falling back to an empty body (the same
                 // "session looks gone" signal the non-live path uses).
                 let same_session = s.preview_cache.session_id.as_deref() == Some(id);
-                // Outside live mode the preview shows the whole window, panes
-                // and all; live mode stays on the pinned `^.0` pane so this
-                // cold-start frame matches what the worker will publish next
-                // instead of flickering between the two shapes.
-                let fork_capture = s.get_instance(id).and_then(|inst| {
-                    if in_live {
-                        inst.capture_output(capture_lines).ok()
-                    } else {
-                        inst.capture_output_composited(capture_lines).ok()
-                    }
-                });
+                // Composited in BOTH modes, matching what the worker publishes.
+                // This fallback also runs on every idle refresh (the worker
+                // dedups unchanged frames, so it has nothing to hand over), so a
+                // pane-0-only capture here would clobber the worker's composite
+                // a beat after each keystroke and leave the split visible for
+                // only one frame at a time. On an unsplit window this returns
+                // the pane bytes verbatim, so nothing changes there.
+                let fork_capture = s
+                    .get_instance(id)
+                    .and_then(|inst| inst.capture_output_composited(capture_lines).ok());
                 if in_live {
                     match fork_capture {
                         Some(content) if !content.is_empty() => Some(content),
@@ -2267,19 +2266,9 @@ impl HomeView {
             false,
             |s| &mut s.terminal_preview_cache,
             |s, id, capture_lines| {
-                let in_live = s
-                    .live_send
-                    .as_ref()
-                    .is_some_and(|st| st.target == live_send::LiveSendTarget::Terminal);
                 s.get_instance(id).map(|inst| {
                     inst.terminal_tmux_session()
-                        .and_then(|sess| {
-                            if in_live {
-                                sess.capture_pane(capture_lines)
-                            } else {
-                                sess.capture_window_composited(capture_lines)
-                            }
-                        })
+                        .and_then(|sess| sess.capture_window_composited(capture_lines))
                         .unwrap_or_default()
                 })
             },
@@ -2306,19 +2295,9 @@ impl HomeView {
             false,
             |s| &mut s.container_terminal_preview_cache,
             |s, id, capture_lines| {
-                let in_live = s
-                    .live_send
-                    .as_ref()
-                    .is_some_and(|st| st.target == live_send::LiveSendTarget::ContainerTerminal);
                 s.get_instance(id).map(|inst| {
                     inst.container_terminal_tmux_session()
-                        .and_then(|sess| {
-                            if in_live {
-                                sess.capture_pane(capture_lines)
-                            } else {
-                                sess.capture_window_composited(capture_lines)
-                            }
-                        })
+                        .and_then(|sess| sess.capture_window_composited(capture_lines))
                         .unwrap_or_default()
                 })
             },
@@ -2350,17 +2329,10 @@ impl HomeView {
             false,
             |s| &mut s.tool_preview_cache,
             |s, id, capture_lines| {
-                let in_live = s.live_send.as_ref().is_some_and(|st| {
-                    st.target == live_send::LiveSendTarget::Tool(tool_name.to_string())
-                });
                 s.get_instance(id).map(|inst| {
-                    let sess = crate::tmux::ToolSession::new(&inst.id, &inst.title, tool_name);
-                    if in_live {
-                        sess.capture_pane(capture_lines)
-                    } else {
-                        sess.capture_window_composited(capture_lines)
-                    }
-                    .unwrap_or_default()
+                    crate::tmux::ToolSession::new(&inst.id, &inst.title, tool_name)
+                        .capture_window_composited(capture_lines)
+                        .unwrap_or_default()
                 })
             },
         );

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -4015,6 +4015,7 @@ mod tests {
             mouse_sgr: false,
             mouse_all: false,
             position_reliable: true,
+            composite_pane0: None,
         }
     }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -11395,6 +11395,7 @@ mod scroll_pane_isolation {
             mouse_sgr,
             mouse_all: false,
             position_reliable: true,
+            composite_pane0: None,
         }
     }
 


### PR DESCRIPTION
## Preview


https://github.com/user-attachments/assets/ae8cce0a-eec1-4585-bc53-3877293f32c9


## Description

Closes #2068.

The session preview captured `^.0` and nothing else, so a pane you split off by hand was invisible: aoe showed the agent's pane and silently dropped everything beside it. No error, no hint, just missing output.

This reads every pane and lays them back out on the window grid with tmux-style borders in the gaps.

```
AGENT PANE                         │LOGS
working...                         │200 ok
                                   │404 nope
                                   │
───────────────────────────────────│
$ tail -f                          │
```

**Input routing is untouched.** Keystrokes still go to `^.0` exclusively, exactly as before (#435, #488). Compositing is read-only, so the mis-targeted-keystroke class of bug that the pin exists to prevent cannot arise here. That asymmetry is the whole reason this is tractable: reading every pane is safe, writing to the wrong one is not.

### Cost

An unsplit window, which is nearly every session, pays nothing new:

- **One fork, as before.** The pane count rides along as a header on the capture that was already happening, and the pane bytes are returned verbatim. There's a test asserting byte-for-byte equality with `capture_pane` on an unsplit window.
- **The VT fast path is preserved.** The capture worker probes the pane count on a lazy 2s cadence (one tiny fork on the single previewed pane), so an unsplit session never leaves its fork-free steady state.

A split window in live mode splits the refresh rates rather than forking per frame. Pane 0 is the only pane receiving input, so it's the only one whose latency can be felt; it keeps coming from its VT grid every frame. The panes beside it are being watched, not driven, so they come from a layout cached for 300ms. That's ~3 forks/sec instead of ~80, with echo latency identical to an unsplit session.

### One nice discovery

tmux puts pane 0 at the window origin, and keeps it there: pane indices follow layout order, and closing pane 0 renumbers whichever pane takes that corner. Verified against a live server. So the VT grid's cursor already indexes the composite with no coordinate translation. What does need restating is the frame it's measured against, since the renderer anchors on `pane_height` against the painted line count, which is now the window rather than one pane.

### Deliberate limits

- **Splits lose scrollback.** Panes have independent histories with no coherent way to stack them, so the composite covers the visible window only. The preview's scroll offset clamps itself to the shorter capture, so this reads as "a split window doesn't scroll back" rather than misbehaving. Close the extra pane and scrollback returns.
- **Wheel and mouse forwarding still go to pane 0** regardless of which pane the pointer is over. Consistent with keystroke routing rather than a new inconsistency, but now that a split window is fully visible, hovering the other pane and scrolling will feel off. Happy to gate it on pane 0's rectangle in a follow-up if reviewers prefer.
- **Border junctions are approximate.** tmux draws tee/cross glyphs where rules meet; this draws `─` and `│` and lets them abut. Deliberate for a preview.

### Also fixes a latent panic

vt100 0.16 underflows whenever content wraps on a one-row grid, and `resize-pane -y 1` is a layout a user can produce. The pane parser now works at two rows minimum and reads back the real height. Found by a unit test, not in the wild.

### Removals

Three methods lost their last caller and are gone per the no-dead-code rule: `Instance::capture_output`, `TerminalSession::capture_pane`, `ContainerTerminalSession::capture_pane`. `Session::capture_pane` stays; the CLI, web API, status detection, and smart-rename all still use it.

## PR Type

- [x] New Feature
- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

The block above is real captured output from a 3-pane layout, not a mockup. A screen recording of the TUI can be attached if reviewers want to see it live.

Docs unchanged: this makes the existing preview show more of what's already there, and adds no setting, command, or flag to document.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

Rust-only; the web live view has its own relay path and is untouched.

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: see below

Covered by 22 unit tests plus 4 integration tests against a real tmux server:

- **Pure splice** (14 tests, no tmux): side-by-side, stacked, a pane shorter than its neighbour, a row missing from a capture, ANSI rows spliced without being cut, the 3-pane layout where a left column's rule must stop at the vertical border, unclaimed columns, zero-width panes, and the first-pane/row-swap contract the live path depends on.
- **Padded row extraction** (5 tests): full-width padding, bare-LF unstaircasing, style reset before padding, the one-row-pane panic, and grid rectangles narrower/taller/equal.
- **Against real tmux** (4 tests): an unsplit window composites byte-identically to `capture_pane`; a split-off pane lands on the same rows as the agent's; the captured layout returns pane 0 first at the origin *with pane 1 selected active*; and both composite transports agree byte-for-byte on a static window.

That last one guards the invariant whose violation produced a real bug during development: the fallback path and the worker path disagreeing made the split visible for one frame after each keystroke and vanish while idle.

**What isn't covered, honestly:** the worker's transport gate itself is a thread over atomics, and the render-side wiring needs a live `HomeView`, so neither is unit-testable. Both were verified by hand (split → composite appears; `Tab` → stays visible while typing; unsplit → unchanged). A TUI e2e that splits a session, enters live mode, types, and waits out an idle cycle would close that gap; glad to add one if reviewers want it before merge.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 5)

**Any Additional AI Details you'd like to share:**

Implemented with Claude Code across two commits, with the design argued out first: whether to follow the active pane, composite read-only, or leave splits alone. The read/write asymmetry (#488 was an input bug, so reads can safely see everything) and the pane-0-at-origin property were both established during that discussion, the latter by probing a live tmux server rather than assuming it.

Two bugs in the work were caught by its own tests: the initial gap-fill rule painted border glyphs into the dead corner beside a short pane, and the vt100 one-row panic. A third, the one-frame flicker, was caught by manual testing and is now pinned by the transport-agreement test.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the TUI session preview to build a composited “window snapshot” that captures **all tmux panes** and renders them into a single preview using the **real tmux window layout**, with **approximate borders/junctions** between panes.
- Added a tmux compositing layer that parses/caches the window layout and **rebuilds pane placement** efficiently for split windows, while keeping **previous byte-identical behavior** for unsplit sessions.
- Switched the preview capture APIs across the session/terminal/container/tool layers from **pane-only** to **composited-window** variants, including cursor metadata updates and documentation of the split-window behavior.
- Refined live-mode behavior:
  - Detects whether the tmux window is split (with throttled pane-count probing).
  - Uses a VT-grid-based compositing path when possible, otherwise falls back to a simpler composited capture.
  - Drops stale cached layouts when panes close.
  - In composite/split mode, **scrollback history is unavailable** and **input/mouse handling is restricted to pane 0** (events outside pane 0 are dropped where appropriate).
- Hardened VT/pane parsing to prevent crashes for edge cases (notably **one-row panes**) by enforcing a minimum parser height and then using the actual pane height after parsing.
- Removed several unused capture methods while keeping the core `Session::capture_pane`.

## Benefits

- Split-window previews now look much closer to what users see in tmux: **all panes are visible**, laid out correctly by **window geometry/order**, and visually separated by **border/junctions**.
- More reliable preview rendering and cursor alignment across resizing and tricky pane dimensions.
- Clearer/safer interaction semantics in split mode: **no misleading scrollback**, and mouse/input routing consistently targets **pane 0**.

## Potential Enhancements

- The border/junction rendering is intentionally approximate; further tuning could improve fidelity for unusual/rapidly changing geometries.
- Cached-layout reuse depends on probing and refresh timing; performance/accuracy tradeoffs may be improved with additional tuning for highly dynamic layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
