### PR TITLE
fix(cli): route fatal startup errors through the tracing sink

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -271,19 +271,19 @@ async fn main() -> Result<()> {
     // Route a fatal from the dispatch through the tracing sink `aoe logs`
     // reads, so a failure after logging init lands in `[logging].file_path`
     // instead of only the process's raw stderr (issue #2896). Both surfaces
-    // use `{e:#}` (anyhow's inline cause chain) on purpose: it keeps one event
-    // on one physical line, which the line-oriented log sink and `aoe logs`
-    // expect, while still carrying the full chain. `{e:?}` is avoided because
-    // its multi-line `Caused by:` block, and any `RUST_BACKTRACE` dump, would
-    // fragment a single log record across many lines. The `eprintln!` is the
-    // interactive fallback: a one-shot CLI runs without a subscriber, so the
-    // tracing line is dropped and stderr is all the user sees. It is skipped
-    // for the detached `--daemon-child`, whose stderr is already redirected
-    // into the same log file by `cli::serve`, so printing would duplicate the
-    // tracing line. Errors before logging init (clap parse, the plugin-command
-    // dispatch taken on a clap-parse miss, and the pre-clap `__vt-pipe` /
-    // `__smart-rename` helpers) still fall through to Rust's default handler;
-    // that pre-init window is a known limitation.
+    // use `{e:#}` (anyhow's inline cause chain): it joins the causes with `: `
+    // and omits the backtrace, so the formatter adds no newlines of its own,
+    // unlike `{e:?}` whose multi-line `Caused by:` block and `RUST_BACKTRACE`
+    // dump would fragment a record across the line-oriented sink. The
+    // `eprintln!` is the interactive fallback: a one-shot CLI runs without a
+    // subscriber, so the tracing line is dropped and stderr is all the user
+    // sees. It is skipped for the detached `--daemon-child`, whose stderr is
+    // already redirected into the same log file by `cli::serve`, so printing
+    // would duplicate the tracing line. Errors before logging init bypass the
+    // sink: clap parse and the serve-availability check exit through clap,
+    // while the pre-clap `__vt-pipe` / `__smart-rename` helpers and the
+    // plugin-command dispatch return before it. That pre-init window is a
+    // known limitation.
     if let Err(e) = run(
         cli,
         is_daemon_child,

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,12 +270,20 @@ async fn main() -> Result<()> {
 
     // Route a fatal from the dispatch through the tracing sink `aoe logs`
     // reads, so a failure after logging init lands in `[logging].file_path`
-    // instead of only the process's raw stderr (issue #2896). The eprintln
-    // stays because the sink is File/Stdout, never stderr, and a one-shot CLI
-    // command runs without a subscriber, so it is the only thing an
-    // interactive user sees. Errors *before* logging init (clap parse, the
-    // pre-clap `__vt-pipe` / `__smart-rename` helpers) still fall through to
-    // Rust's default handler; that pre-init window is a known limitation.
+    // instead of only the process's raw stderr (issue #2896). Both surfaces
+    // use `{e:#}` (anyhow's inline cause chain) on purpose: it keeps one event
+    // on one physical line, which the line-oriented log sink and `aoe logs`
+    // expect, while still carrying the full chain. `{e:?}` is avoided because
+    // its multi-line `Caused by:` block, and any `RUST_BACKTRACE` dump, would
+    // fragment a single log record across many lines. The `eprintln!` is the
+    // interactive fallback: a one-shot CLI runs without a subscriber, so the
+    // tracing line is dropped and stderr is all the user sees. It is skipped
+    // for the detached `--daemon-child`, whose stderr is already redirected
+    // into the same log file by `cli::serve`, so printing would duplicate the
+    // tracing line. Errors before logging init (clap parse, the plugin-command
+    // dispatch taken on a clap-parse miss, and the pre-clap `__vt-pipe` /
+    // `__smart-rename` helpers) still fall through to Rust's default handler;
+    // that pre-init window is a known limitation.
     if let Err(e) = run(
         cli,
         is_daemon_child,
@@ -285,7 +293,9 @@ async fn main() -> Result<()> {
     .await
     {
         tracing::error!(target: "log.runtime", "fatal: {e:#}");
-        eprintln!("Error: {e:#}");
+        if !is_daemon_child {
+            eprintln!("Error: {e:#}");
+        }
         std::process::exit(1);
     }
 
@@ -304,7 +314,7 @@ async fn run(
 ) -> Result<()> {
     // CLI invocations get the dev-namespace drift warning on stderr right
     // away. TUI mode handles it via the existing startup-warning popup
-    // pipeline below — we don't print here for TUI because ratatui's
+    // pipeline below; we don't print here for TUI because ratatui's
     // alt-screen would clobber the message.
     if cli.command.is_some() {
         if let Some((release, dev)) = debug_namespace_drift.as_ref() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,6 +268,40 @@ async fn main() -> Result<()> {
         tracing::info!(target: "log.runtime", "Debug logging at {} to {}", lvl.as_str(), path.display());
     }
 
+    // Route a fatal from the dispatch through the tracing sink `aoe logs`
+    // reads, so a failure after logging init lands in `[logging].file_path`
+    // instead of only the process's raw stderr (issue #2896). The eprintln
+    // stays because the sink is File/Stdout, never stderr, and a one-shot CLI
+    // command runs without a subscriber, so it is the only thing an
+    // interactive user sees. Errors *before* logging init (clap parse, the
+    // pre-clap `__vt-pipe` / `__smart-rename` helpers) still fall through to
+    // Rust's default handler; that pre-init window is a known limitation.
+    if let Err(e) = run(
+        cli,
+        is_daemon_child,
+        debug_namespace_drift,
+        debug_log_warning,
+    )
+    .await
+    {
+        tracing::error!(target: "log.runtime", "fatal: {e:#}");
+        eprintln!("Error: {e:#}");
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+/// Dispatch every command that runs after logging init. Split out of `main`
+/// so one wrapper can route any returned `Err` through the tracing sink before
+/// the process exits. This covers both the app-data-free early-return arms and
+/// the final `match`, so no startup bail can bypass the sink.
+async fn run(
+    cli: Cli,
+    is_daemon_child: bool,
+    debug_namespace_drift: Option<(std::path::PathBuf, std::path::PathBuf)>,
+    debug_log_warning: Option<String>,
+) -> Result<()> {
     // CLI invocations get the dev-namespace drift warning on stderr right
     // away. TUI mode handles it via the existing startup-warning popup
     // pipeline below — we don't print here for TUI because ratatui's

--- a/tests/e2e/errors.rs
+++ b/tests/e2e/errors.rs
@@ -49,3 +49,30 @@ fn test_fatal_error_prints_to_stderr_and_exits_nonzero() {
         "stderr must carry the fatal reason for interactive users; stderr was: {stderr}"
     );
 }
+
+/// Complements the preservation test above: when a one-shot CLI *does* have a
+/// subscriber (opted in via `AOE_LOG_LEVEL`), the generic `main` wrapper must
+/// also route the fatal through the tracing sink, exercising the `OneShotCli` +
+/// file-sink path the serve test (`ServeForeground`) does not. The `fatal:`
+/// record is emitted only by that wrapper, so this fails on the pre-#2896 code
+/// where an `Err` returned from `main` never reached the sink.
+#[test]
+#[serial]
+fn test_fatal_error_routes_to_debug_log_when_subscriber_enabled() {
+    let mut h = TuiTestHarness::new("cli_fatal_logged");
+    h.set_env("AOE_LOG_LEVEL", "info");
+
+    let output = h.run_cli(&["remove", "nonexistent-session-id-12345"]);
+    assert!(
+        !output.status.success(),
+        "a fatal error from main must exit non-zero"
+    );
+
+    let debug_log = crate::harness::app_dir_in(h.home_path()).join("debug.log");
+    let contents = std::fs::read_to_string(&debug_log)
+        .unwrap_or_else(|e| panic!("debug.log unreadable at {}: {}", debug_log.display(), e));
+    assert!(
+        contents.contains("fatal:"),
+        "a one-shot CLI fatal must reach the tracing sink; debug.log was:\n{contents}"
+    );
+}

--- a/tests/e2e/errors.rs
+++ b/tests/e2e/errors.rs
@@ -50,12 +50,9 @@ fn test_fatal_error_prints_to_stderr_and_exits_nonzero() {
     );
 }
 
-/// Complements the preservation test above: when a one-shot CLI *does* have a
-/// subscriber (opted in via `AOE_LOG_LEVEL`), the generic `main` wrapper must
-/// also route the fatal through the tracing sink, exercising the `OneShotCli` +
-/// file-sink path the serve test (`ServeForeground`) does not. The `fatal:`
-/// record is emitted only by that wrapper, so this fails on the pre-#2896 code
-/// where an `Err` returned from `main` never reached the sink.
+/// A CLI subcommand with file logging enabled (`AOE_LOG_LEVEL` set) must route
+/// a fatal error through the tracing sink, so the failure reason is written to
+/// the configured log file and not only to stderr.
 #[test]
 #[serial]
 fn test_fatal_error_routes_to_debug_log_when_subscriber_enabled() {

--- a/tests/e2e/errors.rs
+++ b/tests/e2e/errors.rs
@@ -26,3 +26,26 @@ fn test_cli_remove_nonexistent() {
         stderr
     );
 }
+
+/// Regression test for #2896: routing fatal errors through the tracing sink
+/// must not regress the interactive path. A one-shot CLI command runs without a
+/// tracing subscriber, so the sink swallows the error; `main`'s `eprintln!`
+/// fallback is the only thing the user sees. Assert stderr specifically (not
+/// combined stdout+stderr) carries the reason and the exit stays non-zero.
+#[test]
+#[serial]
+fn test_fatal_error_prints_to_stderr_and_exits_nonzero() {
+    let h = TuiTestHarness::new("cli_fatal_stderr");
+
+    let output = h.run_cli(&["remove", "nonexistent-session-id-12345"]);
+    assert!(
+        !output.status.success(),
+        "a fatal error from main must exit non-zero"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error:"),
+        "stderr must carry the fatal reason for interactive users; stderr was: {stderr}"
+    );
+}

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -528,3 +528,32 @@ fn cli_serve_auth_passphrase_loopback_bypass() {
         panic!("{e}");
     }
 }
+
+/// Regression test for #2896: a fatal startup validation failure must reach the
+/// `tracing` sink `aoe logs` reads, not only the process's raw stderr. A
+/// foreground `aoe serve --behind-proxy` with no `--allowed-host` bails the
+/// DNS-rebinding gate before binding; the reason must land in the configured
+/// `[logging].file_path` (default `debug.log`) so a supervisor-driven
+/// crash-loop is diagnosable from the log, and the process must still exit
+/// non-zero.
+#[test]
+#[serial]
+fn cli_serve_startup_bail_reaches_debug_log() {
+    let h = TuiTestHarness::new("serve_startup_bail_logged");
+
+    let out = h.run_cli(&["serve", "--behind-proxy"]);
+    assert!(
+        !out.status.success(),
+        "serve --behind-proxy without --allowed-host must exit non-zero.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let debug_log = crate::harness::app_dir_in(h.home_path()).join("debug.log");
+    let contents = std::fs::read_to_string(&debug_log)
+        .unwrap_or_else(|e| panic!("debug.log unreadable at {}: {}", debug_log.display(), e));
+    assert!(
+        contents.contains("--behind-proxy requires --allowed-host"),
+        "fatal startup reason must be routed through the tracing sink; debug.log was:\n{contents}"
+    );
+}


### PR DESCRIPTION
## Description

Fatal errors returned from `main` after logging init were surfaced only by Rust's default `Termination` (raw stderr + exit 1), which is disjoint from the `tracing` sink `aoe logs` reads. Any startup validation bail (e.g. `--behind-proxy` without `--allowed-host`, the auth-mode conflicts, the wildcard-bind allowlist check) was therefore invisible in `[logging].file_path` / `debug.log`. Under a supervisor like launchd with `KeepAlive`, this turned a deterministic validation failure into a silent restart loop, with the log surface actively pointing away from the cause.

This implements Proposal A from #2896: the post-init-logging dispatch is extracted into `async fn run(...)` and wrapped once in `main`, so any returned `Err` is logged through `tracing::error!(target: "log.runtime", "fatal: {e:#}")` before `std::process::exit(1)`.

Key details:

- The wrapper covers BOTH dispatch blocks: the app-data-free early-return arms (`aoe completion`, `init`, `logs`, ...) AND the final `match cli.command`. Wrapping only the final `result` would miss every early-return bail, so the whole post-init dispatch moved into `run`.
- The `eprintln!("Error: {e:#}")` is kept: the sink is File/Stdout, never stderr, and a one-shot CLI command runs without a subscriber, so the eprintln remains the only thing an interactive user sees. Exit code stays non-zero. No behavior change on the success paths.
- Known limitation (documented in a code comment): errors BEFORE logging init (clap parse, the pre-clap `__vt-pipe` / `__smart-rename` helpers) still fall through to the default handler and cannot be logged.

Out of scope (unchanged): the DNS-rebinding gate / `--allowed-host` semantics, and the `[logging]` sink itself (#1124).

Closes #2896.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (the pre-init limitation is documented inline; no user-facing docs affected)
- [ ] For UI changes: included screenshot or recording (N/A, no UI change)

## Test Coverage Analysis

Both user stories from the issue are covered by new e2e tests (the issue states "PR is not done without them"):

- `tests/e2e/serve.rs::cli_serve_startup_bail_reaches_debug_log`: runs `aoe serve --behind-proxy` with no `--allowed-host` against an isolated `$HOME`, asserts non-zero exit AND that the configured `debug.log` contains `--behind-proxy requires --allowed-host`.
- `tests/e2e/errors.rs::test_fatal_error_prints_to_stderr_and_exits_nonzero`: runs a failing one-shot CLI command (no tracing subscriber), asserts non-zero exit AND that stderr specifically carries the reason (`Error:`), locking in the preserved interactive path.

Verification (all run locally):

- `cargo fmt --check` clean.
- `cargo clippy --features serve,e2e-tests --all-targets` clean for the changed files (the only warnings are pre-existing `useless use of vec!` in `src/session/groups.rs` tests, present on `main`, untouched here).
- `cargo test --features serve` all pass, 0 failures.
- `cargo test --features serve,e2e-tests --test e2e cli_serve_startup_bail_reaches_debug_log` -> ok.
- `cargo test --features serve,e2e-tests --test e2e test_fatal_error_prints_to_stderr_and_exits_nonzero` -> ok.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (no `web/` change, so `web/tests/coverage-matrix.json` is N/A)

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (Opus) via OpenCode.

**Any Additional AI Details you'd like to share:** AI assisted with investigation of the dispatch structure, the fix, and the regression tests; decisions and review are the author's.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Routes fatal startup errors through the configured logging system after initialization.
- Preserves stderr messages and non-zero exits for interactive users, while avoiding duplicate output for detached daemon processes.
- Extracts post-initialization command handling into a dedicated `run()` function.
- Adds end-to-end coverage for stderr behavior and logging validation failures.

## Benefits

Startup failures are now visible through `aoe logs` and debug log files without changing existing interactive behavior.

## Potential follow-up

Errors occurring before logging initialization still cannot be routed to the tracing sink.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->