### PR TITLE
chore: release v1.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,69 @@ All notable changes to Agent of Empires will be documented in this file.
 
 The format follows [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [1.13.2](https://github.com/agent-of-empires/agent-of-empires/releases/tag/v1.13.2) - 2026-07-29
+
+
+
+### Bug Fixes
+
+- **acp:** Show real rate-limit reset time and continue the turn on resume in [#3061](https://github.com/agent-of-empires/agent-of-empires/pull/3061) by [@Seluj78](https://github.com/Seluj78) ([`b8c2bea`](https://github.com/agent-of-empires/agent-of-empires/commit/b8c2bea8a9219f34fea72fefc8b7e22271c1ac65))
+- Refresh local TUI token after rotation in [#3003](https://github.com/agent-of-empires/agent-of-empires/pull/3003) by [@amanzainal](https://github.com/amanzainal) ([`69edb72`](https://github.com/agent-of-empires/agent-of-empires/commit/69edb72548b1e241ac7158bf34fead906d8eacc1))
+- **session:** Persist engine swap from the restart dialog in [#3077](https://github.com/agent-of-empires/agent-of-empires/pull/3077) by [@Eric162](https://github.com/Eric162) ([`9309c64`](https://github.com/agent-of-empires/agent-of-empires/commit/9309c6421fb7070899a8a886f901f75a8776d008))
+- **web:** Render opencode subagent (task) as a subagent card, not a bare think card in [#3074](https://github.com/agent-of-empires/agent-of-empires/pull/3074) by [@Seluj78](https://github.com/Seluj78) ([`ae83a9a`](https://github.com/agent-of-empires/agent-of-empires/commit/ae83a9ab1c60cd2232a54e8df62a967f1cd13e07))
+- **web:** Add missing subagentToolNames to OMP agent profile in [#3081](https://github.com/agent-of-empires/agent-of-empires/pull/3081) by [@njbrake](https://github.com/njbrake) ([`f89e6fe`](https://github.com/agent-of-empires/agent-of-empires/commit/f89e6fe46b2d05bd4f157a126a1bd7c510836844))
+- **session:** Wire OMP session capture so --resume works in [#3078](https://github.com/agent-of-empires/agent-of-empires/pull/3078) by [@njbrake](https://github.com/njbrake) ([`2a96c43`](https://github.com/agent-of-empires/agent-of-empires/commit/2a96c436428aefa776e7a75e16316f3ceab34d1c))
+- **web:** Scope last-session restore to standalone PWA launch in [#3072](https://github.com/agent-of-empires/agent-of-empires/pull/3072) by [@cwrau](https://github.com/cwrau) ([`5dc514c`](https://github.com/agent-of-empires/agent-of-empires/commit/5dc514c3eef3e0d8f07a68ecb10b8038459c5f00))
+- **serve:** Drop stored ACP session id on /clear so restart starts fresh in [#3083](https://github.com/agent-of-empires/agent-of-empires/pull/3083) by [@Seluj78](https://github.com/Seluj78) ([`752f830`](https://github.com/agent-of-empires/agent-of-empires/commit/752f830f7cb1f5181ca33587bc3487d565bc3844))
+- **test:** Retry recovery_lock reacquire to absorb CI scheduling gap in [#3082](https://github.com/agent-of-empires/agent-of-empires/pull/3082) by [@Seluj78](https://github.com/Seluj78) ([`06ba67e`](https://github.com/agent-of-empires/agent-of-empires/commit/06ba67e0f17bb111e5ad1bfb158612ec28b4de48))
+- **acp:** Stop long-running Terminal keepalives from spawning phantom tool-call cards in [#3085](https://github.com/agent-of-empires/agent-of-empires/pull/3085) by [@Seluj78](https://github.com/Seluj78) ([`c47717f`](https://github.com/agent-of-empires/agent-of-empires/commit/c47717f791c12c0e9eb373ed3586ed093d12f2e4))
+- **acp:** Synthesize Write-tool diffs and stop tool-start merges from dropping them in [#3093](https://github.com/agent-of-empires/agent-of-empires/pull/3093) by [@lucas-m-1](https://github.com/lucas-m-1) ([`4940bf0`](https://github.com/agent-of-empires/agent-of-empires/commit/4940bf045424d7397028eada279f46ab365c90e3))
+- **live:** Web takeover wins the size-owner lock; keyboard-safe sizing and smooth scrolling on mobile in [#3096](https://github.com/agent-of-empires/agent-of-empires/pull/3096) by [@njbrake](https://github.com/njbrake) ([`d1b184e`](https://github.com/agent-of-empires/agent-of-empires/commit/d1b184eacc8d1cb9be485a0414a965a8b0887c39))
+- **web:** Clear rate-limit banner when a session resumes to life in [#3097](https://github.com/agent-of-empires/agent-of-empires/pull/3097) by [@Seluj78](https://github.com/Seluj78) ([`ef8758b`](https://github.com/agent-of-empires/agent-of-empires/commit/ef8758b72704d0d4d8e2399e562b9c622d4c198b))
+- **mcp:** Honor disabled Codex native servers in [#3066](https://github.com/agent-of-empires/agent-of-empires/pull/3066) by [@microHoffman](https://github.com/microHoffman) ([`fba065e`](https://github.com/agent-of-empires/agent-of-empires/commit/fba065eda2d7aea30b3dbf05f132ffe312faaed8))
+- **serve:** Persist config-option mode picks to acp_mode_id in [#3092](https://github.com/agent-of-empires/agent-of-empires/pull/3092) by [@Seluj78](https://github.com/Seluj78) ([`21c6bd2`](https://github.com/agent-of-empires/agent-of-empires/commit/21c6bd26b7ea869f102cf556baa547fc865a1448))
+- Disambiguate reused tool completion ids in [#3107](https://github.com/agent-of-empires/agent-of-empires/pull/3107) by [@gilbertl](https://github.com/gilbertl) ([`db94358`](https://github.com/agent-of-empires/agent-of-empires/commit/db94358261397aa31cc702409b425424605f7cca))
+- **tmux:** Forward desktop/session env (DISPLAY, XDG_*) into sessions in [#3079](https://github.com/agent-of-empires/agent-of-empires/pull/3079) by [@njbrake](https://github.com/njbrake) ([`78fd4da`](https://github.com/agent-of-empires/agent-of-empires/commit/78fd4daebffb5ee8ad39e5fe44c11499e2766e03))
+- **tui:** Single-click the active session to exit live mode in SelectOnly mode in [#3109](https://github.com/agent-of-empires/agent-of-empires/pull/3109) by [@njbrake](https://github.com/njbrake) ([`2b4221a`](https://github.com/agent-of-empires/agent-of-empires/commit/2b4221a08361b92bcbf99dbd03e465e87060ceaa))
+- **tui:** Probe all missing agents in one login shell at startup in [#3111](https://github.com/agent-of-empires/agent-of-empires/pull/3111) by [@njbrake](https://github.com/njbrake) ([`1da94f1`](https://github.com/agent-of-empires/agent-of-empires/commit/1da94f1e06de0d85316c7d7009d536e15aab05c3))
+- Build serve feature on FreeBSD where rlim_t is i64 in [#3100](https://github.com/agent-of-empires/agent-of-empires/pull/3100) by [@golodhrim](https://github.com/golodhrim) ([`9a35c30`](https://github.com/agent-of-empires/agent-of-empires/commit/9a35c30f7a8e596ea6b318b9580a64d3a676700d))
+- **web:** Exclude trashed sessions from dashboard status summary in [#3115](https://github.com/agent-of-empires/agent-of-empires/pull/3115) by [@njbrake](https://github.com/njbrake) ([`ee6186c`](https://github.com/agent-of-empires/agent-of-empires/commit/ee6186c3571c87d2f4c3659da42bdefd345c05cc))
+- **acp:** Pass configured Host Environment to structured workers in [#3113](https://github.com/agent-of-empires/agent-of-empires/pull/3113) by [@CoreInfusion](https://github.com/CoreInfusion) ([`a045ad3`](https://github.com/agent-of-empires/agent-of-empires/commit/a045ad37c21b4a3f9ab2a086cf808f6e96fbeee4))
+- **web:** Flick momentum, scroll gain, and full-pane touch area for alt-screen agents on mobile in [#3116](https://github.com/agent-of-empires/agent-of-empires/pull/3116) by [@njbrake](https://github.com/njbrake) ([`5bac539`](https://github.com/agent-of-empires/agent-of-empires/commit/5bac5397baaf9d00fc70fe40c48cf3b45fb3d6af))
+- **web:** Unstick suspended-session resume, drop 503 toast and draft re-fill in [#3098](https://github.com/agent-of-empires/agent-of-empires/pull/3098) by [@Seluj78](https://github.com/Seluj78) ([`f69379b`](https://github.com/agent-of-empires/agent-of-empires/commit/f69379b2a563e961da732e84ce8ce77841c40bde))
+- **serve:** Persist thought-level picks so they survive a worker respawn in [#3134](https://github.com/agent-of-empires/agent-of-empires/pull/3134) by [@Seluj78](https://github.com/Seluj78) ([`a89a9fa`](https://github.com/agent-of-empires/agent-of-empires/commit/a89a9fa28e03b6c2e62499ca9bc1bfb6cf5eb820))
+- **web:** Respect prefers-reduced-motion for entrance animations in [#3142](https://github.com/agent-of-empires/agent-of-empires/pull/3142) by [@njbrake](https://github.com/njbrake) ([`bff9f0d`](https://github.com/agent-of-empires/agent-of-empires/commit/bff9f0d795ca964ce85562d4dab1f9ee4161caf0))
+- **tui:** Stop the live-send lock retry from stealing back after a takeover in [#3145](https://github.com/agent-of-empires/agent-of-empires/pull/3145) by [@njbrake](https://github.com/njbrake) ([`66a935a`](https://github.com/agent-of-empires/agent-of-empires/commit/66a935abaa64606857b20b4b426e3e7d2f9d104f))
+- **web:** Stagger PWA cold-start paint and clear iOS keyboard bar over Send in [#3131](https://github.com/agent-of-empires/agent-of-empires/pull/3131) by [@njbrake](https://github.com/njbrake) ([`ea0136d`](https://github.com/agent-of-empires/agent-of-empires/commit/ea0136d91d3ff90f8d6210200d0e4b72d23eba82))
+- **status:** Stop pi sessions from sticking on Running after a turn ends in [#3146](https://github.com/agent-of-empires/agent-of-empires/pull/3146) by [@njbrake](https://github.com/njbrake) ([`d23fc3d`](https://github.com/agent-of-empires/agent-of-empires/commit/d23fc3d0e5a2047b60aaf582514c41783e572894))
+- **status:** Reconcile fresh idle hook writes against the pane for Claude in [#3147](https://github.com/agent-of-empires/agent-of-empires/pull/3147) by [@njbrake](https://github.com/njbrake) ([`cbdc1c4`](https://github.com/agent-of-empires/agent-of-empires/commit/cbdc1c4ef703a8bd20b0eb0983adcaff6306cfbc))
+- **tests:** Make restart resume-failed test independent of CLAUDE_CONFIG_DIR in [#3149](https://github.com/agent-of-empires/agent-of-empires/pull/3149) by [@njbrake](https://github.com/njbrake) ([`76a6722`](https://github.com/agent-of-empires/agent-of-empires/commit/76a6722c1aeb9c73d7ff9622b7357a16eef6d1cd))
+- **acp:** Drive a real conversation reset for codex /new in [#3132](https://github.com/agent-of-empires/agent-of-empires/pull/3132) by [@shixi-li](https://github.com/shixi-li) ([`6f25988`](https://github.com/agent-of-empires/agent-of-empires/commit/6f25988cb8c6f329fbec48c10ae23cb447c4dbf4))
+- **acp:** Drive a real conversation reset for claude /clear so it survives a worker restart in [#3151](https://github.com/agent-of-empires/agent-of-empires/pull/3151) by [@Seluj78](https://github.com/Seluj78) ([`d333d79`](https://github.com/agent-of-empires/agent-of-empires/commit/d333d79d2eae2b4d2e21a15dd66ef8ae88140a3e))
+- **cli:** Route fatal startup errors through the tracing sink in [#3150](https://github.com/agent-of-empires/agent-of-empires/pull/3150) by [@jerome-benoit](https://github.com/jerome-benoit) ([`e3a746d`](https://github.com/agent-of-empires/agent-of-empires/commit/e3a746d6a0abbebe59aa20acadeed67808616697))
+
+
+### Features
+
+- **tui:** Refine structured chat hierarchy in [#2966](https://github.com/agent-of-empires/agent-of-empires/pull/2966) by [@amanzainal](https://github.com/amanzainal) ([`5ce23f4`](https://github.com/agent-of-empires/agent-of-empires/commit/5ce23f450479bb28fe70fb36c8f784f9c01fb440))
+- Pin favorites to the top in every sort order in [#3064](https://github.com/agent-of-empires/agent-of-empires/pull/3064) by [@bjkim95](https://github.com/bjkim95) ([`0c71afa`](https://github.com/agent-of-empires/agent-of-empires/commit/0c71afa158240861f9f667a23860cb5bd526a140))
+- Allow "Auto-name now" when smart rename is off in [#3058](https://github.com/agent-of-empires/agent-of-empires/pull/3058) by [@Seluj78](https://github.com/Seluj78) ([`5ddea3f`](https://github.com/agent-of-empires/agent-of-empires/commit/5ddea3f96a782791296f2c25b3b7a33943f60987))
+- Add Oh My Pi (OMP) agent support in [#3073](https://github.com/agent-of-empires/agent-of-empires/pull/3073) by [@leowang-prism](https://github.com/leowang-prism) ([`849cc7e`](https://github.com/agent-of-empires/agent-of-empires/commit/849cc7e6858677847602f96e93be7fdc0528c117))
+- **session:** Make per-session color labels optional via session.show_session_colors in [#3106](https://github.com/agent-of-empires/agent-of-empires/pull/3106) by [@Seluj78](https://github.com/Seluj78) ([`42fa8a2`](https://github.com/agent-of-empires/agent-of-empires/commit/42fa8a27f3996da471eef8d21bd3eef698a4c8dd))
+- **web:** Inline Markdown viewer + Files pane in [#3090](https://github.com/agent-of-empires/agent-of-empires/pull/3090) by [@Seluj78](https://github.com/Seluj78) ([`e90025a`](https://github.com/agent-of-empires/agent-of-empires/commit/e90025a6ffdc75e20e09d1d0e70014fb1f242e52))
+
+
+
+### New Contributors
+
+- [@shixi-li](https://github.com/shixi-li) made their first contribution in [#3132](https://github.com/agent-of-empires/agent-of-empires/pull/3132)
+- [@golodhrim](https://github.com/golodhrim) made their first contribution in [#3100](https://github.com/agent-of-empires/agent-of-empires/pull/3100)
+- [@lucas-m-1](https://github.com/lucas-m-1) made their first contribution in [#3093](https://github.com/agent-of-empires/agent-of-empires/pull/3093)
+- [@cwrau](https://github.com/cwrau) made their first contribution in [#3072](https://github.com/agent-of-empires/agent-of-empires/pull/3072)
+- [@leowang-prism](https://github.com/leowang-prism) made their first contribution in [#3073](https://github.com/agent-of-empires/agent-of-empires/pull/3073)
+- [@bjkim95](https://github.com/bjkim95) made their first contribution in [#3064](https://github.com/agent-of-empires/agent-of-empires/pull/3064)
+
+**Full Changelog**: https://github.com/agent-of-empires/agent-of-empires/compare/v1.13.1...v1.13.2
 ## [1.13.1](https://github.com/agent-of-empires/agent-of-empires/releases/tag/v1.13.1) - 2026-07-22
 
 
@@ -93,6 +156,11 @@ The format follows [Conventional Commits](https://www.conventionalcommits.org/).
 - **tui:** Keep the search bar visible after committing a search in [#3042](https://github.com/agent-of-empires/agent-of-empires/pull/3042) by [@njbrake](https://github.com/njbrake) ([`432120c`](https://github.com/agent-of-empires/agent-of-empires/commit/432120c57226f24de2bc6f742cc632882e452e22))
 - **web:** Add per-panel auto-open toggles for dashboard panes in [#3057](https://github.com/agent-of-empires/agent-of-empires/pull/3057) by [@Seluj78](https://github.com/Seluj78) ([`682c0c0`](https://github.com/agent-of-empires/agent-of-empires/commit/682c0c00911eabcf5684c4d5ce6d6a01a8e1a760))
 - **acp:** Runner owns the ACP handshake and turn over v2 control channel (#2976) in [#3056](https://github.com/agent-of-empires/agent-of-empires/pull/3056) by [@Seluj78](https://github.com/Seluj78) ([`a168e95`](https://github.com/agent-of-empires/agent-of-empires/commit/a168e956f1785165f0192fcb4e536ba53103bc87))
+
+
+### Other
+
+- Merge pull request #3063 from agent-of-empires/release-staging/v1.13.1 in [#3063](https://github.com/agent-of-empires/agent-of-empires/pull/3063) by [@njbrake](https://github.com/njbrake) ([`1da8f46`](https://github.com/agent-of-empires/agent-of-empires/commit/1da8f461e83b98b395eafa820938891578a64838))
 
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "agent-of-empires"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "aes-gcm",
  "agent-client-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "xtask", "aoe-settings-derive", "aoe-plugin-api"]
 
 [package]
 name = "agent-of-empires"
-version = "1.13.1"
+version = "1.13.2"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Agent of Empires Contributors"]


### PR DESCRIPTION
<!-- release-version: 1.13.2 -->

Automated weekly release-staging PR (#1140).

**Current:** `v1.13.1`  
**Proposed:** `v1.13.2` (bump: `patch`)

If you want a different semver bump, edit `Cargo.toml` + `Cargo.lock` on this branch, push the change, and the merge tagger will use whatever version is in `Cargo.toml` at merge time. The `<!-- release-version: ... -->` marker above is cross-checked by the tagger and must match.

## Changes since v1.13.1

- fix(acp): drive a real conversation reset for claude /clear so it survives a worker restart (#3151) (`d333d79d`, Jules Lasne, 2026-07-29)
- feat(web): inline Markdown viewer + Files pane (#3090) (`e90025a6`, Jules Lasne, 2026-07-29)
- fix(acp): drive a real conversation reset for codex /new (#3132) (`6f25988c`, Shixi Li, 2026-07-29)
- fix(tests): make restart resume-failed test independent of CLAUDE_CONFIG_DIR (#3149) (`76a6722c`, Nathan Brake, 2026-07-28)
- fix(status): reconcile fresh idle hook writes against the pane for Claude (#3147) (`cbdc1c4e`, Nathan Brake, 2026-07-28)
- fix(status): stop pi sessions from sticking on Running after a turn ends (#3146) (`d23fc3d0`, Nathan Brake, 2026-07-28)
- fix(web): stagger PWA cold-start paint and clear iOS keyboard bar over Send (#3131) (`ea0136d9`, Nathan Brake, 2026-07-28)
- fix(tui): stop the live-send lock retry from stealing back after a takeover (#3145) (`66a935ab`, Nathan Brake, 2026-07-28)
- fix(web): respect prefers-reduced-motion for entrance animations (#3142) (`bff9f0d7`, Nathan Brake, 2026-07-28)
- fix(serve): persist thought-level picks so they survive a worker respawn (#3134) (`a89a9fa2`, Jules Lasne, 2026-07-28)
- feat(session): make per-session color labels optional via session.show_session_colors (#3106) (`42fa8a27`, Jules Lasne, 2026-07-28)
- fix(web): unstick suspended-session resume, drop 503 toast and draft re-fill (#3098) (`f69379b2`, Jules Lasne, 2026-07-28)
- fix(web): flick momentum, scroll gain, and full-pane touch area for alt-screen agents on mobile (#3116) (`5bac5397`, Nathan Brake, 2026-07-27)
- chore(deps): bump aoe-agent to AI SDK v7 and ACP SDK 1.0 (#3130) (`9f59b135`, Nathan Brake, 2026-07-27)
- chore(deps): bump @agentclientprotocol/sdk in /acp-worker/test-shim (#3123) (`e88eb364`, dependabot[bot], 2026-07-27)
- chore(deps): bump agent-client-protocol from 0.15.1 to 1.0.0 (#3119) (`f9c8bde0`, dependabot[bot], 2026-07-27)
- chore(deps): bump the cargo-minor-patch group across 1 directory with 15 updates (#3118) (`b3e091aa`, dependabot[bot], 2026-07-27)
- chore(deps): bump the actions-minor-patch group with 2 updates (#3117) (`0a9cf62e`, dependabot[bot], 2026-07-27)
- chore(deps): bump tokio-tungstenite from 0.29.0 to 0.30.0 (#3120) (`d3768343`, dependabot[bot], 2026-07-27)
- chore(deps): bump the web-minor-patch group in /web with 14 updates (#3122) (`7617840a`, dependabot[bot], 2026-07-27)
- fix(acp): pass configured Host Environment to structured workers (#3113) (`a045ad37`, CoreInfusion, 2026-07-26)
- fix(web): exclude trashed sessions from dashboard status summary (#3115) (`ee6186c3`, Nathan Brake, 2026-07-26)
- chore(deps): bump quinn-proto from 0.11.14 to 0.11.16 (#3110) (`a813eff0`, dependabot[bot], 2026-07-26)
- chore(deps): bump postcss from 8.5.15 to 8.5.23 in /web (#3112) (`7c34c4e2`, dependabot[bot], 2026-07-26)
- fix: build serve feature on FreeBSD where rlim_t is i64 (#3100) (`9a35c30f`, Martin Scholz, 2026-07-26)
- fix(tui): probe all missing agents in one login shell at startup (#3111) (`1da94f1e`, Nathan Brake, 2026-07-26)
- fix(tui): single-click the active session to exit live mode in SelectOnly mode (#3109) (`2b4221a0`, Nathan Brake, 2026-07-26)
- fix(tmux): forward desktop/session env (DISPLAY, XDG_*) into sessions (#3079) (`78fd4dae`, Nathan Brake, 2026-07-26)
- fix: disambiguate reused tool completion ids (#3107) (`db943582`, gilbertl, 2026-07-26)
- test(hooks): cover Linux privdrop ownership guards (#3095) (`d4a1b83d`, Shixi Li, 2026-07-26)
- fix(serve): persist config-option mode picks to acp_mode_id (#3092) (`21c6bd26`, Jules Lasne, 2026-07-26)
- fix(mcp): honor disabled Codex native servers (#3066) (`fba065ed`, microHoffman, 2026-07-26)
- fix(web): clear rate-limit banner when a session resumes to life (#3097) (`ef8758b7`, Jules Lasne, 2026-07-25)
- fix(live): web takeover wins the size-owner lock; keyboard-safe sizing and smooth scrolling on mobile (#3096) (`d1b184ea`, Nathan Brake, 2026-07-24)
- fix(acp): synthesize Write-tool diffs and stop tool-start merges from dropping them (#3093) (`4940bf04`, lucas-m-1, 2026-07-24)
- fix(acp): stop long-running Terminal keepalives from spawning phantom tool-call cards (#3085) (`c47717f7`, Jules Lasne, 2026-07-24)
- fix(test): retry recovery_lock reacquire to absorb CI scheduling gap (#3082) (`06ba67e0`, Jules Lasne, 2026-07-24)
- fix(serve): drop stored ACP session id on /clear so restart starts fresh (#3083) (`752f830f`, Jules Lasne, 2026-07-24)
- fix(web): scope last-session restore to standalone PWA launch (#3072) (`5dc514c3`, Chris Werner Rau, 2026-07-24)
- fix(session): wire OMP session capture so --resume works (#3078) (`2a96c436`, Nathan Brake, 2026-07-23)
- fix(web): add missing subagentToolNames to OMP agent profile (#3081) (`f89e6fe4`, Nathan Brake, 2026-07-23)
- fix(web): render opencode subagent (task) as a subagent card, not a bare think card (#3074) (`ae83a9ab`, Jules Lasne, 2026-07-23)
- fix(session): persist engine swap from the restart dialog (#3077) (`9309c642`, Eric Shirley, 2026-07-23)
- feat: add Oh My Pi (OMP) agent support (#3073) (`849cc7e6`, Ming Wang, 2026-07-23)
- feat: allow "Auto-name now" when smart rename is off (#3058) (`5ddea3f9`, Jules Lasne, 2026-07-23)
- feat: pin favorites to the top in every sort order (#3064) (`0c71afa1`, Byungjun Kim, 2026-07-23)
- fix: refresh local TUI token after rotation (#3003) (`69edb725`, aman zainal, 2026-07-23)
- feat(tui): refine structured chat hierarchy (#2966) (`5ce23f45`, aman zainal, 2026-07-23)
- chore(deps): bump sharp and astro in /website (#3069) (`93eef285`, dependabot[bot], 2026-07-23)
- chore(deps-dev): bump brace-expansion from 5.0.6 to 5.0.7 in /web (#3031) (`ce08dca0`, dependabot[bot], 2026-07-23)
- chore(deps): bump dompurify from 3.4.11 to 3.4.12 in /web (#3067) (`9500bc25`, dependabot[bot], 2026-07-23)
- chore(deps): bump svgo from 4.0.1 to 4.0.2 in /website (#3068) (`9ff28101`, dependabot[bot], 2026-07-23)
- fix(acp): show real rate-limit reset time and continue the turn on resume (#3061) (`b8c2bea8`, Jules Lasne, 2026-07-23)

## Maintainer checklist

- [ ] Version bump is appropriate for the change set
- [ ] No breaking changes hidden under `refactor:` / `chore:`
- [ ] CI is green
- [ ] Ready to ship — merge this PR to publish


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prepared the `v1.13.2` patch release and bumped the package version from `v1.13.1` to `v1.13.2`.
- Updated `CHANGELOG.md` with a new `v1.13.2` section (bug fixes, features, new contributors) and a full changelog compare link.
- Improved **ACP conversation reset** behavior so rate-limit reset timing is clearer and resets/clears survive resumes and worker restarts.
- Enhanced **web UI** with an inline Markdown viewer and a **Files pane**, plus multiple **mobile web** usability and touch/animation fixes.
- Fixed **session and status** inconsistencies (including resume wiring and “stuck” Running/Idle states), alongside several **serve**, **TUI**, and **testing** reliability improvements.
- Added/expanded **agent support**, including **Oh My Pi (OMP)** agent support, with related rendering/profile fixes.

## Benefits

- More reliable “reset/resume” flows and fewer confusing session state issues.
- A richer and more usable web experience (Markdown + files, better mobile behavior).
- Improved stability across TUI/Web/serve components through targeted fixes and test hardening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->