### PR TITLE
fix(session): avoid nested-runtime panic in opencode preassign

### DIFF
--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -1599,58 +1599,74 @@ fn preassign_opencode_session_id_impl(project_path: &str) -> Result<String> {
     let _guard = ServeGuard(Some(child));
 
     let base = format!("http://127.0.0.1:{port}");
-    // acquire_session_id runs on a synchronous launch thread (the CLI process,
-    // a server `spawn_blocking` worker, or the TUI event loop), never inside a
-    // live async task, so a short-lived current-thread runtime is safe here.
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("failed to build the preassign runtime")?;
-
-    rt.block_on(async {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(2))
+    // `acquire_session_id` runs on a launch thread that may itself be async: on
+    // the CLI it runs under the `#[tokio::main]` entrypoint, i.e. *inside* a live
+    // Tokio runtime. Building a runtime and `block_on`-ing it on that same thread
+    // panics with "Cannot start a runtime from within a runtime". Run the
+    // short-lived current-thread runtime on a dedicated OS thread instead, which
+    // never carries an ambient runtime, so `block_on` is valid regardless of
+    // whether the caller (CLI, a server `spawn_blocking` worker, or the TUI event
+    // loop) is itself async. `thread::scope` lets the worker borrow
+    // `id`/`base`/`project_path` without `'static` clones and keeps the
+    // `opencode serve` `_guard` alive across the join.
+    let preassign = || -> Result<()> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
             .build()
-            .context("failed to build the preassign HTTP client")?;
+            .context("failed to build the preassign runtime")?;
 
-        let deadline = Instant::now() + OPENCODE_PREASSIGN_DEADLINE;
-        loop {
-            if let Ok(resp) = client.get(format!("{base}/api/session")).send().await {
-                if resp.status().is_success() {
-                    break;
+        rt.block_on(async {
+            let client = reqwest::Client::builder()
+                .timeout(Duration::from_secs(2))
+                .build()
+                .context("failed to build the preassign HTTP client")?;
+
+            let deadline = Instant::now() + OPENCODE_PREASSIGN_DEADLINE;
+            loop {
+                if let Ok(resp) = client.get(format!("{base}/api/session")).send().await {
+                    if resp.status().is_success() {
+                        break;
+                    }
                 }
+                if Instant::now() >= deadline {
+                    anyhow::bail!("opencode serve did not become ready within the deadline");
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
             }
-            if Instant::now() >= deadline {
-                anyhow::bail!("opencode serve did not become ready within the deadline");
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
 
-        let body = serde_json::json!({
-            "id": id,
-            "location": { "directory": project_path },
-        });
-        let resp = client
-            .post(format!("{base}/api/session"))
-            .json(&body)
-            .send()
-            .await
-            .context("opencode preassign POST /api/session failed")?;
-        if !resp.status().is_success() {
-            anyhow::bail!("opencode preassign POST returned {}", resp.status());
-        }
-        let created: serde_json::Value = resp
-            .json()
-            .await
-            .context("opencode preassign response was not JSON")?;
-        let created_id = created
-            .get("data")
-            .and_then(|d| d.get("id"))
-            .and_then(|v| v.as_str());
-        if created_id != Some(id.as_str()) {
-            anyhow::bail!("opencode assigned {created_id:?}, expected {id}");
-        }
-        Ok::<(), anyhow::Error>(())
+            let body = serde_json::json!({
+                "id": id,
+                "location": { "directory": project_path },
+            });
+            let resp = client
+                .post(format!("{base}/api/session"))
+                .json(&body)
+                .send()
+                .await
+                .context("opencode preassign POST /api/session failed")?;
+            if !resp.status().is_success() {
+                anyhow::bail!("opencode preassign POST returned {}", resp.status());
+            }
+            let created: serde_json::Value = resp
+                .json()
+                .await
+                .context("opencode preassign response was not JSON")?;
+            let created_id = created
+                .get("data")
+                .and_then(|d| d.get("id"))
+                .and_then(|v| v.as_str());
+            if created_id != Some(id.as_str()) {
+                anyhow::bail!("opencode assigned {created_id:?}, expected {id}");
+            }
+            Ok::<(), anyhow::Error>(())
+        })
+    };
+
+    std::thread::scope(|scope| {
+        scope
+            .spawn(preassign)
+            .join()
+            .map_err(|_| anyhow::anyhow!("opencode preassign worker thread panicked"))?
     })?;
 
     Ok(id)

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -43,6 +43,7 @@ mod kiro_launch;
 mod live_takeover;
 mod logs;
 mod new_session;
+mod opencode_preassign_no_runtime_panic;
 mod opencode_sandbox_resume;
 mod permission_response_e2e;
 mod plugin_command_executor_e2e;

--- a/tests/e2e/opencode_preassign_no_runtime_panic.rs
+++ b/tests/e2e/opencode_preassign_no_runtime_panic.rs
@@ -1,0 +1,137 @@
+//! Regression test for the opencode preassign nested-runtime panic.
+//!
+//! `preassign_opencode_session_id_impl` (src/session/capture.rs) builds a
+//! current-thread Tokio runtime and `block_on`s an HTTP call to reserve the
+//! opencode `ses_` id. The CLI entrypoint is `#[tokio::main]`, so before the
+//! fix, launching an opencode session ran that `block_on` inside a live
+//! runtime and aborted the process with:
+//!
+//! ```text
+//! Cannot start a runtime from within a runtime.
+//! ```
+//!
+//! Running the preassign on a dedicated OS thread makes it safe regardless of
+//! the caller's context. This test enables the opt-in preassign, launches a
+//! real opencode session through the `aoe` binary with a fake `opencode` on
+//! PATH, and asserts the panic is gone -- while proving the preassign path
+//! actually ran (the fake logs a `serve` invocation).
+
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use serial_test::serial;
+
+use crate::harness::{require_tmux, TuiTestHarness};
+
+const TITLE: &str = "OpencodePreassignE2E";
+const RUNTIME_PANIC: &str = "Cannot start a runtime from within a runtime";
+
+fn new_harness(test_name: &str) -> TuiTestHarness {
+    #[cfg(unix)]
+    {
+        TuiTestHarness::new_in_tmp(test_name)
+    }
+    #[cfg(not(unix))]
+    {
+        TuiTestHarness::new(test_name)
+    }
+}
+
+/// Install a fake `opencode` on PATH that records its argv (so the test can
+/// prove preassign spawned `opencode serve`) and then idles. The fake `serve`
+/// never binds its port, so the preassign readiness probe times out and aoe
+/// falls back to the poller -- the graceful path, without a real opencode.
+fn install_fake_opencode(h: &mut TuiTestHarness) -> PathBuf {
+    let bin = h.install_path_command("opencode");
+    let log = h.home_path().join("fake-opencode.log");
+    let script = format!(
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nexec sleep 30\n",
+        log.display()
+    );
+    let script_path = bin.join("opencode");
+    fs::write(&script_path, script).expect("write fake opencode");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755))
+            .expect("chmod fake opencode");
+    }
+    log
+}
+
+/// Turn on the opt-in preassign path in the seeded test config. The harness
+/// seeds only `[updates]` and `[app_state]`, so appending a `[session]` table
+/// here does not clash.
+fn enable_preassign(h: &TuiTestHarness) {
+    let config_path = crate::harness::app_dir_in(h.home_path()).join("config.toml");
+    let mut file = fs::OpenOptions::new()
+        .append(true)
+        .open(&config_path)
+        .unwrap_or_else(|e| panic!("failed to open {}: {}", config_path.display(), e));
+    file.write_all(b"\n[session]\nopencode_preassign_session_id = true\n")
+        .expect("enable opencode preassign");
+}
+
+struct StopSessionOnDrop<'a> {
+    h: &'a TuiTestHarness,
+}
+
+impl Drop for StopSessionOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.h.run_cli(&["session", "stop", TITLE]);
+    }
+}
+
+/// Launching an opencode session with preassign enabled must not panic with
+/// "Cannot start a runtime from within a runtime".
+#[test]
+#[serial]
+fn opencode_launch_with_preassign_does_not_panic_nested_runtime() {
+    require_tmux!();
+
+    let mut h = new_harness("opencode_preassign_no_runtime_panic");
+    let log_path = install_fake_opencode(&mut h);
+    enable_preassign(&h);
+    let project = h.project_path();
+
+    let add = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "--cmd",
+        "opencode",
+        "-t",
+        TITLE,
+    ]);
+    assert!(
+        add.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let _cleanup = StopSessionOnDrop { h: &h };
+
+    // `aoe session start` reaches `acquire_session_id` -> the opencode preassign
+    // inside the `#[tokio::main]` CLI runtime. Before the fix this aborted with
+    // the nested-runtime panic; after it, the preassign runs on a dedicated
+    // thread, the fake serve never gets ready, and aoe falls back to the poller.
+    let start = h.run_cli(&["session", "start", TITLE]);
+    let stderr = String::from_utf8_lossy(&start.stderr);
+
+    assert!(
+        !stderr.contains(RUNTIME_PANIC),
+        "opencode launch hit the nested-runtime panic:\n{stderr}"
+    );
+    assert!(
+        start.status.success(),
+        "aoe session start failed:\n{stderr}"
+    );
+
+    // Prove the preassign path actually ran -- otherwise "no panic" would be
+    // vacuously true. The fake opencode logs every invocation, and preassign
+    // spawns `opencode serve` right before the `block_on` that used to panic.
+    let invocations = fs::read_to_string(&log_path).unwrap_or_default();
+    assert!(
+        invocations.lines().any(|line| line.contains("serve")),
+        "preassign never spawned `opencode serve`; fake log:\n{invocations}"
+    );
+}

