### PR TITLE
fix(tmux): resolve a session's tmux name by session id, not current title

### DIFF
--- a/src/cli/ps.rs
+++ b/src/cli/ps.rs
@@ -395,7 +395,11 @@ fn collect_tmux_states(instances: &mut [Instance]) -> Vec<TmuxState> {
         if inst.is_structured() {
             continue;
         }
-        let name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+        let name = crate::tmux::resolve_agent_session_name(
+            meta.keys().map(String::as_str),
+            &inst.id,
+            &crate::tmux::Session::generate_name(&inst.id, &inst.title),
+        );
         inst.update_status_with_metadata(meta.get(&name));
         let agent = if inst.tool.is_empty() {
             meta.get(&name)

--- a/src/cli/ps.rs
+++ b/src/cli/ps.rs
@@ -395,8 +395,8 @@ fn collect_tmux_states(instances: &mut [Instance]) -> Vec<TmuxState> {
         if inst.is_structured() {
             continue;
         }
-        let name = crate::tmux::resolve_agent_session_name(
-            meta.keys().map(String::as_str),
+        let name = crate::tmux::resolve_agent_session_name_in(
+            &meta,
             &inst.id,
             &crate::tmux::Session::generate_name(&inst.id, &inst.title),
         );

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1437,10 +1437,7 @@ async fn show_session(profile: &str, args: ShowArgs) -> Result<()> {
         if let Some(session_name) = current_session {
             instances
                 .iter()
-                .find(|i| {
-                    let tmux_name = crate::tmux::Session::generate_name(&i.id, &i.title);
-                    tmux_name == session_name
-                })
+                .find(|i| crate::tmux::agent_session_belongs_to(&session_name, &i.id))
                 .ok_or_else(|| {
                     anyhow::anyhow!("Current tmux session is not an Agent of Empires session")
                 })?
@@ -1499,10 +1496,7 @@ async fn capture_session(profile: &str, args: CaptureArgs) -> Result<()> {
         if let Some(session_name) = current_session {
             instances
                 .iter()
-                .find(|i| {
-                    let tmux_name = crate::tmux::Session::generate_name(&i.id, &i.title);
-                    tmux_name == session_name
-                })
+                .find(|i| crate::tmux::agent_session_belongs_to(&session_name, &i.id))
                 .ok_or_else(|| {
                     anyhow::anyhow!("Current tmux session is not an Agent of Empires session")
                 })?
@@ -1588,10 +1582,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         if let Some(session_name) = current_session {
             instances
                 .iter()
-                .find(|i| {
-                    let tmux_name = crate::tmux::Session::generate_name(&i.id, &i.title);
-                    tmux_name == session_name
-                })
+                .find(|i| crate::tmux::agent_session_belongs_to(&session_name, &i.id))
                 .ok_or_else(|| {
                     anyhow::anyhow!("Current tmux session is not an Agent of Empires session")
                 })?
@@ -1755,10 +1746,7 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
         if let Some(session_name) = current_session {
             instances
                 .iter()
-                .find(|i| {
-                    let tmux_name = crate::tmux::Session::generate_name(&i.id, &i.title);
-                    tmux_name == session_name
-                })
+                .find(|i| crate::tmux::agent_session_belongs_to(&session_name, &i.id))
                 .ok_or_else(|| {
                     anyhow::anyhow!("Current tmux session is not an Agent of Empires session")
                 })?
@@ -1857,10 +1845,10 @@ async fn current_session(args: CurrentArgs) -> Result<()> {
     for profile_name in &profiles {
         if let Ok(storage) = Storage::open_unwatched(profile_name) {
             if let Ok((instances, _)) = storage.load_with_groups() {
-                if let Some(inst) = instances.iter().find(|i| {
-                    let tmux_name = crate::tmux::Session::generate_name(&i.id, &i.title);
-                    tmux_name == session_name
-                }) {
+                if let Some(inst) = instances
+                    .iter()
+                    .find(|i| crate::tmux::agent_session_belongs_to(&session_name, &i.id))
+                {
                     if args.json {
                         #[derive(Serialize)]
                         struct CurrentInfo {

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -285,7 +285,7 @@ pub async fn live_terminal_ws(
     let tmux_name = instances
         .iter()
         .find(|i| i.id == id)
-        .map(|inst| crate::tmux::Session::generate_name(&inst.id, &inst.title));
+        .map(|inst| crate::tmux::Session::resolve_name(&inst.id, &inst.title));
     drop(instances);
 
     let read_only = state.read_only;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3995,8 +3995,8 @@ async fn status_poll_loop(state: Arc<AppState>) {
                     continue;
                 }
                 inst.live_status_baseline = prev_for_poll.get(&inst.id).copied();
-                let session_name = crate::tmux::resolve_agent_session_name(
-                    pane_metadata.keys().map(String::as_str),
+                let session_name = crate::tmux::resolve_agent_session_name_in(
+                    &pane_metadata,
                     &inst.id,
                     &crate::tmux::Session::generate_name(&inst.id, &inst.title),
                 );
@@ -4404,8 +4404,8 @@ async fn daemon_startup_recovery_mark(
         instances
             .iter()
             .filter(|i| {
-                let session_name = crate::tmux::resolve_agent_session_name(
-                    pane_meta.keys().map(String::as_str),
+                let session_name = crate::tmux::resolve_agent_session_name_in(
+                    &pane_meta,
                     &i.id,
                     &crate::tmux::Session::generate_name(&i.id, &i.title),
                 );
@@ -4545,8 +4545,8 @@ async fn daemon_startup_recovery_cascade(
                     .iter()
                     .find(|i| i.id == id)
                     .filter(|i| {
-                        let session_name = crate::tmux::resolve_agent_session_name(
-                            pane_meta.keys().map(String::as_str),
+                        let session_name = crate::tmux::resolve_agent_session_name_in(
+                            &pane_meta,
                             &i.id,
                             &crate::tmux::Session::generate_name(&i.id, &i.title),
                         );

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3995,7 +3995,11 @@ async fn status_poll_loop(state: Arc<AppState>) {
                     continue;
                 }
                 inst.live_status_baseline = prev_for_poll.get(&inst.id).copied();
-                let session_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+                let session_name = crate::tmux::resolve_agent_session_name(
+                    pane_metadata.keys().map(String::as_str),
+                    &inst.id,
+                    &crate::tmux::Session::generate_name(&inst.id, &inst.title),
+                );
                 let metadata = pane_metadata.get(&session_name);
                 inst.update_status_with_metadata(metadata);
             }
@@ -4400,7 +4404,11 @@ async fn daemon_startup_recovery_mark(
         instances
             .iter()
             .filter(|i| {
-                let session_name = crate::tmux::Session::generate_name(&i.id, &i.title);
+                let session_name = crate::tmux::resolve_agent_session_name(
+                    pane_meta.keys().map(String::as_str),
+                    &i.id,
+                    &crate::tmux::Session::generate_name(&i.id, &i.title),
+                );
                 let has_live_tmux = pane_meta
                     .get(&session_name)
                     .map(|m| !m.pane_dead)
@@ -4537,7 +4545,11 @@ async fn daemon_startup_recovery_cascade(
                     .iter()
                     .find(|i| i.id == id)
                     .filter(|i| {
-                        let session_name = crate::tmux::Session::generate_name(&i.id, &i.title);
+                        let session_name = crate::tmux::resolve_agent_session_name(
+                            pane_meta.keys().map(String::as_str),
+                            &i.id,
+                            &crate::tmux::Session::generate_name(&i.id, &i.title),
+                        );
                         let has_live_tmux = pane_meta
                             .get(&session_name)
                             .map(|m| !m.pane_dead)

--- a/src/server/pane.rs
+++ b/src/server/pane.rs
@@ -58,7 +58,7 @@ pub(crate) async fn respawn_paired_if_dead(
     index: u32,
 ) -> anyhow::Result<String> {
     let tmux_name =
-        crate::tmux::TerminalSession::generate_name_indexed(&inst.id, &inst.title, index);
+        crate::tmux::TerminalSession::resolve_name_indexed(&inst.id, &inst.title, index);
 
     // Serialize concurrent reconnects for the same session so two
     // simultaneous WS attaches don't both try to recreate the pane.
@@ -124,7 +124,7 @@ pub(crate) async fn respawn_container_if_dead(
     index: u32,
 ) -> anyhow::Result<String> {
     let tmux_name =
-        crate::tmux::ContainerTerminalSession::generate_name_indexed(&inst.id, &inst.title, index);
+        crate::tmux::ContainerTerminalSession::resolve_name_indexed(&inst.id, &inst.title, index);
 
     let lock = state.instance_lock(id).await;
     let _guard = lock.lock().await;

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2950,7 +2950,7 @@ impl Instance {
 
     fn apply_container_terminal_tmux_options(&self, index: u32) {
         let name =
-            tmux::ContainerTerminalSession::generate_name_indexed(&self.id, &self.title, index);
+            tmux::ContainerTerminalSession::resolve_name_indexed(&self.id, &self.title, index);
         self.apply_session_tmux_options(&name, &format!("{} (container)", self.title));
     }
 
@@ -3845,7 +3845,7 @@ impl Instance {
 
 impl Instance {
     fn apply_terminal_tmux_options(&self, index: u32) {
-        let name = tmux::TerminalSession::generate_name_indexed(&self.id, &self.title, index);
+        let name = tmux::TerminalSession::resolve_name_indexed(&self.id, &self.title, index);
         self.apply_session_tmux_options(&name, &format!("{} (terminal)", self.title));
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -5013,7 +5013,7 @@ impl Instance {
                 tracing::trace!(target: "session.store",
                     "status '{}': session.existence()=Absent (tmux name={}), setting Error",
                     self.title,
-                    tmux::Session::generate_name(&self.id, &self.title)
+                    session.name()
                 );
                 self.unknown_since = None;
                 self.status = Status::Error;
@@ -5077,10 +5077,7 @@ impl Instance {
 
         let pane_cmd = metadata
             .and_then(|m| m.pane_current_command.clone())
-            .or_else(|| {
-                let name = tmux::Session::generate_name(&self.id, &self.title);
-                tmux::utils::pane_current_command(&name)
-            });
+            .or_else(|| tmux::utils::pane_current_command(session.name()));
 
         tracing::trace!(target: "session.store",
             "status '{}': exists=true, is_dead={}, pane_cmd={:?}, tool={}, cmd_override={}",
@@ -7647,6 +7644,71 @@ mod tests {
         let _ = crate::tmux::tmux_command()
             .args(["kill-session", "-t", &tmux_name])
             .output();
+    }
+
+    /// Real-tmux integration for #3157: a session whose stored title moved
+    /// without its tmux session being renamed (smart rename, or a manual
+    /// rename whose tmux rename failed) must still be resolvable, so teardown
+    /// stops the running agent instead of a name that never existed, and a
+    /// later start adopts the live session instead of spawning a second one.
+    // Serialized for the same reason as its neighbours: it creates and kills a
+    // real tmux session on the shared test server.
+    #[test]
+    #[serial_test::serial]
+    fn retitled_session_is_still_resolved_and_torn_down() {
+        if crate::tmux::tmux_command().arg("-V").output().is_err() {
+            eprintln!("tmux not available; skipping");
+            return;
+        }
+
+        let mut inst = Instance::new("Vikings", "/tmp/test");
+        let created_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+        let _ = crate::tmux::tmux_command()
+            .args(["kill-session", "-t", &created_name])
+            .output();
+        let created = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &created_name,
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sleep",
+                "60",
+            ])
+            .status();
+        if !created.map(|s| s.success()).unwrap_or(false) {
+            eprintln!("tmux new-session failed; skipping");
+            return;
+        }
+        crate::tmux::refresh_session_cache();
+
+        // The rename that never reached tmux.
+        inst.title = "Refactor billing module".to_string();
+        let derived = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+        assert_ne!(derived, created_name, "the derived name must have moved");
+
+        let session = inst.tmux_session().expect("tmux_session");
+        assert_eq!(
+            session.name(),
+            created_name,
+            "lifecycle ops must resolve onto the live session, not the new derived name"
+        );
+        assert!(
+            session.exists(),
+            "the live session is reachable under the new title, so `create` adopts it \
+             rather than spawning a second agent"
+        );
+
+        inst.kill().expect("kill");
+        crate::tmux::refresh_session_cache();
+        assert!(
+            !crate::tmux::session_exists(&created_name),
+            "teardown must stop the agent that is actually running"
+        );
     }
 
     #[test]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -355,19 +355,25 @@ pub fn resolve_agent_session_name<'a>(
     let suffix = id_suffix(session_id);
     let mut adopted: Option<&str> = None;
     let mut ambiguous = false;
+    let mut derived_is_live = false;
     for name in live_names {
-        if !is_agent_session_name(name, &suffix) {
+        // Test `derived` on its own rather than through the shape filter: a
+        // title that sanitizes under an auxiliary prefix makes the derived name
+        // fail `is_agent_session_name`, and a live derived name must still win
+        // over an older session rather than be filtered out of its own match.
+        if name == derived {
+            derived_is_live = true;
             continue;
         }
-        if name == derived {
-            return derived.to_string();
+        if !is_agent_session_name(name, &suffix) {
+            continue;
         }
         if adopted.replace(name).is_some() {
             ambiguous = true;
         }
     }
     match adopted {
-        Some(name) if !ambiguous => name.to_string(),
+        Some(name) if !derived_is_live && !ambiguous => name.to_string(),
         _ => derived.to_string(),
     }
 }
@@ -1161,6 +1167,27 @@ mod tests {
         assert_eq!(
             resolve_agent_session_name(names.iter().map(String::as_str), ID, &derived),
             derived,
+        );
+    }
+
+    #[test]
+    fn resolve_agent_session_name_handles_a_title_shaped_like_an_aux_prefix() {
+        // A title sanitizing to `term_...` collides with TERMINAL_PREFIX, so
+        // the derived name fails the shape filter. Both directions must still
+        // behave: adopt the stale name when only it is live, and keep the
+        // derived name when it is live, rather than losing its own match to the
+        // shape filter and killing the older pane.
+        let derived = format!("{P}term_rewriting_{ID8}");
+        let stale = format!("{P}Vikings_{ID8}");
+        assert_eq!(
+            resolve_agent_session_name([stale.as_str()], ID, &derived),
+            stale,
+            "retitled INTO an aux-shaped title still resolves onto the live pane"
+        );
+        assert_eq!(
+            resolve_agent_session_name([stale.as_str(), derived.as_str()], ID, &derived),
+            derived,
+            "a live derived name wins even when the shape filter excludes it"
         );
     }
 

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -378,6 +378,25 @@ pub fn resolve_agent_session_name<'a>(
     }
 }
 
+/// [`resolve_agent_session_name`] against a [`batch_pane_metadata`] snapshot
+/// the caller is about to index, with an O(1) fast path for the overwhelmingly
+/// common case where the derived name is live. Without it the per-instance poll
+/// loops would each scan every live session on every pass.
+pub fn resolve_agent_session_name_in(
+    pane_metadata: &HashMap<String, PaneMetadata>,
+    session_id: &str,
+    derived: &str,
+) -> String {
+    if pane_metadata.contains_key(derived) {
+        return derived.to_string();
+    }
+    resolve_agent_session_name(
+        pane_metadata.keys().map(String::as_str),
+        session_id,
+        derived,
+    )
+}
+
 /// [`resolve_agent_session_name`] against the shared session cache, refreshing
 /// a stale snapshot once. Falls back to `derived` when the tmux server cannot
 /// be reached, matching every other lookup here: an unreachable server is not
@@ -1168,6 +1187,42 @@ mod tests {
             resolve_agent_session_name(names.iter().map(String::as_str), ID, &derived),
             derived,
         );
+    }
+
+    #[test]
+    fn resolve_agent_session_name_in_agrees_with_the_scan_on_both_paths() {
+        // The poll loops go through the map wrapper for its O(1) hit path; it
+        // must not diverge from the scan it short-circuits.
+        let meta = |names: &[&str]| -> HashMap<String, PaneMetadata> {
+            names
+                .iter()
+                .map(|n| {
+                    (
+                        n.to_string(),
+                        PaneMetadata {
+                            pane_dead: false,
+                            pane_current_command: None,
+                        },
+                    )
+                })
+                .collect()
+        };
+        let derived = format!("{P}Refactor_{ID8}");
+        let stale = format!("{P}Vikings_{ID8}");
+
+        for names in [
+            vec![derived.as_str()],
+            vec![stale.as_str()],
+            vec![derived.as_str(), stale.as_str()],
+            vec![],
+        ] {
+            let map = meta(&names);
+            assert_eq!(
+                resolve_agent_session_name_in(&map, ID, &derived),
+                resolve_agent_session_name(names.iter().copied(), ID, &derived),
+                "fast path and scan disagree for {names:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -308,21 +308,47 @@ fn id_suffix(session_id: &str) -> String {
     format!("_{}", crate::cli::truncate_id(session_id, 8))
 }
 
-/// True when `name` is shaped like the AGENT tmux session for the `_<id8>`
-/// `suffix`: in this namespace, carrying the suffix, and not one of the
-/// auxiliary kinds (paired terminal, container terminal, tool sub-session),
-/// which nest their own prefixes under `SESSION_PREFIX`.
+/// Auxiliary kinds whose prefixes nest under `SESSION_PREFIX`, so the agent
+/// shape has to exclude them explicitly.
+const AGENT_EXCLUDED_PREFIXES: &[&str] = &[TERMINAL_PREFIX, CONTAINER_TERMINAL_PREFIX, TOOL_PREFIX];
+
+/// How one kind of aoe tmux session's name is shaped for one session id, so a
+/// live session can still be found after the title embedded in the name has
+/// gone stale. Every name of a given kind is
+/// `<prefix><sanitized title><suffix>`, and only the title in the middle moves.
 ///
-/// An agent session whose title sanitizes to something starting with `term_` /
-/// `cterm_` / `tool_` is excluded here too, so it never resolves and callers
-/// keep their title-derived name. Mistaking a paired terminal for the agent
-/// pane would be worse than not resolving at all.
-fn is_agent_session_name(name: &str, suffix: &str) -> bool {
-    name.starts_with(SESSION_PREFIX)
-        && name.ends_with(suffix)
-        && !name.starts_with(TERMINAL_PREFIX)
-        && !name.starts_with(CONTAINER_TERMINAL_PREFIX)
-        && !name.starts_with(TOOL_PREFIX)
+/// - agent: prefix `aoe_`, suffix `_<id8>`, excluding the auxiliary prefixes
+/// - paired terminal: prefix `aoe_term_`, suffix `_<id8>` (or `_<id8>_t<N>`)
+/// - container terminal: prefix `aoe_cterm_`, same suffixes
+/// - tool: prefix `aoe_tool_<tool>_`, suffix `_<id8>`
+pub(crate) struct NameShape<'a> {
+    pub prefix: &'a str,
+    pub suffix: &'a str,
+    /// Prefixes nesting under `prefix` that must never be adopted. Empty for
+    /// every kind but the agent, whose `aoe_` prefixes all the others.
+    pub excluded_prefixes: &'a [&'a str],
+}
+
+impl NameShape<'_> {
+    /// The agent shape for a session id. The suffix must outlive the shape, so
+    /// the caller owns it (see [`id_suffix`]).
+    pub(crate) fn agent<'a>(suffix: &'a str) -> NameShape<'a> {
+        NameShape {
+            prefix: SESSION_PREFIX,
+            suffix,
+            excluded_prefixes: AGENT_EXCLUDED_PREFIXES,
+        }
+    }
+
+    /// True when `name` has this shape. A name whose sanitized title pushes it
+    /// under an excluded prefix fails here, so it never resolves and callers
+    /// keep their title-derived name: mistaking a paired terminal for the agent
+    /// pane would be worse than not resolving at all.
+    fn matches(&self, name: &str) -> bool {
+        name.starts_with(self.prefix)
+            && name.ends_with(self.suffix)
+            && !self.excluded_prefixes.iter().any(|p| name.starts_with(p))
+    }
 }
 
 /// True when `tmux_name` is the agent tmux session belonging to `session_id`,
@@ -332,40 +358,37 @@ fn is_agent_session_name(name: &str, suffix: &str) -> bool {
 /// live session keeps the name it was created with, so an equality check
 /// against the freshly derived name misses the very session it is looking for.
 pub fn agent_session_belongs_to(tmux_name: &str, session_id: &str) -> bool {
-    is_agent_session_name(tmux_name, &id_suffix(session_id))
+    NameShape::agent(&id_suffix(session_id)).matches(tmux_name)
 }
 
-/// The agent tmux session name to act on for `session_id`, resolved against
-/// `live_names` (any iterator of live tmux session names, e.g. the keys of a
-/// [`batch_pane_metadata`] snapshot the caller is about to index).
+/// The tmux session name to act on for one of a session's panes, resolved
+/// against `live_names` (any iterator of live tmux session names).
 ///
-/// `derived` is the title-derived name from [`Session::generate_name`] and
-/// stays the answer unless it is absent from `live_names` while exactly one
-/// other live session carries the session's `_<id8>` tail. That one case is a
-/// session whose stored title moved without its tmux session being renamed:
-/// adopting the live name keeps stop / archive / trash / attach / status
-/// pointed at the running pane instead of a name that never existed, and keeps
-/// `create` from spawning a second agent beside it. Two stale candidates are
+/// `derived` is the title-derived name and stays the answer unless it is absent
+/// from `live_names` while exactly one other live session fits `shape`. That
+/// one case is a session whose stored title moved without its tmux session
+/// being renamed: adopting the live name keeps stop / archive / trash / attach
+/// / status pointed at the running pane instead of a name that never existed,
+/// and keeps `create` from spawning a second pane beside it. Two candidates are
 /// ambiguous, so `derived` wins there as well.
-pub fn resolve_agent_session_name<'a>(
+pub(crate) fn resolve_session_name<'a>(
     live_names: impl IntoIterator<Item = &'a str>,
-    session_id: &str,
     derived: &str,
+    shape: &NameShape,
 ) -> String {
-    let suffix = id_suffix(session_id);
     let mut adopted: Option<&str> = None;
     let mut ambiguous = false;
     let mut derived_is_live = false;
     for name in live_names {
-        // Test `derived` on its own rather than through the shape filter: a
-        // title that sanitizes under an auxiliary prefix makes the derived name
-        // fail `is_agent_session_name`, and a live derived name must still win
-        // over an older session rather than be filtered out of its own match.
+        // Test `derived` on its own rather than through the shape: a title that
+        // sanitizes under an excluded prefix makes the derived name fail
+        // `matches`, and a live derived name must still win over an older
+        // session rather than be filtered out of its own match.
         if name == derived {
             derived_is_live = true;
             continue;
         }
-        if !is_agent_session_name(name, &suffix) {
+        if !shape.matches(name) {
             continue;
         }
         if adopted.replace(name).is_some() {
@@ -376,6 +399,16 @@ pub fn resolve_agent_session_name<'a>(
         Some(name) if !derived_is_live && !ambiguous => name.to_string(),
         _ => derived.to_string(),
     }
+}
+
+/// [`resolve_session_name`] for the agent pane, against `live_names`.
+pub fn resolve_agent_session_name<'a>(
+    live_names: impl IntoIterator<Item = &'a str>,
+    session_id: &str,
+    derived: &str,
+) -> String {
+    let suffix = id_suffix(session_id);
+    resolve_session_name(live_names, derived, &NameShape::agent(&suffix))
 }
 
 /// [`resolve_agent_session_name`] against a [`batch_pane_metadata`] snapshot
@@ -397,22 +430,32 @@ pub fn resolve_agent_session_name_in(
     )
 }
 
-/// [`resolve_agent_session_name`] against the shared session cache, refreshing
-/// a stale snapshot once. Falls back to `derived` when the tmux server cannot
-/// be reached, matching every other lookup here: an unreachable server is not
+/// [`resolve_session_name`] against the shared session cache, refreshing a
+/// stale snapshot once. Falls back to `derived` when the tmux server cannot be
+/// reached, matching every other lookup here: an unreachable server is not
 /// evidence about any name.
-pub fn live_agent_session_name(session_id: &str, derived: &str) -> String {
-    if let Some(name) = agent_session_name_from_cache(session_id, derived) {
+///
+/// Every session kind's `resolve_name` goes through this, so a retitled
+/// session's agent pane, paired terminals, and tool sub-sessions all stay
+/// reachable under their original names.
+pub(crate) fn live_session_name(derived: &str, shape: &NameShape) -> String {
+    if let Some(name) = session_name_from_cache(derived, shape) {
         return name;
     }
     refresh_session_cache();
-    agent_session_name_from_cache(session_id, derived).unwrap_or_else(|| derived.to_string())
+    session_name_from_cache(derived, shape).unwrap_or_else(|| derived.to_string())
+}
+
+/// [`live_session_name`] for the agent pane.
+pub fn live_agent_session_name(session_id: &str, derived: &str) -> String {
+    let suffix = id_suffix(session_id);
+    live_session_name(derived, &NameShape::agent(&suffix))
 }
 
 /// Resolve from the current cache snapshot without spawning. `None` only when
 /// the snapshot is stale or the lock is poisoned, so the caller knows a refresh
 /// could still change the answer.
-fn agent_session_name_from_cache(session_id: &str, derived: &str) -> Option<String> {
+fn session_name_from_cache(derived: &str, shape: &NameShape) -> Option<String> {
     let cache = SESSION_CACHE.read().ok()?;
     let fresh = cache
         .time
@@ -429,10 +472,15 @@ fn agent_session_name_from_cache(session_id: &str, derived: &str) -> Option<Stri
     let Some(names) = cache.data.as_ref() else {
         return Some(derived.to_string());
     };
-    Some(resolve_agent_session_name(
+    // Fast path: the derived name is live, which is the overwhelmingly common
+    // case, so skip the scan.
+    if names.contains_key(derived) {
+        return Some(derived.to_string());
+    }
+    Some(resolve_session_name(
         names.keys().map(String::as_str),
-        session_id,
         derived,
+        shape,
     ))
 }
 
@@ -1292,7 +1340,7 @@ mod tests {
         let derived = format!("{P}Vikings_{ID8}");
         assert_eq!(live_agent_session_name(ID, &derived), derived);
         assert_eq!(
-            agent_session_name_from_cache(ID, &derived),
+            session_name_from_cache(&derived, &NameShape::agent(&id_suffix(ID))),
             Some(derived),
             "the snapshot must satisfy the lookup, so no refresh is attempted"
         );

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -301,6 +301,116 @@ fn is_aoe_session(name: &str) -> bool {
     name.starts_with(SESSION_PREFIX)
 }
 
+/// The `_<id8>` tail every tmux session name aoe derives for a session id
+/// carries. Immutable across renames: only the title portion of the name
+/// moves, so this is the durable handle from a session row to its panes.
+fn id_suffix(session_id: &str) -> String {
+    format!("_{}", crate::cli::truncate_id(session_id, 8))
+}
+
+/// True when `name` is shaped like the AGENT tmux session for the `_<id8>`
+/// `suffix`: in this namespace, carrying the suffix, and not one of the
+/// auxiliary kinds (paired terminal, container terminal, tool sub-session),
+/// which nest their own prefixes under `SESSION_PREFIX`.
+///
+/// An agent session whose title sanitizes to something starting with `term_` /
+/// `cterm_` / `tool_` is excluded here too, so it never resolves and callers
+/// keep their title-derived name. Mistaking a paired terminal for the agent
+/// pane would be worse than not resolving at all.
+fn is_agent_session_name(name: &str, suffix: &str) -> bool {
+    name.starts_with(SESSION_PREFIX)
+        && name.ends_with(suffix)
+        && !name.starts_with(TERMINAL_PREFIX)
+        && !name.starts_with(CONTAINER_TERMINAL_PREFIX)
+        && !name.starts_with(TOOL_PREFIX)
+}
+
+/// True when `tmux_name` is the agent tmux session belonging to `session_id`,
+/// whatever title was embedded in it when it was created. Use this instead of
+/// comparing against `Session::generate_name`: the stored title moves under a
+/// rename (smart rename, or a manual one whose tmux rename failed) while the
+/// live session keeps the name it was created with, so an equality check
+/// against the freshly derived name misses the very session it is looking for.
+pub fn agent_session_belongs_to(tmux_name: &str, session_id: &str) -> bool {
+    is_agent_session_name(tmux_name, &id_suffix(session_id))
+}
+
+/// The agent tmux session name to act on for `session_id`, resolved against
+/// `live_names` (any iterator of live tmux session names, e.g. the keys of a
+/// [`batch_pane_metadata`] snapshot the caller is about to index).
+///
+/// `derived` is the title-derived name from [`Session::generate_name`] and
+/// stays the answer unless it is absent from `live_names` while exactly one
+/// other live session carries the session's `_<id8>` tail. That one case is a
+/// session whose stored title moved without its tmux session being renamed:
+/// adopting the live name keeps stop / archive / trash / attach / status
+/// pointed at the running pane instead of a name that never existed, and keeps
+/// `create` from spawning a second agent beside it. Two stale candidates are
+/// ambiguous, so `derived` wins there as well.
+pub fn resolve_agent_session_name<'a>(
+    live_names: impl IntoIterator<Item = &'a str>,
+    session_id: &str,
+    derived: &str,
+) -> String {
+    let suffix = id_suffix(session_id);
+    let mut adopted: Option<&str> = None;
+    let mut ambiguous = false;
+    for name in live_names {
+        if !is_agent_session_name(name, &suffix) {
+            continue;
+        }
+        if name == derived {
+            return derived.to_string();
+        }
+        if adopted.replace(name).is_some() {
+            ambiguous = true;
+        }
+    }
+    match adopted {
+        Some(name) if !ambiguous => name.to_string(),
+        _ => derived.to_string(),
+    }
+}
+
+/// [`resolve_agent_session_name`] against the shared session cache, refreshing
+/// a stale snapshot once. Falls back to `derived` when the tmux server cannot
+/// be reached, matching every other lookup here: an unreachable server is not
+/// evidence about any name.
+pub fn live_agent_session_name(session_id: &str, derived: &str) -> String {
+    if let Some(name) = agent_session_name_from_cache(session_id, derived) {
+        return name;
+    }
+    refresh_session_cache();
+    agent_session_name_from_cache(session_id, derived).unwrap_or_else(|| derived.to_string())
+}
+
+/// Resolve from the current cache snapshot without spawning. `None` only when
+/// the snapshot is stale or the lock is poisoned, so the caller knows a refresh
+/// could still change the answer.
+fn agent_session_name_from_cache(session_id: &str, derived: &str) -> Option<String> {
+    let cache = SESSION_CACHE.read().ok()?;
+    let fresh = cache
+        .time
+        .map(|t| t.elapsed() <= CACHE_TTL)
+        .unwrap_or(false);
+    if !fresh {
+        return None;
+    }
+    // A fresh snapshot with no data means the last `list-sessions` itself
+    // failed (no server running, unreachable socket). That is not evidence
+    // about any name, and it is an answer, not a stale snapshot: returning
+    // `None` here would make every caller re-refresh into the same failure,
+    // one subprocess per call from render loops that never had a session.
+    let Some(names) = cache.data.as_ref() else {
+        return Some(derived.to_string());
+    };
+    Some(resolve_agent_session_name(
+        names.keys().map(String::as_str),
+        session_id,
+        derived,
+    ))
+}
+
 /// Force-stop every aoe-owned tmux session (agent, terminal, container
 /// terminal, tool) in this namespace. Mirrors `kill_all_tool_sessions_for_id`
 /// but sweeps the whole `SESSION_PREFIX` namespace. Returns the number of
@@ -985,6 +1095,138 @@ mod tests {
         // during a real outage).
         guard.force_unreachable();
         assert_eq!(probe_session_existence(&name), SessionExistence::Unknown);
+    }
+
+    /// A session id long enough that `truncate_id(.., 8)` actually truncates,
+    /// so the tests exercise the real `_<id8>` tail.
+    const ID: &str = "abc12345deadbeef";
+    const ID8: &str = "abc12345";
+
+    #[test]
+    fn resolve_agent_session_name_prefers_the_derived_name_when_it_is_live() {
+        let derived = format!("{P}Refactor_billing_{ID8}");
+        let stale = format!("{P}Vikings_{ID8}");
+        // Both live (a rename that created rather than renamed): the derived
+        // name is the one the current title points at, so it wins.
+        let names = [derived.as_str(), stale.as_str()];
+        assert_eq!(
+            resolve_agent_session_name(names, ID, &derived),
+            derived,
+            "a live derived name is never overridden"
+        );
+    }
+
+    #[test]
+    fn resolve_agent_session_name_adopts_the_stale_name_after_a_retitle() {
+        // The reported bug: smart_rename moved the title, the tmux session
+        // kept the name it was created under, so the derived name matches
+        // nothing while the agent runs on under the old codename.
+        let derived = format!("{P}Refactor_billing_mod_{ID8}");
+        let stale = format!("{P}Vikings_{ID8}");
+        assert_eq!(
+            resolve_agent_session_name([stale.as_str()], ID, &derived),
+            stale,
+            "lifecycle ops must follow the live session, not the derived name"
+        );
+    }
+
+    #[test]
+    fn resolve_agent_session_name_ignores_other_kinds_and_other_ids() {
+        let derived = format!("{P}Refactor_{ID8}");
+        let names = [
+            // Same id, but the paired terminal / container terminal / tool
+            // sub-sessions are not the agent pane.
+            format!("{TERMINAL_PREFIX}Vikings_{ID8}"),
+            format!("{CONTAINER_TERMINAL_PREFIX}Vikings_{ID8}"),
+            format!("{TOOL_PREFIX}lazygit_Vikings_{ID8}"),
+            // Agent-shaped, but a different session's id.
+            format!("{P}Vikings_99999999"),
+            // Not ours at all.
+            "vim".to_string(),
+        ];
+        assert_eq!(
+            resolve_agent_session_name(names.iter().map(String::as_str), ID, &derived),
+            derived,
+            "nothing here is this session's agent pane"
+        );
+    }
+
+    #[test]
+    fn resolve_agent_session_name_falls_back_when_two_candidates_are_ambiguous() {
+        // Two stale agent-shaped sessions for one id, the duplicate state a
+        // pre-fix unarchive could leave behind: there is no basis to pick one,
+        // so keep the derived name rather than guess which pane to kill.
+        let derived = format!("{P}Refactor_{ID8}");
+        let names = [format!("{P}Vikings_{ID8}"), format!("{P}Aztecs_{ID8}")];
+        assert_eq!(
+            resolve_agent_session_name(names.iter().map(String::as_str), ID, &derived),
+            derived,
+        );
+    }
+
+    #[test]
+    fn agent_session_belongs_to_matches_by_id_not_title() {
+        // The inverse lookup (`aoe session current` and friends): map a live
+        // tmux session name back to its row without knowing the title it was
+        // created under.
+        assert!(agent_session_belongs_to(&format!("{P}Vikings_{ID8}"), ID));
+        assert!(agent_session_belongs_to(&format!("{P}Anything_{ID8}"), ID));
+        assert!(!agent_session_belongs_to(
+            &format!("{TERMINAL_PREFIX}Vikings_{ID8}"),
+            ID
+        ));
+        assert!(!agent_session_belongs_to(
+            &format!("{P}Vikings_99999999"),
+            ID
+        ));
+        assert!(!agent_session_belongs_to("vim", ID));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn session_new_resolves_onto_a_retitled_sessions_live_name() {
+        // End to end through the constructor every lifecycle op goes through
+        // (`Instance::tmux_session`): with only the pre-rename session live,
+        // `Session::new` under the NEW title must target it, so trash/archive
+        // stop the running agent and `create` adopts it instead of spawning a
+        // second one.
+        let guard = SessionCacheGuard::capture();
+        let stale = Session::generate_name(ID, "Vikings");
+        guard.force_present(&[stale.as_str()]);
+
+        let session = Session::new(ID, "Refactor billing module").expect("session");
+        assert_eq!(session.name(), stale);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn live_agent_session_name_answers_from_an_unreachable_snapshot_without_refreshing() {
+        // No tmux server (the common state for a user who has not opened a
+        // session yet) is an answer, not a stale snapshot: resolution must
+        // return the derived name straight from the cache rather than spawn a
+        // doomed `list-sessions` on every call from a render loop.
+        let guard = SessionCacheGuard::capture();
+        guard.force_unreachable();
+        let derived = format!("{P}Vikings_{ID8}");
+        assert_eq!(live_agent_session_name(ID, &derived), derived);
+        assert_eq!(
+            agent_session_name_from_cache(ID, &derived),
+            Some(derived),
+            "the snapshot must satisfy the lookup, so no refresh is attempted"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn session_new_keeps_the_derived_name_when_nothing_is_live() {
+        // The creation path: no session for this id yet, so the name must be
+        // the title-derived one `create` will spawn under.
+        let guard = SessionCacheGuard::capture();
+        guard.force_present(&[]);
+
+        let derived = Session::generate_name(ID, "Refactor billing module");
+        let session = Session::new(ID, "Refactor billing module").expect("session");
+        assert_eq!(session.name(), derived);
     }
 
     #[test]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -401,7 +401,7 @@ pub(crate) fn resolve_session_name<'a>(
     }
 }
 
-/// [`resolve_session_name`] for the agent pane, against `live_names`.
+/// `resolve_session_name` for the agent pane, against `live_names`.
 pub fn resolve_agent_session_name<'a>(
     live_names: impl IntoIterator<Item = &'a str>,
     session_id: &str,
@@ -446,7 +446,7 @@ pub(crate) fn live_session_name(derived: &str, shape: &NameShape) -> String {
     session_name_from_cache(derived, shape).unwrap_or_else(|| derived.to_string())
 }
 
-/// [`live_session_name`] for the agent pane.
+/// `live_session_name` for the agent pane.
 pub fn live_agent_session_name(session_id: &str, derived: &str) -> String {
     let suffix = id_suffix(session_id);
     live_session_name(derived, &NameShape::agent(&suffix))

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -221,7 +221,7 @@ impl Session {
     /// title-derived name normally, or the live session carrying this id's
     /// `_<id8>` tail when the stored title has moved out from under it (a
     /// smart rename, or a manual rename whose tmux rename failed). See
-    /// [`crate::tmux::live_agent_session_name`]; every lifecycle operation
+    /// [`crate::tmux::live_session_name`]; every lifecycle operation
     /// resolves through here so trash/archive/attach/status target the pane
     /// that is actually running and `create` adopts it instead of spawning a
     /// second agent beside it.

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -206,7 +206,7 @@ fn chrome_rows(window_height: u16, pane_height: u16) -> u16 {
 impl Session {
     pub fn new(id: &str, title: &str) -> Result<Self> {
         Ok(Self {
-            name: Self::generate_name(id, title),
+            name: Self::resolve_name(id, title),
         })
     }
 
@@ -217,6 +217,24 @@ impl Session {
         }
     }
 
+    /// The name of the tmux session to ACT on for this session id: the
+    /// title-derived name normally, or the live session carrying this id's
+    /// `_<id8>` tail when the stored title has moved out from under it (a
+    /// smart rename, or a manual rename whose tmux rename failed). See
+    /// [`crate::tmux::live_agent_session_name`]; every lifecycle operation
+    /// resolves through here so trash/archive/attach/status target the pane
+    /// that is actually running and `create` adopts it instead of spawning a
+    /// second agent beside it.
+    ///
+    /// Use [`Self::generate_name`] instead only to compute the name a session
+    /// should be renamed TO.
+    pub fn resolve_name(id: &str, title: &str) -> String {
+        crate::tmux::live_agent_session_name(id, &Self::generate_name(id, title))
+    }
+
+    /// Purely derive the tmux session name from a session id and title, with no
+    /// reference to what is live. Callers that want the session's CURRENT name
+    /// want [`Self::resolve_name`].
     pub fn generate_name(id: &str, title: &str) -> String {
         let safe_title = sanitize_session_name(title);
         format!("{}{}_{}", SESSION_PREFIX, safe_title, truncate_id(id, 8))

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -221,7 +221,7 @@ impl Session {
     /// title-derived name normally, or the live session carrying this id's
     /// `_<id8>` tail when the stored title has moved out from under it (a
     /// smart rename, or a manual rename whose tmux rename failed). See
-    /// [`crate::tmux::live_session_name`]; every lifecycle operation
+    /// `crate::tmux::live_session_name` (crate-private); every lifecycle operation
     /// resolves through here so trash/archive/attach/status target the pane
     /// that is actually running and `create` adopts it instead of spawning a
     /// second agent beside it.

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -92,9 +92,41 @@ impl PairedTerminal {
         }
     }
 
+    /// The tail every paired-terminal name for this session id and `index`
+    /// ends with. Index 0 keeps the bare `_<id8>`; later web terminals append
+    /// `_t<N>`, which keeps the indices from resolving onto each other (a
+    /// `_t10` name does not end with `_t1`, since the match is anchored at the
+    /// very end of the name).
+    fn name_suffix(id: &str, index: u32) -> String {
+        let id_suffix = format!("_{}", truncate_id(id, 8));
+        if index == 0 {
+            id_suffix
+        } else {
+            format!("{id_suffix}_t{index}")
+        }
+    }
+
+    /// The paired terminal to ACT on: the title-derived name normally, or the
+    /// live terminal carrying this id's tail when the stored title has moved out
+    /// from under it. Without this a retitled session's terminal view would
+    /// spawn a fresh shell under the new name and orphan the pane the user was
+    /// working in, exactly as the agent pane did before #3157.
+    fn resolve_name(kind: TerminalKind, id: &str, title: &str, index: u32) -> String {
+        let derived = Self::generate_name(kind, id, title, index);
+        let suffix = Self::name_suffix(id, index);
+        crate::tmux::live_session_name(
+            &derived,
+            &crate::tmux::NameShape {
+                prefix: kind.prefix(),
+                suffix: &suffix,
+                excluded_prefixes: &[],
+            },
+        )
+    }
+
     fn new(kind: TerminalKind, id: &str, title: &str, index: u32) -> Self {
         Self {
-            name: Self::generate_name(kind, id, title, index),
+            name: Self::resolve_name(kind, id, title, index),
             kind,
         }
     }
@@ -251,6 +283,20 @@ impl TerminalSession {
         })
     }
 
+    /// The name of the paired terminal to ACT on: the title-derived name
+    /// normally, or the live terminal carrying this session id's tail when the
+    /// stored title has moved out from under it. Callers wanting the session's
+    /// CURRENT name want this; [`Self::generate_name`] stays a pure derivation
+    /// for computing the name to rename TO.
+    pub fn resolve_name(id: &str, title: &str) -> String {
+        Self::resolve_name_indexed(id, title, 0)
+    }
+
+    /// [`Self::resolve_name`] for the web dashboard's additional terminal tabs.
+    pub fn resolve_name_indexed(id: &str, title: &str, index: u32) -> String {
+        PairedTerminal::resolve_name(TerminalKind::Host, id, title, index)
+    }
+
     pub fn generate_name(id: &str, title: &str) -> String {
         Self::generate_name_indexed(id, title, 0)
     }
@@ -316,6 +362,20 @@ impl ContainerTerminalSession {
         Ok(Self {
             inner: PairedTerminal::new(TerminalKind::Container, id, title, index),
         })
+    }
+
+    /// The name of the paired terminal to ACT on: the title-derived name
+    /// normally, or the live terminal carrying this session id's tail when the
+    /// stored title has moved out from under it. Callers wanting the session's
+    /// CURRENT name want this; [`Self::generate_name`] stays a pure derivation
+    /// for computing the name to rename TO.
+    pub fn resolve_name(id: &str, title: &str) -> String {
+        Self::resolve_name_indexed(id, title, 0)
+    }
+
+    /// [`Self::resolve_name`] for the web dashboard's additional terminal tabs.
+    pub fn resolve_name_indexed(id: &str, title: &str, index: u32) -> String {
+        PairedTerminal::resolve_name(TerminalKind::Container, id, title, index)
     }
 
     pub fn generate_name(id: &str, title: &str) -> String {
@@ -427,6 +487,91 @@ mod tests {
         assert!(name.starts_with(CONTAINER_TERMINAL_PREFIX));
         assert!(name.contains("My_Project"));
         assert!(name.contains("abc123de"));
+    }
+
+    /// A session id long enough that `truncate_id(.., 8)` truncates, so the
+    /// tests exercise the real `_<id8>` tail.
+    const ID: &str = "abc12345deadbeef";
+
+    #[test]
+    fn name_suffix_keeps_terminal_indices_from_resolving_onto_each_other() {
+        // The tail is what resolution matches on, so index isolation lives here.
+        // `_t10` must not satisfy index 1's tail, which holds only because the
+        // match is anchored at the very end of the name.
+        let zero = PairedTerminal::name_suffix(ID, 0);
+        let one = PairedTerminal::name_suffix(ID, 1);
+        let ten = PairedTerminal::name_suffix(ID, 10);
+        assert_eq!(zero, "_abc12345");
+        assert_eq!(one, "_abc12345_t1");
+        assert_eq!(ten, "_abc12345_t10");
+        let named =
+            |idx: u32| PairedTerminal::generate_name(TerminalKind::Host, ID, "Vikings", idx);
+        assert!(!named(1).ends_with(&zero), "index 1 must not match index 0");
+        assert!(!named(0).ends_with(&one), "index 0 must not match index 1");
+        assert!(
+            !named(10).ends_with(&one),
+            "index 10 must not match index 1"
+        );
+        assert!(named(10).ends_with(&ten));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_name_adopts_a_retitled_terminal_and_ignores_other_indices() {
+        // #3157 for the paired terminal: the title moved, the terminal kept the
+        // name it was created under. Reopening the terminal view must reattach
+        // to the running shell instead of spawning a fresh one beside it.
+        let guard = crate::tmux::SessionCacheGuard::capture();
+        let stale = TerminalSession::generate_name(ID, "Vikings");
+        let stale_t1 = TerminalSession::generate_name_indexed(ID, "Vikings", 1);
+        guard.force_present(&[stale.as_str(), stale_t1.as_str()]);
+
+        assert_eq!(TerminalSession::resolve_name(ID, "Refactor billing"), stale);
+        // Through the constructor too: that is the path every call site takes,
+        // so `create` adopts the running shell instead of spawning beside it.
+        assert_eq!(
+            TerminalSession::new(ID, "Refactor billing")
+                .expect("terminal")
+                .name(),
+            stale
+        );
+        assert_eq!(
+            TerminalSession::resolve_name_indexed(ID, "Refactor billing", 1),
+            stale_t1,
+            "each terminal tab resolves onto its own index, not another's"
+        );
+        // Index 2 was never created, so it keeps the name it will be spawned
+        // under rather than adopting tab 0 or 1.
+        assert_eq!(
+            TerminalSession::resolve_name_indexed(ID, "Refactor billing", 2),
+            TerminalSession::generate_name_indexed(ID, "Refactor billing", 2)
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_name_keeps_host_and_container_terminals_apart() {
+        // Only the container terminal is live. The host terminal must NOT adopt
+        // it: they are different panes with different shells.
+        let guard = crate::tmux::SessionCacheGuard::capture();
+        let container = ContainerTerminalSession::generate_name(ID, "Vikings");
+        guard.force_present(&[container.as_str()]);
+
+        assert_eq!(
+            ContainerTerminalSession::resolve_name(ID, "Refactor billing"),
+            container
+        );
+        assert_eq!(
+            ContainerTerminalSession::new(ID, "Refactor billing")
+                .expect("container terminal")
+                .name(),
+            container
+        );
+        assert_eq!(
+            TerminalSession::resolve_name(ID, "Refactor billing"),
+            TerminalSession::generate_name(ID, "Refactor billing"),
+            "a live container terminal is not the host terminal"
+        );
     }
 
     #[test]

--- a/src/tmux/tool_session.rs
+++ b/src/tmux/tool_session.rs
@@ -28,7 +28,7 @@ impl ToolSession {
     /// with title `log_T` and tool `git_log` with title `T` produce the same
     /// name. Resolving `git` can therefore see a `git_log` pane as a candidate.
     /// When both tools' panes are live the ambiguity guard in
-    /// [`crate::tmux::resolve_session_name`] keeps the derived name, so the only
+    /// `crate::tmux::resolve_session_name` keeps the derived name, so the only
     /// exposure is a retitled session where the extension-named tool's pane is
     /// live and the shorter one's is not. Resolution is skipped entirely rather
     /// than guessing whenever more than one candidate matches.

--- a/src/tmux/tool_session.rs
+++ b/src/tmux/tool_session.rs
@@ -17,17 +17,51 @@ pub struct ToolSession {
 }
 
 impl ToolSession {
+    /// The tool sub-session name to ACT on. Resolves onto the live sub-session
+    /// for this session id and tool when the stored title has moved out from
+    /// under its name, so reopening a tool after a retitle reattaches to the
+    /// running pane instead of spawning a second one beside it (the same defect
+    /// #3157 fixed for the agent pane).
+    ///
+    /// Known limit, inherited from the name format rather than introduced here:
+    /// the tool/title boundary is not recoverable from the name, so tool `git`
+    /// with title `log_T` and tool `git_log` with title `T` produce the same
+    /// name. Resolving `git` can therefore see a `git_log` pane as a candidate.
+    /// When both tools' panes are live the ambiguity guard in
+    /// [`crate::tmux::resolve_session_name`] keeps the derived name, so the only
+    /// exposure is a retitled session where the extension-named tool's pane is
+    /// live and the shorter one's is not. Resolution is skipped entirely rather
+    /// than guessing whenever more than one candidate matches.
     pub fn new(session_id: &str, session_title: &str, tool_name: &str) -> Self {
-        let safe_title = sanitize_session_name(session_title);
-        let safe_tool = sanitize_session_name(tool_name);
-        let name = format!(
-            "{}{}_{}_{}",
-            TOOL_PREFIX,
-            safe_tool,
-            safe_title,
-            truncate_id(session_id, 8)
+        // The tool name sits in the prefix, so it discriminates between a
+        // session's several tool sub-sessions without reference to the title.
+        let prefix = Self::name_prefix(tool_name);
+        let suffix = format!("_{}", truncate_id(session_id, 8));
+        let name = crate::tmux::live_session_name(
+            &Self::generate_name(session_id, session_title, tool_name),
+            &crate::tmux::NameShape {
+                prefix: &prefix,
+                suffix: &suffix,
+                excluded_prefixes: &[],
+            },
         );
         Self { name }
+    }
+
+    /// Purely derive the sub-session name, with no reference to what is live.
+    /// Callers wanting the session's CURRENT name want [`Self::new`].
+    pub fn generate_name(session_id: &str, session_title: &str, tool_name: &str) -> String {
+        format!(
+            "{}{}_{}",
+            Self::name_prefix(tool_name),
+            sanitize_session_name(session_title),
+            truncate_id(session_id, 8)
+        )
+    }
+
+    /// `aoe_tool_<tool>_`: everything before the (movable) title.
+    fn name_prefix(tool_name: &str) -> String {
+        format!("{TOOL_PREFIX}{}_", sanitize_session_name(tool_name))
     }
 
     pub fn session_name(&self) -> &str {
@@ -210,6 +244,60 @@ pub fn kill_all_tool_sessions_for_id(session_id: &str) {
 mod tests {
     use super::super::test_helpers::TmuxTestSession;
     use super::*;
+
+    /// A session id long enough that `truncate_id(.., 8)` truncates.
+    const ID: &str = "abc12345deadbeef";
+
+    #[test]
+    #[serial_test::serial]
+    fn new_adopts_a_retitled_tool_session_but_not_another_tools() {
+        // #3157 for tool sub-sessions: the title moved, the tool's tmux session
+        // kept the name it was created under. Reopening lazygit must reattach to
+        // the running pane rather than spawn a second one, and must never adopt
+        // a different tool's pane, which the tool name in the prefix guarantees.
+        let guard = crate::tmux::SessionCacheGuard::capture();
+        let stale_lazygit = ToolSession::generate_name(ID, "Vikings", "lazygit");
+        guard.force_present(&[stale_lazygit.as_str()]);
+
+        assert_eq!(
+            ToolSession::new(ID, "Refactor billing", "lazygit").session_name(),
+            stale_lazygit
+        );
+        // yazi was never opened, so it keeps the name it will be spawned under.
+        let yazi = ToolSession::new(ID, "Refactor billing", "yazi")
+            .session_name()
+            .to_string();
+        assert!(
+            yazi.starts_with(&format!("{TOOL_PREFIX}yazi_")),
+            "yazi must not adopt lazygit's pane: {yazi}"
+        );
+        assert!(yazi.contains("Refactor_billing"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn new_keeps_the_derived_name_when_an_extension_named_tool_is_ambiguous() {
+        // The tool/title boundary is not recoverable from the name: tool `git`
+        // with title `log_x` and tool `git_log` with title `x` collide. Guard
+        // the reachable half of that: when both panes are live, resolution must
+        // see two candidates and keep the derived name rather than pick one.
+        let guard = crate::tmux::SessionCacheGuard::capture();
+        let git = ToolSession::generate_name(ID, "Vikings", "git");
+        let git_log = ToolSession::generate_name(ID, "Vikings", "git_log");
+        assert!(
+            git_log.starts_with(&ToolSession::name_prefix("git")),
+            "the collision this guards only exists because `git_log` matches \
+             `git`'s prefix: {git_log}"
+        );
+        guard.force_present(&[git.as_str(), git_log.as_str()]);
+
+        let derived = ToolSession::generate_name(ID, "Refactor billing", "git");
+        assert_eq!(
+            ToolSession::new(ID, "Refactor billing", "git").session_name(),
+            derived,
+            "two candidates are ambiguous, so neither pane is adopted"
+        );
+    }
 
     /// Helper: check if tmux is available for tests that need it
     fn tmux_available() -> bool {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -6112,8 +6112,10 @@ impl HomeView {
     /// from under us between entry and now. Three drift modes:
     /// - Instance row deleted (peer / web structured view / another aoe killed
     ///   it).
-    /// - Title renamed (which regenerates the tmux session name; the
-    ///   worker is now targeting a stale name).
+    /// - Title renamed AND the tmux session renamed with it, so the worker is
+    ///   now targeting a stale name. A retitle whose tmux rename did not land
+    ///   is not drift: `Session::resolve_name` still resolves onto the pane the
+    ///   worker holds, which is the session's pane.
     /// - tmux session itself is gone (`tmux kill-session`, server
     ///   restart) even though our instance row says otherwise. We use
     ///   the existing `session_exists_from_cache` lookup so this costs
@@ -6131,7 +6133,7 @@ impl HomeView {
         };
         let current_name = match &state.target {
             live_send::LiveSendTarget::Agent => {
-                crate::tmux::Session::generate_name(&inst.id, &inst.title)
+                crate::tmux::Session::resolve_name(&inst.id, &inst.title)
             }
             live_send::LiveSendTarget::Terminal => {
                 crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title)

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -6136,10 +6136,10 @@ impl HomeView {
                 crate::tmux::Session::resolve_name(&inst.id, &inst.title)
             }
             live_send::LiveSendTarget::Terminal => {
-                crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title)
+                crate::tmux::TerminalSession::resolve_name(&inst.id, &inst.title)
             }
             live_send::LiveSendTarget::ContainerTerminal => {
-                crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title)
+                crate::tmux::ContainerTerminalSession::resolve_name(&inst.id, &inst.title)
             }
             live_send::LiveSendTarget::Tool(name) => {
                 crate::tmux::ToolSession::new(&inst.id, &inst.title, name)

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3686,7 +3686,11 @@ impl HomeView {
             .instances
             .values()
             .filter(|inst| {
-                let session_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+                let session_name = crate::tmux::resolve_agent_session_name(
+                    pane_meta.keys().map(String::as_str),
+                    &inst.id,
+                    &crate::tmux::Session::generate_name(&inst.id, &inst.title),
+                );
                 let has_live_tmux = pane_meta
                     .get(&session_name)
                     .map(|m| !m.pane_dead)

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -5123,10 +5123,10 @@ impl HomeView {
                 }
             }
             live_send::LiveSendTarget::Terminal => crate::tmux::Session::from_name(
-                &crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title),
+                &crate::tmux::TerminalSession::resolve_name(&inst.id, &inst.title),
             ),
             live_send::LiveSendTarget::ContainerTerminal => crate::tmux::Session::from_name(
-                &crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title),
+                &crate::tmux::ContainerTerminalSession::resolve_name(&inst.id, &inst.title),
             ),
             live_send::LiveSendTarget::Tool(name) => crate::tmux::Session::from_name(
                 crate::tmux::ToolSession::new(&inst.id, &inst.title, name).session_name(),
@@ -5288,10 +5288,10 @@ impl HomeView {
         let tmux_name = match &self.pending_live_send_target {
             live_send::LiveSendTarget::Agent => return self.agent_pane_is_warm(session_id),
             live_send::LiveSendTarget::Terminal => {
-                crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title)
+                crate::tmux::TerminalSession::resolve_name(&inst.id, &inst.title)
             }
             live_send::LiveSendTarget::ContainerTerminal => {
-                crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title)
+                crate::tmux::ContainerTerminalSession::resolve_name(&inst.id, &inst.title)
             }
             live_send::LiveSendTarget::Tool(name) => {
                 crate::tmux::ToolSession::new(&inst.id, &inst.title, name)
@@ -5442,10 +5442,10 @@ impl HomeView {
                 }
             }
             live_send::LiveSendTarget::Terminal => {
-                crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title)
+                crate::tmux::TerminalSession::resolve_name(&inst.id, &inst.title)
             }
             live_send::LiveSendTarget::ContainerTerminal => {
-                crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title)
+                crate::tmux::ContainerTerminalSession::resolve_name(&inst.id, &inst.title)
             }
             live_send::LiveSendTarget::Tool(name) => {
                 crate::tmux::ToolSession::new(&inst.id, &inst.title, name)

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3686,8 +3686,8 @@ impl HomeView {
             .instances
             .values()
             .filter(|inst| {
-                let session_name = crate::tmux::resolve_agent_session_name(
-                    pane_meta.keys().map(String::as_str),
+                let session_name = crate::tmux::resolve_agent_session_name_in(
+                    &pane_meta,
                     &inst.id,
                     &crate::tmux::Session::generate_name(&inst.id, &inst.title),
                 );

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1960,10 +1960,10 @@ impl HomeView {
                 };
                 match mode {
                     TerminalMode::Host => {
-                        crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title)
+                        crate::tmux::TerminalSession::resolve_name(&inst.id, &inst.title)
                     }
                     TerminalMode::Container => {
-                        crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title)
+                        crate::tmux::ContainerTerminalSession::resolve_name(&inst.id, &inst.title)
                     }
                 }
             }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1951,7 +1951,7 @@ impl HomeView {
         let id = self.selected_session.as_ref()?;
         let inst = self.get_instance(id)?;
         let name = match &self.view_mode {
-            ViewMode::Structured => crate::tmux::Session::generate_name(&inst.id, &inst.title),
+            ViewMode::Structured => crate::tmux::Session::resolve_name(&inst.id, &inst.title),
             ViewMode::Terminal => {
                 let mode = if inst.is_sandboxed() {
                     self.get_terminal_mode(id)

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -14669,19 +14669,49 @@ mod live_send_mode {
     #[test]
     #[serial]
     fn drift_check_auto_exits_when_session_renamed() {
-        // Title changes the generated tmux name. After a rename the
-        // worker is targeting a stale name, so the next keystroke
-        // should auto-exit. Simulate the rename by mutating the
-        // instance title after installing live state.
+        // A rename that carried the tmux session with it: the worker now holds
+        // a name tmux no longer has, so the next keystroke should auto-exit.
+        // Force the cache to the post-rename state (only the new name live) so
+        // the id-anchored resolution has nothing stale to adopt.
         let mut env = create_test_env_with_sessions(1);
         let id = install_live_for_first_session(&mut env);
         env.view.mutate_instance(&id, |inst| {
             inst.title = "renamed-after-entry".to_string();
         });
+        let inst = env.view.get_instance(&id).unwrap().clone();
+        let renamed = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+        let guard = crate::tmux::SessionCacheGuard::capture();
+        guard.force_present(&[renamed.as_str()]);
+
         env.view
             .handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), None);
         assert!(env.view.live_send.is_none());
         assert!(env.view.info_dialog.is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn drift_check_stays_when_retitle_did_not_rename_the_tmux_session() {
+        // #3157: smart rename moves the title but the tmux session keeps the
+        // name it was created under. The worker still holds THIS session's
+        // pane, so that is not drift and live mode must survive; auto-exiting
+        // here would kick the user out of a pane that is still correct.
+        let mut env = create_test_env_with_sessions(1);
+        let id = install_live_for_first_session(&mut env);
+        let created = env.view.live_send.as_ref().unwrap().tmux_name.clone();
+        env.view.mutate_instance(&id, |inst| {
+            inst.title = "Refactor billing module".to_string();
+        });
+        let guard = crate::tmux::SessionCacheGuard::capture();
+        guard.force_present(&[created.as_str()]);
+
+        env.view
+            .handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), None);
+        assert!(
+            env.view.live_send.is_some(),
+            "a retitle that never reached tmux must not read as drift"
+        );
+        assert!(env.view.info_dialog.is_none());
     }
 
     #[test]

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -211,8 +211,15 @@ pub(super) fn poll_statuses_once(
                 }
             }
 
-            // Look up pre-fetched metadata for this instance's tmux session
-            let session_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+            // Look up pre-fetched metadata for this instance's tmux session,
+            // resolving the name against this same snapshot so a session whose
+            // title moved without its tmux session being renamed is still
+            // found (and not reported as Error for a live pane).
+            let session_name = crate::tmux::resolve_agent_session_name(
+                pane_metadata.keys().map(String::as_str),
+                &inst.id,
+                &crate::tmux::Session::generate_name(&inst.id, &inst.title),
+            );
             let metadata = pane_metadata.get(&session_name);
             let pane_dead = metadata.map(|m| m.pane_dead).unwrap_or(false);
 

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -215,8 +215,8 @@ pub(super) fn poll_statuses_once(
             // resolving the name against this same snapshot so a session whose
             // title moved without its tmux session being renamed is still
             // found (and not reported as Error for a live pane).
-            let session_name = crate::tmux::resolve_agent_session_name(
-                pane_metadata.keys().map(String::as_str),
+            let session_name = crate::tmux::resolve_agent_session_name_in(
+                &pane_metadata,
                 &inst.id,
                 &crate::tmux::Session::generate_name(&inst.id, &inst.title),
             );


### PR DESCRIPTION
## Description

Fixes #3157. All five symptoms in that report are one defect, and the report's diagnosis holds up in the code.

Every lifecycle operation resolved a session's tmux session by a name derived from the row's **current** title (`Session::generate_name(id, title)`, reached by nearly everything through `Instance::tmux_session`). A title can move without the tmux session being renamed with it: `smart_rename`'s rekey (`src/session/smart_rename.rs:852`) is explicitly best-effort, and so is the manual rename path. From that moment the derived name matched nothing while the agent kept running under the name it was created with, and every failure was silent:

- trash/archive tore down a name that did not exist, stranding the agent
- unarchive created a *second* tmux session under the new derived name, leaving two panes and two agents on one session id
- both status pollers reported `Error` ("tmux session is gone") for panes that were demonstrably alive
- `aoe session current` / `attach` / `capture` could not map the tmux session they were running inside back to its row

**The fix** binds lookups to the one part of the name that never moves: the `_<id8>` tail, as the issue suggested. It is applied to every session kind, not just the agent pane (see below).

`src/tmux/mod.rs` gains the resolution primitives:

- `resolve_agent_session_name(live_names, id, derived)` keeps `derived` when it is live, and otherwise adopts the single live session carrying this id's tail. Two candidates are ambiguous, so `derived` still wins there rather than guessing which pane to kill. Auxiliary kinds (`aoe_term_`, `aoe_cterm_`, `aoe_tool_`) are excluded.
- `live_agent_session_name` resolves against the shared session cache. A fresh-but-unreachable snapshot answers directly instead of re-refreshing, so a box with no tmux server does not get a subprocess per render-loop call.
- `agent_session_belongs_to(tmux_name, id)` is the inverse lookup.

`Session::new` now routes through the new `Session::resolve_name`, so every lifecycle path is covered at one point. `generate_name` stays pure and is used only to compute the name to rename *to*. Call sites that already hold a `batch_pane_metadata` snapshot resolve against those keys and spawn nothing: both status pollers, both recovery filters, `aoe ps`. The five `tmux_name == session_name` inverse lookups in `src/cli/session.rs` now use `agent_session_belongs_to`.

Because `create_with_size` early-returns when the session exists, resolution also stops unarchive from spawning a second agent. Nothing is persisted and no migration is needed, so already-diverged rows self-heal on their next operation.

One behavior change falls out: a retitle that never reached tmux is no longer live-send "drift". The worker still holds this session's pane, so auto-exiting would kick the user out of a pane that is still correct. The existing drift test was updated to force the genuine post-rename cache state (it still asserts auto-exit) and a companion test covers the new case.

### Extended to the other session kinds

Paired terminals (`aoe_term_`/`aoe_cterm_`) and tool sub-sessions (`aoe_tool_<tool>_`) embed the title identically and nothing renames them either. Their *teardown* was already id-anchored (`kill_all_terminals_for_id`, `kill_all_tool_sessions_for_id`), but their lookup paths were not: opening the terminal view or reopening a tool on a retitled session spawned a fresh pane under the new name and orphaned the one the user was working in, shell history and all.

The agent-pane resolution is generalized into a `NameShape` (prefix + suffix + excluded prefixes) so every kind resolves the same way:

| kind | prefix | suffix |
|---|---|---|
| agent | `aoe_` | `_<id8>`, excluding the auxiliary prefixes |
| paired terminal | `aoe_term_` | `_<id8>`, or `_<id8>_t<N>` per web tab |
| container terminal | `aoe_cterm_` | the same suffixes |
| tool | `aoe_tool_<tool>_` | `_<id8>` |

`PairedTerminal::new` and `ToolSession::new` now resolve, covering every call site that constructs one; the terminal call sites that derived a name directly move to the new `resolve_name{,_indexed}`. `ToolSession` gains a pure `generate_name` so derivation and resolution are separable, matching the other kinds. Terminal indices stay isolated because the suffix match is anchored at the end of the name, so `_t10` does not satisfy `_t1`.

**One limitation worth your call.** The tool/title boundary is not recoverable from the name: tool `git` with title `log_x` and tool `git_log` with title `x` produce the same string (verified with a standalone reproduction, not reasoned about). That predates this change. Resolution inherits it and refuses to guess whenever more than one candidate matches, which covers the case where both panes are live; the residual exposure is a retitled session where the extension-named tool's pane is live and the shorter one's is not. It is documented on `ToolSession::new` with a test pinning the guard. If you would rather not carry even that much, dropping tool resolution and keeping the terminal + agent halves is a one-line change.

### Still not in scope

The issue's two hardening items are deliberately left out, to keep this to one concern:

- Teardown does not verify it stopped something. The resolution fix removes the lookup miss that made this invisible, but no guard is added.
- `aoe ps` substituting `pane_current_command`. Worth flagging that this fallback is not actually gated on a lookup miss: it fires when `inst.tool` is empty (`src/cli/ps.rs:404`), which is legitimate for shell sessions, so it needs its own decision.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt --check` clean. `cargo clippy --features serve --all-targets` introduces no new warnings; the 7 that remain are pre-existing in `acp_client.rs`, `groups.rs`, and `tui/home/mod.rs`.

`cargo test --features serve --no-fail-fast`: 5787 pass, every integration target green. Two failures remain, `acp::supervisor::tests::shutdown_and_wait_degrades_when_load_errs_without_peer` and `process::worker_registry::tests::pid_source_for_falls_back_to_peer_pid_on_load_err`. Both fail identically on unmodified `main` in my sandbox: their fixtures force a read error through file permissions, which does not hold when running as root. Unrelated to this change.

No docs changes needed; the behavior is internal and the reasoning lives in the doc comments on the new functions.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

Rust-only diff, so no `web/tests/coverage-matrix.json` entry is required.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the regression is reproducible at a tighter layer, and I could verify the test actually fails without the fix there. `retitled_session_is_still_resolved_and_torn_down` (`src/session/instance.rs`) is a real-tmux test that creates a live session, retitles the row without renaming tmux, then asserts resolution lands on the live name and `kill()` actually stops it. I confirmed it fails on the pre-fix code and passes after. Driving the same divergence through the full binary would need a real smart-rename round trip whose tmux rekey fails, which is not deterministic from the e2e harness.

Also added:

- 9 unit tests in `src/tmux/mod.rs`: derived-wins, stale-adopted, other-kinds and other-ids ignored, ambiguity fallback, the aux-shaped-title case in both directions, inverse lookup, `Session::new` end-to-end both ways, the unreachable-snapshot no-refresh guard, and fast-path/scan agreement.
- 4 in `src/tmux/terminal_session.rs` and `src/tmux/tool_session.rs`: terminal index isolation, retitled-terminal adoption through both `resolve_name` and the constructor, host-vs-container separation, retitled-tool adoption without cross-tool bleed, and the extension-named-tool ambiguity guard. I ran a negative control on these: reverting the constructor resolution fails them, which is how I caught that an earlier version only exercised `resolve_name` and not the path the call sites actually take.
- `drift_check_stays_when_retitle_did_not_rename_the_tmux_session` in `src/tui/home/tests.rs`, plus the update to `drift_check_auto_exits_when_session_renamed` described above.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Claude investigated the issue against the code, proposed the id-anchored resolution design, implemented it, and wrote the tests. I reviewed the design choice (id-suffix resolution over a persisted `tmux_session_name` field, which would have needed a migration and would not have self-healed the already-broken rows in the report), reviewed the diff, and directed the extension to the terminal and tool kinds rather than leaving them as follow-ups. Two defects in Claude's own first pass were caught by adversarial checks it ran on itself: a live derived name losing to an older session when the title sanitizes under an auxiliary prefix (found by building a false-positive matrix over the suffix primitive), and terminal tests that passed against a reverted constructor (found by running a negative control). Both are fixed in their own commits. The prose here is Claude's.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed tmux session targeting to use the actually-running session name derived from the immutable `_<id8>` suffix (instead of relying on mutable title-derived names), preventing stranded agents and duplicate sessions after title changes.
- Added centralized, ID-based tmux name resolution helpers, including inverse lookup from cached pane metadata, and routed agent/session lookups and updates through them.
- Updated core flows to consistently resolve the correct tmux targets across:
  - agent sessions,
  - paired terminal sessions (host/container) and their indexed sub-sessions,
  - tool sub-sessions.
- Improved status/polling and pane liveness behavior to consult the live-resolved tmux session name when matching panes and extracting pane-related command/status details.
- Updated UI/live-send behavior so drift detection and displayed pane tmux names use the resolved (live) tmux names rather than generated ones.
- Extended tests and added regressions to cover retitles without tmux renames, correct adoption of the right existing live pane, index isolation for paired terminals, ambiguous “session-shaped” matches, and teardown resolving the correct running session.
- Left out-of-scope hardening (teardown verification and `aoe ps` fallback behavior) unchanged.

## Benefits

Prevents stranded agents during trash/archive, avoids duplicate agent/terminal/tool sessions during unarchive, fixes incorrect “missing/absent” status handling caused by name divergence, and restores reliable `current`, `attach`, and `capture` lookup behavior after title changes. Existing divergent records self-heal on the next operation by re-resolving to the real live tmux session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->