### PR TITLE
fix(tui): source structured-session status from the daemon

### DIFF
--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -30,13 +30,14 @@ mod v019_move_acp_defaults_to_acp;
 mod v020_move_tui_branch_suffix_to_row_tag;
 mod v021_split_app_state_to_state_toml;
 mod v022_prune_tuning_settings;
+mod v023_clear_structured_container_error;
 
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-const CURRENT_VERSION: u32 = 22;
+const CURRENT_VERSION: u32 = 23;
 const VERSION_FILE: &str = ".schema_version";
 
 struct Migration {
@@ -155,6 +156,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 22,
         name: "prune_tuning_settings",
         run: v022_prune_tuning_settings::run,
+    },
+    Migration {
+        version: 23,
+        name: "clear_structured_container_error",
+        run: v023_clear_structured_container_error::run,
     },
 ];
 

--- a/src/migrations/v023_clear_structured_container_error.rs
+++ b/src/migrations/v023_clear_structured_container_error.rs
@@ -22,9 +22,10 @@
 //! ## Failure policy
 //!
 //! Per `AGENTS.md > Data Migrations`, a returned `Err` aborts boot. A
-//! sessions.json that fails to parse is logged and skipped (a corrupt file
-//! must not block boot or spam every launch). Only `get_app_dir` and
-//! directory-read failures propagate.
+//! sessions.json that fails to read or parse is logged and skipped: an
+//! unreadable or corrupt file must not block boot or spam every launch, and
+//! this heal is best-effort. Only `get_app_dir` and directory-read failures
+//! propagate.
 
 use anyhow::Result;
 use std::fs;
@@ -61,7 +62,16 @@ fn clear_structured_error(path: &Path) -> Result<()> {
     if !path.exists() {
         return Ok(());
     }
-    let content = fs::read_to_string(path)?;
+    // Read failures are skipped for the same reason parse failures are: this
+    // is a best-effort heal, and a permissions hiccup or non-UTF-8 file must
+    // not abort boot. `?` here would have propagated straight out of `run()`.
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(e) => {
+            debug!("v023: failed to read {}: {e}, skipping", path.display());
+            return Ok(());
+        }
+    };
     let mut value: serde_json::Value = match serde_json::from_str(&content) {
         Ok(v) => v,
         Err(e) => {

--- a/src/migrations/v023_clear_structured_container_error.rs
+++ b/src/migrations/v023_clear_structured_container_error.rs
@@ -1,0 +1,186 @@
+//! Migration v023: clear the spurious container Error left on structured
+//! (ACP) sessions by builds whose TUI status poller ran the sandbox-dead
+//! check before bailing on `is_structured()`.
+//!
+//! Those builds took a structured session with `sandbox_info` set, looked up
+//! its container in `batch_container_health()`, and on a not-running reading
+//! stamped `status = "error"` with `"Container is not running"`. A structured
+//! session's container is owned by its ACP worker rather than by a tmux pane,
+//! so that reading says nothing about the session, and the heal in
+//! `update_status_with_metadata_inner` only cleared `last_error` for the
+//! tmux-gone message, leaving the row `Idle` with a phantom container error.
+//! `last_error` is `#[serde(skip)]`, so what survives a restart is the
+//! `status = "error"` alone.
+//!
+//! The poller now returns `None` for structured rows and the daemon overlay
+//! (`DaemonStatusPoller`) is their only status producer, so no new rows can be
+//! poisoned. This one-shot demotes the existing ones back to Idle. Any
+//! persisted Error on a structured row can only be that spurious transition:
+//! the daemon never persisted structured status at all in those builds (see
+//! the durability contract on `apply_acp_overlay_inplace`).
+//!
+//! ## Failure policy
+//!
+//! Per `AGENTS.md > Data Migrations`, a returned `Err` aborts boot. A
+//! sessions.json that fails to parse is logged and skipped (a corrupt file
+//! must not block boot or spam every launch). Only `get_app_dir` and
+//! directory-read failures propagate.
+
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+use tracing::{debug, info};
+
+pub fn run() -> Result<()> {
+    let app_dir = crate::session::get_app_dir()?;
+    run_in(&app_dir)
+}
+
+pub(crate) fn run_in(app_dir: &Path) -> Result<()> {
+    let profiles_dir = app_dir.join("profiles");
+    if profiles_dir.exists() {
+        for entry in fs::read_dir(&profiles_dir)? {
+            let entry = entry?;
+            if entry.path().is_dir() {
+                clear_structured_error(&entry.path().join("sessions.json"))?;
+            }
+        }
+    }
+    // Legacy top-level sessions.json (pre-profiles layout).
+    clear_structured_error(&app_dir.join("sessions.json"))?;
+    Ok(())
+}
+
+/// Demote any structured session persisted at `status = "error"` back to
+/// `"idle"`. Terminal rows keep their Error: the tmux poller is a real
+/// producer for those and the status is meaningful.
+///
+/// `view` is skipped in serialization when it holds the default `Terminal`
+/// (`View::is_terminal`), so an absent field means terminal, not structured.
+fn clear_structured_error(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let content = fs::read_to_string(path)?;
+    let mut value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            debug!("v023: failed to parse {}: {e}, skipping", path.display());
+            return Ok(());
+        }
+    };
+
+    let mut healed = 0usize;
+    if let Some(array) = value.as_array_mut() {
+        for instance in array.iter_mut() {
+            if let Some(obj) = instance.as_object_mut() {
+                let structured = obj.get("view").and_then(|v| v.as_str()) == Some("structured");
+                let errored = obj.get("status").and_then(|v| v.as_str()) == Some("error");
+                if structured && errored {
+                    obj.insert(
+                        "status".to_string(),
+                        serde_json::Value::String("idle".to_string()),
+                    );
+                    healed += 1;
+                }
+            }
+        }
+    }
+
+    if healed > 0 {
+        crate::session::atomic_write(path, serde_json::to_string_pretty(&value)?.as_bytes())?;
+        info!(
+            "v023: cleared spurious container Error on {healed} structured session(s) in {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clears_only_structured_error_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        fs::write(
+            &path,
+            r#"[
+                {"id":"a","status":"error","view":"structured"},
+                {"id":"b","status":"error","view":"terminal"},
+                {"id":"c","status":"error"},
+                {"id":"d","status":"idle","view":"structured"},
+                {"id":"e","status":"stopped","view":"structured"}
+            ]"#,
+        )
+        .unwrap();
+
+        clear_structured_error(&path).unwrap();
+
+        let v: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let arr = v.as_array().unwrap();
+        // structured + error -> idle (the bug footprint)
+        assert_eq!(arr[0]["status"], "idle");
+        // explicit terminal error -> untouched (real tmux producer)
+        assert_eq!(arr[1]["status"], "error");
+        // absent view means terminal (View::is_terminal skips it) -> untouched
+        assert_eq!(arr[2]["status"], "error");
+        // structured non-error -> untouched
+        assert_eq!(arr[3]["status"], "idle");
+        assert_eq!(arr[4]["status"], "stopped");
+    }
+
+    #[test]
+    fn is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        fs::write(
+            &path,
+            r#"[{"id":"a","status":"error","view":"structured"}]"#,
+        )
+        .unwrap();
+        clear_structured_error(&path).unwrap();
+        let first = fs::read_to_string(&path).unwrap();
+        clear_structured_error(&path).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), first);
+    }
+
+    #[test]
+    fn missing_file_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        clear_structured_error(&dir.path().join("does-not-exist.json")).unwrap();
+    }
+
+    #[test]
+    fn corrupt_file_is_skipped_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        fs::write(&path, "{ not valid json").unwrap();
+        clear_structured_error(&path).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "{ not valid json");
+    }
+
+    #[test]
+    fn walks_profiles_and_legacy_layouts() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile = dir.path().join("profiles").join("work");
+        fs::create_dir_all(&profile).unwrap();
+        let row = r#"[{"id":"a","status":"error","view":"structured"}]"#;
+        fs::write(profile.join("sessions.json"), row).unwrap();
+        fs::write(dir.path().join("sessions.json"), row).unwrap();
+
+        run_in(dir.path()).unwrap();
+
+        for p in [
+            profile.join("sessions.json"),
+            dir.path().join("sessions.json"),
+        ] {
+            let v: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&p).unwrap()).unwrap();
+            assert_eq!(v[0]["status"], "idle", "{}", p.display());
+        }
+    }
+}

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -67,6 +67,32 @@ impl Status {
         }
     }
 
