### PR TITLE
fix(tui): stop the live-send lock retry from stealing back after a takeover

### DIFF
--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -487,9 +487,12 @@ impl LiveSendWorker {
                 LIVE_SEND_WORKER_COUNTER.fetch_add(1, Ordering::Relaxed)
             );
             let session = crate::tmux::Session::from_name(&tmux_name);
-            // False only when the tmux session is missing/broken at entry
-            // (the steal is unconditional otherwise); retried on the next
-            // resize batch so a slow-to-appear pane still gets owned.
+            // Entering live mode is explicit user intent, so entry forces the
+            // lock even over a live holder. False means either the tmux
+            // session is missing/broken at entry or another surface won the
+            // confirm-read race; the retry on the next resize batch tells
+            // those apart (a slow-to-appear pane still gets owned, a real
+            // takeover is flagged instead of fought).
             let mut owned = session.steal_size_owner(&owner_id);
             // Refresh-or-flag: bump our heartbeat iff we still hold the
             // lock; a failed refresh means another surface took over, which
@@ -532,10 +535,21 @@ impl LiveSendWorker {
                         // plain keystrokes never read the lock.
                         if batch_needs_owner_first(&batch) {
                             if !owned {
-                                // Entry steal failed (session missing at
-                                // spawn); live entry is user intent, so keep
-                                // trying to take the size until it works.
-                                owned = session.steal_size_owner(&owner_id);
+                                // Entry steal failed. Claim rather than steal:
+                                // a vacant, stale, or already-ours lock still
+                                // gets taken (the slow-to-appear pane case),
+                                // but a live holder means another surface won
+                                // the lock and must not be stomped. Re-forcing
+                                // here would fight a takeover the entry race
+                                // makes indistinguishable from a missing pane,
+                                // and would never flag the loss.
+                                owned = session
+                                    .claim_size_owner(&owner_id, crate::tmux::SIZE_OWNER_TTL);
+                                if !owned && session.has_active_size_owner() {
+                                    // Our own claim would have succeeded if the
+                                    // live owner were us, so this is a takeover.
+                                    thread_lock_lost.store(true, Ordering::Relaxed);
+                                }
                             } else {
                                 maintain(owned);
                             }
@@ -2922,5 +2936,108 @@ mod tests {
             || pane_width(guard.name()) == 60,
         );
         assert!(!worker.lock_lost());
+    }
+
+    /// The entry steal can come up empty two ways: the pane has not appeared
+    /// yet, or another surface won the confirm-read race. The retry path used
+    /// to force-steal for both, which silently stomped a live owner and never
+    /// flagged the loss. Spawning before the session exists reproduces the
+    /// `owned == false` entry deterministically, without racing tmux forks.
+    #[test]
+    #[serial_test::serial]
+    fn worker_defers_to_live_owner_when_entry_steal_found_no_session() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let guard = crate::tmux::test_helpers::TmuxTestSession::new("aoe_test_livelock_late");
+        // Spawn against a name that does not exist yet: the entry steal sees
+        // no session and leaves the worker unowned.
+        let worker = LiveSendWorker::spawn(guard.name().to_string(), None);
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        let out = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                guard.name(),
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sleep 30",
+            ])
+            .output()
+            .expect("tmux new-session");
+        assert!(out.status.success());
+        crate::tmux::refresh_session_cache();
+        let session = crate::tmux::Session::from_name(guard.name());
+
+        // Another surface owns the pane before the worker ever retries.
+        assert!(session.steal_size_owner("live-test-thief"));
+        assert!(!worker.lock_lost());
+
+        // The retry must claim, not steal: a live holder is a takeover, so the
+        // loss is flagged and the resize dropped.
+        worker.resize(60, 20);
+        wait_until("lock_lost flag", std::time::Duration::from_secs(5), || {
+            worker.lock_lost()
+        });
+        assert_eq!(
+            session.size_owner().map(|(id, _)| id),
+            Some("live-test-thief".to_string()),
+            "unowned retry must not steal from a live owner"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        assert_eq!(
+            pane_width(guard.name()),
+            80,
+            "dropped resize must not dispatch"
+        );
+    }
+
+    /// The same retry path must still take a vacant lock, so a genuinely
+    /// slow-to-appear pane gets owned instead of being abandoned.
+    #[test]
+    #[serial_test::serial]
+    fn worker_claims_vacant_lock_when_session_appears_late() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let guard = crate::tmux::test_helpers::TmuxTestSession::new("aoe_test_livelock_vacant");
+        let worker = LiveSendWorker::spawn(guard.name().to_string(), None);
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        let out = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                guard.name(),
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sleep 30",
+            ])
+            .output()
+            .expect("tmux new-session");
+        assert!(out.status.success());
+        crate::tmux::refresh_session_cache();
+        let session = crate::tmux::Session::from_name(guard.name());
+
+        worker.resize(60, 20);
+        wait_until(
+            "late resize dispatch",
+            std::time::Duration::from_secs(5),
+            || pane_width(guard.name()) == 60,
+        );
+        assert!(!worker.lock_lost());
+        assert!(
+            matches!(session.size_owner(), Some((id, _)) if id.starts_with("tui-")),
+            "vacant lock must still be claimed on the retry path"
+        );
     }
 }


