### PR TITLE
refactor(core): consolidate now_secs, now_ms and system_time_to_ms epoch helpers

### DIFF
--- a/src/cli/ps.rs
+++ b/src/cli/ps.rs
@@ -17,6 +17,7 @@ use clap::Args;
 use serde::Serialize;
 
 use crate::session::{Instance, Status, Storage};
+use crate::util::now_secs;
 
 const COL_SESSION: usize = 30;
 const COL_SUBSTRATE: usize = 9;
@@ -352,13 +353,6 @@ fn render_table(rows: &[Row]) -> String {
         );
     }
     out
-}
-
-fn now_secs() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
 }
 
 fn load_instances(profile: &str, profile_explicit: bool) -> Vec<Instance> {

--- a/src/file_watch.rs
+++ b/src/file_watch.rs
@@ -863,10 +863,7 @@ fn handle_kernel(svc: &Arc<FileWatchService>, res: notify::Result<notify::Event>
     let ev = match res {
         Ok(ev) => ev,
         Err(e) => {
-            let now_ms = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis() as i64)
-                .unwrap_or(0);
+            let now_ms = crate::util::now_ms() as i64;
             let last = svc
                 .last_kernel_warn_unix_ms
                 .load(std::sync::atomic::Ordering::Acquire);

--- a/src/hooks/status_file.rs
+++ b/src/hooks/status_file.rs
@@ -122,10 +122,7 @@ pub fn read_hook_urgent(instance_id: &str) -> bool {
         return false;
     }
     if let Some(exp) = value.get("urgent_expires_at").and_then(|v| v.as_i64()) {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
+        let now = crate::util::now_secs() as i64;
         if now > exp {
             return false;
         }
@@ -313,11 +310,7 @@ mod tests {
     #[serial_test::serial(hook_base)]
     fn test_read_hook_urgent_true_when_expires_future() {
         let (_g, _, _tmp) = BaseGuard::ready();
-        let future = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-            + 3600;
+        let future = crate::util::now_secs() + 3600;
         let body = format!(r#"{{"urgent":true,"urgent_expires_at":{}}}"#, future);
         write_attention_json("urgent_future", &body);
         assert!(read_hook_urgent("urgent_future"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,3 +35,4 @@ pub mod tips;
 pub mod tmux;
 pub mod tui;
 pub mod update;
+mod util;

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -47,7 +47,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use clap::Args;
@@ -61,6 +61,7 @@ use tracing::{debug, info, warn};
 use super::worker_registry::{self, WorkerRecord};
 use crate::acp::control_protocol::{self, ControlBody, PromptOutcome};
 use crate::process::worker::RunnerRecordState;
+use crate::util::now_secs;
 
 /// How often the abandonment watchdog inspects its own registry record.
 const WATCHDOG_POLL_INTERVAL: Duration = Duration::from_secs(10);
@@ -105,13 +106,6 @@ const ATTACHED: u64 = 0;
 /// detached, or [`ATTACHED`] while a daemon is connected. Written by the
 /// accept loop on connect/disconnect, read by the watchdog.
 type DetachedSince = AtomicU64;
-
-fn now_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
-}
 
 /// Why the runner is tearing down. Drives whether teardown deletes the
 /// registry entry: a superseded runner must NOT delete, since the files

--- a/src/process/worker_registry.rs
+++ b/src/process/worker_registry.rs
@@ -22,11 +22,12 @@
 //! restart at worst causes a re-attach instead of a clean attach.
 
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
+
+use crate::util::now_secs;
 
 // Generic worker-subprocess plumbing now lives in `process::worker`; the
 // registry is the ACP consumer of it. Re-exported so the names referenced
@@ -126,13 +127,6 @@ impl WorkerRecord {
             detached_at: None,
         }
     }
-}
-
-fn now_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
 }
 
 /// Directory holding worker JSON files, log files, and the per-session

--- a/src/server/login.rs
+++ b/src/server/login.rs
@@ -35,6 +35,7 @@ use tokio_util::sync::CancellationToken;
 
 use super::auth::resolve_client_ip;
 use super::AppState;
+use crate::util::{now_ms, system_time_to_ms};
 
 /// Session lifetime (sliding window). Refreshes on every
 /// authenticated request, so an active user never sees it; the
@@ -660,16 +661,6 @@ struct PersistedSession {
     /// Lockout deadline as Unix epoch milliseconds; 0 means no lockout.
     #[serde(default)]
     elevation_locked_until_ms: u64,
-}
-
-fn system_time_to_ms(t: SystemTime) -> u64 {
-    t.duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
-}
-
-fn now_ms() -> u64 {
-    system_time_to_ms(SystemTime::now())
 }
 
 /// Convert an in-memory `Instant` deadline to a wall-clock epoch-ms

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -559,8 +559,10 @@ impl AppState {
 
     /// Record that an authenticated web client just made a request.
     pub fn touch_web_activity(&self) {
-        self.last_web_activity
-            .store(epoch_millis(), std::sync::atomic::Ordering::Relaxed);
+        self.last_web_activity.store(
+            crate::util::now_ms() as i64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
     }
 
     /// Returns true if an authenticated web request arrived within `threshold`.
@@ -571,16 +573,9 @@ impl AppState {
         if last == 0 {
             return false;
         }
-        let elapsed_ms = epoch_millis() - last;
+        let elapsed_ms = crate::util::now_ms() as i64 - last;
         elapsed_ms >= 0 && (elapsed_ms as u64) < threshold.as_millis() as u64
     }
-}
-
-fn epoch_millis() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as i64
 }
 
 /// Raise the soft `RLIMIT_NOFILE` so the server can sustain many WS

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -2428,9 +2428,7 @@ const KIMI_MTIME_FLOOR_SLACK_MS: f64 = 2000.0;
 fn kimi_session_dir_mtime_ms(session_dir: &str) -> u64 {
     std::fs::metadata(session_dir)
         .and_then(|m| m.modified())
-        .ok()
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_millis() as u64)
+        .map(crate::util::system_time_to_ms)
         .unwrap_or(0)
 }
 
@@ -4656,10 +4654,7 @@ mod tests {
         // session is eligible; with a future floor, neither is.
         let proj = tempfile::TempDir::new().unwrap();
         let proj_path = proj.path().to_str().unwrap().to_string();
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as f64;
+        let now_ms = crate::util::now_ms() as f64;
         let sessions = vec![
             KimiSession {
                 id: "session_fresh".to_string(),

--- a/src/session/claude_import.rs
+++ b/src/session/claude_import.rs
@@ -217,10 +217,8 @@ fn summarize_file(path: &Path) -> Option<ClaudeSessionSummary> {
     let session_id = path.file_stem()?.to_str()?.to_string();
 
     let last_modified_ms = fs::metadata(path)
-        .ok()
-        .and_then(|m| m.modified().ok())
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_millis() as u64)
+        .and_then(|m| m.modified())
+        .map(crate::util::system_time_to_ms)
         .unwrap_or(0);
 
     let file = fs::File::open(path).ok()?;

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -4109,10 +4109,7 @@ impl Instance {
                 }
             }
             "opencode" => {
-                let launch_time_ms = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_millis() as f64)
-                    .unwrap_or(0.0);
+                let launch_time_ms = crate::util::now_ms() as f64;
                 if self.is_sandboxed() {
                     let container_name = match self.sandbox_info.as_ref() {
                         Some(s) => s.container_name.clone(),
@@ -4279,10 +4276,7 @@ impl Instance {
                 if self.is_sandboxed() {
                     return;
                 }
-                let launch_time_ms = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_millis() as f64)
-                    .unwrap_or(0.0);
+                let launch_time_ms = crate::util::now_ms() as f64;
                 Box::new(kimi_poll_fn(
                     self.project_path.clone(),
                     self.id.clone(),

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -18,6 +18,7 @@ use crate::cli::truncate_id;
 use crate::process;
 use crate::session::config::should_apply_tmux_clipboard;
 use crate::session::Status;
+use crate::util::now_ms;
 
 pub struct Session {
     name: String,
@@ -55,15 +56,6 @@ pub const SIZE_OWNER_TTL: Duration = Duration::from_secs(4);
 /// [`SIZE_OWNER_TTL`] so a live-but-idle owner keeps the lock while connected;
 /// the lock only frees on disconnect/crash (TTL expiry) or explicit take-over.
 pub const SIZE_OWNER_HEARTBEAT: Duration = Duration::from_millis(1500);
-
-/// Wall-clock millis since the unix epoch. The size-owner heartbeat is compared
-/// across processes, so it must be wall-clock, not a per-process monotonic.
-fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
-}
 
 /// The active pane's cursor, queried alongside a `capture-pane` so the
 /// live-send preview can paint a real cursor (`capture-pane` returns cell
@@ -882,6 +874,8 @@ impl Session {
         if !self.exists() {
             return false;
         }
+        // Heartbeats are compared across processes, so this must be wall-clock
+        // (crate::util::now_ms), never a per-process monotonic clock.
         let now = now_ms();
         let claimable = match self.owner_at(opt, hb_opt) {
             None => true,

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,3 +10,58 @@ pub(crate) fn now_secs() -> u64 {
         .map(|d| d.as_secs())
         .unwrap_or(0)
 }
+
+/// Whole milliseconds between `t` and the Unix epoch, saturating to 0 if `t`
+/// predates the epoch.
+pub(crate) fn system_time_to_ms(t: SystemTime) -> u64 {
+    t.duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Current Unix time in whole milliseconds. Wall-clock (not a per-process
+/// monotonic), so values are comparable across processes; saturating to 0 if
+/// the clock is before the epoch.
+pub(crate) fn now_ms() -> u64 {
+    system_time_to_ms(SystemTime::now())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn system_time_to_ms_at_epoch_is_zero() {
+        assert_eq!(system_time_to_ms(UNIX_EPOCH), 0);
+    }
+
+    #[test]
+    fn system_time_to_ms_converts_offset() {
+        let t = UNIX_EPOCH + Duration::from_millis(1_500);
+        assert_eq!(system_time_to_ms(t), 1_500);
+    }
+
+    #[test]
+    fn pre_epoch_saturates_to_zero() {
+        let before = UNIX_EPOCH - Duration::from_secs(1);
+        assert_eq!(system_time_to_ms(before), 0);
+    }
+
+    #[test]
+    fn now_ms_matches_seconds_at_same_instant() {
+        let t = SystemTime::now();
+        let ms = system_time_to_ms(t);
+        let secs = t
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        assert_eq!(ms / 1_000, secs);
+    }
+
+    #[test]
+    fn now_helpers_are_post_epoch() {
+        assert!(now_secs() > 0);
+        assert!(now_ms() > 0);
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,12 @@
+//! Small crate-internal utilities shared across modules.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Current Unix time in whole seconds, saturating to 0 if the clock is before
+/// the epoch (which should never happen on a sane system).
+pub(crate) fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}


### PR DESCRIPTION
## Description

Duplicated Unix-epoch time helpers, built on `std::time`, were reimplemented across the crate. This PR routes them through one crate-internal `src/util.rs`.

**Seconds (`now_secs`).** The `now_secs()` body (`SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)`) was reimplemented near-identically in `src/process/worker_registry.rs`, `src/process/runner.rs`, and `src/cli/ps.rs` (same logic; `ps.rs` used fully-qualified paths, the other two the imported names). A single `pub(crate)` copy now lives in `src/util.rs`; the three call sites route through it. The `worker_registry.rs` diff (the #2975 churn zone) stays minimal.

**Milliseconds (`now_ms` / `system_time_to_ms`).** The same duplication existed for wall-clock millis. `src/util.rs` gains `now_ms()` and `system_time_to_ms(t: SystemTime)`, and the near-identical `std::time` reimplementations route through them:

- `src/server/mod.rs` (was `epoch_millis`)
- `src/file_watch.rs` (kernel-warn throttle)
- `src/tmux/session.rs` (was `now_ms`; size-owner heartbeat)
- `src/session/instance.rs` (opencode/kimi launch stamps, x2)
- `src/hooks/status_file.rs` (urgent-expiry check, prod + test)
- `src/server/login.rs` (was `system_time_to_ms`/`now_ms`)
- `src/session/capture.rs` (kimi dir mtime + test)
- `src/session/claude_import.rs` (session file mtime)

`system_time_to_ms` converts an arbitrary `SystemTime`, so besides `now` it also absorbs the two file-mtime conversions (`kimi_session_dir_mtime_ms` in `capture.rs`, and `claude_import.rs`), keeping a single `SystemTime -> ms` idiom.

Behavior is unchanged: production sites keep their `unwrap_or(0)` fallback and their existing `i64`/`f64` cast at the call site. The two **test** sites that previously used `.unwrap()` (which would panic on a pre-epoch clock) now saturate to 0 instead; no observable difference in practice. Names use the `_ms` suffix to match the crate's existing convention (`chunk_now_ms`, `dwell_ms`, `instant_deadline_to_ms`, `kimi_session_dir_mtime_ms`) and the exact names removed here.

### Scope

Only the `std::time`-based epoch reimplementations are consolidated. The `chrono::Utc::now().timestamp_millis()` (`i64`) sites in the ACP and plugin subsystems are a separate, already-documented convention (see the doc at `src/acp/acp_client.rs`) and are intentionally left untouched; folding them in would change their type and reach well beyond this cleanup. Deliberately excluded too: `src/tmux/vt.rs::chunk_now_ms()` (monotonic `Instant`, not wall-clock) and the nanos tempdir stamp in `src/session/mod.rs`.

Per the issue, the compact-duration formatter (`format_age` in `ps.rs`) is left local (promote only if a second CLI consumer appears), and the TUI formatters (`format_relative_age`, `format_snooze_remaining`, `humanize_minutes`) are out of scope (different input types and semantics).

Closes #3026.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Verified locally: `cargo fmt --check` clean, `cargo clippy --features serve` clean, and `cargo test --features serve --lib` green on the touched modules (`util::` 5 unit tests, `server::login::` 42, `hooks::status_file::` 29, `session::claude_import::` 11, plus the two `capture.rs` mtime/launch-floor tests). `git grep "duration_since(UNIX_EPOCH)"` now shows the only `SystemTime`-based epoch conversions living in `src/util.rs`.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Pure internal refactor with no observable behavior change. The new pure helpers get direct unit tests in `src/util.rs`; the routed call sites are exercised by the existing tests covering their modules.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus

**Any Additional AI Details you'd like to share:** AI-assisted implementation of the consolidation described in #3026, plus an initial multi-agent review; changes reviewed before submission.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a new internal `util` module (`src/util.rs`) to centralize Unix-epoch time helpers.
- Replaced several duplicated `now_secs()` implementations with `crate::util::now_secs()` across CLI/process/worker code paths.
- Introduced shared millisecond helpers (`now_ms()` and `system_time_to_ms()`) and switched multiple subsystems (server login, server web activity tracking, session handling, hooks, file watching, and tmux session logic) to use them for wall-clock millisecond timestamps.
- Removed local epoch/millisecond conversion helpers where they were superseded by the shared utilities, keeping unrelated duration/TUI/chrono-based formatting logic unchanged.
- Added unit tests for the shared epoch conversion behavior, including pre-epoch saturation behavior, and updated affected tests accordingly.

## Benefits

- Makes timestamp behavior more consistent across the application by using one shared conversion implementation.
- Reduces duplicated time-handling code, lowering the chance of future drift or subtle bugs.
- Improves confidence with targeted unit tests covering second/millisecond conversions and edge cases.

## Potential areas for further enhancement

- If more CLI/TUI components start needing the same shared timestamp semantics, consider extending the shared utilities to cover those formatting/time shapes as well (currently left intentionally local/excluded).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->