### PR TITLE
fix(web): respect prefers-reduced-motion for entrance animations

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -425,6 +425,16 @@ body {
 .animate-slide-in-right {
   animation: slide-in-right 0.2s ease-out;
 }
+/* Reduced-motion users get the settled end state (elements default to opacity 1
+   / no transform) with no entrance movement or fade. Matches the per-animation
+   opt-out used by the blink and settings-highlight utilities below. */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in,
+  .animate-slide-up,
+  .animate-slide-in-right {
+    animation: none;
+  }
+}
 
 /* Live terminal cursor blink while its input is focused (MobileLiveTerminal's
    `Row`). Only oscillates the filled-cursor colors set by the inline style;


### PR DESCRIPTION
## Description

The entrance-animation utilities in `web/src/index.css` (`.animate-fade-in`, `.animate-slide-up`, `.animate-slide-in-right`) ran unconditionally. Users who request reduced motion still got the fade and, for the two slide utilities, the translate movement that `prefers-reduced-motion` is meant to suppress.

This gates all three to `animation: none` under `@media (prefers-reduced-motion: reduce)`, so those users land on the settled end state (opacity 1 / no transform) instantly. It matches the per-animation opt-out already used by the `term-cursor-blink` and `settings-highlight` utilities in the same file.

Noticed while reviewing #3131, where CodeRabbit flagged an ungated `animate-fade-in` in a new skeleton. Fixing it at the CSS definition site is repo-wide and covers every existing usage (dialogs, panels, etc.), rather than patching one call site.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (n/a)
- [ ] For UI changes: included screenshot or recording (n/a; the change is the absence of motion under reduced-motion)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: pure CSS styling change. Reduced-motion media queries are not practical to assert in jsdom/Vitest, and this follows the existing gated animations, which carry no tests. Verified by building and confirming the `@media (prefers-reduced-motion: reduce)` block survives into the compiled CSS bundle.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Change drafted with Claude Code; reasoning and decisions reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added reduced-motion support for fade-in and slide-in animations.
- Users who prefer reduced motion now see content immediately in its settled state, without visual movement or fading.
- Applied the change centrally so all existing uses of these animations are covered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->