+    /// Parse the form `/api/sessions` puts on the wire. That endpoint
+    /// serializes with `format!("{:?}", inst.status)`, not serde, so the
+    /// variant names are `CamelCase` rather than the `lowercase` rename
+    /// `as_str` and `Deserialize` use. Kept next to `as_str` so both
+    /// spellings of the same enum are read together;
+    /// `status_api_wire_form_round_trips` locks the pairing against the
+    /// server's formatter.
+    ///
+    /// `None` for anything unrecognized, which is how a newer daemon
+    /// reaches an older client: the caller leaves the row's status alone
+    /// rather than inventing one.
+    pub fn from_api_str(s: &str) -> Option<Status> {
+        match s {
+            "Running" => Some(Status::Running),
+            "Waiting" => Some(Status::Waiting),
+            "Idle" => Some(Status::Idle),
+            "Unknown" => Some(Status::Unknown),
+            "Stopped" => Some(Status::Stopped),
+            "Error" => Some(Status::Error),
+            "Starting" => Some(Status::Starting),
+            "Deleting" => Some(Status::Deleting),
+            "Creating" => Some(Status::Creating),
+            _ => None,
+        }
+    }
+
     /// Whether this status blocks an in-place worktree edit (move dir /
     /// rename branch). The worktree's checkout must be quiescent: an
     /// actively running agent, a session mid-start, or one being
@@ -5523,6 +5549,45 @@ mod tests {
         let guard = crate::tmux::SessionCacheGuard::capture();
         guard.force_present(&["aoe_some_other_session"]);
         guard
+    }
+
+    /// `/api/sessions` puts `format!("{:?}", inst.status)` on the wire, so
+    /// `from_api_str` has to speak `CamelCase` while `as_str` and serde speak
+    /// `lowercase`. Two spellings of one enum drift silently unless the pairing
+    /// is asserted against the actual formatter, which is what this does: a new
+    /// variant that nobody teaches `from_api_str` fails here rather than
+    /// showing up as a structured row whose status stops moving.
+    #[test]
+    fn status_api_wire_form_round_trips() {
+        for status in [
+            Status::Running,
+            Status::Waiting,
+            Status::Idle,
+            Status::Unknown,
+            Status::Stopped,
+            Status::Error,
+            Status::Starting,
+            Status::Deleting,
+            Status::Creating,
+        ] {
+            let wire = format!("{status:?}");
+            assert_eq!(
+                Status::from_api_str(&wire),
+                Some(status),
+                "wire form {wire} must parse back"
+            );
+            // The lowercase serde/`as_str` spelling is a different vocabulary
+            // and must NOT be accepted here, or a caller mixing the two would
+            // silently work for `error` and fail for `Error`.
+            assert_eq!(
+                Status::from_api_str(status.as_str()),
+                None,
+                "from_api_str must not accept the lowercase spelling {}",
+                status.as_str()
+            );
+        }
+        assert_eq!(Status::from_api_str(""), None);
+        assert_eq!(Status::from_api_str("Hibernating"), None);
     }
 
     #[cfg(feature = "serve")]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -830,6 +830,8 @@ impl App {
         let mut last_refresh_at: Option<std::time::Instant> = None;
         const REFRESH_COOLDOWN: Duration = Duration::from_millis(15);
         let mut last_status_refresh = std::time::Instant::now();
+        #[cfg(feature = "serve")]
+        let mut last_daemon_status_refresh = std::time::Instant::now();
         let mut last_disk_refresh = std::time::Instant::now();
         let mut last_spinner_redraw = std::time::Instant::now();
         let mut last_heartbeat = std::time::Instant::now();