--- a/tests/e2e/opencode_preassign_no_runtime_panic.rs
+++ b/tests/e2e/opencode_preassign_no_runtime_panic.rs
@@ -13,35 +13,24 @@
 //! Running the preassign on a dedicated OS thread makes it safe regardless of
 //! the caller's context. This test enables the opt-in preassign, launches a
 //! real opencode session through the `aoe` binary with a fake `opencode` on
-//! PATH, and asserts the panic is gone -- while proving the preassign path
+//! PATH, and asserts the panic is gone, while proving the preassign path
 //! actually ran (the fake logs a `serve` invocation).
 
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
-use serial_test::serial;
+use serial_test::parallel;
 
 use crate::harness::{require_tmux, TuiTestHarness};
 
 const TITLE: &str = "OpencodePreassignE2E";
 const RUNTIME_PANIC: &str = "Cannot start a runtime from within a runtime";
 
-fn new_harness(test_name: &str) -> TuiTestHarness {
-    #[cfg(unix)]
-    {
-        TuiTestHarness::new_in_tmp(test_name)
-    }
-    #[cfg(not(unix))]
-    {
-        TuiTestHarness::new(test_name)
-    }
-}
-
 /// Install a fake `opencode` on PATH that records its argv (so the test can
 /// prove preassign spawned `opencode serve`) and then idles. The fake `serve`
 /// never binds its port, so the preassign readiness probe times out and aoe
