### PR TITLE
feat(tmux): experimental shared tmux session with named tabs

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1177,6 +1177,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 }
 
                 let tmux_session = crate::tmux::Session::new(&instance.id, &instance.title)?;
+                tmux_session.focus_own_window();
                 tmux_session.attach()?;
             }
             Err(e) => {

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1418,6 +1418,9 @@ async fn attach_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         );
     }
 
+    // Land on the agent's own tab, not whichever paired-terminal tab was last
+    // viewed under `AOE_USE_SHARED_TMUX_SESSION`.
+    tmux_session.focus_own_window();
     tmux_session.attach()?;
     Ok(())
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -38,6 +38,27 @@ pub struct TerminalInfo {
     pub created: bool,
 }
 
+/// Tab label for a paired host terminal. Index 0 is the only terminal the TUI
+/// uses and stays unnumbered; the web dashboard's additional terminals (#2437)
+/// are numbered from 2 so the strip reads `terminal`, `terminal 2`, ... matching
+/// how the web already labels those tabs.
+pub(crate) fn terminal_window_name(index: u32) -> String {
+    if index == 0 {
+        "terminal".to_string()
+    } else {
+        format!("terminal {}", index + 1)
+    }
+}
+
+/// Container counterpart of [`terminal_window_name`].
+pub(crate) fn container_window_name(index: u32) -> String {
+    if index == 0 {
+        "container".to_string()
+    } else {
+        format!("container {}", index + 1)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Status {
@@ -2772,6 +2793,7 @@ impl Instance {
             session.create_with_size(&self.project_path, None, size)?;
             // Apply all configured tmux options to terminal sessions too
             self.apply_terminal_tmux_options(index);
+            self.link_paired_window_into_agent(session.name());
         }
 
         // The persisted `terminal_info` cache is the index-0 fast path the TUI
@@ -2889,9 +2911,50 @@ impl Instance {
         if is_new {
             session.create_with_size(&self.project_path, Some(&session_cmd), size)?;
             self.apply_container_terminal_tmux_options(index);
+            self.link_paired_window_into_agent(session.name());
         }
 
         Ok(())
+    }
+
+    /// Under `AOE_USE_SHARED_TMUX_SESSION`, graft a freshly created paired
+    /// terminal's window into this session's agent tmux session so it shows up as
+    /// a tab there. The terminal keeps its own session, so this is purely
+    /// additive: `link-window` makes one window belong to both, leaving every
+    /// `<terminal>:^.0` pane target and the separate kill path intact.
+    ///
+    /// Silently does nothing when the flag is off, when the agent has no tmux
+    /// session (structured/ACP sessions never create one), or when the link
+    /// fails; in every case the terminal is still usable on its own session.
+    fn link_paired_window_into_agent(&self, terminal_session_name: &str) {
+        if !crate::tmux::use_shared_tmux_session() {
+            return;
+        }
+        let Ok(agent) = self.tmux_session() else {
+            return;
+        };
+        if !agent.exists() {
+            return;
+        }
+        crate::tmux::link_window_into(terminal_session_name, agent.name());
+    }
+
+    /// Re-attach every surviving paired terminal as a tab of `agent_session`.
+    ///
+    /// A restart kills and recreates the agent's tmux session, which discards its
+    /// window list while leaving the terminals' own sessions (and their scrollback)
+    /// untouched. Without this the terminals are still alive but no longer reachable
+    /// as tabs, so the restart looks like it destroyed them.
+    ///
+    /// Idempotent: `link_window_into` skips terminals already linked, so this is
+    /// safe to run on every launch, not just restarts.
+    pub(crate) fn relink_paired_windows(instance_id: &str, agent_session: &str) {
+        if !crate::tmux::use_shared_tmux_session() {
+            return;
+        }
+        for name in crate::tmux::paired_terminal_sessions_for_id(instance_id) {
+            crate::tmux::link_window_into(&name, agent_session);
+        }
     }
 
     pub fn kill_container_terminal(&self) -> Result<()> {
@@ -2933,7 +2996,12 @@ impl Instance {
     }
 
     /// Apply all configured tmux options to a session with the given name and title.
-    fn apply_session_tmux_options(&self, session_name: &str, display_title: &str) {
+    fn apply_session_tmux_options(
+        &self,
+        session_name: &str,
+        display_title: &str,
+        window_name: Option<&str>,
+    ) {
         let branch = self
             .worktree_info
             .as_ref()
@@ -2945,13 +3013,28 @@ impl Instance {
             display_title,
             branch,
             sandbox.as_ref(),
+            window_name,
         );
+    }
+
+    /// Tab label for this session's agent window, e.g. `agent (claude)`.
+    /// Falls back to a bare `agent` when the tool name is empty.
+    pub(crate) fn agent_window_name(&self) -> String {
+        if self.tool.is_empty() {
+            "agent".to_string()
+        } else {
+            format!("agent ({})", self.tool)
+        }
     }
 
     fn apply_container_terminal_tmux_options(&self, index: u32) {
         let name =
             tmux::ContainerTerminalSession::resolve_name_indexed(&self.id, &self.title, index);
-        self.apply_session_tmux_options(&name, &format!("{} (container)", self.title));
+        self.apply_session_tmux_options(
+            &name,
+            &format!("{} (container)", self.title),
+            Some(&container_window_name(index)),
+        );
     }
 
     pub fn start(&mut self) -> Result<()> {
@@ -3511,6 +3594,11 @@ impl Instance {
         let title = self.title.clone();
         let branch = self.worktree_info.as_ref().map(|w| w.branch.clone());
         let sandbox = self.sandbox_display();
+        let window_name = self.agent_window_name();
+        // A restart recreates this tmux session, dropping the linked terminal tabs
+        // it used to show while the terminals themselves survive; re-link them so
+        // the tab strip comes back with the agent.
+        let relink_id = self.id.clone();
         match std::thread::Builder::new()
             .name(format!("finalize-tmux-{}", instance_id_for_log))
             .spawn(move || {
@@ -3520,7 +3608,9 @@ impl Instance {
                         &title,
                         branch.as_deref(),
                         sandbox.as_ref(),
+                        Some(&window_name),
                     );
+                    Self::relink_paired_windows(&relink_id, &session_name);
                 })) {
                     tracing::error!(target: "session.store", "finalize-tmux thread panicked: {:?}", panic);
                 }
@@ -3846,7 +3936,11 @@ impl Instance {
 impl Instance {
     fn apply_terminal_tmux_options(&self, index: u32) {
         let name = tmux::TerminalSession::resolve_name_indexed(&self.id, &self.title, index);
-        self.apply_session_tmux_options(&name, &format!("{} (terminal)", self.title));
+        self.apply_session_tmux_options(
+            &name,
+            &format!("{} (terminal)", self.title),
+            Some(&terminal_window_name(index)),
+        );
     }
 
     pub fn get_container_for_instance(&mut self) -> Result<containers::DockerContainer> {
@@ -5663,6 +5757,39 @@ mod tests {
         let pinned = "/workspace/myrepo-worktrees/contexec".to_string();
         inst.sandbox_info.as_mut().unwrap().container_workdir = Some(pinned.clone());
         assert_eq!(inst.container_workdir(), pinned);
+    }
+
+    /// Tab labels must name the surface, not leak tmux's `automatic-rename`
+    /// output. The agent tab in particular has to read `agent (claude)` rather
+    /// than the bare version string Claude Code's versioned install path yields.
+    #[test]
+    fn agent_window_name_labels_the_tool() {
+        let mut inst = Instance::new("my-session", "/tmp/test");
+        inst.tool = "claude".to_string();
+        assert_eq!(inst.agent_window_name(), "agent (claude)");
+
+        inst.tool = "pi".to_string();
+        assert_eq!(inst.agent_window_name(), "agent (pi)");
+    }
+
+    #[test]
+    fn agent_window_name_falls_back_without_a_tool() {
+        let mut inst = Instance::new("my-session", "/tmp/test");
+        inst.tool = String::new();
+        assert_eq!(inst.agent_window_name(), "agent");
+    }
+
+    /// Index 0 is the TUI's only terminal and stays unnumbered; the web
+    /// dashboard's extra terminals are numbered from 2 to match how it already
+    /// labels those tabs.
+    #[test]
+    fn terminal_window_names_match_the_web_tab_labels() {
+        assert_eq!(terminal_window_name(0), "terminal");
+        assert_eq!(terminal_window_name(1), "terminal 2");
+        assert_eq!(terminal_window_name(2), "terminal 3");
+
+        assert_eq!(container_window_name(0), "container");
+        assert_eq!(container_window_name(1), "container 2");
     }
 
     #[test]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -21,9 +21,15 @@ pub(crate) use status_detection::{
     reconcile_claude_hook_status, reconcile_claude_idle_hook_status, reconcile_codex_hook_status,
     reconcile_waiting_hook,
 };
-pub use terminal_session::{kill_all_terminals_for_id, ContainerTerminalSession, TerminalSession};
+pub use terminal_session::{
+    kill_all_terminals_for_id, paired_terminal_sessions_for_id, ContainerTerminalSession,
+    TerminalSession,
+};
 pub use tool_session::{kill_all_tool_sessions_for_id, ToolSession};
-pub use utils::tmux_prefix_display;
+pub use utils::{
+    kill_first_window, link_window_into, select_first_window, select_linked_window,
+    set_window_name, tmux_prefix_display,
+};
 
 #[cfg(any(test, feature = "test-support"))]
 #[doc(hidden)]
@@ -205,6 +211,24 @@ pub const TOOL_PREFIX: &str = if cfg!(debug_assertions) {
 } else {
     "aoe_tool_"
 };
+
+/// Experimental: render an agent and its paired terminals as tabs (tmux
+/// windows) of a single attached session instead of separate sessions the user
+/// has to switch between.
+///
+/// Each surface still gets its own tmux session, so every existing
+/// `<session>:^.0` pane target keeps resolving; the paired terminal's window is
+/// additionally `link-window`'d into the agent's session, which is how one tmux
+/// window comes to belong to two sessions. That keeps the change additive: no
+/// pane targeting, session-scoped `@aoe_*` lock, or kill path has to change.
+///
+/// Gated on `AOE_USE_SHARED_TMUX_SESSION` while we decide whether to keep it.
+/// Read uncached so tests (and a user mid-session) can toggle it.
+pub fn use_shared_tmux_session() -> bool {
+    std::env::var("AOE_USE_SHARED_TMUX_SESSION")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
 
 /// Pre-fetched pane metadata from a single `tmux list-panes -a` call.
 #[derive(Debug, Clone)]
@@ -1083,6 +1107,33 @@ mod tests {
     // (`aoe_`) and debug (`aoe_dev_`) builds. Use the constant so the same
     // test bodies cover both.
     const P: &str = SESSION_PREFIX;
+
+    /// The shared-session model is opt-in while we evaluate it, so an unset or
+    /// unrecognized `AOE_USE_SHARED_TMUX_SESSION` must leave every existing user
+    /// on the separate-session behavior.
+    #[test]
+    #[serial_test::serial]
+    fn use_shared_tmux_session_is_opt_in() {
+        let key = "AOE_USE_SHARED_TMUX_SESSION";
+        let original = std::env::var(key).ok();
+
+        std::env::remove_var(key);
+        assert!(!use_shared_tmux_session(), "must default to off");
+
+        for on in ["1", "true", "TRUE"] {
+            std::env::set_var(key, on);
+            assert!(use_shared_tmux_session(), "`{on}` should enable it");
+        }
+        for off in ["0", "", "yes", "off"] {
+            std::env::set_var(key, off);
+            assert!(!use_shared_tmux_session(), "`{off}` should not enable it");
+        }
+
+        match original {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
 
     #[test]
     fn test_tmux_command_carries_socket_flag() {

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -1105,6 +1105,24 @@ impl Session {
     /// the policy `append_window_size_args` installs at session create.
     /// Best-effort: failures (session gone, tmux ENOENT) are swallowed
     /// so a stuck pane never blocks the user's exit from live mode.
+    /// Focus this session's own window before attaching, so an agent attach lands
+    /// on the agent and not on whichever tab was last viewed.
+    ///
+    /// Only meaningful under `AOE_USE_SHARED_TMUX_SESSION`, where paired terminals
+    /// are tabs of this session: attaching a terminal selects its tab, and tmux
+    /// persists that as the session's current window, so the next agent attach
+    /// would otherwise resume on the terminal.
+    ///
+    /// Deliberately a separate call rather than part of [`Self::attach`], because
+    /// the paired-terminal attach routes *through* this session's `attach` after
+    /// selecting the terminal's tab on purpose; folding this in would override it.
+    pub fn focus_own_window(&self) {
+        if !crate::tmux::use_shared_tmux_session() {
+            return;
+        }
+        crate::tmux::select_first_window(&self.name);
+    }
+
     pub fn reset_size_to_latest_client(&self) {
         if !self.exists() {
             return;

--- a/src/tmux/status_bar.rs
+++ b/src/tmux/status_bar.rs
@@ -77,6 +77,24 @@ pub fn apply_status_bar(
     )?;
     set_session_option(session_name, "status-left-length", "50")?;
 
+    // With shared sessions the window list is the tab strip, so it has to match
+    // the themed bar; tmux's default `#I:#W#{?window_flags,...}` renders raw
+    // index-and-flag noise against aoe's colors. Left untouched when the flag is
+    // off, where there is only ever one window and no tabs to style.
+    if crate::tmux::use_shared_tmux_session() {
+        set_session_option(session_name, "window-status-separator", " ")?;
+        set_session_option(
+            session_name,
+            "window-status-format",
+            &format!(" #[fg={hint}]#W "),
+        )?;
+        set_session_option(
+            session_name,
+            "window-status-current-format",
+            &format!(" #[fg={accent},bold]#W#[fg={fg},nobold] "),
+        )?;
+    }
+
     Ok(())
 }
 
@@ -124,9 +142,20 @@ pub fn apply_all_tmux_options(
     title: &str,
     branch: Option<&str>,
     sandbox: Option<&SandboxDisplay>,
+    window_name: Option<&str>,
 ) {
     use crate::session::config::{should_apply_tmux_mouse, should_apply_tmux_status_bar};
     use crate::tui::styles::load_theme;
+
+    // Naming is only meaningful once surfaces share a session and the tab list
+    // is visible, so it rides the same experimental flag. Deliberately outside
+    // the status-bar preference below: the window name is tmux state, not aoe
+    // chrome, so a user running their own status config still gets real labels.
+    if crate::tmux::use_shared_tmux_session() {
+        if let Some(name) = window_name {
+            crate::tmux::set_window_name(session_name, name);
+        }
+    }
 
     if should_apply_tmux_status_bar() {
         // Theme is a global preference; match the TUI's empty-name fallback
@@ -153,6 +182,9 @@ pub fn apply_all_tmux_options(
             "status-right",
             "status-right-length",
             "status-style",
+            "window-status-separator",
+            "window-status-format",
+            "window-status-current-format",
         ] {
             let _ = set_session_option_unset(session_name, option);
         }

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -218,6 +218,14 @@ impl PairedTerminal {
             process::kill_process_tree(pane_pid);
         }
 
+        // Kill the window before the session. `kill-session` alone would leave a
+        // window that is linked into the paired agent session alive there, as a
+        // stranded dead-pane tab, and the next terminal start would then append a
+        // second tab beside it. Killing the window drops the tab from every
+        // session holding it; tmux destroys a session left with no windows, so
+        // this subsumes the session kill in the common single-window case and the
+        // call below only matters if the user split off extra windows.
+        super::utils::kill_first_window(&self.name);
         super::utils::kill_session_if_present(&self.name)?;
 
         refresh_session_cache();
@@ -259,6 +267,24 @@ impl PairedTerminal {
         }
 
         Ok(())
+    }
+
+    /// Attach so this terminal is visible as a tab of `host_session` (the paired
+    /// agent session) rather than on its own. Selects the linked window there,
+    /// then hands off to the agent session's own attach, which is what makes the
+    /// tab strip visible at all.
+    ///
+    /// Falls back to [`Self::attach`] whenever the window is not actually linked
+    /// into the host, so a failed or skipped `link-window` still yields a usable
+    /// terminal instead of an error.
+    fn attach_via_host(&self, host_session: &str) -> Result<()> {
+        if !self.exists() {
+            bail!("{} does not exist: {}", self.kind.label(), self.name);
+        }
+        if !crate::tmux::select_linked_window(host_session, &self.name) {
+            return self.attach();
+        }
+        super::Session::from_name(host_session).attach()
     }
 
     fn capture_window_composited(&self, lines: usize) -> Result<String> {
@@ -343,6 +369,10 @@ impl TerminalSession {
         self.inner.attach()
     }
 
+    pub fn attach_via_host(&self, host_session: &str) -> Result<()> {
+        self.inner.attach_via_host(host_session)
+    }
+
     /// Preview capture with the window's other panes composited in; see
     /// [`super::Session::capture_window_composited`].
     pub fn capture_window_composited(&self, lines: usize) -> Result<String> {
@@ -422,6 +452,10 @@ impl ContainerTerminalSession {
         self.inner.attach()
     }
 
+    pub fn attach_via_host(&self, host_session: &str) -> Result<()> {
+        self.inner.attach_via_host(host_session)
+    }
+
     /// Preview capture with the window's other panes composited in; see
     /// [`super::Session::capture_window_composited`].
     pub fn capture_window_composited(&self, lines: usize) -> Result<String> {
@@ -435,41 +469,54 @@ impl ContainerTerminalSession {
 /// web tabs (`_t{N}` suffixes) and any title-change orphans are all reaped on
 /// session teardown. Mirrors [`crate::tmux::kill_all_tool_sessions_for_id`].
 pub fn kill_all_terminals_for_id(id: &str) {
-    let needle = format!("_{}", truncate_id(id, 8));
-
-    let output = crate::tmux::tmux_command()
-        .args(["list-sessions", "-F", "#{session_name}"])
-        .output();
-
-    if let Ok(out) = output {
-        if out.status.success() {
-            let stdout = String::from_utf8_lossy(&out.stdout);
-            for line in stdout.lines() {
-                if !line.starts_with(TERMINAL_PREFIX)
-                    && !line.starts_with(CONTAINER_TERMINAL_PREFIX)
-                {
-                    continue;
-                }
-                // The id segment is at the end for index 0, or immediately
-                // before the `_t{N}` suffix for additional terminals.
-                let Some(pos) = line.rfind(&needle) else {
-                    continue;
-                };
-                let after = &line[pos + needle.len()..];
-                if !after.is_empty() && !after.starts_with("_t") {
-                    continue;
-                }
-                if let Some(pid) = process::get_pane_pid(line) {
-                    process::kill_process_tree(pid);
-                }
-                let _ = crate::tmux::tmux_command()
-                    .args(["kill-session", "-t", line])
-                    .output();
-            }
+    for name in paired_terminal_sessions_for_id(id) {
+        if let Some(pid) = process::get_pane_pid(&name) {
+            process::kill_process_tree(pid);
         }
+        // Window before session, for the same reason as `PairedTerminal::kill`:
+        // a window linked into the agent session outlives `kill-session`.
+        crate::tmux::kill_first_window(&name);
+        let _ = crate::tmux::tmux_command()
+            .args(["kill-session", "-t", &name])
+            .output();
     }
 
     refresh_session_cache();
+}
+
+/// Live paired terminal tmux session names (host and container, any index)
+/// belonging to `id`, discovered by scanning tmux rather than from persisted
+/// state: only index 0 is cached on the `Instance`, so the multi-terminal web
+/// tabs (`_t{N}`) and any title-change orphans are otherwise invisible.
+pub fn paired_terminal_sessions_for_id(id: &str) -> Vec<String> {
+    let needle = format!("_{}", truncate_id(id, 8));
+
+    let Ok(out) = crate::tmux::tmux_command()
+        .args(["list-sessions", "-F", "#{session_name}"])
+        .output()
+    else {
+        return Vec::new();
+    };
+    if !out.status.success() {
+        return Vec::new();
+    }
+
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|line| {
+            if !line.starts_with(TERMINAL_PREFIX) && !line.starts_with(CONTAINER_TERMINAL_PREFIX) {
+                return false;
+            }
+            // The id segment is at the end for index 0, or immediately
+            // before the `_t{N}` suffix for additional terminals.
+            let Some(pos) = line.rfind(&needle) else {
+                return false;
+            };
+            let after = &line[pos + needle.len()..];
+            after.is_empty() || after.starts_with("_t")
+        })
+        .map(str::to_string)
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -200,6 +200,184 @@ pub fn append_clipboard_passthrough_args(args: &mut Vec<String>, target: &str) {
     ]);
 }
 
+/// Pin the first window's name to `window_name` so the tab reads e.g.
+/// `agent (claude)` or `terminal` instead of tmux's default.
+///
+/// tmux's default `automatic-rename on` names a window after
+/// `#{pane_current_command}`, which for an agent installed at a versioned path
+/// (Claude Code lives at `.../claude/versions/2.1.220/claude`) renders as a bare
+/// version string. Both rename mechanisms are disabled explicitly:
+///   * `automatic-rename off` stops the command-name tracking.
+///   * `allow-rename off` stops the agent's own OSC 2 title escapes from
+///     overriding the name we just set.
+///
+/// Best-effort: a missing session or a tmux ENOENT is swallowed, since a tab
+/// label is cosmetic and must never fail a launch. Chained into one invocation
+/// so the window is never briefly visible under the wrong name.
+pub fn set_window_name(session_name: &str, window_name: &str) {
+    let target = format!("{session_name}:^");
+    let _ = crate::tmux::tmux_command()
+        .args([
+            "set-option",
+            "-w",
+            "-t",
+            &target,
+            "automatic-rename",
+            "off",
+            ";",
+            "set-option",
+            "-w",
+            "-t",
+            &target,
+            "allow-rename",
+            "off",
+            ";",
+            "rename-window",
+            "-t",
+            &target,
+            window_name,
+        ])
+        .output();
+}
+
+/// Make `source`'s first window appear as an additional tab in `dest`, without
+/// moving it: tmux linked windows belong to both sessions at once, so
+/// `source:^.0` keeps resolving to the same pane and every existing target
+/// string in aoe stays valid.
+///
+/// `-a` appends after the highest index rather than colliding with an existing
+/// one. Returns false when the link could not be made (either session missing,
+/// tmux unavailable), so the caller can fall back to the separate-session flow.
+///
+/// Already-linked windows are detected up front and reported as success: tmux is
+/// happy to link one window into the same session twice, at two indices, which
+/// would show the user duplicate tabs onto the same pane.
+pub fn link_window_into(source: &str, dest: &str) -> bool {
+    let Some(window_id) = first_window_id(source) else {
+        tracing::debug!(target: "tmux.window",
+            source = %source, dest = %dest, "link-window skipped: source window not found");
+        return false;
+    };
+    if window_index_in(dest, &window_id).is_some() {
+        return true;
+    }
+
+    let src_target = format!("{source}:^");
+    let dest_target = format!("{dest}:");
+    match crate::tmux::tmux_command()
+        .args(["link-window", "-a", "-s", &src_target, "-t", &dest_target])
+        .output()
+    {
+        Ok(out) if out.status.success() => true,
+        Ok(out) => {
+            tracing::debug!(target: "tmux.window",
+                source = %source, dest = %dest,
+                "link-window failed: {}", String::from_utf8_lossy(&out.stderr).trim());
+            false
+        }
+        Err(e) => {
+            tracing::debug!(target: "tmux.window",
+                source = %source, dest = %dest, "link-window spawn failed: {}", e);
+            false
+        }
+    }
+}
+
+/// Make `session_name`'s own first window current, undoing a previous
+/// [`select_linked_window`].
+///
+/// A tmux session remembers its current window, and `attach-session` resumes
+/// there. Selecting a paired terminal's tab therefore persists: without this, a
+/// later agent attach would land on the terminal tab instead of the agent.
+///
+/// `^` is the lowest-numbered window, which is the surface's own: the session is
+/// created with it, and `link_window_into` appends paired terminals after it.
+/// Best-effort; a missing session is not an error.
+pub fn select_first_window(session_name: &str) {
+    let _ = crate::tmux::tmux_command()
+        .args(["select-window", "-t", &format!("{session_name}:^")])
+        .output();
+}
+
+/// Destroy `session_name`'s first window, removing it from *every* session that
+/// holds it.
+///
+/// This is the teardown counterpart of [`link_window_into`] and the reason a
+/// paired terminal cannot be torn down with `kill-session` alone: a linked window
+/// survives its originating session's death for as long as another session holds
+/// it, so killing the terminal's session leaves a dead-pane tab stranded in the
+/// agent's session. Killing the window removes the tab everywhere, and tmux then
+/// destroys any session left with no windows.
+///
+/// Best-effort; a missing session or window is not an error.
+pub fn kill_first_window(session_name: &str) {
+    let _ = crate::tmux::tmux_command()
+        .args(["kill-window", "-t", &format!("{session_name}:^")])
+        .output();
+}
+
+/// Make the window `source` owns current in `host`, so attaching `host` lands
+/// on that tab. Returns false when the window is not linked into `host` (or
+/// tmux is unreachable), letting the caller fall back to attaching `source`
+/// directly.
+///
+/// The window is addressed by its tmux window id (`@N`, stable across
+/// index renumbering) but selected by its index *within `host`*: a linked window
+/// belongs to several sessions, so `select-window -t @N` alone leaves it
+/// ambiguous which session's current window moves.
+pub fn select_linked_window(host: &str, source: &str) -> bool {
+    let Some(window_id) = first_window_id(source) else {
+        return false;
+    };
+    let Some(index) = window_index_in(host, &window_id) else {
+        return false;
+    };
+    crate::tmux::tmux_command()
+        .args(["select-window", "-t", &format!("{host}:{index}")])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// tmux window id (`@N`) of `session_name`'s first window.
+fn first_window_id(session_name: &str) -> Option<String> {
+    crate::tmux::tmux_command()
+        .args([
+            "display-message",
+            "-t",
+            &format!("{session_name}:^"),
+            "-p",
+            "#{window_id}",
+        ])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Index of the window with `window_id` as seen from `host`, or `None` when that
+/// window is not one of `host`'s.
+fn window_index_in(host: &str, window_id: &str) -> Option<String> {
+    let output = crate::tmux::tmux_command()
+        .args([
+            "list-windows",
+            "-t",
+            host,
+            "-F",
+            "#{window_index} #{window_id}",
+        ])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    stdout.lines().find_map(|line| {
+        let (index, id) = line.trim().split_once(' ')?;
+        (id == window_id).then(|| index.to_string())
+    })
+}
+
 pub fn is_pane_dead(session_name: &str) -> bool {
     // Use `^.0` to target the first window's first pane regardless of
     // base-index or which pane is active, so the check always hits the
@@ -313,12 +491,374 @@ fn format_tmux_prefix(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tmux::test_helpers::TmuxTestSession;
 
     #[test]
     fn test_sanitize_session_name() {
         assert_eq!(sanitize_session_name("my-project"), "my-project");
         assert_eq!(sanitize_session_name("my project"), "my_project");
         assert_eq!(sanitize_session_name("a".repeat(30).as_str()).len(), 20);
+    }
+
+    fn tmux_available_for_window_tests() -> bool {
+        crate::tmux::tmux_command()
+            .arg("-V")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn spawn_probe_session(name: &str) {
+        let output = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                name,
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sleep 30",
+            ])
+            .output()
+            .expect("tmux new-session");
+        assert!(output.status.success(), "failed to create {name}");
+    }
+
+    fn window_names_in(session: &str) -> Vec<String> {
+        let out = crate::tmux::tmux_command()
+            .args(["list-windows", "-t", session, "-F", "#{window_name}"])
+            .output()
+            .expect("tmux list-windows");
+        String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .map(|l| l.trim().to_string())
+            .collect()
+    }
+
+    /// `set_window_name` must survive tmux's own renaming: with the default
+    /// `automatic-rename on` the window would be renamed back to
+    /// `#{pane_current_command}` (`sleep` here, a bare version string for a
+    /// real agent), so this locks the `automatic-rename off` half of the fix.
+    #[test]
+    #[serial_test::serial]
+    fn set_window_name_pins_the_tab_label() {
+        if !tmux_available_for_window_tests() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let guard = TmuxTestSession::new("aoe_test_winname");
+        spawn_probe_session(guard.name());
+
+        set_window_name(guard.name(), "agent (claude)");
+
+        assert_eq!(window_names_in(guard.name()), vec!["agent (claude)"]);
+
+        let automatic = crate::tmux::tmux_command()
+            .args([
+                "show-options",
+                "-w",
+                "-v",
+                "-t",
+                &format!("{}:^", guard.name()),
+                "automatic-rename",
+            ])
+            .output()
+            .expect("tmux show-options");
+        assert_eq!(
+            String::from_utf8_lossy(&automatic.stdout).trim(),
+            "off",
+            "automatic-rename must be off or tmux renames the tab back"
+        );
+    }
+
+    /// The core of the shared-session model: after `link_window_into` the
+    /// terminal's window is a second tab of the agent session, while the
+    /// terminal session still exists and still resolves its own `:^.0` pane
+    /// target. That last assertion is what keeps the change additive.
+    #[test]
+    #[serial_test::serial]
+    fn link_window_into_adds_a_tab_without_moving_the_window() {
+        if !tmux_available_for_window_tests() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let agent = TmuxTestSession::new("aoe_test_link_agent");
+        let term = TmuxTestSession::new("aoe_test_link_term");
+        spawn_probe_session(agent.name());
+        spawn_probe_session(term.name());
+        set_window_name(agent.name(), "agent (claude)");
+        set_window_name(term.name(), "terminal");
+
+        assert!(link_window_into(term.name(), agent.name()));
+
+        assert_eq!(
+            window_names_in(agent.name()),
+            vec!["agent (claude)", "terminal"],
+            "the agent session should now show both tabs, agent first"
+        );
+        assert_eq!(
+            window_names_in(term.name()),
+            vec!["terminal"],
+            "the terminal session must still own its window"
+        );
+
+        let pane = crate::tmux::tmux_command()
+            .args([
+                "display-message",
+                "-t",
+                &format!("{}:^.0", term.name()),
+                "-p",
+                "#{pane_dead}",
+            ])
+            .output()
+            .expect("tmux display-message");
+        assert!(
+            pane.status.success(),
+            "`<terminal>:^.0` must keep resolving after linking, or every \
+             existing pane target in aoe breaks"
+        );
+    }
+
+    /// `kill-session` is not enough to tear down a linked terminal: tmux keeps the
+    /// window alive for as long as another session holds it, stranding a dead-pane
+    /// tab in the agent session that the next terminal start then doubles up on.
+    /// This pins the semantics that force `kill_first_window` to exist.
+    #[test]
+    #[serial_test::serial]
+    fn kill_session_alone_strands_a_linked_window() {
+        if !tmux_available_for_window_tests() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let agent = TmuxTestSession::new("aoe_test_strand_agent");
+        let term = TmuxTestSession::new("aoe_test_strand_term");
+        spawn_probe_session(agent.name());
+        spawn_probe_session(term.name());
+        set_window_name(term.name(), "terminal");
+        assert!(link_window_into(term.name(), agent.name()));
+
+        kill_session_if_present(term.name()).expect("kill terminal session");
+
+        assert!(
+            window_names_in(agent.name()).contains(&"terminal".to_string()),
+            "documents the tmux behavior the teardown fix works around"
+        );
+    }
+
+    /// The bug-2 fix: killing the window drops the tab from the agent session too,
+    /// so exiting and restarting a terminal cannot accumulate stale tabs.
+    #[test]
+    #[serial_test::serial]
+    fn kill_first_window_removes_the_tab_from_the_host() {
+        if !tmux_available_for_window_tests() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let agent = TmuxTestSession::new("aoe_test_killwin_agent");
+        let term = TmuxTestSession::new("aoe_test_killwin_term");
+        spawn_probe_session(agent.name());
+        spawn_probe_session(term.name());
+        set_window_name(agent.name(), "agent (claude)");
+        set_window_name(term.name(), "terminal");
+        assert!(link_window_into(term.name(), agent.name()));
+
+        kill_first_window(term.name());
+
+        assert_eq!(
+            window_names_in(agent.name()),
+            vec!["agent (claude)"],
+            "the terminal tab must be gone from the agent session"
+        );
+        assert!(
+            !crate::tmux::session_exists(term.name()),
+            "tmux should destroy the terminal session once its last window dies"
+        );
+    }
+
+    /// Re-linking an already-linked window is treated as success, so a repeated
+    /// terminal start (or a respawn after a dead pane) is idempotent rather than
+    /// logging a spurious failure.
+    #[test]
+    #[serial_test::serial]
+    fn link_window_into_is_idempotent() {
+        if !tmux_available_for_window_tests() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let agent = TmuxTestSession::new("aoe_test_relink_agent");
+        let term = TmuxTestSession::new("aoe_test_relink_term");
+        spawn_probe_session(agent.name());
+        spawn_probe_session(term.name());
+
+        assert!(link_window_into(term.name(), agent.name()));
+        assert!(link_window_into(term.name(), agent.name()));
+        assert_eq!(
+            window_names_in(agent.name()).len(),
+            2,
+            "re-linking must not append a duplicate tab"
+        );
+    }
+
+    /// The bug-1 shape: a restart kills and recreates the agent session, which
+    /// drops its window list while the terminal's own session survives. Re-linking
+    /// must restore the tab, with the terminal's pane (and scrollback) intact,
+    /// rather than the terminal appearing destroyed.
+    #[test]
+    #[serial_test::serial]
+    fn relinking_restores_the_tab_after_the_agent_session_is_recreated() {
+        if !tmux_available_for_window_tests() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let agent = TmuxTestSession::new("aoe_test_restart_agent");
+        let term = TmuxTestSession::new("aoe_test_restart_term");
+        spawn_probe_session(agent.name());
+        spawn_probe_session(term.name());
+        set_window_name(term.name(), "terminal");
+        assert!(link_window_into(term.name(), agent.name()));
+        let pane_pid_before = crate::process::get_pane_pid(term.name());
+        assert!(pane_pid_before.is_some());
+
+        // What `Instance::kill_clean` does on restart: kill only the agent session.
+        kill_session_if_present(agent.name()).expect("kill agent session");
+        assert!(
+            crate::tmux::session_exists(term.name()),
+            "the terminal session must outlive an agent restart"
+        );
+        spawn_probe_session(agent.name());
+        set_window_name(agent.name(), "agent (claude)");
+        assert_eq!(
+            window_names_in(agent.name()),
+            vec!["agent (claude)"],
+            "the recreated agent session starts with no terminal tabs"
+        );
+
+        assert!(link_window_into(term.name(), agent.name()));
+
+        assert_eq!(
+            window_names_in(agent.name()),
+            vec!["agent (claude)", "terminal"],
+            "the terminal tab should be back, after the agent tab"
+        );
+        assert_eq!(
+            crate::process::get_pane_pid(term.name()),
+            pane_pid_before,
+            "re-linking must reuse the surviving pane, not respawn it"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn link_window_into_fails_for_missing_session() {
+        if !tmux_available_for_window_tests() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let term = TmuxTestSession::new("aoe_test_link_orphan");
+        spawn_probe_session(term.name());
+        assert!(
+            !link_window_into(term.name(), "aoe_test_link_no_such_session"),
+            "linking into a missing session must report failure so the caller \
+             falls back to the standalone attach"
+        );
+    }
+
+    /// `select_linked_window` makes the linked tab current in the *host*, which
+    /// is what lets the attach land on the terminal tab.
+    #[test]
+    #[serial_test::serial]
+    fn select_linked_window_makes_the_tab_current_in_the_host() {
+        if !tmux_available_for_window_tests() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let agent = TmuxTestSession::new("aoe_test_sel_agent");
+        let term = TmuxTestSession::new("aoe_test_sel_term");
+        spawn_probe_session(agent.name());
+        spawn_probe_session(term.name());
+        set_window_name(agent.name(), "agent (claude)");
+        set_window_name(term.name(), "terminal");
+        assert!(link_window_into(term.name(), agent.name()));
+
+        assert!(select_linked_window(agent.name(), term.name()));
+
+        let current = crate::tmux::tmux_command()
+            .args([
+                "display-message",
+                "-t",
+                agent.name(),
+                "-p",
+                "#{window_name}",
+            ])
+            .output()
+            .expect("tmux display-message");
+        assert_eq!(
+            String::from_utf8_lossy(&current.stdout).trim(),
+            "terminal",
+            "the host session's current window should be the linked terminal"
+        );
+    }
+
+    /// tmux persists a session's current window, and `attach-session` resumes
+    /// there, so selecting a terminal tab leaks into the *next* agent attach:
+    /// pressing Enter on the agent would land on the terminal. `select_first_window`
+    /// is what brings focus back to the agent's own tab.
+    #[test]
+    #[serial_test::serial]
+    fn selecting_a_terminal_tab_persists_until_the_first_window_is_reselected() {
+        if !tmux_available_for_window_tests() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let agent = TmuxTestSession::new("aoe_test_focus_agent");
+        let term = TmuxTestSession::new("aoe_test_focus_term");
+        spawn_probe_session(agent.name());
+        spawn_probe_session(term.name());
+        set_window_name(agent.name(), "agent (claude)");
+        set_window_name(term.name(), "terminal");
+        assert!(link_window_into(term.name(), agent.name()));
+
+        let current = |session: &str| -> String {
+            let out = crate::tmux::tmux_command()
+                .args(["display-message", "-t", session, "-p", "#{window_name}"])
+                .output()
+                .expect("tmux display-message");
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        };
+
+        assert!(select_linked_window(agent.name(), term.name()));
+        assert_eq!(
+            current(agent.name()),
+            "terminal",
+            "documents the sticky current-window behavior behind the bug"
+        );
+
+        select_first_window(agent.name());
+
+        assert_eq!(
+            current(agent.name()),
+            "agent (claude)",
+            "an agent attach must resume on the agent tab, not the terminal"
+        );
+    }
+
+    /// An unlinked terminal must report false rather than silently selecting
+    /// something else, so `attach_via_host` falls back to its own session.
+    #[test]
+    #[serial_test::serial]
+    fn select_linked_window_false_when_not_linked() {
+        if !tmux_available_for_window_tests() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let agent = TmuxTestSession::new("aoe_test_nolink_agent");
+        let term = TmuxTestSession::new("aoe_test_nolink_term");
+        spawn_probe_session(agent.name());
+        spawn_probe_session(term.name());
+
+        assert!(!select_linked_window(agent.name(), term.name()));
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3712,6 +3712,9 @@ impl App {
         // preview geometry against the now-grown window instead of leaving the
         // top clipped.
         tmux_session.reset_size_to_latest_client();
+        // Attaching a paired terminal leaves its tab as this session's current
+        // window; an agent attach must come back to the agent's own tab.
+        tmux_session.focus_own_window();
         self.home.clear_preview_pane_sync();
         let (attach_result, attached_status_updates) =
             self.with_attached_status_hooks(terminal, || tmux_session.attach())?;
@@ -3765,6 +3768,21 @@ impl App {
         // Get terminal size to pass to tmux session creation
         let size = crate::terminal::get_size();
 
+        // Under `AOE_USE_SHARED_TMUX_SESSION` the paired terminal's window is
+        // linked into the agent's session, so attach there and select the tab:
+        // attaching the terminal's own session would show a single window and no
+        // tab strip, defeating the point. `None` (no agent tmux session, e.g. a
+        // structured/ACP session) keeps the standalone attach.
+        let host_session = if crate::tmux::use_shared_tmux_session() {
+            instance
+                .tmux_session()
+                .ok()
+                .filter(|s| s.exists())
+                .map(|s| s.name().to_string())
+        } else {
+            None
+        };
+
         // Prepare the tmux session before leaving TUI mode
         let attach_fn: Box<dyn FnOnce() -> Result<()>> = match mode {
             TerminalMode::Container if instance.is_sandboxed() => {
@@ -3782,7 +3800,10 @@ impl App {
                         return Ok(());
                     }
                 }
-                Box::new(move || container_session.attach())
+                match host_session {
+                    Some(host) => Box::new(move || container_session.attach_via_host(&host)),
+                    None => Box::new(move || container_session.attach()),
+                }
             }
             _ => {
                 let terminal_session = instance.terminal_tmux_session()?;
@@ -3799,7 +3820,10 @@ impl App {
                         return Ok(());
                     }
                 }
-                Box::new(move || terminal_session.attach())
+                match host_session {
+                    Some(host) => Box::new(move || terminal_session.attach_via_host(&host)),
+                    None => Box::new(move || terminal_session.attach()),
+                }
             }
         };
 
@@ -3884,6 +3908,7 @@ impl App {
             &format!("{} ({})", instance.title, tool_name),
             branch,
             None,
+            Some(tool_name),
         );
 
         let attach_fn: Box<dyn FnOnce() -> Result<()>> = Box::new(move || tool_session.attach());


### PR DESCRIPTION
Refs #3144 — motivation, tradeoffs, and breaking changes are written up there.

## Description

Experiment behind `AOE_USE_SHARED_TMUX_SESSION`: render an agent and its paired terminals as **tabs of one attached session** instead of separate tmux sessions you switch between, and give every window a real name.

Draft — the flag is deliberate. If we like it, it graduates to a real setting via the single-source settings schema.

### Two problems

1. Attaching a terminal `switch-client`s to a wholly separate session (`aoe_term_*`), so there's no tab strip and no visual relationship to the agent.
2. The tab reads as a bare version string like `2.1.220`. aoe never set a window name — repo-wide grep for `rename-window` / `automatic-rename` / `allow-rename` / `set-titles` / `window-status-*` returned zero production hits — so tmux's default `automatic-rename on` named the window `#{pane_current_command}`. Claude Code installs at `.../claude/versions/2.1.220/claude`, so the executable's **basename is the version**.

### Approach: `link-window`, not a session→window migration

The obvious implementation (make the terminal a window of the agent's session) is expensive: `^` means *first window*, and `format!("{}:^.0", name)` is hardcoded at 16 call sites for every capture, send-keys, respawn, resize, pane-pid and pane-dead check. The session-scoped `@aoe_size_owner` / `@aoe_vt_owner` cross-process locks would collide, and `kill-session` would become `kill-window` with "last window destroys the session" semantics.

Instead **each surface keeps its own tmux session**, and the terminal's window is additionally `link-window`'d into the agent's session. tmux linked windows belong to both sessions at once, so `<terminal>:^.0` keeps resolving:

```
aoe_Smoke_96439cdd      win 0  id=@0  agent (claude)
aoe_Smoke_96439cdd      win 1  id=@2  terminal
aoe_term_Smoke_96439cdd win 0  id=@2  terminal      <- same window id
```

Nothing about pane targeting, the locks, or teardown had to change. There's a test asserting `<terminal>:^.0` still resolves after linking, since that's the property the whole approach rests on.

Attach is redirected: `attach_via_host` selects the linked window in the agent session then hands off to the agent's existing `attach()`, because attaching the terminal's own session would show one window and no tab strip. It falls back to the standalone attach whenever the window isn't actually linked.

### Naming

`automatic-rename off` + `allow-rename off` (ignoring the agent's OSC 2 title escapes entirely) + explicit `rename-window`. Tabs read `agent (claude)` / `agent (pi)` from `instance.tool`, `terminal`, `container`, or the tool name; the web dashboard's extra terminals number from 2 (`terminal 2`) to match its existing labels. `window-status-format` is styled to the theme, since tmux's default `0:name-` clashes with aoe's bar.

### Three lifecycle traps from dual window ownership

Found by testing, each fixed with a test that first asserts the underlying tmux behavior so the reason the code exists is recorded rather than implied:

- **`kill-session` does not destroy a linked window.** It survives in the agent session as a stranded dead-pane tab, and the next terminal start appends a second one beside it. Teardown now kills the window first (`kill_first_window`), which drops the tab from every session holding it; tmux then destroys any session left with no windows.
- **A restart drops the tabs while the terminals live on.** `kill_clean` kills only the agent session, so the terminals' sessions and scrollback survive, but the recreated agent session has an empty window list. `finalize_launch` now re-links them (idempotent, so it runs on every launch).
- **Selecting a terminal tab leaked into the next agent attach.** tmux persists a session's current window and `attach-session` resumes there, so pressing Enter on the agent landed on the terminal. Agent attach sites now call `focus_own_window()` first. Deliberately *not* inside `Session::attach()` — the terminal attach routes through it right after selecting the terminal tab on purpose, and folding it in would break that instead.

### Flag off

Unchanged: separate sessions, one window each, tmux default names, `window-status-*` untouched. Verified on the same binary.

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary <!-- intentionally none: undocumented experimental env flag; docs land if it graduates to a setting -->
- [x] For UI changes: included screenshot or recording <!-- terminal output above; the visible change is the tmux tab strip -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The web reaches all of this through `Instance` (`server/pane.rs:101`/`:162`, `api/sessions.rs:5459`/`:5561`), so it inherits the behavior with no dashboard-flow change of its own.

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: **flagged experiment, and I want reviewer input on the approach before investing in the harness work.** 12 new tests cover the tmux mechanics against a live server, and all three bugs plus the flag-off path were verified end-to-end by driving the real binary through tmux (transcripts in the commit discussion). If this graduates past the flag, the e2e belongs on the `aoe serve` ensure-terminal endpoint, which exercises the same `Instance` path without the attach hijacking the test's tmux client. Happy to add it in this PR if preferred.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 5)

**Any Additional AI Details you'd like to share:**

Explored the tmux session model, proposed the `link-window` approach over a session→window migration, implemented, and found/fixed the three lifecycle bugs. One test (`link_window_into_is_idempotent`) caught a real bug during development: tmux happily links the same window twice at two indices, producing duplicate tabs onto one pane — fixed in the code rather than by relaxing the test.

- [x] I am an AI Agent filling out this form (check box if true)