### PR TITLE
refactor(tmux): resolve id -> live session name through NameShape

### DIFF
--- a/src/cli/ps.rs
+++ b/src/cli/ps.rs
@@ -400,7 +400,7 @@ fn collect_tmux_states(instances: &mut [Instance]) -> Vec<TmuxState> {
             &inst.id,
             &crate::tmux::Session::generate_name(&inst.id, &inst.title),
         );
-        inst.update_status_with_metadata(meta.get(&name));
+        inst.update_status_with_metadata(meta.get(&name), Some(&name));
         let agent = if inst.tool.is_empty() {
             meta.get(&name)
                 .and_then(|m| m.pane_current_command.clone())

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4001,7 +4001,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
                     &crate::tmux::Session::generate_name(&inst.id, &inst.title),
                 );
                 let metadata = pane_metadata.get(&session_name);
-                inst.update_status_with_metadata(metadata);
+                inst.update_status_with_metadata(metadata, Some(&session_name));
             }
             (instances, live_structured_worker_records())
         })

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -9,7 +9,6 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::cli::truncate_id;
 use crate::containers::{self, DockerContainer};
 use crate::tmux;
 
@@ -1251,7 +1250,6 @@ fn override_if_distinct(stored: Option<&str>, fresh: String) -> Option<String> {
 }
 
 fn tmux_env_session_name_for_instance_id(instance_id: &str) -> Option<String> {
-    let suffix = format!("_{}", truncate_id(instance_id, 8));
     let output = crate::tmux::tmux_command()
         .args(["list-sessions", "-F", "#{session_name}"])
         .output()
@@ -1259,28 +1257,8 @@ fn tmux_env_session_name_for_instance_id(instance_id: &str) -> Option<String> {
     if !output.status.success() {
         return None;
     }
-
-    let mut agent = None;
-    let mut terminal = None;
-    let mut container = None;
-    for name in String::from_utf8_lossy(&output.stdout).lines() {
-        if !name.ends_with(&suffix)
-            || name.starts_with(tmux::TOOL_PREFIX)
-            || crate::tmux::utils::is_pane_dead(name)
-        {
-            continue;
-        }
-
-        if name.starts_with(tmux::TERMINAL_PREFIX) {
-            terminal.get_or_insert_with(|| name.to_string());
-        } else if name.starts_with(tmux::CONTAINER_TERMINAL_PREFIX) {
-            container.get_or_insert_with(|| name.to_string());
-        } else if name.starts_with(tmux::SESSION_PREFIX) {
-            agent.get_or_insert_with(|| name.to_string());
-        }
-    }
-
-    agent.or(terminal).or(container)
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    crate::tmux::live_any_kind_name_for_id(stdout.lines(), instance_id)
 }
 
 /// A passively-detected status transition, queued for a batched disk write.

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -4854,9 +4854,13 @@ impl Instance {
     /// guard shape (baseline vs. newly detected). Every call re-seeds the
     /// baseline at exit, so the next call compares against a value this
     /// method itself wrote.
-    pub fn update_status_with_metadata(&mut self, metadata: Option<&tmux::PaneMetadata>) {
+    pub fn update_status_with_metadata(
+        &mut self,
+        metadata: Option<&tmux::PaneMetadata>,
+        resolved_name: Option<&str>,
+    ) {
         let baseline = self.live_status_baseline;
-        self.update_status_with_metadata_inner(metadata);
+        self.update_status_with_metadata_inner(metadata, resolved_name);
         if let Some(prev) = baseline {
             if prev != self.status {
                 self.log_status_transition(prev);
@@ -4918,7 +4922,11 @@ impl Instance {
         }
     }
 
-    fn update_status_with_metadata_inner(&mut self, metadata: Option<&tmux::PaneMetadata>) {
+    fn update_status_with_metadata_inner(
+        &mut self,
+        metadata: Option<&tmux::PaneMetadata>,
+        resolved_name: Option<&str>,
+    ) {
         if matches!(
             self.status,
             Status::Stopped | Status::Deleting | Status::Creating
@@ -4968,22 +4976,25 @@ impl Instance {
             }
         }
 
-        let session = match self.tmux_session() {
-            Ok(s) => s,
-            Err(_) => {
-                tracing::trace!(target: "session.store",
-                    "status '{}': tmux_session() failed, setting Error",
-                    self.title
-                );
-                self.status = Status::Error;
-                if self.last_error.is_none() {
-                    self.last_error = Some(
-                        "Could not reach tmux. Is tmux still running on the host?".to_string(),
+        let session = match resolved_name {
+            Some(name) => tmux::Session::from_name(name),
+            None => match self.tmux_session() {
+                Ok(s) => s,
+                Err(_) => {
+                    tracing::trace!(target: "session.store",
+                        "status '{}': tmux_session() failed, setting Error",
+                        self.title
                     );
+                    self.status = Status::Error;
+                    if self.last_error.is_none() {
+                        self.last_error = Some(
+                            "Could not reach tmux. Is tmux still running on the host?".to_string(),
+                        );
+                    }
+                    self.last_error_check = Some(std::time::Instant::now());
+                    return;
                 }
-                self.last_error_check = Some(std::time::Instant::now());
-                return;
-            }
+            },
         };
 
         match session.existence() {
@@ -5225,7 +5236,7 @@ impl Instance {
     }
 
     pub fn update_status(&mut self) {
-        self.update_status_with_metadata(None);
+        self.update_status_with_metadata(None, None);
     }
 
     /// Capture the session's window for the preview, with any panes the user
@@ -5805,7 +5816,7 @@ mod tests {
         // Red on the pre-fix tree, where the tmux probe stamps Error.
         let mut inst = Instance::new("test", "/tmp/test");
         inst.archive();
-        inst.update_status_with_metadata(None);
+        inst.update_status_with_metadata(None, None);
         assert_ne!(inst.status, Status::Error);
         assert_eq!(inst.status, Status::Idle);
         assert_eq!(inst.last_error, None);
@@ -5821,7 +5832,7 @@ mod tests {
         inst.archive();
         inst.status = Status::Error;
         inst.last_error = Some("agent crashed".to_string());
-        inst.update_status_with_metadata(None);
+        inst.update_status_with_metadata(None, None);
         assert_eq!(inst.status, Status::Error);
         assert_eq!(inst.last_error.as_deref(), Some("agent crashed"));
     }
@@ -5836,9 +5847,9 @@ mod tests {
         inst.archive();
         inst.status = Status::Error;
         inst.last_error = Some("agent crashed".to_string());
-        inst.update_status_with_metadata(None);
+        inst.update_status_with_metadata(None, None);
         inst.unarchive();
-        inst.update_status_with_metadata(None);
+        inst.update_status_with_metadata(None, None);
         assert_eq!(inst.status, Status::Error);
         assert_eq!(inst.last_error.as_deref(), Some("agent crashed"));
     }
@@ -5860,11 +5871,44 @@ mod tests {
         // name is not in it: a confirmed-absent session.
         guard.force_present(&["some_other_session"]);
 
-        inst.update_status_with_metadata_inner(None);
+        inst.update_status_with_metadata_inner(None, None);
 
         assert_eq!(inst.status, Status::Error);
         assert_eq!(inst.last_error.as_deref(), Some(TMUX_SESSION_GONE_ERROR));
         assert!(inst.last_error_check.is_some());
+    }
+
+    /// R2: the poller / serve / ps loops resolve the session's live tmux name
+    /// once against the batch snapshot; the status probe must act on that name
+    /// instead of resolving the id a second time from the (possibly stale)
+    /// title. A live name the title could never derive proves which path ran:
+    /// only the resolved-name path can confirm it present.
+    #[test]
+    #[serial_test::serial]
+    fn update_status_probes_the_resolved_name_not_the_title() {
+        let resolved = format!("{}live_elsewhere_00000000", crate::tmux::SESSION_PREFIX);
+
+        let guard = crate::tmux::SessionCacheGuard::capture();
+        guard.force_present(&[resolved.as_str()]);
+
+        let mut inst = Instance::new("resolve-r2", "/tmp/resolve-r2");
+        inst.status = Status::Running;
+        inst.update_status_with_metadata_inner(None, Some(&resolved));
+        assert!(
+            inst.ever_confirmed_present,
+            "the passed resolved name must be the one probed"
+        );
+        assert_ne!(inst.status, Status::Error);
+
+        let mut untold = Instance::new("resolve-r2", "/tmp/resolve-r2");
+        untold.status = Status::Running;
+        untold.update_status_with_metadata_inner(None, None);
+        assert_eq!(
+            untold.status,
+            Status::Error,
+            "without the resolved name the title-derived name is absent from the cache"
+        );
+        assert_eq!(untold.last_error.as_deref(), Some(TMUX_SESSION_GONE_ERROR));
     }
 
     /// A tmux-server-unreachable probe (`SessionExistence::Unknown`) must not
@@ -5884,7 +5928,7 @@ mod tests {
         // connection), not a confirmed-absent session.
         guard.force_unreachable();
 
-        inst.update_status_with_metadata_inner(None);
+        inst.update_status_with_metadata_inner(None, None);
 
         assert_eq!(inst.status, Status::Running);
         assert_eq!(inst.last_error, None);
@@ -5909,7 +5953,7 @@ mod tests {
         let guard = crate::tmux::SessionCacheGuard::capture();
         guard.force_unreachable();
 
-        inst.update_status_with_metadata_inner(None);
+        inst.update_status_with_metadata_inner(None, None);
 
         assert_eq!(inst.status, Status::Error);
         assert_eq!(inst.last_error.as_deref(), Some("agent crashed"));
@@ -5939,7 +5983,7 @@ mod tests {
         let guard = crate::tmux::SessionCacheGuard::capture();
         guard.force_unreachable();
 
-        inst.update_status_with_metadata_inner(None);
+        inst.update_status_with_metadata_inner(None, None);
 
         assert_eq!(inst.status, Status::Error);
         assert_eq!(
@@ -5968,7 +6012,7 @@ mod tests {
         let guard = crate::tmux::SessionCacheGuard::capture();
         guard.force_unreachable();
 
-        inst.update_status_with_metadata_inner(None);
+        inst.update_status_with_metadata_inner(None, None);
 
         assert_eq!(inst.status, Status::Idle);
         assert_eq!(inst.last_error, None);
@@ -5993,7 +6037,7 @@ mod tests {
         let guard = crate::tmux::SessionCacheGuard::capture();
         guard.force_unreachable();
 
-        inst.update_status_with_metadata_inner(None);
+        inst.update_status_with_metadata_inner(None, None);
 
         assert_eq!(inst.status, Status::Running);
         assert_eq!(inst.last_error, None);
@@ -6024,7 +6068,7 @@ mod tests {
         let guard = crate::tmux::SessionCacheGuard::capture();
         guard.force_unreachable();
 
-        inst.update_status_with_metadata_inner(None);
+        inst.update_status_with_metadata_inner(None, None);
 
         assert_eq!(inst.status, Status::Error);
         assert_eq!(
@@ -6051,7 +6095,7 @@ mod tests {
         let guard = crate::tmux::SessionCacheGuard::capture();
         guard.force_present(&[name.as_str()]);
 
-        inst.update_status_with_metadata_inner(None);
+        inst.update_status_with_metadata_inner(None, None);
 
         assert!(inst.ever_confirmed_present);
         assert_eq!(inst.unknown_since, None);
@@ -7237,7 +7281,7 @@ mod tests {
         // socket, making the test schedule-dependent and flaky (#2936).
         let _cache = force_session_absent();
 
-        inst.update_status_with_metadata(None);
+        inst.update_status_with_metadata(None, None);
 
         // Detection confirms the session Absent, resolving to Error, which
         // differs from the stale disk `Starting`. That mismatch must NOT be
@@ -7274,7 +7318,7 @@ mod tests {
         let _cache = force_session_absent();
 
         let before = Utc::now();
-        inst.update_status_with_metadata(None);
+        inst.update_status_with_metadata(None, None);
         let after = Utc::now();
 
         // Detection confirms the session Absent, resolving to Error: a
@@ -7305,7 +7349,7 @@ mod tests {
         // (see #2936; without this the outcome is schedule-dependent).
         let _cache = force_session_absent();
 
-        inst.update_status_with_metadata(None);
+        inst.update_status_with_metadata(None, None);
         assert_eq!(inst.status, Status::Error);
         assert_eq!(
             inst.idle_entered_at, sentinel_idle,
@@ -7316,7 +7360,7 @@ mod tests {
             "first call must not restamp"
         );
 
-        inst.update_status_with_metadata(None);
+        inst.update_status_with_metadata(None, None);
         assert_eq!(inst.status, Status::Error);
         assert_eq!(
             inst.idle_entered_at, sentinel_idle,
@@ -7344,7 +7388,7 @@ mod tests {
         inst.status = Status::Running;
 
         let before1 = Utc::now();
-        inst.update_status_with_metadata(None);
+        inst.update_status_with_metadata(None, None);
         let after1 = Utc::now();
         assert_eq!(
             inst.status,
@@ -7360,7 +7404,7 @@ mod tests {
 
         inst.status = Status::Idle;
         let before2 = Utc::now();
-        inst.update_status_with_metadata(None);
+        inst.update_status_with_metadata(None, None);
         let after2 = Utc::now();
         assert_eq!(inst.status, Status::Idle);
         let second_idle = inst
@@ -7419,7 +7463,7 @@ mod tests {
         // being the canonical one (`src/session/instance.rs`).
         inst.status = Status::Starting;
 
-        inst.update_status_with_metadata(None);
+        inst.update_status_with_metadata(None, None);
 
         assert_eq!(
             inst.last_accessed_at, None,

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -341,6 +341,26 @@ impl NameShape<'_> {
         }
     }
 
+    /// The paired-terminal shape for a session id. `TERMINAL_PREFIX` does not
+    /// nest under any other kind's prefix, so nothing is excluded.
+    pub(crate) fn terminal<'a>(suffix: &'a str) -> NameShape<'a> {
+        NameShape {
+            prefix: TERMINAL_PREFIX,
+            suffix,
+            excluded_prefixes: &[],
+        }
+    }
+
+    /// The container-terminal shape for a session id. `CONTAINER_TERMINAL_PREFIX`
+    /// does not nest under any other kind's prefix, so nothing is excluded.
+    pub(crate) fn container<'a>(suffix: &'a str) -> NameShape<'a> {
+        NameShape {
+            prefix: CONTAINER_TERMINAL_PREFIX,
+            suffix,
+            excluded_prefixes: &[],
+        }
+    }
+
     /// True when `name` has this shape. A name whose sanitized title pushes it
     /// under an excluded prefix fails here, so it never resolves and callers
     /// keep their title-derived name: mistaking a paired terminal for the agent
@@ -360,6 +380,39 @@ impl NameShape<'_> {
 /// against the freshly derived name misses the very session it is looking for.
 pub fn agent_session_belongs_to(tmux_name: &str, session_id: &str) -> bool {
     NameShape::agent(&id_suffix(session_id)).matches(tmux_name)
+}
+
+/// The live tmux session name carrying `session_id`'s `_<id8>` tail, preferring
+/// the agent pane, then a paired terminal, then a container terminal, skipping
+/// dead panes (tool sub-sessions never match any of these shapes). Unlike
+/// [`resolve_agent_session_name`] this takes no title-derived name: it is an
+/// id -> live-name lookup for liveness checks and poller-spawn resolution,
+/// where any live pane for the id is evidence the session exists. Matching runs
+/// through [`NameShape`] so the name shapes stay the single source of truth.
+pub(crate) fn live_any_kind_name_for_id<'a>(
+    live_names: impl IntoIterator<Item = &'a str>,
+    session_id: &str,
+) -> Option<String> {
+    let suffix = id_suffix(session_id);
+    let agent = NameShape::agent(&suffix);
+    let terminal = NameShape::terminal(&suffix);
+    let container = NameShape::container(&suffix);
+    let (mut agent_hit, mut terminal_hit, mut container_hit) = (None, None, None);
+    for name in live_names {
+        let bucket = if agent.matches(name) {
+            &mut agent_hit
+        } else if terminal.matches(name) {
+            &mut terminal_hit
+        } else if container.matches(name) {
+            &mut container_hit
+        } else {
+            continue;
+        };
+        if bucket.is_none() && !utils::is_pane_dead(name) {
+            *bucket = Some(name.to_string());
+        }
+    }
+    agent_hit.or(terminal_hit).or(container_hit)
 }
 
 /// The tmux session name to act on for one of a session's panes, resolved
@@ -1311,6 +1364,49 @@ mod tests {
             ID
         ));
         assert!(!agent_session_belongs_to("vim", ID));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn live_any_kind_name_for_id_prefers_agent_then_terminal_then_container() {
+        // None of these fake names is a live tmux session, so the internal
+        // `is_pane_dead` probe returns false for all of them and the ordering
+        // under test is the kind-preference, not liveness.
+        let agent = format!("{P}Refactor_{ID8}");
+        let terminal = format!("{TERMINAL_PREFIX}Refactor_{ID8}");
+        let container = format!("{CONTAINER_TERMINAL_PREFIX}Refactor_{ID8}");
+
+        let all = [agent.as_str(), terminal.as_str(), container.as_str()];
+        assert_eq!(
+            live_any_kind_name_for_id(all, ID).as_deref(),
+            Some(agent.as_str()),
+            "the agent pane wins when present"
+        );
+        assert_eq!(
+            live_any_kind_name_for_id([terminal.as_str(), container.as_str()], ID).as_deref(),
+            Some(terminal.as_str()),
+            "the paired terminal is preferred over the container terminal"
+        );
+        assert_eq!(
+            live_any_kind_name_for_id([container.as_str()], ID).as_deref(),
+            Some(container.as_str()),
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn live_any_kind_name_for_id_excludes_tool_subsessions_and_other_ids() {
+        let names = [
+            format!("{TOOL_PREFIX}lazygit_Refactor_{ID8}"),
+            format!("{P}Refactor_99999999"),
+            format!("{TERMINAL_PREFIX}Refactor_99999999"),
+            "vim".to_string(),
+        ];
+        assert_eq!(
+            live_any_kind_name_for_id(names.iter().map(String::as_str), ID),
+            None,
+            "a tool sub-session and other ids are never this session's pane"
+        );
     }
 
     #[test]

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -224,7 +224,7 @@ pub(super) fn poll_statuses_once(
             let pane_dead = metadata.map(|m| m.pane_dead).unwrap_or(false);
 
             let prev_status = inst.status;
-            inst.update_status_with_metadata(metadata);
+            inst.update_status_with_metadata(metadata, Some(&session_name));
             // On the first turn's `Running -> Idle` edge, best-effort auto-name a
             // still-default-named terminal session from its first turn. Detached
             // and self-gating, so this is cheap for the common (ineligible) case.


### PR DESCRIPTION
## Description

Follow-up to #3158, addressing the non-blocking maintainability points raised in that review.

### R1: dedup id -> live tmux name resolution through `NameShape`

`tmux_env_session_name_for_instance_id` (`src/session/instance.rs`) re-implemented, inline, the two things `NameShape` already owns: the `_<id8>` suffix computation and the per-kind prefix classification (agent / paired-terminal / container-terminal, with the tool sub-session exclusion). That duplication is exactly the kind of scattered, hand-rolled id-resolution that made the #3157 title-vs-id bug possible in the first place.

- Adds `NameShape::terminal(suffix)` / `NameShape::container(suffix)` constructors alongside the existing `NameShape::agent`.
- Adds a `live_any_kind_name_for_id(live_names, session_id)` helper next to the other `NameShape` resolvers in `src/tmux/mod.rs`, so the name shapes remain the single source of truth.
- Rewrites `tmux_env_session_name_for_instance_id` to keep its own `list-sessions` call and delegate all matching to the helper.

Behavior preserving: same dead-pane filter, same tool exclusion, same `agent > terminal > container` preference, same `_<id8>` suffix semantics. The dead-pane probe (`is_pane_dead`, which shells out to tmux) runs for each kind's candidates until its first live one, so it is called at most as often as the previous inline loop, never more.

### R2: reuse the poller's resolved session name in the status probe

The status poller (`src/tui/status_poller.rs`), `aoe serve`'s poll loop (`src/server/mod.rs`), and `aoe ps` (`src/cli/ps.rs`) each resolve a session's live tmux name against the batch pane-metadata snapshot via `resolve_agent_session_name_in`, then called `update_status_with_metadata`, which resolved the *same id a second time* via `tmux_session()` -> `Session::resolve_name`.

- `update_status_with_metadata` / `update_status_with_metadata_inner` now take `resolved_name: Option<&str>`.
- The three hot paths pass the name they already resolved; the probe acts on it via `Session::from_name` instead of re-resolving.
- Every other caller passes `None` and keeps the title-derived `tmux_session()` fallback.

The `None` path is the original code moved verbatim into the `None` arm (only re-indented). The resolved path is **not** a pure behavioral identity, and intentionally so: the probed name now comes from the batch `list-panes` snapshot the poller already resolved and indexed metadata against, while `existence()` still consults the session cache. This makes the metadata lookup and the existence probe agree on a single resolved name where previously they could disagree within one poll cycle. Both the old and new code carry one narrow race, in opposite directions, when a rename lands in the sub-millisecond gap between the cache refresh and the batch scan: the old code re-resolved the probe name from the cache, so metadata and probe could target different names for one cycle while the session stayed `Present`; the new code binds both to the batch name, so a not-yet-in-cache name reads `Absent` and surfaces a transient `Error` for that instance, self-healing on a later poll once the two snapshots realign. A unit test proves the resolved name is the one actually probed (a live name the title could never derive is confirmed present only when passed in, and absent -> `Error` when it is not).

### R3 (out of scope)

The `truncate_id(id, 8)` collision domain flagged in #3158 is pre-existing across the codebase, not a regression introduced or touched here, and changing the id length is a data-format concern (session-name stability, live tmux sessions carry the `_<id8>` tail) that would need a migration and does not belong in this refactor.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A: no UI change)

## Test Coverage Analysis

Added unit tests in `src/tmux/mod.rs` (kind-preference ordering; tool / other-id exclusion for the new helper) and `src/session/instance.rs` (the resolved-name path probes the passed name, not the title-derived one). The neighbouring `resolve_agent_session_name*` and `update_status_with_metadata_inner` suites continue to pass.

Note: `update_status_reconciles_running_hook_to_waiting_on_claude_approval_prompt` fails locally on this machine both with and without this change (a pre-existing, environment-dependent tmux pane-capture / Claude-prompt-detection test); it is unrelated to this PR.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: internal refactor of status-resolution helpers; behavior preserved on the fallback path and covered by unit tests, no TUI rendering / CLI subcommand / session-lifecycle change

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (Opus) via OpenCode

**Any Additional AI Details you'd like to share:** AI assisted with the refactor and tests; the behavior-preservation analysis (verbatim `None` path, prefix non-nesting, probe-call-count parity, and the R2 snapshot-consistency nuance) was cross-reviewed by three independent agents and reviewed by hand.

- [x] I am an AI Agent filling out this form (check box if true)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Centralized tmux session ID-to-name resolution with shared `NameShape` helpers and consistent preference ordering.
- Added terminal and container session matching, while preserving exclusions and existing suffix behavior.
- Reused resolved session names across status polling, `aoe serve`, and `aoe ps` to avoid duplicate lookups and probe the correct session.
- Updated the instance status API and tests to support explicitly resolved names.

## Benefits

- More reliable status reporting when session titles differ from live tmux names.
- Less repeated tmux name resolution.
- Improved coverage for session matching, exclusions, and preference behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->