-/// falls back to the poller -- the graceful path, without a real opencode.
+/// falls back to the poller: the graceful path, without a real opencode.
 fn install_fake_opencode(h: &mut TuiTestHarness) -> PathBuf {
     let bin = h.install_path_command("opencode");
     let log = h.home_path().join("fake-opencode.log");
@@ -86,11 +75,11 @@ impl Drop for StopSessionOnDrop<'_> {
 /// Launching an opencode session with preassign enabled must not panic with
 /// "Cannot start a runtime from within a runtime".
 #[test]
-#[serial]
+#[parallel]
 fn opencode_launch_with_preassign_does_not_panic_nested_runtime() {
     require_tmux!();
 
-    let mut h = new_harness("opencode_preassign_no_runtime_panic");
+    let mut h = TuiTestHarness::new("opencode_preassign_no_runtime_panic");
     let log_path = install_fake_opencode(&mut h);
     enable_preassign(&h);
     let project = h.project_path();
@@ -126,7 +115,7 @@ fn opencode_launch_with_preassign_does_not_panic_nested_runtime() {
         "aoe session start failed:\n{stderr}"
     );
 
-    // Prove the preassign path actually ran -- otherwise "no panic" would be
+    // Prove the preassign path actually ran; otherwise "no panic" would be
     // vacuously true. The fake opencode logs every invocation, and preassign
     // spawns `opencode serve` right before the `block_on` that used to panic.
     let invocations = fs::read_to_string(&log_path).unwrap_or_default();


### PR DESCRIPTION
## Description

opencode sessions crash on launch when I set `session.opencode_preassign_session_id = true`:

```
thread 'main' panicked at src/session/capture.rs:
Cannot start a runtime from within a runtime. This happens because a function
(like `block_on`) attempted to block the current thread while the thread is
being used to drive asynchronous tasks.
```

`aoe add --launch`, `aoe session start`, `aoe session restart`, and creating a session in the TUI all hit it. claude and copilot launch fine — only opencode breaks. I hit it on v1.13.1, and it's still there on v1.13.2 and `main`.

### Why it happens

`preassign_opencode_session_id_impl` (`src/session/capture.rs`) spawns a throwaway `opencode serve`, builds its own current-thread Tokio runtime, and blocks on a `POST /api/session` to reserve the `ses_` id:

```rust
let rt = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
rt.block_on(async { /* wait for serve, POST the id */ })
```

The comment above it says this "never runs inside a live async task." It does. `src/main.rs` is `#[tokio::main]`, so the CLI is already inside a runtime. The launch path calls `acquire_session_id` → `preassign_opencode_session_id`, builds a second runtime on the same thread, and panics.

Only opencode hits it — `src/session/instance.rs` gates preassign to opencode:

```rust
let preassign = self.tool == "opencode" && self.opencode_preassign_enabled();
```

Setting the flag to `false` avoids the crash, but I use preassign to keep opencode sessions from cross-wiring when several agents share a directory. I want it on.

### The fix

Run the runtime on a dedicated OS thread with `std::thread::scope`. A fresh OS thread has no ambient runtime, so `block_on` is safe no matter who calls it — the CLI, a server `spawn_blocking` worker, or the TUI event loop.

- The scoped thread borrows `id` / `base` / `project_path` — no `'static` clones.
- The `opencode serve` guard stays alive across the join.
- The preassign protocol doesn't change.

### How I tested

- `cargo build --release`, `cargo fmt --check`, `cargo clippy`.
- `aoe session start` on an opencode session with preassign on: no crash. It panicked every time before.
- Added an e2e test, `tests/e2e/opencode_preassign_no_runtime_panic.rs`. It fails on the old code with the same panic and passes with the fix.
- copilot still launches fine.

One note on the diff: it looks big, but it's mostly indentation — the async block moves one level deeper into the closure. The logic is the same.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**


**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed OpenCode launch crashes when session ID preassignment runs inside an existing async runtime.
- Moved preassignment work to a dedicated thread while preserving the existing fallback behavior.
- Added a parallel-safe end-to-end test that verifies successful launch and `opencode serve` invocation.

## Benefits

- Prevents nested-runtime panics.
- Improves confidence in OpenCode preassignment across launch paths.
- Keeps launches resilient when the preassignment server is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->