### PR TITLE
fix(acp): drive a real conversation reset for claude /clear so it survives a worker restart

### DIFF
--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -329,7 +329,10 @@ session later idles out or the daemon restarts, the next prompt resumes the
 post-clear conversation instead of starting from nothing. The trade-off is that
 a clear is refused while background sub-agents or tool calls are still draining,
 because switching conversations mid-drain would file their remaining output
-under the new one. Wait for that work to finish, then send the clear again.
+under the new one. Wait for that work to finish, then send the clear again. A
+clear can also fail outright if starting the new conversation fails, for
+instance when an MCP server will not re-initialize; the existing conversation is
+left untouched when that happens, so no divider appears and nothing is lost.
 
 A `/clear` queued mid-turn (or any agent's clear alias, e.g. codex / opencode
 `/new`) fires as its own send when the turn ends. An ordering like `foo`,

--- a/docs/structured-view/troubleshooting.md
+++ b/docs/structured-view/troubleshooting.md
@@ -323,6 +323,14 @@ model still won't see those turns. See
 
 The slash-command palette and mode picker stay populated across a `/clear`.
 
+For claude and codex, a clear starts a genuinely new agent conversation rather
+than clearing the existing one in place, so it survives a worker restart: if the
+session later idles out or the daemon restarts, the next prompt resumes the
+post-clear conversation instead of starting from nothing. The trade-off is that
+a clear is refused while background sub-agents or tool calls are still draining,
+because switching conversations mid-drain would file their remaining output
+under the new one. Wait for that work to finish, then send the clear again.
+
 A `/clear` queued mid-turn (or any agent's clear alias, e.g. codex / opencode
 `/new`) fires as its own send when the turn ends. An ordering like `foo`,
 `/clear`, `bar` lands as three separate prompts; the queued-prompt strip shows

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -486,7 +486,9 @@ enum ClientCmd {
     /// one, and emit `SessionCleared` + `SessionContextReset` +
     /// `AcpSessionAssigned` + a terminal `Stopped` so bookkeeping and
     /// the UI follow. Issued by the supervisor when a clear command hits
-    /// a profile whose adapter has no native reset (codex `/new`). `text`
+    /// a profile whose adapter cannot give AoE a durable post-reset id
+    /// (codex `/new` has no native reset; claude `/clear` has one but
+    /// withholds the new conversation id). `text`
     /// carries the user's original clear invocation, used only by the
     /// mid-turn refusal's `PromptRejected` so the retry pill shows what
     /// was typed. See #2979.
@@ -2882,7 +2884,8 @@ impl AcpClient {
     /// task issues a fresh `session/new`, swaps its ACP session id, and
     /// emits `SessionCleared` + `SessionContextReset` +
     /// `AcpSessionAssigned` + a terminal `Stopped`. Used for clear
-    /// commands whose adapter has no native reset (codex `/new`, #2979).
+    /// commands whose adapter cannot hand AoE a durable post-reset session
+    /// id (codex `/new`, #2979; claude `/clear`, upstream #906).
     /// `text` is the user's clear invocation, surfaced in the mid-turn
     /// refusal's `PromptRejected`. Bounded so a wedged adapter cannot
     /// stall the prompt path; a `session/new` timeout surfaces as a
@@ -8036,9 +8039,11 @@ async fn run_connection_task<W, R>(
                             continue;
                         }
                         // Driven conversation reset (#2979): a clear command
-                        // hit a profile whose adapter has no native reset
-                        // (codex `/new`), so open a genuinely fresh session
-                        // on the live worker and swap onto its id.
+                        // hit a profile whose adapter cannot hand back a
+                        // durable post-reset id (codex `/new` has no native
+                        // reset; claude `/clear` resets but keeps serving the
+                        // pre-clear id), so open a genuinely fresh session on
+                        // the live worker and swap onto its id.
                         //
                         // Deliberately over the byte relay, NOT the v2
                         // control channel: the runner's `EstablishSession`

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -29,15 +29,25 @@ pub struct AgentProfile {
     /// for agents whose reset semantic isn't a slash command (or isn't
     /// known yet).
     pub clear_aliases: &'static [&'static str],
-    /// When true, the adapter has no native handler for this profile's
-    /// clear aliases: forwarding the raw text would be swallowed as an
-    /// unknown command and the conversation would keep its full context
-    /// (codex-acp has no `/new`; adding one was declined in the upstream
-    /// codex-acp issue `#317`). The server must drive the reset itself by
-    /// opening a fresh `session/new` on the live worker and swapping the
-    /// ACP session id, instead of forwarding the prompt. False for
-    /// claude-agent-acp, which implements `/clear` locally, so Claude
-    /// keeps the text-forward path. See #2979.
+    /// When true, forwarding this profile's clear aliases as text cannot
+    /// produce a conversation AoE is able to resume, so the server must
+    /// drive the reset itself: open a fresh `session/new` on the live
+    /// worker and swap the ACP session id. Two distinct adapter defects
+    /// land here.
+    ///
+    /// - No native handler at all: the raw text is answered as an unknown
+    ///   command and the conversation keeps its full context (codex-acp has
+    ///   no `/new`; adding one was declined upstream in codex-acp `#317`).
+    ///   See #2979.
+    /// - A native handler that withholds the new conversation id: the
+    ///   context does reset, but the adapter keeps serving the pre-clear
+    ///   ACP session id, so AoE cannot persist a resume target and the
+    ///   post-clear conversation dies with the worker (claude-agent-acp;
+    ///   upstream #906).
+    ///
+    /// False for adapters whose clear is native and whose post-clear
+    /// resumability is either fine or simply unverified; see the per-profile
+    /// comments before flipping one.
     pub clear_requires_driven_reset: bool,
     /// When true, the server synthesises a `PlanUpdated` event from a
     /// `kind: switch_mode` tool call (Claude's ExitPlanMode shape).
@@ -123,9 +133,20 @@ pub const CLAUDE: AgentProfile = AgentProfile {
     key: "claude",
     parent_meta_namespaces: &["claudeCode"],
     clear_aliases: &["/clear"],
-    // claude-agent-acp handles `/clear` locally ("Local-only commands"),
-    // so the forwarded text performs a real reset; no driven reset needed.
-    clear_requires_driven_reset: false,
+    // claude-agent-acp handles `/clear` locally ("Local-only commands"), so a
+    // forwarded `/clear` does reset the model context, but it does NOT rotate
+    // the ACP session id and the adapter discards the `conversation_reset`
+    // stream message carrying the new conversation id (0.62.0
+    // `dist/acp-agent.js`: "safe to drop"; upstream #906). So AoE is left
+    // holding an id that `session/load` resolves back to the PRE-clear
+    // conversation. #3083 works around that by dropping the stored id on
+    // `SessionCleared`, which makes the POST-clear conversation unresumable:
+    // any worker restart after a `/clear` (idle auto-stop, daemon restart)
+    // starts an empty session and loses everything since the clear. Driving
+    // the reset ourselves mints an id we can persist, so a later restart
+    // resumes the post-clear conversation. Revisit if #906 lands a structured
+    // reset result that carries the new id.
+    clear_requires_driven_reset: true,
     supports_exit_plan_mode: true,
     supports_wakeup_tools: true,
     emits_heartbeat_keepalives: true,
@@ -259,6 +280,12 @@ pub const KIMI: AgentProfile = AgentProfile {
 /// has its own conventions.
 pub const AOE_AGENT: AgentProfile = AgentProfile {
     key: "aoe-agent",
+    // Deliberately NOT inherited from CLAUDE: aoe-agent is multi-provider, and
+    // nobody has checked whether its clear rotates an observable session id the
+    // way claude-agent-acp fails to. Driving a reset on an adapter that already
+    // handles the alias natively would double-reset it, so it stays on the
+    // forward path until someone verifies it.
+    clear_requires_driven_reset: false,
     ..CLAUDE
 };
 
@@ -406,26 +433,26 @@ mod tests {
         assert!(!OMP.is_clear_command("/clear"));
     }
 
-    /// #2979: only codex needs the server-driven reset because codex-acp
-    /// has no native `/new` (the upstream codex-acp issue `#317`), so the
-    /// text-forward path silently keeps the conversation's context.
-    /// Claude's `/clear` is handled by its adapter and must stay on the
-    /// forward path; the other `/new` mappings (opencode, omp, kimi) are
-    /// unverified and deliberately keep the old behavior until observed.
+    /// Two different defects share the driven-reset remedy. codex-acp has no
+    /// native `/new` at all (upstream codex-acp `#317`), so a forwarded alias
+    /// is swallowed and the context survives (#2979). claude-agent-acp does
+    /// handle `/clear`, but withholds the post-clear conversation id, so the
+    /// text-forward path leaves the new conversation unresumable across a
+    /// worker restart. Both need AoE to mint the id itself.
+    ///
+    /// `aoe-agent` must NOT inherit claude's answer here even though it
+    /// inherits the rest of the profile via `..CLAUDE`: it is a different
+    /// multi-provider adapter whose clear semantics nobody has verified. The
+    /// assertion below is what stops a future `..CLAUDE` edit from silently
+    /// flipping it. Same standard for the unverified `/new` mappings
+    /// (opencode, omp, kimi), which keep the old behavior until observed.
     #[test]
-    fn clear_requires_driven_reset_only_for_codex() {
-        assert!(resolve("codex").clear_requires_driven_reset);
+    fn clear_requires_driven_reset_for_codex_and_claude() {
+        for profile in [&CODEX, &CLAUDE, &CLAUDE_CODE] {
+            assert!(profile.clear_requires_driven_reset, "{}", profile.key);
+        }
         for profile in [
-            &CLAUDE,
-            &CLAUDE_CODE,
-            &AOE_AGENT,
-            &OPENCODE,
-            &GEMINI,
-            &VIBE,
-            &PI,
-            &OMP,
-            &KIMI,
-            &DEFAULT,
+            &AOE_AGENT, &OPENCODE, &GEMINI, &VIBE, &PI, &OMP, &KIMI, &DEFAULT,
         ] {
             assert!(!profile.clear_requires_driven_reset, "{}", profile.key);
         }

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -2211,9 +2211,11 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// `SessionContextReset` + `AcpSessionAssigned` + a terminal `Stopped`
     /// so bookkeeping and the UI follow). Used instead of `send_prompt`
     /// when a clear command hits a profile whose adapter has no native
-    /// reset (codex `/new`), where forwarding the text would be swallowed
-    /// as an unknown command and the context would silently survive. See
-    /// #2979.
+    /// reset, or has one that withholds the new conversation id. For codex
+    /// `/new` forwarding the text would be swallowed as an unknown command
+    /// and the context would silently survive (#2979); for claude `/clear`
+    /// the context does reset but AoE is left unable to resume the new
+    /// conversation after a worker restart (upstream #906).
     ///
     /// After a successful reset, re-asserts the session's persisted mode
     /// (or the profile's YOLO bypass mode) the same way `spawn_inner`
@@ -4322,27 +4324,56 @@ mod tests {
     }
 
     /// `publish_user_prompt` emits a synthetic `SessionCleared` event
-    /// immediately after the `UserPromptSent` for a `/clear`
-    /// invocation, so the UI can fold the pre-clear transcript and
-    /// drop stale capability caches without waiting for an upstream
-    /// signal the adapter doesn't send. See #1101.
+    /// immediately after the `UserPromptSent` for a clear invocation on a
+    /// profile that still forwards the alias, so the UI can fold the
+    /// pre-clear transcript and drop stale capability caches without
+    /// waiting for an upstream signal the adapter doesn't send. See #1101.
+    ///
+    /// Exercised through `opencode` rather than claude: claude now drives
+    /// its own reset, which defers the boundary until `session/new`
+    /// commits, so it no longer publishes `SessionCleared` here. opencode
+    /// is one of the profiles still on the forward path.
     #[tokio::test]
+    #[serial_test::serial]
     async fn publish_user_prompt_emits_session_cleared_for_clear_command() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // SAFETY: serialised by `#[serial]`; subsequent serial tests
+        // reassign these env vars, which is the existing pattern.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        }
+        let session_id = "attached-opencode-clear-1";
+        let dir = crate::process::worker_registry::workers_dir().unwrap();
+        let record = crate::process::worker_registry::WorkerRecord::new(
+            session_id.into(),
+            std::process::id(),
+            dir.join(format!("{session_id}.sock")),
+            "opencode".into(),
+            "opencode".into(),
+            std::env::temp_dir(),
+            None,
+            vec![],
+            vec![],
+            None,
+            None,
+        );
+        crate::process::worker_registry::save(&record).unwrap();
+
         let sink = VecSink::new();
         let sup = Supervisor::new(sink.clone());
-        let disposition = sup.publish_user_prompt("s-1", "/clear".into()).await;
-        // Claude's adapter handles `/clear` natively, so the text keeps
-        // the forward path; the codex-only driven reset (#2979) must not
-        // change this. See `clear_requires_driven_reset`.
+        let disposition = sup.publish_user_prompt(session_id, "/new".into()).await;
         assert_eq!(disposition, PromptDisposition::Forward);
         let frames = sink.frames.lock().unwrap().clone();
         assert_eq!(frames.len(), 2);
         assert!(matches!(
             &frames[0].2,
-            Event::UserPromptSent { text, .. } if text == "/clear"
+            Event::UserPromptSent { text, .. } if text == "/new"
         ));
         assert!(matches!(&frames[1].2, Event::SessionCleared));
         assert_eq!(frames[1].1, 2, "SessionCleared must use the next seq");
+
+        crate::process::worker_registry::delete(session_id).ok();
     }
 
     /// Regression: `agent_key_for_session` must resolve the registry
@@ -4414,6 +4445,75 @@ mod tests {
         crate::process::worker_registry::delete(session_id).ok();
     }
 
+    /// A claude `/clear` must route onto the driven-reset path, not the
+    /// text forward. Forwarding it does reset the model context, but
+    /// claude-agent-acp keeps serving the pre-clear ACP session id and
+    /// discards the `conversation_reset` message carrying the new one
+    /// (upstream #906), so AoE cannot persist a resume target for the
+    /// post-clear conversation. `SessionCleared` must also be deferred
+    /// until the driven `session/new` commits: publishing it here would
+    /// fold the transcript (and, via the server's listener, drop the
+    /// stored resume id) for a reset that might still fail.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn publish_user_prompt_drives_reset_for_claude_clear() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // SAFETY: serialised by `#[serial]`; subsequent serial tests
+        // reassign these env vars, which is the existing pattern.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        }
+        let session_id = "attached-claude-clear-1";
+        let dir = crate::process::worker_registry::workers_dir().unwrap();
+        let record = crate::process::worker_registry::WorkerRecord::new(
+            session_id.into(),
+            std::process::id(),
+            dir.join(format!("{session_id}.sock")),
+            "claude-agent-acp".into(),
+            "claude".into(),
+            std::env::temp_dir(),
+            None,
+            vec![],
+            vec![],
+            None,
+            None,
+        );
+        crate::process::worker_registry::save(&record).unwrap();
+
+        let sink = VecSink::new();
+        let sup = Supervisor::new(sink.clone());
+        let disposition = sup.publish_user_prompt(session_id, "/clear".into()).await;
+        assert_eq!(
+            disposition,
+            PromptDisposition::ResetContext,
+            "claude /clear must drive a real session/new so the post-clear id is persistable"
+        );
+        let frames = sink.frames.lock().unwrap().clone();
+        assert_eq!(frames.len(), 1, "expected UserPromptSent, got {frames:?}");
+        assert!(matches!(&frames[0].2, Event::UserPromptSent { .. }));
+        assert!(
+            !frames
+                .iter()
+                .any(|(_, _, event)| matches!(event, Event::SessionCleared)),
+            "claude /clear must defer SessionCleared until the driven reset succeeds"
+        );
+
+        // An ordinary prompt on the same profile must be unaffected.
+        let sink2 = VecSink::new();
+        let sup2 = Supervisor::new(sink2.clone());
+        let disposition2 = sup2
+            .publish_user_prompt(session_id, "clear the build cache".into())
+            .await;
+        assert_eq!(
+            disposition2,
+            PromptDisposition::Forward,
+            "a non-alias prompt on claude must keep the forward path"
+        );
+
+        crate::process::worker_registry::delete(session_id).ok();
+    }
+
     /// Legacy registry records (written before the `agent_key` field
     /// existed) fall back to `"claude"` so existing claude sessions
     /// keep working through the rollout. The supervisor falls through
@@ -4453,10 +4553,15 @@ mod tests {
 
         let sink = VecSink::new();
         let sup = Supervisor::new(sink.clone());
-        sup.publish_user_prompt(session_id, "/clear".into()).await;
+        let disposition = sup.publish_user_prompt(session_id, "/clear".into()).await;
+        // `ResetContext` is the discriminator: it is reachable only via
+        // claude's profile, since `DEFAULT` lists no clear aliases and would
+        // have returned `Forward`. The boundary event itself is deferred until
+        // the driven `session/new` commits, so only the prompt is published.
+        assert_eq!(disposition, PromptDisposition::ResetContext);
         let frames = sink.frames.lock().unwrap().clone();
-        assert_eq!(frames.len(), 2);
-        assert!(matches!(&frames[1].2, Event::SessionCleared));
+        assert_eq!(frames.len(), 1, "expected UserPromptSent, got {frames:?}");
+        assert!(matches!(&frames[0].2, Event::UserPromptSent { .. }));
         crate::process::worker_registry::delete(session_id).ok();
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5274,13 +5274,18 @@ fn apply_acp_session_change(
                 session = %session_id,
                 "clearing stored ACP session id after a user /clear"
             );
-            // AoE never learns the adapter's post-clear conversation id
-            // (upstream claude-agent-acp #906), so the only way to stop a
+            // For a profile that forwards its clear alias, AoE never learns the
+            // adapter's post-clear conversation id, so the only way to stop a
             // restart from resurrecting the pre-clear conversation via
             // session/load is to drop the stored id now and force a fresh
-            // session/new. Clear the paired fork/import markers
-            // unconditionally too: a /clear issued before a pending
-            // fork/import resolves must still restart clean, not
+            // session/new. That leaves the post-clear conversation
+            // unresumable, which is why the profiles whose adapters withhold
+            // the new id drive the reset themselves instead
+            // (`clear_requires_driven_reset`); on that path this arm still
+            // runs, but the driven burst ends in `AcpSessionAssigned`, which
+            // re-pins the id the adapter just minted. Clear the paired
+            // fork/import markers unconditionally too: a /clear issued before
+            // a pending fork/import resolves must still restart clean, not
             // re-session/fork the parent. See #3080.
             inst.acp_session_id = None;
             inst.fork_pending = None;

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -443,10 +443,12 @@ impl SessionService {
         //
         // The publish step owns clear-command detection and tells us what to
         // do with the text: either forward it as an ordinary prompt or drive
-        // a real reset on the live worker for a clear alias whose adapter has
-        // no native reset (codex `/new`). Forwarding the raw
-        // alias there would be swallowed as an unknown command and the
-        // conversation would silently keep its context. See #2979.
+        // a real reset on the live worker for a clear alias whose adapter
+        // cannot hand back a durable post-reset session id. Forwarding a codex
+        // `/new` would be swallowed as an unknown command and the conversation
+        // would silently keep its context (#2979); forwarding a claude
+        // `/clear` resets the context but leaves the new conversation
+        // unresumable across a worker restart (upstream #906).
         let disposition = self
             .acp_supervisor
             .publish_user_prompt_with_attachments(id, text.to_string(), attachments)

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -1171,16 +1171,21 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
       // pending approvals, and the session usage snapshot.
       //
       // We deliberately preserve availableCommands, availableModes,
-      // and currentModeId. claude-agent-sdk caches the supported
-      // command surface at Query init and does not recreate the
-      // Query on /clear, so the cached list stays authoritative for
-      // the lifetime of the structured view's underlying agent process. The
-      // prior over-clear (#1101 A.1) was based on an assumption that
-      // doesn't hold for this SDK; emptying availableCommands made
-      // the slash palette stay empty forever after the first /clear
-      // because no AvailableCommandsUpdated event arrives to refill
-      // it (tracked upstream at
+      // and currentModeId. The prior over-clear (#1101 A.1) assumed a
+      // refill would follow, which it does not: emptying
+      // availableCommands made the slash palette stay empty forever
+      // after the first /clear because no AvailableCommandsUpdated
+      // event arrives to repopulate it (tracked upstream at
       // agentclientprotocol/claude-agent-acp#657). See #1128.
+      //
+      // A driven reset (claude /clear, codex /new) DOES open a new
+      // session, so the preserved command list is no longer guaranteed
+      // authoritative for it: the fresh session could advertise a
+      // different surface. Preserving is still the better failure mode,
+      // since a possibly-stale palette beats a permanently empty one,
+      // and the reset path re-announces modes and config options so the
+      // pickers stay correct. Revisit if an adapter's command surface
+      // starts varying across sessions in the same process.
       next.activity = [
         ...next.activity,
         {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2000,6 +2000,19 @@
       ]
     },
     {
+      "id": "acp.claude-clear-reset",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": ["tests/live/acp-claude-clear-reset.spec.ts"],
+      "components": [
+        "src/acp/acp_client.rs",
+        "src/acp/agent_profiles.rs",
+        "src/acp/supervisor.rs",
+        "src/server/mod.rs",
+        "src/server/session_service.rs"
+      ]
+    },
+    {
       "id": "acp.idle-dormant-wake",
       "kind": "vitest",
       "risk": "high",

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -305,16 +305,28 @@ export function tmuxSocketPath(home: string): string {
  * Resolve where the daemon will write `serve.token` (and other serve.*
  * state files) under the test's isolated filesystem tree. Mirrors the
  * Rust `get_app_dir_path` logic at `src/session/mod.rs:83`: Linux uses
- * `$XDG_CONFIG_HOME/agent-of-empires[-dev]`, macOS/Windows uses
- * `$HOME/.agent-of-empires[-dev]`. Debug builds carry the `-dev`
+ * `$XDG_CONFIG_HOME/agent-of-empires[-dev]`. Debug builds carry the `-dev`
  * suffix, derived from the binary path the same way as `tmuxPrefixFor`.
+ *
+ * macOS/Windows go through `session::macos_app_dir` (#1948), whose precedence
+ * is: the XDG path if it exists, else the legacy `~/.agent-of-empires` if that
+ * exists, else the XDG path whenever `XDG_CONFIG_HOME` is set, else legacy.
+ * The harness always sets `XDG_CONFIG_HOME` on an isolated tree, so a fresh
+ * test home resolves to the XDG path, NOT the legacy one. Returning the legacy
+ * path unconditionally here pointed specs at a directory the daemon never
+ * touches, which reads as a passing no-op on macOS while CI (Linux) took the
+ * correct branch.
  */
 export function appDirFor(home: string, xdg: string, binaryPath: string): string {
   const suffix = binaryPath.includes("/target/debug/") ? "-dev" : "";
+  const xdgDir = join(xdg, `agent-of-empires${suffix}`);
   if (process.platform === "linux") {
-    return join(xdg, `agent-of-empires${suffix}`);
+    return xdgDir;
   }
-  return join(home, `.agent-of-empires${suffix}`);
+  const legacy = join(home, `.agent-of-empires${suffix}`);
+  if (existsSync(xdgDir)) return xdgDir;
+  if (existsSync(legacy)) return legacy;
+  return xdg ? xdgDir : legacy;
 }
 
 /**

--- a/web/tests/live/acp-claude-clear-reset.spec.ts
+++ b/web/tests/live/acp-claude-clear-reset.spec.ts
@@ -50,16 +50,45 @@ test("claude /clear opens a fresh session/new and persists the new acp session i
       const replay = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/replay?since=0`).then((r) => r.json());
       return replay.frames ?? [];
     };
+    // An event is either a bare string for a unit variant (`"SessionCleared"`)
+    // or a single-key object (`{ SessionContextReset: { reason } }`).
+    type FrameEvent = string | Record<string, { acp_session_id?: string; reason?: string }>;
+    const eventOf = (f: unknown): FrameEvent | undefined => (f as { event?: FrameEvent }).event;
+    const kindOf = (ev: FrameEvent | undefined): string | undefined =>
+      typeof ev === "string" ? ev : ev ? Object.keys(ev)[0] : undefined;
+    const payloadOf = (ev: FrameEvent | undefined) =>
+      typeof ev === "string" || !ev ? undefined : Object.values(ev)[0];
+
     const assignedIds = async (): Promise<string[]> => {
       const ids: string[] = [];
       for (const f of await replayFrames()) {
-        const ev = (f as { event?: Record<string, { acp_session_id?: string }> }).event;
-        if (ev && typeof ev === "object" && "AcpSessionAssigned" in ev) {
-          const id = ev.AcpSessionAssigned?.acp_session_id;
+        const ev = eventOf(f);
+        if (kindOf(ev) === "AcpSessionAssigned") {
+          const id = payloadOf(ev)?.acp_session_id;
           if (id) ids.push(id);
         }
       }
       return ids;
+    };
+    /**
+     * The ordered contract of a successful driven reset, by frame index rather
+     * than substring match: `SessionCleared`, then `SessionContextReset`, then
+     * a SECOND `AcpSessionAssigned`, then a terminal `Stopped(session_reset)`.
+     *
+     * Order is the load-bearing part, not just presence. The server's listener
+     * folds `SessionCleared` and `SessionContextReset` to a null stored id and
+     * `AcpSessionAssigned` to the new one, so the assignment landing LAST is the
+     * only reason the fresh id is what ends up persisted.
+     */
+    const resetSequenceComplete = async (): Promise<boolean> => {
+      const kinds = (await replayFrames()).map((f) => ({ kind: kindOf(eventOf(f)), payload: payloadOf(eventOf(f)) }));
+      const cleared = kinds.findIndex((k) => k.kind === "SessionCleared");
+      if (cleared < 0) return false;
+      const reset = kinds.findIndex((k, i) => i > cleared && k.kind === "SessionContextReset");
+      if (reset < 0) return false;
+      const assigned = kinds.findIndex((k, i) => i > reset && k.kind === "AcpSessionAssigned");
+      if (assigned < 0) return false;
+      return kinds.some((k, i) => i > assigned && k.kind === "Stopped" && k.payload?.reason === "session_reset");
     };
     // `acp_session_id` is not exposed over the REST API, so read the same
     // on-disk record a respawn would read. The harness roots the daemon at an
@@ -101,22 +130,8 @@ test("claude /clear opens a fresh session/new and persists the new acp session i
     });
     expect(resetResponse.status).toBe(202);
 
-    // The reset's full event contract, in one poll: clear boundary, reset
-    // boundary, a second assigned id, and the terminal Stopped.
-    await expect
-      .poll(
-        async () => {
-          const json = JSON.stringify(await replayFrames());
-          return (
-            json.includes('"SessionCleared"') &&
-            json.includes("SessionContextReset") &&
-            json.includes("session_reset") &&
-            (await assignedIds()).length >= 2
-          );
-        },
-        { timeout: 45_000, intervals: [500] },
-      )
-      .toBe(true);
+    // The reset's full ordered event contract in one poll.
+    await expect.poll(resetSequenceComplete, { timeout: 45_000, intervals: [500] }).toBe(true);
 
     const ids = await assignedIds();
     const freshId = ids[ids.length - 1]!;

--- a/web/tests/live/acp-claude-clear-reset.spec.ts
+++ b/web/tests/live/acp-claude-clear-reset.spec.ts
@@ -1,0 +1,133 @@
+// Live: a claude `/clear` drives a REAL conversation reset and persists the
+// new resume id, so the post-clear conversation survives a worker restart.
+//
+// claude-agent-acp DOES handle `/clear` locally, so the old text-forward path
+// reset the model context correctly. What it never did was rotate the ACP
+// session id: the adapter keeps serving the pre-clear id and discards the
+// `conversation_reset` message carrying the new conversation id (upstream
+// #906). #3083 responded by dropping the stored id on `SessionCleared`, which
+// stopped the pre-clear conversation from resurrecting but left the post-clear
+// one unresumable. Observed in the wild as a session that worked for two hours
+// after a `/clear`, idled out overnight, and came back with no context at all.
+//
+// The server now drives the reset itself. This spec asserts the full contract
+// against a real `aoe serve` plus the fake claude ACP agent:
+//
+//   - the clear boundary (`SessionCleared`) still renders,
+//   - the reset boundary (`SessionContextReset`) fires,
+//   - a SECOND `AcpSessionAssigned` lands with a NEW acp session id (proof a
+//     fresh session/new ran rather than the alias being forwarded),
+//   - and, the part the incident turned on, that new id is what ends up
+//     PERSISTED in sessions.json, because that on-disk value is the only
+//     handle a later respawn can feed to session/load.
+//
+// The persisted-id assertion is the actual regression guard. Everything above
+// it was already true of a forwarded `/clear` from the UI's point of view,
+// which is precisely why the data loss went unnoticed.
+//
+// API-only (no page): the routing decision is unit-tested in
+// `src/acp/supervisor.rs`, the profile table in `src/acp/agent_profiles.rs`.
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions, seedSessionViaAoeAdd, appDirFor, resolveAoeBinary } from "../helpers/aoeServe";
+
+test("claude /clear opens a fresh session/new and persists the new acp session id", async ({}, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    acp: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "claude-clear-reset", tool: "claude" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const sessionId = sessions[0]!.id;
+
+    const replayFrames = async (): Promise<unknown[]> => {
+      const replay = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/replay?since=0`).then((r) => r.json());
+      return replay.frames ?? [];
+    };
+    const assignedIds = async (): Promise<string[]> => {
+      const ids: string[] = [];
+      for (const f of await replayFrames()) {
+        const ev = (f as { event?: Record<string, { acp_session_id?: string }> }).event;
+        if (ev && typeof ev === "object" && "AcpSessionAssigned" in ev) {
+          const id = ev.AcpSessionAssigned?.acp_session_id;
+          if (id) ids.push(id);
+        }
+      }
+      return ids;
+    };
+    // `acp_session_id` is not exposed over the REST API, so read the same
+    // on-disk record a respawn would read. The harness roots the daemon at an
+    // isolated HOME, so this is the test's own sessions.json, not the user's.
+    //
+    // The profile directory name is resolved (or bootstrapped) by
+    // `config::resolve_default_profile`, so it is not reliably "default";
+    // scan `profiles/*/sessions.json` for the one holding this session.
+    const persistedAcpSessionId = (): string | undefined => {
+      const appDir = appDirFor(serve.home, serve.env.XDG_CONFIG_HOME!, resolveAoeBinary());
+      const profilesDir = join(appDir, "profiles");
+      for (const profile of readdirSync(profilesDir)) {
+        const path = join(profilesDir, profile, "sessions.json");
+        if (!existsSync(path)) continue;
+        const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+        const all = Array.isArray(parsed) ? parsed : ((parsed as { sessions?: unknown[] }).sessions ?? []);
+        const inst = (all as { id?: string; acp_session_id?: string }[]).find((s) => s.id === sessionId);
+        if (inst) return inst.acp_session_id;
+      }
+      return undefined;
+    };
+
+    await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/enable`, { method: "POST" });
+
+    // Handshake oracle: the first AcpSessionAssigned frame proves the fake
+    // claude worker is live and its initial session/new completed.
+    await expect
+      .poll(async () => (await assignedIds()).length, { timeout: 45_000, intervals: [500] })
+      .toBeGreaterThan(0);
+    const firstId = (await assignedIds())[0]!;
+
+    // `/clear` goes through the ordinary prompt endpoint; the server-side clear
+    // detection reroutes it onto the driven-reset path. The assigned id above
+    // proves the worker is ready, so submit this stateful request exactly once.
+    const resetResponse = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/prompt`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "/clear" }),
+    });
+    expect(resetResponse.status).toBe(202);
+
+    // The reset's full event contract, in one poll: clear boundary, reset
+    // boundary, a second assigned id, and the terminal Stopped.
+    await expect
+      .poll(
+        async () => {
+          const json = JSON.stringify(await replayFrames());
+          return (
+            json.includes('"SessionCleared"') &&
+            json.includes("SessionContextReset") &&
+            json.includes("session_reset") &&
+            (await assignedIds()).length >= 2
+          );
+        },
+        { timeout: 45_000, intervals: [500] },
+      )
+      .toBe(true);
+
+    const ids = await assignedIds();
+    const freshId = ids[ids.length - 1]!;
+    expect(freshId, "the reset must mint a NEW acp session id via session/new").not.toBe(firstId);
+
+    // The regression guard. Pre-fix this settled on `null`, because
+    // `SessionCleared` nulled the stored id and a forwarded `/clear` never
+    // produced an `AcpSessionAssigned` to re-pin it. A respawn then had nothing
+    // to resume and silently started an empty conversation.
+    await expect.poll(persistedAcpSessionId, { timeout: 15_000, intervals: [250] }).toBe(freshId);
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the investigation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A claude structured-view session lost two hours of agent context overnight. Reconstructed from the event DB and worker log:

| When (local) | What | Evidence |
|---|---|---|
| 07-28 15:55:09 | `/clear` sent | `acp_events` seq `17279` `SessionCleared` |
| same instant | stored ACP session id dropped | `acp.event_listener: clearing stored ACP session id after a user /clear` |
| 15:55 → 17:40 | ~2h of real work | ran under claude session `e4b62bd7`, which appears **nowhere** in the event store |
| 07-28 18:40:26 | idle auto stop | `acp.protocol: shutdown received, exiting connection loop` |
| 07-29 07:40:21 | next prompt respawns | `acp.protocol: creating fresh session via session/new` → empty session |

Every respawn for the preceding three weeks logged `resuming session via session/load stored_id=a3b9323f-...`. Only this one did `session/new`.

**Root cause.** claude-agent-acp does handle `/clear` locally, so forwarding the text resets the model context correctly. What it does not do is rotate the ACP session id, and it explicitly discards the `conversation_reset` stream message that carries the new conversation id (0.62.0 `dist/acp-agent.js`: `` `conversation_reset` ... is safe to drop ``; upstream [claude-agent-acp#906](https://github.com/agentclientprotocol/claude-agent-acp/issues/906) is still open). AoE is left holding an id that `session/load` resolves back to the *pre-clear* conversation.

#3080 / #3083 responded by dropping the stored id on `SessionCleared`. That correctly stopped the pre-clear conversation from resurrecting, but it made the post-clear conversation unresumable: any worker restart after a `/clear` starts an empty session. The two failure modes were traded for one another, and the second one is silent.

**Fix.** Flip `CLAUDE` and `CLAUDE_CODE` onto the driven-reset path built for codex in #2979 and hardened in #3132. A driven reset opens a genuinely fresh `session/new` on the live worker and ends its success burst with `AcpSessionAssigned`, so the id AoE persists is the one the adapter is actually serving, and a later restart resumes the post-clear conversation. The adapter maps `session/load` straight onto the Claude SDK `resume:` option (`dist/acp-agent.js`), so a minted id is a valid resume target.

No new mechanism, no event-schema change, no UI rework. One flag, plus the scoping and tests around it.

**`aoe-agent` is deliberately excluded.** It inherits every field via `..CLAUDE`, so the flip would have silently changed a different multi-provider adapter whose clear semantics nobody has verified. It now sets `clear_requires_driven_reset: false` explicitly, and a test pins that so a future `..CLAUDE` edit cannot re-flip it by accident. `opencode` / `omp` / `kimi` may carry the identical defect but stay on the forward path for the same reason; the log signature is distinctive enough to diagnose if it bites.

**Two behavior changes, both accepted deliberately.** A clear now costs a `session/new` handshake instead of an in-adapter reset, so it can fail where it previously could not (an MCP server that will not re-init). On failure the existing path emits no `SessionCleared` and leaves the conversation untouched, which is the correct contract. And a clear is refused with `PromptRejected { reason: "agent_busy" }` while between-prompt tools or background sub-agents are draining, because switching conversations mid-drain would misattribute their remaining output. Claude uses sub-agents heavily, so this refusal will be more common for claude than it has been for codex. See "Known follow-ups".

This also incidentally resolves an inconsistency worth noting: `Event::SessionCleared` has no arm in the supervisor drain loop, so a forwarded claude `/clear` nulled the id in `sessions.json` while leaving the worker-registry copy holding the pre-clear id. The driven burst ends in `AcpSessionAssigned`, which writes both stores. Left as-is for the profiles still forwarding.

**Design was adjudicated by a three-model debate** before implementation. It killed my first hardening idea (profile-gating the listener arms so `AcpSessionAssigned` became the sole id writer): `SessionContextReset` is overloaded as the `session/load` and `session/fork` failure signal, where the nulling is required, so profile is the wrong predicate, and the residual states invert such that a crash before `Assigned` would leave the *pre-clear* id on disk and resurrect #3080. Dropped.

A local CodeRabbit review then raised one finding, now fixed: the live spec's replay poll substring-matched `JSON.stringify(frames)`, which could pass coincidentally and asserted nothing about sequence. Since order is the load-bearing part (the assignment landing last is the only reason the fresh id is what persists), the spec now parses each frame and asserts by index. CodeRabbit re-run is clean at 0 findings.

The same three models also reviewed the finished diff and all voted to ship it. Two findings were worth acting on and are folded in: the reducer's stated reason for preserving `availableCommands` across a clear ("does not recreate the Query on `/clear`") no longer holds for a driven reset, and the durability caveat in the follow-ups below needed stating precisely rather than loosely. A third finding, that the slash-command palette might empty after a driven reset, was checked against `web/src/lib/acpTypes.ts` and does not reproduce: the reducer deliberately preserves the command list, which is what #1128 fixed.

**Not an issue-backed PR** by request, so there is no `Closes` line. Related: #3080, #3083 (the workaround this supersedes for claude), #2979 and #3132 (the machinery reused), upstream claude-agent-acp #906.

## How to test

Behavioral steps against a claude structured-view session:

- [ ] Open a claude structured-view session and send a prompt so it has real context. Ask it something only that context can answer (e.g. "what did I just ask you?").
- [ ] Send `/clear`. Confirm the transcript folds behind the `Show N earlier turns` banner and a "Conversation cleared" divider appears, exactly as before.
- [ ] Send a couple more prompts so the post-clear conversation has content of its own.
- [ ] Stop the worker to simulate the overnight idle: `aoe acp stop <session-id>` (or wait out `idle_auto_stop`, or restart the daemon).
- [ ] Send another prompt to respawn the worker, then ask the agent about something from the *post-clear* turns. It should remember them.
- [ ] Confirm the worker log resumed rather than started fresh: `grep -E "session/load|session/new" ~/.agent-of-empires/acp-workers/<session-id>.log | tail -3` should show `resuming session via session/load`, not `creating fresh session via session/new`.
- [ ] Confirm the agent does **not** remember anything from before the `/clear` (the #3080 direction must stay fixed).
- [ ] Kick off something that spawns a background sub-agent, and send `/clear` while it is still running. Expect a visible `agent_busy` rejection with your text preserved in a retry pill, not a silent no-op.
- [ ] Sanity-check codex is unaffected: `/new` in a codex structured-view session still resets and still survives a restart.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy --features serve --all-targets`, and `cargo test --features serve` (6013 passed) are clean. `npm run format:check`, `npm run lint`, `npx tsc -b`, and `npx vitest run` (3571 passed) are clean, as is a local CodeRabbit review (0 findings). Docs: one terse addition to `docs/structured-view/troubleshooting.md` covering the two non-discoverable facts (a clear now outlives a restart; it is refused while background work drains). No UI change, so no screenshot.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

`web/tests/live/acp-claude-clear-reset.spec.ts` drives a real `aoe serve` plus the fake claude ACP agent through the production prompt endpoint and asserts the reset contract, ending with the assertion that actually matters: the new id is what gets **persisted to `sessions.json`**, since that on-disk value is the only handle a respawn can feed to `session/load`. Every weaker assertion was already satisfiable by a forwarded `/clear` as far as the UI could tell, which is precisely why the data loss went unnoticed.

Verified red before the fix, not just green after: with the flag reverted and the release binary rebuilt, no second `AcpSessionAssigned` is ever emitted and the contract poll times out. The two Rust unit tests were likewise checked red in an ephemeral detached worktree (`Forward` vs `ResetContext`) before being confirmed green.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: this is session lifecycle, but the live Playwright spec already exercises it end-to-end through a real daemon and a real ACP worker, which is the layer this behavior lives at. `tests/e2e/` is tmux and TUI oriented and would test strictly less of the path.

## Known follow-ups

Two findings from the investigation and debate that are real but out of scope here. Happy to file both as issues.

1. **A failed `sessions.json` save is only warned about.** `src/server/mod.rs` logs `save after acp_session_id update: {e}` and continues while memory retains the new id. On the driven path the preceding `SessionCleared` write has already put `None` on disk, so a failed `AcpSessionAssigned` save leaves `None` there: the user works for hours against an id only memory knows about, and a restart lands them in an empty session. Same user-visible failure as the incident above, different trigger. This is pre-existing, applies equally to the ordinary spawn path and to codex, and is neither created nor widened by this change beyond exposure, but it does mean "survives a worker restart" describes the happy path rather than a guarantee.
2. **The busy-refusal UX.** An exclusive wait-or-cancel barrier would beat the flat `agent_busy` rejection. Worth recording that a naive deferred reset is *unsafe*: a queued destructive op can erase context created by prompts accepted while it waited, unless the whole prompt lane is serialized around it.

Also surfaced and worth its own issue: `aoe session set-session-id` explicitly refuses structured-view sessions, so a user who hit this bug had **no supported way** to repin their conversation. Recovering the affected session needed a hand-edit of `sessions.json`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-investigate` then `/aoe-implement`, with a `/debate` panel of gemini-3.1-pro, gpt-5.6-sol, and grok-4.5 for the design call)

**Any Additional AI Details you'd like to share:**

I brought the symptom ("why did this session's context reset overnight"). Claude did the log and event-DB forensics, read the adapter source, ran the design debate, and wrote the code, tests, and prose under my direction. I made the calls on scope: PR without a tracking issue, exclude `aoe-agent` rather than let it inherit, leave the unverified profiles alone, and keep the durability and busy-refusal hardening as follow-ups instead of bundling them.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated Claude and Claude Code `/clear` to start a fresh, restartable conversation instead of forwarding the command.
- Explicitly excluded `aoe-agent`; other unverified adapters retain their existing behavior.
- Added protections for busy workers and failed session initialization.
- Expanded documentation and comments to explain reset and restart behavior.
- Added end-to-end coverage verifying reset event ordering and persistence of the new session ID.
- Fixed macOS and Windows test-harness app-directory resolution.

## Benefits

- Conversations can resume correctly after worker restarts.
- Clear operations are safer and provide more predictable failure behavior.
- Improved regression coverage and cross-platform test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->