### PR TITLE
fix(status): reconcile fresh idle hook writes against the pane for Claude

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -376,6 +376,15 @@ pub struct PermissionResponse {
 /// gap (silent tool stop) has no hook, so it is recovered pane-side by
 /// `reconcile_claude_hook_status`.
 ///
+/// The `idle_prompt` backstop also introduces a write race: `Stop` and
+/// `UserPromptSubmit` hooks are awaited, but `Notification` hooks are
+/// fire-and-forget, so when a queued prompt submits the moment a turn ends,
+/// the notification's `idle` write can land after `UserPromptSubmit`'s
+/// `running`, leaving the file on `idle` while the new turn generates (no
+/// running-mapped hook fires again until its first `PreToolUse`). An `idle`
+/// read on a session last observed Running/Waiting is therefore reconciled
+/// against the pane (`reconcile_claude_idle_hook_status`).
+///
 /// The `Notification` matchers also carry the agent-view identifiers added in
 /// Claude Code 2.1.198: `agent_needs_input` (background session blocked on the
 /// user → Waiting) rides the permission group, and `agent_completed`

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -4885,16 +4885,59 @@ impl Instance {
     pub fn update_status_with_metadata(&mut self, metadata: Option<&tmux::PaneMetadata>) {
         let baseline = self.live_status_baseline;
         self.update_status_with_metadata_inner(metadata);
-        if baseline.is_some_and(|prev| prev != self.status) {
-            let now = Utc::now();
-            self.last_accessed_at = Some(now);
-            self.idle_entered_at = if self.status == Status::Idle {
-                Some(now)
-            } else {
-                None
-            };
+        if let Some(prev) = baseline {
+            if prev != self.status {
+                self.log_status_transition(prev);
+                let now = Utc::now();
+                self.last_accessed_at = Some(now);
+                self.idle_entered_at = if self.status == Status::Idle {
+                    Some(now)
+                } else {
+                    None
+                };
+            }
         }
         self.live_status_baseline = Some(self.status);
+    }
+
+    /// One `info` line per observed status transition, carrying the evidence a
+    /// wrong-state report needs: the hook file's value and age at the moment
+    /// of the flip, and (for Claude) a content-free fingerprint of which pane
+    /// markers were on screen. Intermittent status flakes can't be reproduced
+    /// on demand, so this trail must land at the default log level; the
+    /// per-rule detector traces stay at debug/trace for when a report narrows
+    /// the hunt.
+    ///
+    /// The hook file is re-read here rather than threaded out of the detection
+    /// path, so a value that changed in the microseconds since detection can
+    /// disagree with the decision; the age field makes that visible. Costs one
+    /// file stat, plus one pane capture for Claude, gated on an actual
+    /// transition, so steady-state polling pays nothing.
+    fn log_status_transition(&self, prev: Status) {
+        let detection_tool = if self.detect_as.is_empty() {
+            &self.tool
+        } else {
+            &self.detect_as
+        };
+        let hook = crate::hooks::read_hook_status(&self.id);
+        let hook_age_ms = crate::hooks::read_hook_status_age(&self.id).map(|age| age.as_millis());
+        if detection_tool == "claude" {
+            let fingerprint = self
+                .tmux_session()
+                .ok()
+                .and_then(|s| s.capture_pane(50).ok())
+                .map(|pane| tmux::claude_pane_marker_fingerprint(&pane))
+                .unwrap_or_else(|| "capture_failed".to_string());
+            tracing::info!(target: "session.status_change",
+                "'{}' [{}] {:?} -> {:?} (hook={:?} hook_age_ms={:?} pane={})",
+                self.title, detection_tool, prev, self.status, hook, hook_age_ms, fingerprint
+            );
+        } else {
+            tracing::info!(target: "session.status_change",
+                "'{}' [{}] {:?} -> {:?} (hook={:?} hook_age_ms={:?})",
+                self.title, detection_tool, prev, self.status, hook, hook_age_ms
+            );
+        }
     }
 
     fn update_status_with_metadata_inner(&mut self, metadata: Option<&tmux::PaneMetadata>) {
@@ -5068,7 +5111,7 @@ impl Instance {
                     self.last_error = Some(summarize_error_from_pane(&pane_content));
                 }
             } else {
-                // Two hook/pane mismatches need the pane captured and consulted:
+                // Three hook/pane mismatches need the pane captured and consulted:
                 //
                 // 1. Running hook, pane parked on a blocking prompt: Codex and
                 //    Claude keep re-emitting running-mapped hooks while blocked,
@@ -5083,14 +5126,28 @@ impl Instance {
                 //    fires no completing hook, so the file sticks on `waiting`
                 //    until the next turn (regression from #2937). Any such agent
                 //    is reconciled against the pane by reconcile_waiting_hook.
+                // 3. Idle hook on a session last observed Running/Waiting:
+                //    Claude's `Notification(idle_prompt)` hook is
+                //    fire-and-forget, so when a queued prompt submits at turn
+                //    end its `idle` write can land after `UserPromptSubmit`'s
+                //    `running`, showing Idle mid-turn until the first
+                //    PreToolUse rewrites the file. The previous-status gate
+                //    keeps parked sessions (the dominant steady state) from
+                //    paying a capture per poll; see
+                //    reconcile_claude_idle_hook_status.
                 let reconciles_running = (detection_tool == "codex" || detection_tool == "claude")
                     && hook_status == Status::Running;
                 let reconciles_waiting = hook_status == Status::Waiting;
-                self.status = if reconciles_running || reconciles_waiting {
+                let reconciles_idle = detection_tool == "claude"
+                    && hook_status == Status::Idle
+                    && matches!(self.status, Status::Running | Status::Waiting);
+                self.status = if reconciles_running || reconciles_waiting || reconciles_idle {
                     match session.capture_pane(50) {
                         Ok(pane_content) => {
                             if reconciles_waiting {
                                 tmux::reconcile_waiting_hook(detection_tool, &pane_content)
+                            } else if reconciles_idle {
+                                tmux::reconcile_claude_idle_hook_status(&pane_content)
                             } else if detection_tool == "codex" {
                                 tmux::reconcile_codex_hook_status(hook_status, &pane_content)
                             } else {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -4908,6 +4908,12 @@ impl Instance {
     /// per-rule detector traces stay at debug/trace for when a report narrows
     /// the hunt.
     ///
+    /// Sessions are identified by the opaque instance id, not the title:
+    /// smart-rename derives titles from the first prompt, so a title in an
+    /// always-on log would leak conversation-derived text and break the
+    /// content-free promise the pane fingerprint keeps. `aoe list` maps ids
+    /// back to titles when correlating.
+    ///
     /// The hook file is re-read here rather than threaded out of the detection
     /// path, so a value that changed in the microseconds since detection can
     /// disagree with the decision; the age field makes that visible. Costs one
@@ -4929,13 +4935,13 @@ impl Instance {
                 .map(|pane| tmux::claude_pane_marker_fingerprint(&pane))
                 .unwrap_or_else(|| "capture_failed".to_string());
             tracing::info!(target: "session.status_change",
-                "'{}' [{}] {:?} -> {:?} (hook={:?} hook_age_ms={:?} pane={})",
-                self.title, detection_tool, prev, self.status, hook, hook_age_ms, fingerprint
+                "{} [{}] {:?} -> {:?} (hook={:?} hook_age_ms={:?} pane={})",
+                self.id, detection_tool, prev, self.status, hook, hook_age_ms, fingerprint
             );
         } else {
             tracing::info!(target: "session.status_change",
-                "'{}' [{}] {:?} -> {:?} (hook={:?} hook_age_ms={:?})",
-                self.title, detection_tool, prev, self.status, hook, hook_age_ms
+                "{} [{}] {:?} -> {:?} (hook={:?} hook_age_ms={:?})",
+                self.id, detection_tool, prev, self.status, hook, hook_age_ms
             );
         }
     }

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -16,8 +16,9 @@ pub use session::{PaneCursor, Session, SIZE_OWNER_HEARTBEAT, SIZE_OWNER_TTL};
 pub use status_bar::{get_session_info_for_current, get_status_for_current_session};
 pub use status_detection::detect_status_from_content;
 pub(crate) use status_detection::{
-    claude_pane_is_ambiguous_typed_prompt, reconcile_claude_hook_status,
-    reconcile_codex_hook_status, reconcile_waiting_hook,
+    claude_pane_is_ambiguous_typed_prompt, claude_pane_marker_fingerprint,
+    reconcile_claude_hook_status, reconcile_claude_idle_hook_status, reconcile_codex_hook_status,
+    reconcile_waiting_hook,
 };
 pub use terminal_session::{kill_all_terminals_for_id, ContainerTerminalSession, TerminalSession};
 pub use tool_session::{kill_all_tool_sessions_for_id, ToolSession};

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -667,28 +667,44 @@ pub(crate) fn reconcile_waiting_hook(agent: &str, raw_content: &str) -> Status {
 /// `Idle` analogue of the stale-`waiting` race `reconcile_waiting_hook`
 /// handles.
 ///
-/// The pane is the tie-breaker, using only positive evidence: a live
-/// active-turn signal (spinner+verb line, interrupt hint, live token counter,
-/// background-agent wait) upgrades to Running, and a blocking prompt upgrades
-/// to Waiting (the same lost-write race applies to the `permission_prompt`
-/// notification). Anything else, including an empty capture, keeps the hook's
-/// `idle`. These are the same markers the hookless pane path and the Running
-/// reconciler already trust, so no new false-positive surface is added.
+/// The pane is the tie-breaker, using only line-anchored positive evidence: a
+/// live spinner+verb line (`✶ Working…`) or the background-agent wait line
+/// upgrades to Running, and a blocking prompt upgrades to Waiting (the same
+/// lost-write race applies to the `permission_prompt` notification). Anything
+/// else, including an empty capture, keeps the hook's `idle`.
+///
+/// This deliberately does NOT reuse `claude_pane_has_running_signal`, whose
+/// bare-substring interrupt-hint and token-counter checks are biased toward
+/// Running because they back a hook that already said `running`, where holding
+/// Running is the safe direction. Here the hook said `idle`, and the cost
+/// asymmetry flips: pane text merely *echoing* those substrings (a diff of
+/// this file, this repo's own test fixtures in Read output, quoted docs) would
+/// pin a genuinely parked session on Running with no recovery until the text
+/// scrolls away, while a missed upgrade only means the pre-fix bounded
+/// staleness (the next PreToolUse rewrites the file). The two anchored line
+/// shapes resist echoes structurally: echoed lines carry a prefix (line
+/// numbers, `+`, `⎿`, quotes), so they fail the leading-frame-char match. The
+/// legitimate signals survive the narrowing: the interrupt hint and token
+/// counter only render on the spinner line itself, so a live turn that shows
+/// either also shows the anchored spinner shape.
 ///
 /// The caller gates this on the session having last been observed Running or
 /// Waiting: parked sessions (the dominant steady state) never pay the pane
 /// capture, and the reconciliation disarms once a genuine turn end is
 /// accepted.
 pub(crate) fn reconcile_claude_idle_hook_status(raw_content: &str) -> Status {
-    with_claude_recent_pane(raw_content, |recent, recent_joined, recent_lower| {
+    with_claude_recent_pane(raw_content, |recent, _recent_joined, recent_lower| {
         if let Some(rule) = claude_blocking_prompt_rule(recent, recent_lower) {
             tracing::debug!(target: "tmux.status",
                 "claude reconciler: hook Idle upgraded to Waiting ({rule})");
             return Status::Waiting;
         }
-        if claude_pane_has_running_signal(recent, recent_joined, recent_lower) {
+        if recent
+            .iter()
+            .any(|line| claude_line_is_active_spinner(line) || claude_line_is_background_wait(line))
+        {
             tracing::debug!(target: "tmux.status",
-                "claude reconciler: hook Idle upgraded to Running (live running signal)");
+                "claude reconciler: hook Idle upgraded to Running (live spinner line)");
             return Status::Running;
         }
         Status::Idle
@@ -2469,6 +2485,24 @@ enter to select · esc to cancel";
         assert_eq!(reconcile_claude_idle_hook_status(pane), Status::Idle);
         // An empty capture carries no evidence either way; keep the hook.
         assert_eq!(reconcile_claude_idle_hook_status("  \n \n"), Status::Idle);
+    }
+
+    #[test]
+    fn test_reconcile_claude_idle_hook_resists_echoed_running_text() {
+        // A parked session whose last tool output echoed running-signal text
+        // (a diff of this repo's own detector, quoted docs) must keep the
+        // hook's idle. Echoed lines carry a prefix (line numbers, `+`,
+        // quotes), so the anchored spinner-line match rejects them; the loose
+        // interrupt-hint and token-counter substrings would have pinned this
+        // pane on Running with no recovery until the text scrolled away.
+        let pane = "\
+●  Read(src/tmux/status_detection.rs)\n\
+  ⎿  2472:        let pane = \"✶ Working… (4s · ↓ 88 tokens)\\n  esc to interrupt\";\n\
+  ⎿  +    if collapsed.contains(\"esc to interrupt\") {\n\
+✻ Worked for 12s\n\
+❯\n\
+  ? for shortcuts";
+        assert_eq!(reconcile_claude_idle_hook_status(pane), Status::Idle);
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -654,6 +654,115 @@ pub(crate) fn reconcile_waiting_hook(agent: &str, raw_content: &str) -> Status {
     }
 }
 
+/// Reconcile an `idle` hook write against the live pane for Claude.
+///
+/// Claude's idle writers are not all ordered with its running writers. `Stop`
+/// hooks are awaited before the next prompt is processed, but `Notification`
+/// hooks are fire-and-forget: when a queued prompt submits the moment a turn
+/// ends, the `idle_prompt` notification's async `idle` write can land *after*
+/// `UserPromptSubmit`'s `running` write, leaving the status file on `idle`
+/// while the new turn is already generating. No running-mapped hook fires
+/// again until the turn's first `PreToolUse`, so during a long thinking or
+/// prose stretch the session shows Idle for tens of seconds. This is the
+/// `Idle` analogue of the stale-`waiting` race `reconcile_waiting_hook`
+/// handles.
+///
+/// The pane is the tie-breaker, using only positive evidence: a live
+/// active-turn signal (spinner+verb line, interrupt hint, live token counter,
+/// background-agent wait) upgrades to Running, and a blocking prompt upgrades
+/// to Waiting (the same lost-write race applies to the `permission_prompt`
+/// notification). Anything else, including an empty capture, keeps the hook's
+/// `idle`. These are the same markers the hookless pane path and the Running
+/// reconciler already trust, so no new false-positive surface is added.
+///
+/// The caller gates this on the session having last been observed Running or
+/// Waiting: parked sessions (the dominant steady state) never pay the pane
+/// capture, and the reconciliation disarms once a genuine turn end is
+/// accepted.
+pub(crate) fn reconcile_claude_idle_hook_status(raw_content: &str) -> Status {
+    with_claude_recent_pane(raw_content, |recent, recent_joined, recent_lower| {
+        if let Some(rule) = claude_blocking_prompt_rule(recent, recent_lower) {
+            tracing::debug!(target: "tmux.status",
+                "claude reconciler: hook Idle upgraded to Waiting ({rule})");
+            return Status::Waiting;
+        }
+        if claude_pane_has_running_signal(recent, recent_joined, recent_lower) {
+            tracing::debug!(target: "tmux.status",
+                "claude reconciler: hook Idle upgraded to Running (live running signal)");
+            return Status::Running;
+        }
+        Status::Idle
+    })
+}
+
+/// Content-free structural fingerprint of a Claude pane, for status-transition
+/// diagnostics: which of the positive markers the detectors and reconcilers
+/// key on are present in the recent window. Logged on every observed session
+/// status transition (`session.status_change`), so an intermittent wrong-state
+/// report carries enough evidence to identify the detector rule involved
+/// without needing the flake reproduced under trace logging. Deliberately
+/// emits marker names only, never pane text, so no conversation content lands
+/// in the log at the default `info` level.
+pub(crate) fn claude_pane_marker_fingerprint(raw_content: &str) -> String {
+    if raw_content.trim().is_empty() {
+        return "empty_capture".to_string();
+    }
+    with_claude_recent_pane(raw_content, |recent, recent_joined, recent_lower| {
+        let mut markers: Vec<&str> = Vec::new();
+        if recent
+            .iter()
+            .any(|line| claude_line_is_active_spinner(line))
+        {
+            markers.push("spinner");
+        }
+        let collapsed = collapse_ascii_whitespace(recent_lower);
+        if collapsed.contains("esc to interrupt") || collapsed.contains("ctrl+c to interrupt") {
+            markers.push("esc_hint");
+        }
+        if has_claude_live_token_counter(recent_joined) {
+            markers.push("token_counter");
+        }
+        if recent
+            .iter()
+            .any(|line| claude_line_is_background_wait(line))
+        {
+            markers.push("bg_wait");
+        }
+        if let Some(rule) = claude_blocking_prompt_rule(recent, recent_lower) {
+            markers.push(rule);
+        }
+        if recent.iter().any(|line| line.trim() == "❯") {
+            markers.push("empty_prompt");
+        }
+        if recent_lower.contains("? for shortcuts")
+            || recent.iter().any(|line| {
+                let trimmed = line.trim_start();
+                (trimmed.starts_with('⏵') || trimmed.starts_with('⏸'))
+                    && trimmed.to_lowercase().contains("shift+tab to cycle")
+            })
+        {
+            markers.push("idle_footer");
+        }
+        if recent
+            .iter()
+            .any(|line| claude_line_is_completed_turn(line))
+        {
+            markers.push("completed_turn");
+        }
+        if recent_lower.contains(CLAUDE_INTERRUPT_MARKER) {
+            markers.push("interrupt_banner");
+        }
+        if claude_typed_prompt_without_parked_evidence(recent) {
+            markers.push("typed_prompt_ambiguous");
+        }
+        if markers.is_empty() {
+            "no_markers".to_string()
+        } else {
+            markers.join("+")
+        }
+    })
+}
+
 pub fn detect_opencode_status(raw_content: &str) -> Status {
     let content = raw_content.to_lowercase();
     let lines: Vec<&str> = content.lines().collect();
@@ -2330,6 +2439,69 @@ enter to select · esc to cancel";
         // flip a live prompt to Idle. Keep the hook's Waiting.
         assert_eq!(reconcile_waiting_hook("claude", ""), Status::Waiting);
         assert_eq!(reconcile_waiting_hook("claude", "   \n\n"), Status::Waiting);
+    }
+
+    #[test]
+    fn test_reconcile_claude_idle_hook_running_pane_upgrades_to_running() {
+        // The boundary race: a queued prompt submits the moment a turn ends,
+        // and the fire-and-forget `idle_prompt` notification lands its `idle`
+        // write after `UserPromptSubmit`'s `running`. The pane shows the new
+        // turn's live spinner, so the fresh idle must read as Running.
+        let pane = "✶ Working… (4s · ↓ 88 tokens)\n  esc to interrupt";
+        assert_eq!(reconcile_claude_idle_hook_status(pane), Status::Running);
+    }
+
+    #[test]
+    fn test_reconcile_claude_idle_hook_blocking_prompt_upgrades_to_waiting() {
+        // Same race shape for the permission_prompt notification: the pane
+        // shows a blocking approval prompt while the file says idle.
+        let pane = "\
+  Do you want to proceed?\n\
+  ❯ 1. Yes\n    2. No\n\n  Esc to cancel · Tab to amend";
+        assert_eq!(reconcile_claude_idle_hook_status(pane), Status::Waiting);
+    }
+
+    #[test]
+    fn test_reconcile_claude_idle_hook_parked_pane_keeps_idle() {
+        // Genuine turn end: completion line above the ready prompt, no live
+        // signal. The hook's idle is accepted.
+        let pane = "✻ Worked for 1m 52s\n❯\n  ? for shortcuts";
+        assert_eq!(reconcile_claude_idle_hook_status(pane), Status::Idle);
+        // An empty capture carries no evidence either way; keep the hook.
+        assert_eq!(reconcile_claude_idle_hook_status("  \n \n"), Status::Idle);
+    }
+
+    #[test]
+    fn test_claude_pane_marker_fingerprint_running() {
+        let pane = "\
+● Sure, let me look at that.\n\
+✶ Working… (4s · ↓ 88 tokens)\n\
+  esc to interrupt\n";
+        assert_eq!(
+            claude_pane_marker_fingerprint(pane),
+            "spinner+esc_hint+token_counter"
+        );
+    }
+
+    #[test]
+    fn test_claude_pane_marker_fingerprint_parked() {
+        let pane = "\
+✻ Worked for 1m 52s\n\
+❯\n\
+  ? for shortcuts\n";
+        assert_eq!(
+            claude_pane_marker_fingerprint(pane),
+            "empty_prompt+idle_footer+completed_turn"
+        );
+    }
+
+    #[test]
+    fn test_claude_pane_marker_fingerprint_empty_and_bare() {
+        assert_eq!(claude_pane_marker_fingerprint("   \n  \n"), "empty_capture");
+        assert_eq!(
+            claude_pane_marker_fingerprint("plain prose only"),
+            "no_markers"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Claude sessions intermittently showed Idle while a turn was actively generating.

Root cause (most likely mechanism, confirmed against hook semantics): Claude's `Stop` and `UserPromptSubmit` hooks are awaited, but `Notification` hooks are fire-and-forget. When a queued prompt submits the moment a turn ends, the `idle_prompt` notification's async `idle` write can land after `UserPromptSubmit`'s `running` write. The status file then reads `idle` while the new turn generates, and no running-mapped hook fires again until the turn's first `PreToolUse`, so during a long thinking or prose stretch the session shows Idle for tens of seconds. Orchestrated sessions that queue prompts via `aoe send` hit this boundary constantly.

Fix: reconcile an `idle` hook read against the pane when the session was last observed Running or Waiting (`reconcile_claude_idle_hook_status`). A live active-turn signal (spinner+verb line, interrupt hint, live token counter, background-agent wait) upgrades to Running; a blocking prompt upgrades to Waiting (the same lost-write race applies to the `permission_prompt` notification). This is the `Idle` analogue of the existing `reconcile_waiting_hook`. Two properties keep it cheap and safe:

- The previous-status gate means parked sessions (the dominant steady state) never pay a pane capture per poll; the reconciliation disarms as soon as a genuine turn end is accepted.
- The pane markers are the same positive signals the hookless path and the Running reconciler already trust, so no new false-positive surface is added.

Because the flake is intermittent and this fixes the most likely of several candidate mechanisms, this PR also adds an always-on status-transition log (`session.status_change` target, `info` level, on by default): one line per observed status flip recording the hook file's value and age at that moment, plus a content-free fingerprint of which Claude pane markers were on screen (marker names only, never conversation text). If a wrong-status report still occurs, `grep status_change debug.log` identifies the detector path involved without needing a live reproduction.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the race window is between two hook subprocess writes inside Claude Code, which cannot be triggered deterministically from an e2e harness. The reconciler is covered by unit tests over the three pane states (live turn, blocking prompt, parked), and the fingerprint by three more; the dispatcher gate is a two-line condition mirroring the existing reconcile paths.

Testing: `cargo fmt`, `cargo clippy`, `cargo test --lib` (4287 passed; the one failure, `restart_selected_session_surfaces_resume_failed_after_async_restart`, is pre-existing on `main` in the dev sandbox and unrelated).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 via Claude Code

**Any Additional AI Details you'd like to share:**
Claude traced the status pipeline, identified three candidate mechanisms for the intermittent Idle-while-running flake, implemented the fix for the most likely one plus the diagnostic logging to confirm it in the field; reviewed and directed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed intermittent Claude session status showing `Idle` during an active turn by reconciling the `idle` hook against the latest pane signals.
- Upgraded status based on detected pane context:
  - active turn signals → `Running`
  - blocking prompt signals → `Waiting`
  - parked sessions → keep `Idle` (avoids incorrect pane capture)
- Added always-on `session.status_change` logging at `info` level, capturing transition timing/age and privacy-safe pane detection fingerprints (without logging conversation-derived titles/content).
- Added a more robust, line-anchored idle reconciler to avoid false `Running` detection from echoed substrings.
- Expanded unit tests to cover live-turn, blocking-prompt, parked-session, fingerprinting, and dispatcher/gating behavior.

## Benefits

- More accurate, trustworthy session status indicators during concurrent/async hook updates.
- Improved observability of status transitions while keeping pane details and conversation text private.
- Reduced debugging time by making the “why” of a status change visible through fingerprints and timing.

## Validation

`cargo fmt`, `cargo clippy`, and `cargo test --lib` passed 4,287 tests, with one unrelated pre-existing failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->