@@ -841,6 +843,12 @@ impl App {
         // the 20Hz loop rate.
         let mut last_update_eval = std::time::Instant::now();
         const STATUS_REFRESH_INTERVAL: Duration = Duration::from_millis(500);
+        // Structured rows read their status over HTTP from the daemon rather
+        // than from a local tmux scrape, and `/api/sessions` costs the daemon
+        // a few SQLite lookups per structured row. Half the tmux cadence
+        // keeps a status dot feeling live while halving that request rate.
+        #[cfg(feature = "serve")]
+        const DAEMON_STATUS_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
         const DISK_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
         // Fastest spinner (breathe) changes every 180ms; 120ms ensures smooth animation
         const SPINNER_REDRAW_INTERVAL: Duration = Duration::from_millis(120);
@@ -1765,6 +1773,18 @@ impl App {
             if self.home.apply_status_updates() {
                 refresh_needed = true;
                 needs_full_refresh = true;
+            }
+
+            #[cfg(feature = "serve")]
+            {
+                if last_daemon_status_refresh.elapsed() >= DAEMON_STATUS_REFRESH_INTERVAL {
+                    self.home.request_daemon_status_refresh();
+                    last_daemon_status_refresh = std::time::Instant::now();
+                }
+                if self.home.apply_daemon_status_updates() {
+                    refresh_needed = true;
+                    needs_full_refresh = true;
+                }
             }
 
             if self.home.apply_deletion_results() {

--- a/src/tui/daemon_status_poller.rs
+++ b/src/tui/daemon_status_poller.rs
@@ -36,9 +36,15 @@ pub(super) struct DaemonStatusUpdate {
 
 /// Subset of `/api/sessions`'s `SessionResponse` this poller reads.
 /// `serde` ignores unknown fields, so the daemon can grow the response
-/// without breaking an older TUI. Every field is `#[serde(default)]` for
-/// the same reason in reverse: an older daemon that omits one must not
-/// fail the whole parse and blank out every row's status.
+/// without breaking an older TUI. Every *optional* field carries
+/// `#[serde(default)]` for the same reason in reverse: an older daemon that
+/// omits one must not fail the whole parse and blank out every row's status
+/// for that tick.
+///
+/// `id` is deliberately required. It identifies the row, so a row without one
+/// is unusable rather than degraded, and `SessionResponse.id` is a plain
+/// `String` with no `skip_serializing_if`, so no daemon version can omit it.
+/// Defaulting it would trade a loud parse failure for a silently dropped row.
 #[derive(Debug, Clone, Deserialize)]
 struct DaemonSessionRow {
     id: String,
@@ -86,9 +92,17 @@ fn parse_ts(raw: Option<&str>) -> Option<chrono::DateTime<chrono::Utc>> {
 }
 
 async fn fetch_structured_statuses() -> Vec<DaemonStatusUpdate> {
-    // `require_daemon` rather than a bare `discover`: it honours
-    // `AOE_DAEMON_URL` so a TUI pointed at a remote daemon reads that
-    // daemon's statuses, and it never spawns one as a side effect.
+    // `require_daemon` is the same resolver `open_structured_view` uses, so
+    // this poller and the view it feeds can never disagree about which daemon
+    // they are talking to, and neither spawns one as a side effect.
+    //
+    // Its `AOE_DAEMON_URL` branch is unreachable from here: `tui::run` swaps
+    // the whole app over to `remote_home::run_standalone` when that variable
+    // is set (`src/tui/mod.rs`), so the local home view this poller belongs to
+    // only ever runs against a local daemon. Kept anyway rather than dropping
+    // to a bare `discover()`, so that if the remote-home split is ever folded
+    // back into one home view, this reads the daemon the user asked for
+    // instead of silently reading the local one.
     let endpoint = match crate::acp::client::require_daemon().await {
         Ok(endpoint) => endpoint,
         Err(e) => {

--- a/src/tui/daemon_status_poller.rs
+++ b/src/tui/daemon_status_poller.rs
@@ -1,0 +1,263 @@
+//! Structured (ACP) session status, sourced from the `aoe serve` daemon.
+//!
+//! Structured sessions have no tmux pane, so the tmux/docker probes in
+//! [`crate::tui::status_poller`] cannot observe them (they bail on
+//! `is_structured()`). The authority is the daemon: `derive_acp_status`
+//! maps ACP events onto `Running` / `Waiting` / `Idle` / `Error` and
+//! `apply_status_intent` folds them into the daemon's in-memory
+//! `state.instances`. That value is deliberately never persisted to
+//! `sessions.json` (see the durability contract on
+//! `apply_acp_overlay_inplace`), so a TUI reading disk would show a
+//! structured row frozen at whatever creation or an explicit start/stop
+//! wrote. This poller closes that gap the same way the web dashboard
+//! does: by asking `GET /api/sessions`.
+//!
+//! No daemon reachable means an empty result, not an error state. A
+//! structured session cannot be running without one (the event store is
+//! opened by `aoe serve`, and `require_daemon` refuses to auto-spawn), so
+//! there is no status to report and the row keeps its last value.
+
+use std::sync::mpsc::TryRecvError;
+
+use serde::Deserialize;
+
+use crate::session::{Status, View};
+use crate::tui::worker::Worker;
+
+/// One structured row's status as the daemon sees it.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct DaemonStatusUpdate {
+    pub id: String,
+    pub status: Status,
+    pub last_error: Option<String>,
+    pub last_accessed_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub idle_entered_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Subset of `/api/sessions`'s `SessionResponse` this poller reads.
+/// `serde` ignores unknown fields, so the daemon can grow the response
+/// without breaking an older TUI. Every field is `#[serde(default)]` for
+/// the same reason in reverse: an older daemon that omits one must not
+/// fail the whole parse and blank out every row's status.
+#[derive(Debug, Clone, Deserialize)]
+struct DaemonSessionRow {
+    id: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    last_error: Option<String>,
+    #[serde(default)]
+    last_accessed_at: Option<String>,
+    #[serde(default)]
+    idle_entered_at: Option<String>,
+    #[serde(default)]
+    view: View,
+}
+
+/// Project the daemon's rows onto the structured sessions the TUI cares
+/// about. Pure so the wire-shape handling is testable without a daemon.
+///
+/// Terminal rows are dropped: the tmux poller owns those, and letting the
+/// daemon's copy through would give them two producers racing on
+/// alternating cycles. An unparseable `status` is dropped rather than
+/// coerced, so a newer daemon variant leaves the row alone instead of
+/// forcing it to a wrong value.
+fn structured_updates(rows: Vec<DaemonSessionRow>) -> Vec<DaemonStatusUpdate> {
+    rows.into_iter()
+        .filter(|row| row.view == View::Structured)
+        .filter_map(|row| {
+            let status = Status::from_api_str(&row.status)?;
+            Some(DaemonStatusUpdate {
+                id: row.id,
+                status,
+                last_error: row.last_error,
+                last_accessed_at: parse_ts(row.last_accessed_at.as_deref()),
+                idle_entered_at: parse_ts(row.idle_entered_at.as_deref()),
+            })
+        })
+        .collect()
+}
+
+fn parse_ts(raw: Option<&str>) -> Option<chrono::DateTime<chrono::Utc>> {
+    let raw = raw?;
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|t| t.with_timezone(&chrono::Utc))
+}
+
+async fn fetch_structured_statuses() -> Vec<DaemonStatusUpdate> {
+    // `require_daemon` rather than a bare `discover`: it honours
+    // `AOE_DAEMON_URL` so a TUI pointed at a remote daemon reads that
+    // daemon's statuses, and it never spawns one as a side effect.
+    let endpoint = match crate::acp::client::require_daemon().await {
+        Ok(endpoint) => endpoint,
+        Err(e) => {
+            tracing::trace!(
+                target: "tui.daemon_status",
+                "no daemon for structured status: {e}"
+            );
+            return Vec::new();
+        }
+    };
+    let client = match crate::acp::client::HttpClient::new(endpoint) {
+        Ok(client) => client,
+        Err(e) => {
+            tracing::debug!(
+                target: "tui.daemon_status",
+                "daemon status client: {e}"
+            );
+            return Vec::new();
+        }
+    };
+    match client.list_sessions::<DaemonSessionRow>().await {
+        Ok(rows) => structured_updates(rows),
+        Err(e) => {
+            tracing::debug!(
+                target: "tui.daemon_status",
+                "daemon status fetch: {e}"
+            );
+            Vec::new()
+        }
+    }
+}
+
+/// Background thread that reads structured-session status from the daemon.
+pub struct DaemonStatusPoller {
+    worker: Worker<(), Vec<DaemonStatusUpdate>>,
+}
+
+impl DaemonStatusPoller {
+    pub fn new() -> Self {
+        // One current-thread runtime for the worker's lifetime. Building it
+        // per request would pay setup on every tick, and the TUI's own
+        // runtime is not reachable from this thread.
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build();
+        if let Err(e) = &runtime {
+            tracing::warn!(
+                target: "tui.daemon_status",
+                "runtime build failed; structured status stays at its last value: {e}"
+            );
+        }
+        Self {
+            worker: Worker::spawn("aoe-daemon-status", move |()| match runtime.as_ref() {
+                Ok(rt) => rt.block_on(fetch_structured_statuses()),
+                Err(_) => Vec::new(),
+            }),
+        }
+    }
+
+    /// Request a fetch (non-blocking).
+    pub fn request_refresh(&self) {
+        self.worker.request(());
+    }
+
+    /// Try to receive results without blocking. Surfaces `Disconnected` so
+    /// the caller can respawn: swallowing it would leave the in-flight flag
+    /// set forever and freeze every structured row's status, the exact bug
+    /// this poller exists to fix.
+    pub fn try_recv_updates(&self) -> Result<Vec<DaemonStatusUpdate>, TryRecvError> {
+        self.worker.try_recv()
+    }
+}
+
+impl Default for DaemonStatusPoller {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(id: &str, status: &str, view: View) -> DaemonSessionRow {
+        DaemonSessionRow {
+            id: id.to_string(),
+            status: status.to_string(),
+            last_error: None,
+            last_accessed_at: None,
+            idle_entered_at: None,
+            view,
+        }
+    }
+
+    #[test]
+    fn structured_updates_keeps_only_structured_rows() {
+        let updates = structured_updates(vec![
+            row("a", "Running", View::Structured),
+            row("b", "Running", View::Terminal),
+        ]);
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].id, "a");
+        assert_eq!(updates[0].status, Status::Running);
+    }
+
+    #[test]
+    fn structured_updates_drops_unparseable_status() {
+        // A newer daemon variant must leave the row alone, not coerce it to
+        // a wrong status.
+        let updates = structured_updates(vec![row("a", "Hibernating", View::Structured)]);
+        assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn structured_updates_parses_every_status_the_daemon_emits() {
+        for status in [
+            Status::Running,
+            Status::Waiting,
+            Status::Idle,
+            Status::Unknown,
+            Status::Stopped,
+            Status::Error,
+            Status::Starting,
+            Status::Deleting,
+            Status::Creating,
+        ] {
+            let wire = format!("{status:?}");
+            let updates = structured_updates(vec![row("a", &wire, View::Structured)]);
+            assert_eq!(
+                updates.first().map(|u| u.status),
+                Some(status),
+                "wire form {wire} must round-trip"
+            );
+        }
+    }
+
+    #[test]
+    fn structured_updates_carries_error_and_timestamps() {
+        let updates = structured_updates(vec![DaemonSessionRow {
+            id: "a".into(),
+            status: "Error".into(),
+            last_error: Some("agent failed to start".into()),
+            last_accessed_at: Some("2026-07-30T12:00:00Z".into()),
+            idle_entered_at: None,
+            view: View::Structured,
+        }]);
+        assert_eq!(updates[0].status, Status::Error);
+        assert_eq!(
+            updates[0].last_error.as_deref(),
+            Some("agent failed to start")
+        );
+        assert!(updates[0].last_accessed_at.is_some());
+        assert_eq!(updates[0].idle_entered_at, None);
+    }
+
+    #[test]
+    fn daemon_row_deserializes_from_a_minimal_response() {
+        // An older daemon that omits fields must still parse; a hard failure
+        // here would blank out every structured row's status at once.
+        let row: DaemonSessionRow = serde_json::from_str(r#"{"id":"a"}"#).unwrap();
+        assert_eq!(row.view, View::Terminal);
+        assert_eq!(row.status, "");
+        assert!(Status::from_api_str(&row.status).is_none());
+    }
+
+    #[test]
+    fn parse_ts_rejects_garbage() {
+        assert!(parse_ts(Some("not a timestamp")).is_none());
+        assert!(parse_ts(None).is_none());
+        assert!(parse_ts(Some("2026-07-30T12:00:00Z")).is_some());
+    }
+}

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2831,6 +2831,19 @@ impl HomeView {
         self.pending_daemon_status_refresh = true;
     }
 
+    /// Whether a daemon-sourced status may be applied to `id`, mirroring the
+    /// exclusions [`Self::pollable_instances`] applies to the tmux producer.
+    /// A row mid-restart or mid-recovery-cascade has its post-cascade
+    /// `Instance` delivered by `apply_restart_results` /
+    /// `apply_recovery_updates`; letting the daemon's copy land during that
+    /// window races those transitions. Recovery already skips structured rows
+    /// (`recovery::is_recovery_candidate`), so in practice this is the restart
+    /// guard, but both are checked so the two producers stay symmetrical.
+    #[cfg(feature = "serve")]
+    fn daemon_status_applies_to(&self, id: &str) -> bool {
+        !self.recovery_in_flight.contains(id) && !self.restart_in_flight.contains(id)
+    }
+
     /// Apply any pending daemon-sourced statuses. Returns true if the
     /// caller should redraw.
     #[cfg(feature = "serve")]
@@ -2875,6 +2888,7 @@ impl HomeView {
         &mut self,
         update: super::daemon_status_poller::DaemonStatusUpdate,
     ) {
+        use crate::session::Status;
         use crate::tui::status_poller::IdleIntent;
 
         if !self
@@ -2882,6 +2896,30 @@ impl HomeView {
             .is_some_and(|i| i.is_structured())
         {
             return;
+        }
+        if !self.daemon_status_applies_to(&update.id) {
+            return;
+        }
+        // Lift a locally-`Stopped` row before the shared apply path sees it.
+        // `apply_status_update`'s guard drops every update whose row is
+        // `Stopped`, which is right for tmux rows (nothing but an explicit
+        // start should wake one) but wrong here: stopping a structured session
+        // persists `Stopped`, and reopening it in the structured view does not
+        // clear that (`open_structured_view` only mounts the view), so without
+        // this the pill stays grey through the whole next turn, which is the
+        // bug this producer exists to fix.
+        //
+        // The daemon has already applied its own, stricter `Stopped` guard
+        // (`apply_status_intent`: only a `HealError` from `AcpSessionAssigned`
+        // or `RateLimitAutoResumed` lifts `Stopped`, and both are emitted only
+        // when a fresh worker attaches). So a non-`Stopped` reading from the
+        // daemon provably means a new worker epoch, never a trailing
+        // post-stop event. Reproducing the daemon's own Stopped -> Idle step
+        // here keeps the two ladders identical.
+        if update.status != Status::Stopped
+            && self.get_instance(&update.id).map(|i| i.status) == Some(Status::Stopped)
+        {
+            self.mutate_instance(&update.id, |inst| inst.status = Status::Idle);
         }
         self.apply_status_update(
             StatusUpdate {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -717,6 +717,13 @@ pub struct HomeView {
     pub(super) status_poller: StatusPoller,
     pub(super) pending_status_refresh: bool,
 
+    // Structured (ACP) rows: the tmux poller above bails on them, so their
+    // status comes from the daemon instead. See `daemon_status_poller`.
+    #[cfg(feature = "serve")]
+    pub(super) daemon_status_poller: super::daemon_status_poller::DaemonStatusPoller,
+    #[cfg(feature = "serve")]
+    pub(super) pending_daemon_status_refresh: bool,
+
     // Performance: background deletion
     pub(super) deletion_poller: DeletionPoller,
 
@@ -2213,6 +2220,10 @@ impl HomeView {
             available_tools,
             status_poller: StatusPoller::new(),
             pending_status_refresh: false,
+            #[cfg(feature = "serve")]
+            daemon_status_poller: super::daemon_status_poller::DaemonStatusPoller::new(),
+            #[cfg(feature = "serve")]
+            pending_daemon_status_refresh: false,
             deletion_poller: DeletionPoller::new(),
             stop_poller: StopPoller::new(),
             trash_poller: crate::tui::trash_poller::TrashPoller::new(),
@@ -2803,6 +2814,97 @@ impl HomeView {
                 true
             }
         }
+    }
+
+    /// Request the daemon's view of every structured row's status
+    /// (non-blocking). Skipped entirely when no structured session is
+    /// loaded, so a terminal-only home view never talks to the daemon.
+    #[cfg(feature = "serve")]
+    pub fn request_daemon_status_refresh(&mut self) {
+        if self.pending_daemon_status_refresh {
+            return;
+        }
+        if !self.instances.values().any(|i| i.is_structured()) {
+            return;
+        }
+        self.daemon_status_poller.request_refresh();
+        self.pending_daemon_status_refresh = true;
+    }
+
+    /// Apply any pending daemon-sourced statuses. Returns true if the
+    /// caller should redraw.
+    #[cfg(feature = "serve")]
+    pub fn apply_daemon_status_updates(&mut self) -> bool {
+        use std::sync::mpsc::TryRecvError;
+
+        match self.daemon_status_poller.try_recv_updates() {
+            Ok(updates) => {
+                let applied = !updates.is_empty();
+                for update in updates {
+                    self.apply_daemon_status_update(update);
+                }
+                self.pending_daemon_status_refresh = false;
+                applied
+            }
+            Err(TryRecvError::Empty) => false,
+            Err(TryRecvError::Disconnected) => {
+                // Same failure mode as the tmux poller: without a respawn the
+                // in-flight flag stays set and every structured row's status
+                // freezes for the rest of the process.
+                tracing::error!(
+                    target: "tui.home",
+                    "daemon status poller worker gone; respawning a fresh poller",
+                );
+                self.daemon_status_poller = super::daemon_status_poller::DaemonStatusPoller::new();
+                self.pending_daemon_status_refresh = false;
+                true
+            }
+        }
+    }
+
+    /// Fold one daemon-sourced structured status into the shared apply path,
+    /// so sounds, status hooks, unread marking, and the `sessions.json`
+    /// patch all behave exactly as they do for a tmux-derived transition.
+    ///
+    /// The row is re-checked against `is_structured()` here rather than
+    /// trusted from the wire: the daemon's `view` and the local row's could
+    /// disagree for a session mid-conversion, and the tmux poller owns
+    /// terminal rows. Dropping the mismatch keeps one producer per row.
+    #[cfg(feature = "serve")]
+    pub(super) fn apply_daemon_status_update(
+        &mut self,
+        update: super::daemon_status_poller::DaemonStatusUpdate,
+    ) {
+        use crate::tui::status_poller::IdleIntent;
+
+        if !self
+            .get_instance(&update.id)
+            .is_some_and(|i| i.is_structured())
+        {
+            return;
+        }
+        self.apply_status_update(
+            StatusUpdate {
+                id: update.id,
+                status: update.status,
+                last_error: update.last_error,
+                // Mirror the daemon's own value rather than deriving one, so
+                // the TUI's idle fade matches the web dashboard's for the
+                // same session instead of restarting on the first local
+                // observation.
+                idle_entered_at: match update.idle_entered_at {
+                    Some(ts) => IdleIntent::Set(ts),
+                    None => IdleIntent::Clear,
+                },
+                last_accessed_at: update.last_accessed_at,
+                // Structured rows have no pane, so the Attention sort's
+                // dead-pane tier never applies to them.
+                pane_dead: false,
+                live_status_baseline: Some(update.status),
+            },
+            true,
+            true,
+        );
     }
 
     /// Apply a single status update from the poller. Extracted from the

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -17999,3 +17999,163 @@ mod settings_scroll_wiring {
         );
     }
 }
+
+/// Structured (ACP) rows get their status from the daemon, because nothing else
+/// can tell you what an ACP session is doing: they have no tmux pane, the tmux
+/// poller bails on them, and the daemon deliberately never persists their
+/// status to `sessions.json` (see the durability contract on
+/// `apply_acp_overlay_inplace`). Before this wiring existed the pill sat frozen
+/// at whatever creation or an explicit start/stop wrote, for the whole life of
+/// the session.
+#[cfg(feature = "serve")]
+mod daemon_status_apply_tests {
+    use super::*;
+    use crate::session::Status;
+    use crate::tui::daemon_status_poller::DaemonStatusUpdate;
+
+    fn structured_row(env: &mut TestEnv, status: Status) -> String {
+        let mut inst = Instance::new("acp-session", "/tmp/repo");
+        inst.source_profile = "test".to_string();
+        inst.tool = "claude".into();
+        inst.view = crate::session::View::Structured;
+        inst.status = status;
+        let id = inst.id.clone();
+        env.view.add_instance(inst);
+        id
+    }
+
+    fn update(id: &str, status: Status) -> DaemonStatusUpdate {
+        DaemonStatusUpdate {
+            id: id.to_string(),
+            status,
+            last_error: None,
+            last_accessed_at: None,
+            idle_entered_at: None,
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn daemon_status_moves_a_structured_row_off_idle() {
+        let mut env = create_test_env_empty();
+        let id = structured_row(&mut env, Status::Idle);
+
+        env.view
+            .apply_daemon_status_update(update(&id, Status::Running));
+
+        assert_eq!(
+            env.view.get_instance(&id).map(|i| i.status),
+            Some(Status::Running),
+            "a Running turn on the daemon must move the TUI's pill"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn daemon_status_carries_the_waiting_state_for_a_pending_approval() {
+        // `derive_acp_status` maps ApprovalRequested/ElicitationRequested to
+        // Waiting; the whole point of the yellow pill is spotting a session
+        // blocked on you from the home list without opening it.
+        let mut env = create_test_env_empty();
+        let id = structured_row(&mut env, Status::Running);
+
+        env.view
+            .apply_daemon_status_update(update(&id, Status::Waiting));
+
+        assert_eq!(
+            env.view.get_instance(&id).map(|i| i.status),
+            Some(Status::Waiting)
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn daemon_status_clears_a_stale_error_message() {
+        // The pre-fix sandbox-dead branch left sandboxed structured rows at
+        // Idle with a phantom "Container is not running" hanging off them. The
+        // daemon's own `last_error` is authoritative, so applying it clears the
+        // leftover rather than letting it sit on the row for the session's life.
+        let mut env = create_test_env_empty();
+        let id = structured_row(&mut env, Status::Error);
+        env.view.mutate_instance(&id, |inst| {
+            inst.last_error = Some("Container is not running".to_string())
+        });
+
+        env.view
+            .apply_daemon_status_update(update(&id, Status::Idle));
+
+        let inst = env.view.get_instance(&id).expect("row still present");
+        assert_eq!(inst.status, Status::Idle);
+        assert_eq!(inst.last_error, None, "the phantom container error is gone");
+    }
+
+    #[test]
+    #[serial]
+    fn daemon_status_ignores_a_terminal_row() {
+        // The tmux poller owns terminal rows. Letting the daemon's copy through
+        // would give them two producers fighting on alternating cycles.
+        let mut env = create_test_env_empty();
+        let mut inst = Instance::new("tmux-session", "/tmp/repo");
+        inst.source_profile = "test".to_string();
+        inst.status = Status::Idle;
+        let id = inst.id.clone();
+        env.view.add_instance(inst);
+
+        env.view
+            .apply_daemon_status_update(update(&id, Status::Running));
+
+        assert_eq!(
+            env.view.get_instance(&id).map(|i| i.status),
+            Some(Status::Idle),
+            "a terminal row must not be driven by the daemon overlay"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn daemon_status_ignores_an_unknown_session_id() {
+        let mut env = create_test_env_empty();
+        let id = structured_row(&mut env, Status::Idle);
+
+        env.view
+            .apply_daemon_status_update(update("not-a-session", Status::Running));
+
+        assert_eq!(
+            env.view.get_instance(&id).map(|i| i.status),
+            Some(Status::Idle)
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn request_daemon_status_refresh_is_a_no_op_without_structured_rows() {
+        // A terminal-only home view must never talk to the daemon; that would
+        // be one HTTP round trip per second for nothing.
+        let mut env = create_test_env_empty();
+        let mut inst = Instance::new("tmux-session", "/tmp/repo");
+        inst.source_profile = "test".to_string();
+        let _ = inst.id.clone();
+        env.view.add_instance(inst);
+
+        env.view.request_daemon_status_refresh();
+
+        assert!(
+            !env.view.pending_daemon_status_refresh,
+            "no structured rows means no fetch is issued"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn request_daemon_status_refresh_fires_once_per_in_flight_fetch() {
+        let mut env = create_test_env_empty();
+        let _id = structured_row(&mut env, Status::Idle);
+
+        env.view.request_daemon_status_refresh();
+        assert!(env.view.pending_daemon_status_refresh);
+        // A second request while one is outstanding must not queue another;
+        // otherwise a slow daemon backs up one request per tick.
+        env.view.request_daemon_status_refresh();
+        assert!(env.view.pending_daemon_status_refresh);
+    }
+}

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -18145,17 +18145,116 @@ mod daemon_status_apply_tests {
         );
     }
 
+    /// The in-flight flag is the only thing stopping a slow daemon from
+    /// accumulating one queued request per tick, so assert the full cycle:
+    /// a first request arms it, a second while armed is dropped, and draining
+    /// the worker disarms it so the next tick can fetch again. Asserting only
+    /// that the flag is still true after the second call would pass even if
+    /// the second call had enqueued another request.
     #[test]
     #[serial]
-    fn request_daemon_status_refresh_fires_once_per_in_flight_fetch() {
+    fn request_daemon_status_refresh_arms_and_disarms_the_in_flight_flag() {
         let mut env = create_test_env_empty();
         let _id = structured_row(&mut env, Status::Idle);
 
+        assert!(!env.view.pending_daemon_status_refresh, "starts disarmed");
+        env.view.request_daemon_status_refresh();
+        assert!(env.view.pending_daemon_status_refresh, "first request arms");
+
+        // While armed, further ticks are dropped at the guard rather than
+        // reaching the worker.
+        env.view.pending_daemon_status_refresh = true;
         env.view.request_daemon_status_refresh();
         assert!(env.view.pending_daemon_status_refresh);
-        // A second request while one is outstanding must not queue another;
-        // otherwise a slow daemon backs up one request per tick.
-        env.view.request_daemon_status_refresh();
-        assert!(env.view.pending_daemon_status_refresh);
+
+        // Draining the worker disarms, so the next tick can fetch again. The
+        // fetch itself returns empty here (no daemon in the test env), which is
+        // the same path a daemon-less TUI takes.
+        while env.view.pending_daemon_status_refresh {
+            if env.view.apply_daemon_status_updates() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(
+            !env.view.pending_daemon_status_refresh,
+            "draining the worker disarms the flag"
+        );
+    }
+
+    /// The regression that made this producer necessary in the first place,
+    /// surviving in a reachable path: stopping a structured session persists
+    /// `Stopped`, `open_structured_view` does not clear it, and
+    /// `apply_status_update` drops every update whose row is `Stopped`. Without
+    /// the explicit lift, the pill stays grey through the entire next turn.
+    #[test]
+    #[serial]
+    fn daemon_status_lifts_a_locally_stopped_structured_row() {
+        let mut env = create_test_env_empty();
+        let id = structured_row(&mut env, Status::Stopped);
+
+        env.view
+            .apply_daemon_status_update(update(&id, Status::Running));
+
+        assert_eq!(
+            env.view.get_instance(&id).map(|i| i.status),
+            Some(Status::Running),
+            "a fresh worker epoch on the daemon must wake a locally-Stopped row"
+        );
+    }
+
+    /// The other side of that lift: a daemon still reporting `Stopped` must not
+    /// be turned into a wake-up. Only a non-Stopped reading, which the daemon
+    /// emits only after `AcpSessionAssigned` heals its own row, counts.
+    #[test]
+    #[serial]
+    fn daemon_status_stopped_leaves_a_stopped_row_alone() {
+        let mut env = create_test_env_empty();
+        let id = structured_row(&mut env, Status::Stopped);
+
+        env.view
+            .apply_daemon_status_update(update(&id, Status::Stopped));
+
+        assert_eq!(
+            env.view.get_instance(&id).map(|i| i.status),
+            Some(Status::Stopped)
+        );
+    }
+
+    /// A row mid-restart has its post-cascade `Instance` delivered by
+    /// `apply_restart_results`; the daemon's copy landing inside that window
+    /// races it. `pollable_instances` excludes these rows from the tmux
+    /// producer, so this producer has to match.
+    #[test]
+    #[serial]
+    fn daemon_status_skips_a_row_mid_restart() {
+        let mut env = create_test_env_empty();
+        let id = structured_row(&mut env, Status::Starting);
+        env.view.restart_in_flight.insert(id.clone());
+
+        env.view
+            .apply_daemon_status_update(update(&id, Status::Idle));
+
+        assert_eq!(
+            env.view.get_instance(&id).map(|i| i.status),
+            Some(Status::Starting),
+            "the restart cascade owns this row until it reports back"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn daemon_status_skips_a_row_mid_recovery() {
+        let mut env = create_test_env_empty();
+        let id = structured_row(&mut env, Status::Starting);
+        env.view.recovery_in_flight.insert(id.clone());
+
+        env.view
+            .apply_daemon_status_update(update(&id, Status::Idle));
+
+        assert_eq!(
+            env.view.get_instance(&id).map(|i| i.status),
+            Some(Status::Starting)
+        );
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -5,6 +5,8 @@ mod attached_status_hooks;
 pub(crate) mod clipboard;
 mod components;
 mod creation_poller;
+#[cfg(feature = "serve")]
+mod daemon_status_poller;
 mod deletion_poller;
 pub mod dialogs;
 pub mod diff;

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -200,6 +200,15 @@ pub(super) fn poll_statuses_once(
             // as a stale `last_error` while flipping the status back to Idle.
             // Rows already poisoned by a pre-fix build are cleaned up once by
             // the v023 migration.
+            //
+            // Returning early also gives up the `Error -> Idle` heal in
+            // `update_status_with_metadata_inner`, deliberately. That heal
+            // existed to undo tmux-derived errors this branch no longer
+            // produces; the only remaining source of `Error` on a structured
+            // row is the daemon reporting `AgentStartupError`, which is a real
+            // failure the user should keep seeing rather than have silently
+            // downgraded to Idle a cycle later. It clears on the next daemon
+            // reading, or on an explicit stop/start.
             if inst.is_structured() {
                 return None;
             }

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -184,6 +184,26 @@ pub(super) fn poll_statuses_once(
                 return None;
             }
 
+            // Structured (ACP) rows have no tmux pane, and their sandbox
+            // container is owned by the worker rather than by a tmux pane, so
+            // neither probe below can say anything true about them. The
+            // `aoe serve` daemon derives their status from ACP events
+            // (`derive_acp_status`) and `DaemonStatusPoller` is the only
+            // producer that carries it into the TUI; emitting anything here
+            // would fight that overlay on alternating cycles.
+            //
+            // This bails before the sandbox-dead branch on purpose. That
+            // branch used to be the one tmux/docker-derived write that landed
+            // on a structured row, pinning sandboxed structured sessions to a
+            // red `Error` with a `"Container is not running"` message that the
+            // heal path (`update_status_with_metadata_inner`) then left behind
+            // as a stale `last_error` while flipping the status back to Idle.
+            // Rows already poisoned by a pre-fix build are cleaned up once by
+            // the v023 migration.
+            if inst.is_structured() {
+                return None;
+            }
+
             // For sandboxed sessions, check if the container is dead before
             // falling through to tmux-based status detection.
             if inst.is_sandboxed()
@@ -440,5 +460,75 @@ mod tests {
                 update.idle_entered_at
             );
         }
+    }
+
+    fn dead_container_sandbox(name: &str) -> crate::session::SandboxInfo {
+        crate::session::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "ubuntu:latest".to_string(),
+            container_name: name.to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: Vec::new(),
+            container_workdir: None,
+        }
+    }
+
+    /// Pin `container_states` for the per-instance decision: the live
+    /// `batch_container_health()` refresh would otherwise overwrite the seeded
+    /// map with an empty one (no docker in the test environment), and an
+    /// absent entry skips the sandbox-dead branch for the wrong reason.
+    fn state_with_dead_container(name: &str) -> StatusPollState {
+        let mut state = StatusPollState::new();
+        state.last_container_check = Instant::now();
+        state.container_states.insert(name.to_string(), false);
+        state
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn structured_rows_never_get_a_container_error() {
+        // The sandbox-dead branch used to run before the `is_structured()`
+        // bail, making it the one tmux/docker-derived write that landed on a
+        // structured row: a red `Error` with "Container is not running" that
+        // `home::apply_status_update` then persisted, and that the heal in
+        // `update_status_with_metadata_inner` only half-cleared (status back
+        // to Idle, message left behind). A structured session's container
+        // belongs to its ACP worker, not to a tmux pane, so this reading says
+        // nothing about the session; the daemon overlay owns its status.
+        let mut inst = Instance::new("structured-sandboxed", "/tmp/structured");
+        inst.view = crate::session::View::Structured;
+        inst.status = Status::Idle;
+        inst.sandbox_info = Some(dead_container_sandbox("aoe-sandbox-structured"));
+
+        let mut state = state_with_dead_container("aoe-sandbox-structured");
+        let updates = poll_statuses_once(vec![inst], &mut state);
+
+        assert!(
+            updates.is_empty(),
+            "structured rows must produce no tmux/docker status update; got {updates:?}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn terminal_sandboxed_rows_still_get_a_container_error() {
+        // The other half of the guard above: bailing on structured rows must
+        // not disarm the sandbox-dead branch for terminal ones, where a dead
+        // container really does mean the session is broken.
+        let mut inst = Instance::new("terminal-sandboxed", "/tmp/terminal");
+        inst.status = Status::Idle;
+        inst.sandbox_info = Some(dead_container_sandbox("aoe-sandbox-terminal"));
+
+        let mut state = state_with_dead_container("aoe-sandbox-terminal");
+        let updates = poll_statuses_once(vec![inst], &mut state);
+
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].status, Status::Error);
+        assert_eq!(
+            updates[0].last_error.as_deref(),
+            Some("Container is not running")
+        );
     }
 }


### PR DESCRIPTION
## Description

Structured (ACP) sessions showed a frozen status pill in the TUI home list. It
sat at whatever session creation or an explicit start/stop wrote and never moved
through a turn, so there was no way to tell from the list which structured
session was working, which was blocked on an approval, and which was done.

### Root cause

Nothing carried ACP-derived status to the TUI. The derivation itself is correct,
and it is daemon-side:

1. `derive_acp_status` (`src/server/mod.rs:5346`) maps ACP events onto
   `Running` / `Waiting` / `Idle` / `Error`.
2. `apply_status_intent` (`src/server/mod.rs:5132`) folds that into the daemon's
   in-memory `state.instances`.
3. That value is deliberately never persisted. `decide_passive_transition`
   (`src/server/mod.rs:3737`) returns `patch: None` for `is_structured()` rows,
   per the durability contract documented on `apply_acp_overlay_inplace`.
4. The TUI home view reads `sessions.json` from disk and runs the tmux status
   poller, which early-returns for structured rows
   (`src/session/instance.rs:4951`).
5. The native structured view does compute a local turn state
   (`AcpTranscript.turn_active`, `src/tui/structured_view/reducer.rs:90`) but
   uses it only to gate the prompt queue; it never reaches the `Instance`.

The web dashboard was unaffected because it asks the daemon. So did every other
consumer of live structured status. The TUI was the one surface reading disk.

### Fix

The TUI now asks the daemon too, over the same `GET /api/sessions` the web uses.

- `src/tui/daemon_status_poller.rs` (new): a `Worker` thread that resolves the
  daemon through `require_daemon` (so it honours `AOE_DAEMON_URL` and never
  auto-spawns), fetches `/api/sessions`, and projects structured rows only.
  No daemon reachable means an empty result, not an error state: a structured
  session cannot be running without one, so there is no status to report and
  the row keeps its last value.
- `src/tui/home/mod.rs`: `request_daemon_status_refresh` /
  `apply_daemon_status_updates` / `apply_daemon_status_update`. The result is
  folded through the existing `apply_status_update`, so sounds, status hooks,
  unread marking, and the `sessions.json` patch all behave exactly as they do
  for a tmux-derived transition. The fetch is skipped entirely when no
  structured row is loaded, so a terminal-only home view never talks to the
  daemon, and only one request is ever outstanding.
- `src/tui/app.rs`: 1s tick, half the tmux cadence, because `/api/sessions`
  costs the daemon a few SQLite lookups per structured row.
- `Status::from_api_str` (`src/session/instance.rs`): parses the `CamelCase`
  `Debug` form that `/api/sessions` puts on the wire, as opposed to the
  `lowercase` spelling `as_str` and serde use. Kept next to `as_str` with a
  round-trip test against the server's own formatter so the two spellings
  cannot drift.

### Second, related bug (docker sandbox)

The sandbox-dead branch in the status poller (`src/tui/status_poller.rs:189`)
ran *before* the `is_structured()` bail, which made it the one tmux/docker
derived write that landed on a structured row. A structured session's container
belongs to its ACP worker rather than to a tmux pane, so a not-running reading
says nothing about the session, yet it stamped `Error` with
"Container is not running" and `home::apply_status_update` persisted it.
Recovery was lossy: the heal in `update_status_with_metadata_inner` flipped the
status back to `Idle` but only cleared `last_error` when it equalled
`TMUX_SESSION_GONE_ERROR`, so rows ended up `Idle` with a phantom container
error stuck on them. The daemon has no container health check at all, so the
daemon and the TUI actively disagreed on the same row.

Structured rows now return `None` before that branch, and migration `v023`
clears the rows already poisoned on disk. `last_error` is `#[serde(skip)]`, so
the durable footprint is `status: "error"` alone.

This is why the symptom looked worse under a sandbox, and it is why the two
fixes ship together.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

On docs: no user-facing doc changes. The behaviour being fixed is what the docs
already describe; the new module and the migration carry their reasoning in
module-level docstrings.

On the screenshot box: this changes which value drives an existing status pill,
not how anything is drawn, so there is no visual diff to capture in a still. A
recording would need a live daemon plus a real turn, which is exactly the e2e
gap called out below.

### How this was tested

`cargo test --features serve --lib`: 5860 passed, 2 failed. Both failures
(`acp::supervisor::tests::shutdown_and_wait_degrades_when_load_errs_without_peer`
and
`process::worker_registry::tests::pid_source_for_falls_back_to_peer_pid_on_load_err`)
reproduce identically on a clean `HEAD` in this sandbox and are unrelated to
this change: their fixtures `chmod 000` a file to force a load error, and the
sandbox runs as root, which reads it anyway.

`cargo fmt --check` clean. `cargo clippy --features serve --all-targets` clean,
no new warnings on the changed files. `cargo build` without `--features serve`
also clean, which is the check that matters for the cfg gating, since the new
poller is serve-only.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

No `web/` files change, and the daemon side is untouched, so the dashboard
behaves exactly as before. No `coverage-matrix.json` entry is required.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: see below

18 unit tests land with this change:

- `src/tui/status_poller.rs`: `structured_rows_never_get_a_container_error`
  (the docker bug) and `terminal_sandboxed_rows_still_get_a_container_error`
  (pins that the fix did not disarm the branch where a dead container really
  does mean a broken session).
- `src/tui/home/tests.rs::daemon_status_apply_tests`: 7 cases covering
  Idle to Running, the Waiting state for a pending approval, clearing a stale
  container error, ignoring terminal rows and unknown ids, and the two
  request-gating rules.
- `src/tui/daemon_status_poller.rs`: 6 cases on the wire shape, including
  every status the daemon emits, an unparseable status being dropped rather
  than coerced, and a minimal response from an older daemon still parsing.
- `src/session/instance.rs::status_api_wire_form_round_trips`.
- `src/migrations/v023_*`: 5 cases including idempotency and both storage
  layouts.

What is deliberately not here: a live e2e that stands up a real
`aoe serve --daemon`, drives a turn with the fake ACP agent, and asserts the
home-list pill moves Idle to Running to Waiting to Idle. The harness for it
already exists (`tests/e2e/acp_focus_isolation_e2e.rs`, `install_acp_shim`,
`stop_daemon_on_drop`), so this is a small addition rather than new
infrastructure. I held it back because it is the natural home for several
related structured-view TUI fixes that are queued behind this one, and I would
rather write it once against the full set than three times. Happy to add it to
this PR if a reviewer would prefer it landed here.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Root cause was traced through the status pipeline before any code was written,
and the two candidate fixes (have the TUI ask the daemon, versus start
persisting structured status to `sessions.json`) were weighed explicitly. The
persist-to-disk route was rejected because it reverses the documented #2690
contract and, with no tmux poller able to heal a structured row, a daemon crash
mid-turn would leave a session stuck spinning `Running` forever. Asking the
daemon keeps a single authority and matches what the web already does.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added periodic daemon status updates for structured sessions in the TUI.
- Updated session states such as `Running`, `Waiting`, `Idle`, and `Error`.
- Prevented local checks from replacing structured-session statuses with container errors.
- Restored locally stopped structured sessions when the daemon reports a new status.
- Added migration `v023` to clear older structured-session container errors.
- Added tests for polling, status parsing, recovery handling, request gating, and migration behavior.

## Benefits

The TUI now shows current structured-session states more accurately and avoids misleading container errors. Existing sounds, hooks, unread indicators, and persistence behavior remain unchanged.

## Potential follow-up

Add a live end-to-end test for daemon status updates in the running TUI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->