### PR DESCRIPTION
## Description

`tui::home::live_send::tests::worker_flags_lock_loss_and_drops_resize_after_external_steal` has been failing intermittently on the macOS leg, on `main` (e.g. `42fa8a27`) as well as on open PRs, with:

```
timed out waiting for lock_lost flag
```

It is not a test-only flake; it exposes a real hole in the size-owner lock retry.

`LiveSendWorker::spawn`'s entry `steal_size_owner` returns `false` for two unrelated reasons:

1. the tmux session is missing or broken at spawn (the slow-to-appear pane case), or
2. another surface won the confirm-read race.

Both collapsed into a single `owned == false`, and the retry on the next resize batch force-stole the lock for either one:

```rust
if !owned {
    owned = session.steal_size_owner(&owner_id);  // unconditional force
} else {
    maintain(owned);                              // the only path that sets lock_lost
}
```

So a genuine takeover had its grid stomped and `lock_lost` was never set. The UI loop polls `lock_lost` to leave live mode, so the TUI stayed in live mode indefinitely instead of showing "Live send ended". That contradicts the invariant the surrounding code documents 40 lines earlier: a failed refresh "is flagged once and never fought".

Why it shows up on macOS: every lock read and write is a separate `tmux` fork, and this file's own comment puts those at 3-13ms each on macOS. That makes the window between the entry steal's owner write and its confirm-read wide enough for a web takeover to land inside it, which flips `owned` to `false` and sends the worker down the force-steal path.

The retry now claims instead of steals. A vacant, stale, or already-ours lock is still taken, so a slow-to-appear pane gets owned exactly as before; a live holder is treated as the takeover it is and flagged once. `has_active_size_owner()` distinguishes the two: our own claim would have succeeded if the live owner were us, so a refused claim plus a live owner means someone else holds it.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No screenshot: the change is in worker lock bookkeeping, with no visual surface of its own. The user-visible effect is that live mode now exits on a web takeover in the raced case, which is the behavior the existing tests already assert.

Verification:

- `cargo test --lib tmux::` clean (303 passed).
- `cargo fmt` clean; `cargo clippy --all-targets` adds no new warnings (the remaining ones are pre-existing in `session/groups.rs`, `tui/home/mod.rs`, `session/poller.rs`).
- The two new tests looped 10/10 clean.
- `cargo test --features serve,e2e-tests --test e2e live_takeover` passes.

Unrelated pre-existing failure seen locally, present with and without this change and passing in CI, so it looks environment-dependent rather than introduced here: `tui::home::tests::restart_selected_session_surfaces_resume_failed_after_async_restart` (`tests.rs:9332`).

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the existing e2e `live_takeover::test_web_takeover_exits_tui_live_mode_with_dialog` already covers the takeover path end to end, and it passes both before and after this change, so it does not discriminate the fix. The raced entry state this PR fixes is not reachable on demand through the TUI, so it is covered by two unit tests that force it deterministically instead:
  - `worker_defers_to_live_owner_when_entry_steal_found_no_session` spawns the worker before the tmux session exists, which makes `owned == false` without racing forks, then has another surface take the lock. It asserts the live owner keeps the lock, the loss is flagged, and the resize is dropped. On the old code this test fails with the exact CI panic, `timed out waiting for lock_lost flag`.
  - `worker_claims_vacant_lock_when_session_appears_late` guards the other direction, so the claim-not-steal change cannot regress the slow-to-appear pane case.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 via Claude Code

**Any Additional AI Details you'd like to share:**

Claude triaged the failing checks on two unrelated open PRs, traced the failure to `main` rather than to either PR, identified the root cause in the retry path, wrote the fix and the two regression tests, and verified the reproduction by reverting the production hunk and confirming the new test failed with the same panic message as CI. The diagnosis and code were reviewed by @njbrake before pushing.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed TUI live-send retries so they no longer forcibly overwrite ownership held by another surface.
- Retries can now reclaim vacant or stale locks, while confirmed takeovers stop the worker and mark the lock as lost.
- Added regression tests for both late session creation and takeover scenarios.

## Benefits

- Prevents grid data from being overwritten during lock handoffs.
- Ensures the UI exits live mode correctly after a takeover.
- Improves reliability around tmux session startup timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->