### PR TITLE
fix(serve): stop the phantom status_change loop on structured sessions

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2718,9 +2718,61 @@ fn seed_unknown_tracking(
     }
 }
 
-/// Carry the acp-authoritative live status onto a freshly disk-loaded
-/// structured row, and report whether the caller must skip the tmux status
-/// decision for it.
+/// One tick's per-instance status decision: seed each freshly disk-loaded row's
+/// live baseline from `prev`, then let tmux speak for the rows tmux owns.
+///
+/// Split out of `status_poll_loop` with [`observed_transitions`] so the two
+/// halves stay testable as a pair. They are a pair by contract: this one decides
+/// each row's status, that one reports which of those differ from `prev`. Fold
+/// either back inline and the phantom-transition regression this guards (see
+/// [`skip_tmux_decision_for_structured`]) loses its only coverage.
+fn apply_tick_status_decisions(
+    instances: &mut [Instance],
+    prev: &std::collections::HashMap<String, crate::session::Status>,
+    suppressed_ids: &std::collections::HashSet<String>,
+    pane_metadata: &std::collections::HashMap<String, crate::tmux::PaneMetadata>,
+) {
+    for inst in instances.iter_mut() {
+        if suppressed_ids.contains(&inst.id) {
+            inst.status = Status::Starting;
+            continue;
+        }
+        inst.live_status_baseline = prev.get(&inst.id).copied();
+        if skip_tmux_decision_for_structured(inst) {
+            continue;
+        }
+        let session_name = crate::tmux::resolve_agent_session_name_in(
+            pane_metadata,
+            &inst.id,
+            &crate::tmux::Session::generate_name(&inst.id, &inst.title),
+        );
+        inst.update_status_with_metadata(pane_metadata.get(&session_name), Some(&session_name));
+    }
+}
+
+/// The real status transitions this tick observed, as `(index into instances,
+/// previous status)` pairs.
+///
+/// The other half of [`apply_tick_status_decisions`]; see its docstring for why
+/// they belong together. A row absent from `prev` is new this tick and has no
+/// transition to report. Indices are only valid against the same slice, which
+/// the caller consumes immediately.
+fn observed_transitions(
+    instances: &[Instance],
+    prev: &std::collections::HashMap<String, crate::session::Status>,
+) -> Vec<(usize, Status)> {
+    instances
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, inst)| {
+            let old = *prev.get(&inst.id)?;
+            (old != inst.status).then_some((idx, old))
+        })
+        .collect()
+}
+
+/// Report whether the caller must skip the tmux status decision for this row,
+/// carrying the acp-authoritative live status onto it when so.
 ///
 /// A structured row has no tmux pane to probe, so the poller has no say in its
 /// status: [`apply_acp_overlay_inplace`] re-pins the in-memory value on every
@@ -2729,12 +2781,17 @@ fn seed_unknown_tracking(
 /// with live, and `status_poll_loop` compares exactly those two: `prev` comes
 /// from `state.instances` (overlaid, live), `fresh` from disk. Left alone, every
 /// tick reads that standing mismatch as a brand new transition, which logs a
-/// `session.status_change` line, broadcasts a `StatusChange`, resets the push
-/// dwell timer in `server::push`, and re-marks the session unread. Forever, at
-/// the 2s tick, surviving daemon restarts because `seed_acp_statuses` re-derives
-/// the same live status from the stored event log on boot. One session whose
-/// worker died with `AgentStartupError` wrote 81k such lines into a single 43MB
-/// log file.
+/// `session.status_change` line, broadcasts a `StatusChange`, and resets the
+/// push dwell timer in `server::push`. Forever, at the 2s tick, surviving daemon
+/// restarts because `seed_acp_statuses` re-derives the same live status from the
+/// stored event log on boot. One session whose worker died with
+/// `AgentStartupError` wrote 81k such lines into a single 43MB log file.
+///
+/// A phantom whose live side is `Running` costs one more: `mark_unread` in
+/// `decide_passive_transition` is not gated on `is_structured`, so it re-marks
+/// the row unread seconds after the user reads it. That one needs `old ==
+/// Running` specifically, so the `AgentStartupError` case above never reached
+/// it.
 ///
 /// Aligning `status` with the baseline the caller just seeded makes that
 /// comparison like-for-like, so a structured row reports a transition only when
@@ -2746,16 +2803,11 @@ fn seed_unknown_tracking(
 /// `Idle` unconditionally, which is correct for the TUI poller and `aoe ps`
 /// (neither has an overlay to re-pin the value) but is what mints the phantom
 /// here, since the overlay restores `Error` moments later.
-fn carry_live_status_for_structured(inst: &mut Instance) -> bool {
+fn skip_tmux_decision_for_structured(inst: &mut Instance) -> bool {
     if !inst.is_structured() {
         return false;
     }
-    // The same stale-error clear the short-circuit performs, kept so a row
-    // converted from a terminal session stops showing a tmux message that
-    // cannot apply to it any more.
-    if inst.last_error.as_deref() == Some(crate::session::TMUX_SESSION_GONE_ERROR) {
-        inst.last_error = None;
-    }
+    inst.clear_stale_tmux_error();
     // `None` means the row is newer than the last tick and has no live value
     // yet; its disk status is all there is, and the absent baseline already
     // suppresses a transition report.
@@ -4036,23 +4088,12 @@ async fn status_poll_loop(state: Arc<AppState>) {
             seed_unknown_tracking(&mut instances, &prev_unknown_tracking);
             crate::tmux::refresh_session_cache();
             let pane_metadata = crate::tmux::batch_pane_metadata().unwrap_or_default();
-            for inst in &mut instances {
-                if suppressed_ids.contains(&inst.id) {
-                    inst.status = Status::Starting;
-                    continue;
-                }
-                inst.live_status_baseline = prev_for_poll.get(&inst.id).copied();
-                if carry_live_status_for_structured(inst) {
-                    continue;
-                }
-                let session_name = crate::tmux::resolve_agent_session_name_in(
-                    &pane_metadata,
-                    &inst.id,
-                    &crate::tmux::Session::generate_name(&inst.id, &inst.title),
-                );
-                let metadata = pane_metadata.get(&session_name);
-                inst.update_status_with_metadata(metadata, Some(&session_name));
-            }
+            apply_tick_status_decisions(
+                &mut instances,
+                &prev_for_poll,
+                &suppressed_ids,
+                &pane_metadata,
+            );
             (instances, live_structured_worker_records())
         })
         .await;
@@ -4062,7 +4103,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
             // row, status_tx must observe the raw post-suppression,
             // post-tmux-scrape value, never the acp overlay that helper
             // re-applies. A structured row is the deliberate exception:
-            // `carry_live_status_for_structured` above already put the live acp
+            // `skip_tmux_decision_for_structured` above already put the live acp
             // status on it, which is what makes it compare equal to `prev` here
             // instead of reporting a phantom transition every tick.
             let now = chrono::Utc::now();
@@ -4076,27 +4117,22 @@ async fn status_poll_loop(state: Arc<AppState>) {
             // #2690.
             let mut bundles: std::collections::HashMap<String, PassiveTransitionWrites> =
                 std::collections::HashMap::new();
-            for inst in &instances {
-                let Some(old) = prev.get(&inst.id) else {
-                    continue;
-                };
-                if *old == inst.status {
-                    continue;
-                }
+            for (idx, old) in observed_transitions(&instances, &prev) {
+                let inst = &instances[idx];
                 // First turn's `Running -> Idle` edge: best-effort auto-name a
                 // still-default-named terminal session. Detached and
                 // self-gating, so ineligible sessions cost only the cheap gate.
-                if *old == Status::Running && inst.status == Status::Idle {
+                if old == Status::Running && inst.status == Status::Idle {
                     crate::session::smart_rename::maybe_spawn_terminal_smart_rename(inst);
                 }
                 let _ = state.status_tx.send(StatusChange {
                     instance_id: inst.id.clone(),
                     instance_title: inst.title.clone(),
-                    old: *old,
+                    old,
                     new: inst.status,
                     at: now,
                 });
-                let decision = decide_passive_transition(inst, *old, unread_enabled);
+                let decision = decide_passive_transition(inst, old, unread_enabled);
                 if decision.patch.is_none() && !decision.mark_unread {
                     continue;
                 }
@@ -6654,74 +6690,161 @@ mod tests {
         );
     }
 
+    /// A structured row as the poll loop finds it mid-phantom: disk says `Idle`,
+    /// the live acp status is `Error` because the worker died with
+    /// `AgentStartupError` and `seed_acp_statuses` re-derives that on every boot.
+    fn phantom_structured_row(id: &str) -> Instance {
+        let mut inst = Instance::new(id, "/tmp/test");
+        inst.view = crate::session::View::Structured;
+        inst.status = Status::Idle;
+        inst
+    }
+
     #[test]
-    fn carry_live_status_for_structured_suppresses_the_phantom_transition() {
+    fn skip_tmux_decision_for_structured_suppresses_the_phantom_transition() {
         // The other half of #2690 / #2697. That pair stopped the poller from
         // *persisting* its (void) view of a structured row's status, but left
         // `status_poll_loop` still comparing the live `prev` against the
         // disk-loaded `fresh`. Those two never converge for a structured row,
         // so the loop reported one fresh transition per 2s tick forever: a
-        // `session.status_change` line, a `StatusChange` broadcast, a reset
-        // push dwell timer, and a re-marked-unread session.
-        let mut inst = Instance::new("acp-session", "/tmp/test");
-        inst.view = crate::session::View::Structured;
-        // Disk says Idle; the live acp status is Error (worker died with
-        // `AgentStartupError`, which `seed_acp_statuses` re-derives on boot).
-        inst.status = Status::Idle;
+        // `session.status_change` line, a `StatusChange` broadcast, and a reset
+        // push dwell timer, plus a re-marked-unread row when the live side was
+        // `Running`.
+        let mut inst = phantom_structured_row("acp-session");
         inst.live_status_baseline = Some(Status::Error);
 
         assert!(
-            carry_live_status_for_structured(&mut inst),
+            skip_tmux_decision_for_structured(&mut inst),
             "a structured row must skip the tmux status decision"
         );
 
-        // No transition to log: `update_status_with_metadata` compares the
-        // post-decision status against this baseline.
-        assert_eq!(
-            inst.status,
-            inst.live_status_baseline.expect("baseline stays seeded"),
-            "status must match the baseline so no transition is logged"
-        );
-        // No transition to broadcast, persist, or mark unread: the diff loop
-        // in `status_poll_loop` compares `prev` against this same status.
+        // Nothing downstream sees a transition: `observed_transitions` compares
+        // `prev` against this status, and the baseline stays in step with it for
+        // any later consumer. `update_status_with_metadata` is not involved, the
+        // caller's `continue` skips it outright.
         assert_eq!(
             inst.status,
             Status::Error,
             "the live acp status is authoritative, not the disk value"
         );
+        assert_eq!(
+            inst.live_status_baseline,
+            Some(inst.status),
+            "baseline must stay in step with the carried status"
+        );
     }
 
     #[test]
-    fn carry_live_status_for_structured_keeps_disk_status_without_a_baseline() {
+    fn tick_reports_no_transition_for_a_structured_phantom() {
+        // The regression at tick level, over the two halves together. The
+        // helper tests above pass even if the `continue` is dropped from
+        // `apply_tick_status_decisions`; this one does not, so it is what
+        // actually guards the 81k-log-lines bug.
+        let inst = phantom_structured_row("acp-session");
+        let prev = std::collections::HashMap::from([(inst.id.clone(), Status::Error)]);
+        let mut instances = vec![inst];
+
+        apply_tick_status_decisions(
+            &mut instances,
+            &prev,
+            &std::collections::HashSet::new(),
+            &std::collections::HashMap::new(),
+        );
+
+        assert_eq!(
+            observed_transitions(&instances, &prev),
+            vec![],
+            "a structured row whose live status did not move must report no \
+             transition, so status_tx stays silent and nothing is persisted or \
+             marked unread"
+        );
+        // Note this holds for *every* structured row, not just a phantom: the
+        // tick always carries `prev` onto them, so this path reports nothing for
+        // them ever. That is the design. A real structured transition comes from
+        // `apply_status_intent`, which mutates `state.instances` and broadcasts
+        // its own `StatusChange`, so `prev` already carries it next tick. See
+        // `tick_forces_a_recently_restarted_row_to_starting` for the proof that
+        // the tick still reports transitions it does own.
+    }
+
+    #[test]
+    fn tick_skips_a_row_that_is_new_since_the_last_snapshot() {
+        // No `prev` entry means the row was created since the last tick; there
+        // is no previous status to have transitioned from.
+        let mut instances = vec![phantom_structured_row("acp-session")];
+        let prev = std::collections::HashMap::new();
+
+        apply_tick_status_decisions(
+            &mut instances,
+            &prev,
+            &std::collections::HashSet::new(),
+            &std::collections::HashMap::new(),
+        );
+
+        assert_eq!(instances[0].status, Status::Idle, "disk status stands");
+        assert_eq!(instances[0].live_status_baseline, None);
+        assert_eq!(observed_transitions(&instances, &prev), vec![]);
+    }
+
+    #[test]
+    fn tick_forces_a_recently_restarted_row_to_starting() {
+        // Two things at once. The suppression branch must keep winning over the
+        // structured carry (a worker mid-restart is Starting, not whatever the
+        // last tick saw), and it doubles as the positive control that the
+        // structured suppression is not a blanket mute: a transition this tick
+        // genuinely owns is still reported. Suppression is the one branch that
+        // moves a status without consulting tmux, so it proves that without
+        // needing a live pane.
+        let inst = phantom_structured_row("acp-session");
+        let id = inst.id.clone();
+        let prev = std::collections::HashMap::from([(id.clone(), Status::Error)]);
+        let mut instances = vec![inst];
+
+        apply_tick_status_decisions(
+            &mut instances,
+            &prev,
+            &std::collections::HashSet::from([id]),
+            &std::collections::HashMap::new(),
+        );
+
+        assert_eq!(instances[0].status, Status::Starting);
+        assert_eq!(
+            observed_transitions(&instances, &prev),
+            vec![(0, Status::Error)],
+            "a transition the tick does own must still be reported"
+        );
+    }
+
+    #[test]
+    fn skip_tmux_decision_for_structured_keeps_disk_status_without_a_baseline() {
         // A row created since the last tick has no live value yet. Its disk
         // status is all there is, and the absent baseline already suppresses
         // the transition report.
-        let mut inst = Instance::new("acp-session", "/tmp/test");
-        inst.view = crate::session::View::Structured;
+        let mut inst = phantom_structured_row("acp-session");
         inst.status = Status::Running;
 
-        assert!(carry_live_status_for_structured(&mut inst));
+        assert!(skip_tmux_decision_for_structured(&mut inst));
 
         assert_eq!(inst.status, Status::Running);
         assert_eq!(inst.live_status_baseline, None);
     }
 
     #[test]
-    fn carry_live_status_for_structured_clears_a_stale_tmux_error() {
-        // Preserves what the structured short-circuit in
-        // `update_status_with_metadata_inner` does for a row converted from a
-        // terminal session: the tmux message cannot apply to it any more.
-        let mut inst = Instance::new("acp-session", "/tmp/test");
-        inst.view = crate::session::View::Structured;
+    fn skip_tmux_decision_for_structured_clears_a_stale_tmux_error() {
+        // Shares `Instance::clear_stale_tmux_error` with the structured
+        // short-circuit in `update_status_with_metadata_inner`, for a row
+        // converted from a terminal session: the tmux message cannot apply to
+        // it any more.
+        let mut inst = phantom_structured_row("acp-session");
         inst.last_error = Some(crate::session::TMUX_SESSION_GONE_ERROR.to_string());
 
-        assert!(carry_live_status_for_structured(&mut inst));
+        assert!(skip_tmux_decision_for_structured(&mut inst));
 
         assert_eq!(inst.last_error, None);
     }
 
     #[test]
-    fn carry_live_status_for_structured_leaves_tmux_sessions_to_the_poller() {
+    fn skip_tmux_decision_for_structured_leaves_tmux_sessions_to_the_poller() {
         // A terminal session has a real pane; the poller is authoritative and
         // must still run its tmux decision against the disk-loaded row.
         let mut inst = Instance::new("tmux-session", "/tmp/test");
@@ -6730,7 +6853,7 @@ mod tests {
         inst.last_error = Some(crate::session::TMUX_SESSION_GONE_ERROR.to_string());
 
         assert!(
-            !carry_live_status_for_structured(&mut inst),
+            !skip_tmux_decision_for_structured(&mut inst),
             "a tmux-backed session must not skip the tmux status decision"
         );
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4058,9 +4058,13 @@ async fn status_poll_loop(state: Arc<AppState>) {
         .await;
 
         if let Ok((mut instances, live_worker_records)) = updated {
-            // Diff BEFORE the helper: status_tx must observe the raw
-            // post-suppression, post-tmux-scrape values, never the acp
-            // overlay applied by the helper.
+            // Diff BEFORE `reload_state_instances_from_disk`: for a tmux-backed
+            // row, status_tx must observe the raw post-suppression,
+            // post-tmux-scrape value, never the acp overlay that helper
+            // re-applies. A structured row is the deliberate exception:
+            // `carry_live_status_for_structured` above already put the live acp
+            // status on it, which is what makes it compare equal to `prev` here
+            // instead of reporting a phantom transition every tick.
             let now = chrono::Utc::now();
             let unread_enabled = crate::session::unread_enabled();
             // Passive status transitions observed this tick, batched per

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2718,6 +2718,53 @@ fn seed_unknown_tracking(
     }
 }
 
+/// Carry the acp-authoritative live status onto a freshly disk-loaded
+/// structured row, and report whether the caller must skip the tmux status
+/// decision for it.
+///
+/// A structured row has no tmux pane to probe, so the poller has no say in its
+/// status: [`apply_acp_overlay_inplace`] re-pins the in-memory value on every
+/// reload, and `decide_passive_transition` deliberately never persists the
+/// poller's view (#2690 / #2697). Disk therefore stays permanently out of step
+/// with live, and `status_poll_loop` compares exactly those two: `prev` comes
+/// from `state.instances` (overlaid, live), `fresh` from disk. Left alone, every
+/// tick reads that standing mismatch as a brand new transition, which logs a
+/// `session.status_change` line, broadcasts a `StatusChange`, resets the push
+/// dwell timer in `server::push`, and re-marks the session unread. Forever, at
+/// the 2s tick, surviving daemon restarts because `seed_acp_statuses` re-derives
+/// the same live status from the stored event log on boot. One session whose
+/// worker died with `AgentStartupError` wrote 81k such lines into a single 43MB
+/// log file.
+///
+/// Aligning `status` with the baseline the caller just seeded makes that
+/// comparison like-for-like, so a structured row reports a transition only when
+/// its live status actually moved, which for these rows means an acp event
+/// handler moved it.
+///
+/// Deliberately does not lean on the structured short-circuit in
+/// `Instance::update_status_with_metadata_inner`: that path heals `Error` to
+/// `Idle` unconditionally, which is correct for the TUI poller and `aoe ps`
+/// (neither has an overlay to re-pin the value) but is what mints the phantom
+/// here, since the overlay restores `Error` moments later.
+fn carry_live_status_for_structured(inst: &mut Instance) -> bool {
+    if !inst.is_structured() {
+        return false;
+    }
+    // The same stale-error clear the short-circuit performs, kept so a row
+    // converted from a terminal session stops showing a tmux message that
+    // cannot apply to it any more.
+    if inst.last_error.as_deref() == Some(crate::session::TMUX_SESSION_GONE_ERROR) {
+        inst.last_error = None;
+    }
+    // `None` means the row is newer than the last tick and has no live value
+    // yet; its disk status is all there is, and the absent baseline already
+    // suppresses a transition report.
+    if let Some(live) = inst.live_status_baseline {
+        inst.status = live;
+    }
+    true
+}
+
 // INVARIANTS for `reload_state_instances_from_disk` (do not break without
 // revisiting `tests/serve_disk_reload_helper_equivalence.rs`):
 // 1. Both call sites (`status_poll_loop` and `disk_watcher_consumer`) must
@@ -3995,6 +4042,9 @@ async fn status_poll_loop(state: Arc<AppState>) {
                     continue;
                 }
                 inst.live_status_baseline = prev_for_poll.get(&inst.id).copied();
+                if carry_live_status_for_structured(inst) {
+                    continue;
+                }
                 let session_name = crate::tmux::resolve_agent_session_name_in(
                     &pane_metadata,
                     &inst.id,
@@ -6597,6 +6647,94 @@ mod tests {
         assert!(
             decision.patch.is_none(),
             "structured sessions must never get a passive status patch"
+        );
+    }
+
+    #[test]
+    fn carry_live_status_for_structured_suppresses_the_phantom_transition() {
+        // The other half of #2690 / #2697. That pair stopped the poller from
+        // *persisting* its (void) view of a structured row's status, but left
+        // `status_poll_loop` still comparing the live `prev` against the
+        // disk-loaded `fresh`. Those two never converge for a structured row,
+        // so the loop reported one fresh transition per 2s tick forever: a
+        // `session.status_change` line, a `StatusChange` broadcast, a reset
+        // push dwell timer, and a re-marked-unread session.
+        let mut inst = Instance::new("acp-session", "/tmp/test");
+        inst.view = crate::session::View::Structured;
+        // Disk says Idle; the live acp status is Error (worker died with
+        // `AgentStartupError`, which `seed_acp_statuses` re-derives on boot).
+        inst.status = Status::Idle;
+        inst.live_status_baseline = Some(Status::Error);
+
+        assert!(
+            carry_live_status_for_structured(&mut inst),
+            "a structured row must skip the tmux status decision"
+        );
+
+        // No transition to log: `update_status_with_metadata` compares the
+        // post-decision status against this baseline.
+        assert_eq!(
+            inst.status,
+            inst.live_status_baseline.expect("baseline stays seeded"),
+            "status must match the baseline so no transition is logged"
+        );
+        // No transition to broadcast, persist, or mark unread: the diff loop
+        // in `status_poll_loop` compares `prev` against this same status.
+        assert_eq!(
+            inst.status,
+            Status::Error,
+            "the live acp status is authoritative, not the disk value"
+        );
+    }
+
+    #[test]
+    fn carry_live_status_for_structured_keeps_disk_status_without_a_baseline() {
+        // A row created since the last tick has no live value yet. Its disk
+        // status is all there is, and the absent baseline already suppresses
+        // the transition report.
+        let mut inst = Instance::new("acp-session", "/tmp/test");
+        inst.view = crate::session::View::Structured;
+        inst.status = Status::Running;
+
+        assert!(carry_live_status_for_structured(&mut inst));
+
+        assert_eq!(inst.status, Status::Running);
+        assert_eq!(inst.live_status_baseline, None);
+    }
+
+    #[test]
+    fn carry_live_status_for_structured_clears_a_stale_tmux_error() {
+        // Preserves what the structured short-circuit in
+        // `update_status_with_metadata_inner` does for a row converted from a
+        // terminal session: the tmux message cannot apply to it any more.
+        let mut inst = Instance::new("acp-session", "/tmp/test");
+        inst.view = crate::session::View::Structured;
+        inst.last_error = Some(crate::session::TMUX_SESSION_GONE_ERROR.to_string());
+
+        assert!(carry_live_status_for_structured(&mut inst));
+
+        assert_eq!(inst.last_error, None);
+    }
+
+    #[test]
+    fn carry_live_status_for_structured_leaves_tmux_sessions_to_the_poller() {
+        // A terminal session has a real pane; the poller is authoritative and
+        // must still run its tmux decision against the disk-loaded row.
+        let mut inst = Instance::new("tmux-session", "/tmp/test");
+        inst.status = Status::Idle;
+        inst.live_status_baseline = Some(Status::Error);
+        inst.last_error = Some(crate::session::TMUX_SESSION_GONE_ERROR.to_string());
+
+        assert!(
+            !carry_live_status_for_structured(&mut inst),
+            "a tmux-backed session must not skip the tmux status decision"
+        );
+
+        assert_eq!(inst.status, Status::Idle, "disk status must be untouched");
+        assert_eq!(
+            inst.last_error.as_deref(),
+            Some(crate::session::TMUX_SESSION_GONE_ERROR),
+            "a tmux-backed session's tmux error must survive for the poller"
         );
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -4922,6 +4922,20 @@ impl Instance {
         }
     }
 
+    /// Drop a [`TMUX_SESSION_GONE_ERROR`] left on a row that no longer has a
+    /// tmux pane to speak for it, so the UI stops showing a message that cannot
+    /// apply to it any more (a session converted to, or restarted in, the
+    /// structured view).
+    ///
+    /// Shared by the structured short-circuit below and by the daemon poll
+    /// loop's `skip_tmux_decision_for_structured`, which skips that
+    /// short-circuit outright; one copy keeps the two from drifting.
+    pub(crate) fn clear_stale_tmux_error(&mut self) {
+        if self.last_error.as_deref() == Some(TMUX_SESSION_GONE_ERROR) {
+            self.last_error = None;
+        }
+    }
+
     fn update_status_with_metadata_inner(
         &mut self,
         metadata: Option<&tmux::PaneMetadata>,
@@ -4949,12 +4963,7 @@ impl Instance {
         // events over the broadcast. Probing tmux here only ever produces
         // a spurious "tmux session is gone" Error transition.
         if self.is_structured() {
-            // Clear any stale tmux-derived error so the UI doesn't show
-            // a misleading message after a session is converted or
-            // restarted in the structured view.
-            if self.last_error.as_deref() == Some(TMUX_SESSION_GONE_ERROR) {
-                self.last_error = None;
-            }
+            self.clear_stale_tmux_error();
             if self.status == Status::Error {
                 self.status = Status::Idle;
             }


### PR DESCRIPTION
**Note:** Claude handled the investigation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`status_poll_loop` compares two status sources that can never converge for a structured session, and reads the standing mismatch as a brand new transition on every 2s tick.

`prev` is snapshotted from `state.instances`, whose status `apply_acp_overlay_inplace` re-pins to the live acp value on every reload (`src/server/mod.rs:2890`). `fresh` is loaded from disk, which `decide_passive_transition` deliberately never updates for these rows, because a structured session has no tmux pane and the poller has no say in its status (#2690, PR #2697). The two therefore sit permanently out of step, and the loop diffs exactly those two values. Nothing converges them, so the "transition" is reported again 2 seconds later, forever. It survives daemon restarts too: `seed_acp_statuses` re-derives the same live status from the stored event log on boot.

Found on a live daemon. Two structured `codex` sessions whose workers died with `AgentStartupError` on 2026-07-15 wrote **81,624** `[codex] Error -> Idle` lines into one 43MB `debug.log`, 23.5% of the file, alongside five rotated 50MB logs. Real diagnostics get rotated out by the noise. A `claude` structured session did the same with 7,223 `Running -> Idle` lines.

Two consequences past the log spam, both observed in that log:

- **Push notifications starved.** `handle_status_change` resets `idle_since` to now on every phantom edge (`src/server/push.rs:498`) and `DWELL_TERMINAL_MS` is 2000, so a 2s tick means Idle and Error pushes for these sessions can essentially never accumulate their dwell window.
- **Unread could not be cleared.** `mark_unread` is not gated on `is_structured` (`src/server/mod.rs:3738`), so the phantom `Running -> Idle` edge re-marked a structured session unread seconds after it was read. The log carries 228 `patches=0 unread=1` writes, in pairs 2 to 4 seconds apart.

The fix carries the live status onto the disk-loaded row and skips the tmux status decision that the overlay was discarding anyway. The row then compares equal to `prev`, so the diff loop short-circuits and all four symptoms fall to the one guard. This is the other half of #2690 / PR #2697: that pair stopped the poller from *persisting* its void view of a structured row's status, but left the baseline and the diff still reading disk.

`src/session/instance.rs` is deliberately untouched. Its structured short-circuit heals `Error` to `Idle` unconditionally, which is correct for the TUI poller (`src/tui/status_poller.rs:227`) and `aoe ps`, neither of which has an overlay to re-pin the value; in the daemon that heal was already discarded, and it is what minted the phantom. The stale `TMUX_SESSION_GONE_ERROR` clear that short-circuit also performs is preserved in the new guard, so a row converted from a terminal session still stops showing a tmux message that can no longer apply to it.

Not addressed here, flagged as separate: `seed_acp_statuses` resurrects a 15-day-old `AgentStartupError` on every daemon boot, so those two dead rows still sit at `Error` in the sidebar. Quietly now, but arguably they should not.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start `aoe serve` with at least one structured session whose acp worker is dead (or has never started), then `tail -f ~/.agent-of-empires/debug.log | grep session.status_change`. No lines for that session, where before the fix one appeared every 2 seconds.
- [ ] Confirm genuine transitions still land: prompt a live structured session and watch `session.status_change` log its real `Idle -> Running` and `Running -> Idle` edges.
- [ ] Confirm terminal sessions are unaffected: prompt a tmux-backed session and watch its transitions log and persist as before.
- [ ] Open a structured session that shows an unread marker, read it, then wait 10 seconds. It stays read, where before the fix it re-marked itself unread within a couple of seconds.
- [ ] Leave the daemon idle with `aoe` closed and confirm Idle push notifications still fire for a session that goes idle, i.e. the dwell timer is no longer being reset every 2 seconds.
- [ ] Check log volume over a few minutes of an otherwise-quiet daemon; `debug.log` should grow by kilobytes, not megabytes.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Docs: none warranted. The change is internal daemon behavior with no operator-facing knob, no config, and no new surface a user could discover or need explained.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the defect lives in the daemon's poll-loop diff, not in TUI rendering or a CLI surface. Four unit tests sit next to the #2697 precedent in `src/server/mod.rs` and lock the invariant directly: a structured row's status matches its seeded baseline (no transition logged), matches `prev` (no broadcast, no persist, no unread re-mark), keeps its disk status when no live baseline exists yet, clears a stale `TMUX_SESSION_GONE_ERROR`, and leaves tmux-backed rows entirely to the poller. Reproducing it end to end in e2e would mean standing up a daemon, killing an acp worker, and asserting on log volume across many 2s ticks, which is slow and timing-shaped for a defect whose reproduction is one struct comparison.

On the red direction: the reproduction here is the 81,624 live log lines rather than a synthetic failing test. The testable seam is the helper the fix introduces, so a pre-fix run would prove a compile error, not the symptom. Recording that honestly instead of claiming a red-to-green cycle that did not happen.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-investigate` then `/aoe-implement`)

**Any Additional AI Details you'd like to share:**

I hit the symptom (logs flooded with codex status changes for a session I did not have running) and pointed Claude at it. It traced the loop end to end against the live `debug.log`, `sessions.json`, and `acp_events.db`, then drafted the fix and the tests. I made the scoping calls: fix the poll-loop guard, leave `instance.rs` and the stale `seed_acp_statuses` seed alone, and skip the live daemon restart demo since the daemon in question hosts the session this work was done in.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed false `status_change` reports for structured sessions.
- Reorganized per-tick status evaluation and transition reporting.
- Reused live status baselines and skipped tmux decisions for structured sessions.
- Added shared cleanup for stale tmux errors.
- Added tests for phantom transitions, baseline handling, stale-error cleanup, and tmux-backed sessions.

## Benefits

Prevents duplicate logs, broadcasts, push dwell resets, and incorrect unread marking. Preserves valid transitions and existing tmux-backed behavior.

## Further enhancement

Startup-restored `AgentStartupError` values from `seed_acp_statuses` remain outside the scope of this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->