### PR TITLE
fix: four bugs found in a live debug.log (ws heartbeat, phantom status transitions, wedged trash purge, worktree move gate)

### DIFF
--- a/src/acp/client/ws.rs
+++ b/src/acp/client/ws.rs
@@ -1,13 +1,20 @@
 //! WebSocket client for the structured view broadcast stream.
 //!
 //! Subscribes to `/sessions/{id}/acp/ws?since=N` and yields a
-//! stream of decoded events. The daemon may push two shapes:
+//! stream of decoded events. The daemon may push three shapes:
 //!
 //! - `{"kind":"frame", ...AcpBroadcastFrame}`: the next replayed
 //!   or live event.
 //! - `{"kind":"lagged"}`: the in-memory ring buffer evicted events
 //!   the client hadn't acked yet. The consumer must drop its local
 //!   state and rehydrate via [`super::http::HttpClient::replay`].
+//! - `{"kind":"heartbeat"}`: the app-level keepalive the daemon emits
+//!   on every ping tick (`PING_INTERVAL` in `src/server/acp_ws.rs`).
+//!   Carries no state, so the reader loop drops it without waking the
+//!   consumer. Any new `kind` sentinel the daemon grows must be added
+//!   here too: an unrecognised sentinel falls through to the frame
+//!   parse and surfaces as [`WsError::Parse`], which consumers treat
+//!   as a dropped socket. See #2287 and `parse_text`.
 //!
 //! Auth: the bearer token is sent as a `?token=<>` query string on the
 //! WebSocket URL. Most WS clients do not surface custom headers cleanly,
@@ -155,9 +162,20 @@ async fn reader_loop(
             next = stream.next() => {
                 match next {
                     Some(Ok(Message::Text(text))) => {
-                        let msg = parse_text(&text);
-                        if tx.send(msg).await.is_err() {
-                            return; // consumer dropped
+                        match parse_text(&text) {
+                            // Keepalive: no consumer-visible state, so
+                            // don't wake the consumer at all.
+                            Ok(None) => {}
+                            Ok(Some(msg)) => {
+                                if tx.send(Ok(msg)).await.is_err() {
+                                    return; // consumer dropped
+                                }
+                            }
+                            Err(e) => {
+                                if tx.send(Err(e)).await.is_err() {
+                                    return; // consumer dropped
+                                }
+                            }
                         }
                     }
                     Some(Ok(Message::Binary(_))) => {
@@ -186,24 +204,33 @@ async fn reader_loop(
     }
 }
 
-fn parse_text(raw: &str) -> Result<WsMessage, WsError> {
-    // The daemon sends either a `AcpBroadcastFrame` JSON object or
-    // a `{ "kind": "lagged" }` sentinel. We try the sentinel first
-    // (cheap discriminant probe) and fall back to a full frame parse.
+/// Decode one text frame. `Ok(None)` means the frame was a sentinel with
+/// nothing for the consumer to act on (the daemon's keepalive), which is
+/// distinct from `Err` because consumers escalate a parse error to a
+/// socket teardown and reconnect.
+fn parse_text(raw: &str) -> Result<Option<WsMessage>, WsError> {
+    // The daemon sends an `AcpBroadcastFrame` JSON object or one of the
+    // `{ "kind": ... }` sentinels. We try the sentinels first (cheap
+    // discriminant probe) and fall back to a full frame parse.
     #[derive(serde::Deserialize)]
     struct KindProbe<'a> {
         kind: Option<&'a str>,
     }
     if let Ok(probe) = serde_json::from_str::<KindProbe>(raw) {
-        if probe.kind == Some("lagged") {
-            return Ok(WsMessage::Lagged);
+        match probe.kind {
+            Some("lagged") => return Ok(Some(WsMessage::Lagged)),
+            // App-level keepalive (#2287). A real frame always carries
+            // `session_id`/`seq`/`event` and never a `kind`, so this
+            // cannot shadow one.
+            Some("heartbeat") => return Ok(None),
+            _ => {}
         }
     }
     let frame: AcpBroadcastFrame = serde_json::from_str(raw).map_err(|e| {
         warn!(target: "acp.client.ws", error = %e, "ws frame parse failed");
         WsError::Parse(e.to_string())
     })?;
-    Ok(WsMessage::Frame(Arc::new(frame)))
+    Ok(Some(WsMessage::Frame(Arc::new(frame))))
 }
 
 fn ws_url(endpoint: &DaemonEndpoint, session_id: &str, since: u64) -> String {
@@ -294,7 +321,34 @@ mod tests {
     #[test]
     fn parse_text_lagged_sentinel() {
         let m = parse_text(r#"{"kind":"lagged"}"#).unwrap();
-        assert!(matches!(m, WsMessage::Lagged));
+        assert!(matches!(m, Some(WsMessage::Lagged)));
+    }
+
+    /// The daemon emits `{"kind":"heartbeat"}` every `PING_INTERVAL`
+    /// (30s). Before #2287's client-side follow-up this fell through to
+    /// the `AcpBroadcastFrame` parse, failed on the missing `session_id`
+    /// field, and surfaced as `WsError::Parse`, which
+    /// `tui::structured_view` treats as a dropped socket: an error toast
+    /// plus a full reconnect every 30 seconds on any quiet session.
+    /// Asserted against the server's literal wire bytes (kept stable by
+    /// `heartbeat_frame_shape_is_stable` in `src/server/acp_ws.rs`) so a
+    /// drift on either side fails one of the two tests.
+    #[test]
+    fn parse_text_heartbeat_is_ignored_not_an_error() {
+        let m = parse_text(r#"{"kind":"heartbeat"}"#)
+            .expect("heartbeat must not surface as a parse error");
+        assert!(
+            m.is_none(),
+            "heartbeat carries no consumer-visible state and must not wake the consumer"
+        );
+    }
+
+    /// An unrecognised `kind` sentinel must still surface as a parse
+    /// error rather than being silently swallowed: the client cannot
+    /// know whether it carried state it needed.
+    #[test]
+    fn parse_text_unknown_kind_sentinel_is_an_error() {
+        assert!(parse_text(r#"{"kind":"something_new"}"#).is_err());
     }
 
     #[test]
@@ -307,12 +361,12 @@ mod tests {
         .unwrap();
         let m = parse_text(&raw).unwrap();
         match m {
-            WsMessage::Frame(f) => {
+            Some(WsMessage::Frame(f)) => {
                 assert_eq!(f.session_id, "s-1");
                 assert_eq!(f.seq, 7);
                 assert!(matches!(*f.event, Event::ThinkingStarted));
             }
-            WsMessage::Lagged => panic!("expected frame"),
+            other => panic!("expected frame, got {other:?}"),
         }
     }
 

--- a/src/acp/client/ws.rs
+++ b/src/acp/client/ws.rs
@@ -318,37 +318,53 @@ mod tests {
         assert!(ws_url(&e, "s-1", 0).starts_with("wss://"));
     }
 
-    #[test]
-    fn parse_text_lagged_sentinel() {
-        let m = parse_text(r#"{"kind":"lagged"}"#).unwrap();
-        assert!(matches!(m, Some(WsMessage::Lagged)));
+    /// How each `{"kind":...}` sentinel the daemon can send must classify.
+    ///
+    /// The heartbeat row is the #3171 regression. The daemon emits
+    /// `{"kind":"heartbeat"}` every `PING_INTERVAL` (30s); before this it
+    /// fell through to the `AcpBroadcastFrame` parse, failed on the missing
+    /// `session_id` field, and surfaced as `WsError::Parse`, which
+    /// `tui::structured_view` treats as a dropped socket: an error toast plus
+    /// a full reconnect every 30 seconds on any quiet session. Asserted
+    /// against the server's literal wire bytes, kept stable by
+    /// `heartbeat_frame_shape_is_stable` in `src/server/acp_ws.rs`, so drift
+    /// on either side fails one of the two tests.
+    #[derive(Debug)]
+    enum Expect {
+        Lagged,
+        Ignored,
+        ParseError,
     }
 
-    /// The daemon emits `{"kind":"heartbeat"}` every `PING_INTERVAL`
-    /// (30s). Before #2287's client-side follow-up this fell through to
-    /// the `AcpBroadcastFrame` parse, failed on the missing `session_id`
-    /// field, and surfaced as `WsError::Parse`, which
-    /// `tui::structured_view` treats as a dropped socket: an error toast
-    /// plus a full reconnect every 30 seconds on any quiet session.
-    /// Asserted against the server's literal wire bytes (kept stable by
-    /// `heartbeat_frame_shape_is_stable` in `src/server/acp_ws.rs`) so a
-    /// drift on either side fails one of the two tests.
     #[test]
-    fn parse_text_heartbeat_is_ignored_not_an_error() {
-        let m = parse_text(r#"{"kind":"heartbeat"}"#)
-            .expect("heartbeat must not surface as a parse error");
-        assert!(
-            m.is_none(),
-            "heartbeat carries no consumer-visible state and must not wake the consumer"
-        );
-    }
-
-    /// An unrecognised `kind` sentinel must still surface as a parse
-    /// error rather than being silently swallowed: the client cannot
-    /// know whether it carried state it needed.
-    #[test]
-    fn parse_text_unknown_kind_sentinel_is_an_error() {
-        assert!(parse_text(r#"{"kind":"something_new"}"#).is_err());
+    fn parse_text_classifies_kind_sentinels() {
+        let cases = [
+            // Ring buffer evicted events; consumer must rehydrate.
+            (r#"{"kind":"lagged"}"#, Expect::Lagged),
+            // Keepalive: no consumer-visible state, must not wake the
+            // consumer and must not read as a dropped socket.
+            (r#"{"kind":"heartbeat"}"#, Expect::Ignored),
+            // An unrecognised sentinel must still surface as an error rather
+            // than being silently swallowed: the client cannot know whether
+            // it carried state it needed.
+            (r#"{"kind":"something_new"}"#, Expect::ParseError),
+        ];
+        for (raw, expect) in cases {
+            let got = parse_text(raw);
+            match expect {
+                Expect::Lagged => assert!(
+                    matches!(got, Ok(Some(WsMessage::Lagged))),
+                    "{raw}: expected Lagged, got {got:?}"
+                ),
+                Expect::Ignored => assert!(
+                    matches!(got, Ok(None)),
+                    "{raw}: expected to be ignored, got {got:?}"
+                ),
+                Expect::ParseError => {
+                    assert!(got.is_err(), "{raw}: expected a parse error, got {got:?}")
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1623,10 +1623,11 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         crate::tmux::refresh_session_cache();
         live.update_status();
         // A sandbox session's container keeps the worktree dir mounted even
-        // while the agent is Idle, so `git worktree move` would fail with
-        // EBUSY; stopping the session tears the container down and releases it.
+        // while the agent is Idle, so `git worktree move` would fail. The gate
+        // drops a merely-stopped container to free the mount and only reports
+        // held for a live one, which the user has to stop.
         if live.status.blocks_worktree_edit()
-            || crate::session::worktree_edit::sandbox_container_holds_worktree(
+            || crate::session::worktree_edit::ensure_sandbox_container_released(
                 &id,
                 live.is_sandboxed(),
             )
@@ -1776,10 +1777,14 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
     crate::tmux::refresh_session_cache();
     live.update_status();
     // A sandbox container keeps the worktree dir mounted even while the agent
-    // is Idle, so the move would fail with EBUSY; stopping the session releases
-    // the mount, same as the active-status case.
+    // is Idle, so the move would fail. The gate drops a merely-stopped
+    // container to free the mount and only reports held for a live one, which
+    // the user has to stop, same as the active-status case.
     if live.status.blocks_worktree_edit()
-        || crate::session::worktree_edit::sandbox_container_holds_worktree(&id, live.is_sandboxed())
+        || crate::session::worktree_edit::ensure_sandbox_container_released(
+            &id,
+            live.is_sandboxed(),
+        )
     {
         bail!("Cannot edit the workdir name while the session is active; stop it first");
     }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1622,19 +1622,26 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         let mut live = inst.clone();
         crate::tmux::refresh_session_cache();
         live.update_status();
+        let leaf = crate::session::worktree_edit::worktree_leaf_from_title(&effective_title);
         // A sandbox session's container keeps the worktree dir mounted even
         // while the agent is Idle, so `git worktree move` would fail. The gate
         // drops a merely-stopped container to free the mount and only reports
-        // held for a live one, which the user has to stop.
+        // held for a live one, which the user has to stop. Gated on the
+        // directory actually moving so a branch-only rename does not discard a
+        // container for a move that never happens.
+        let moves_worktree = crate::session::worktree_edit::worktree_move_required(
+            std::path::Path::new(&current_path),
+            &leaf,
+        );
         if live.status.blocks_worktree_edit()
-            || crate::session::worktree_edit::ensure_sandbox_container_released(
-                &id,
-                live.is_sandboxed(),
-            )
+            || (moves_worktree
+                && crate::session::worktree_edit::ensure_sandbox_container_released(
+                    &id,
+                    live.is_sandboxed(),
+                ))
         {
             bail!("Stop the session before renaming it: its worktree directory moves to match the new name. Disable session.tie_workdir_to_name to relabel a running session.");
         }
-        let leaf = crate::session::worktree_edit::worktree_leaf_from_title(&effective_title);
         match crate::session::worktree_edit::edit_worktree_workdir(
             crate::session::worktree_edit::WorktreeEditRequest {
                 worktree_info: &worktree_info,
@@ -1779,12 +1786,19 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
     // A sandbox container keeps the worktree dir mounted even while the agent
     // is Idle, so the move would fail. The gate drops a merely-stopped
     // container to free the mount and only reports held for a live one, which
-    // the user has to stop, same as the active-status case.
+    // the user has to stop, same as the active-status case. Gated on the
+    // directory actually moving so a no-op or branch-only edit does not discard
+    // a container for a move that never happens.
+    let moves_worktree = crate::session::worktree_edit::worktree_move_required(
+        std::path::Path::new(&current_path),
+        args.name.trim(),
+    );
     if live.status.blocks_worktree_edit()
-        || crate::session::worktree_edit::ensure_sandbox_container_released(
-            &id,
-            live.is_sandboxed(),
-        )
+        || (moves_worktree
+            && crate::session::worktree_edit::ensure_sandbox_container_released(
+                &id,
+                live.is_sandboxed(),
+            ))
     {
         bail!("Cannot edit the workdir name while the session is active; stop it first");
     }

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -249,6 +249,25 @@ impl DockerContainer {
         classify_removal(self.remove(true))
     }
 
+    /// Remove this container only if it is not running, preserving its named
+    /// ignore volumes.
+    ///
+    /// The non-force counterpart to [`Self::discard`], for the one caller that
+    /// legitimately reaches removal through a `probe_running()` gate
+    /// ([`crate::session::worktree_edit::ensure_sandbox_container_released`]).
+    /// That gate must not force-remove: it runs unlocked from the CLI and TUI
+    /// paths, so a container that started between the probe and here would be
+    /// force-killed under a live agent. Without `-f` the runtime refuses,
+    /// which surfaces as [`Teardown::Failed`] and makes the gate report the
+    /// worktree as held, which is the fail-closed answer it already wants.
+    ///
+    /// Do not reach for this anywhere else: [`Self::discard`]'s
+    /// invoke-unconditionally invariant (#2596) still holds for every other
+    /// removal path.
+    pub fn discard_if_stopped(&self) -> Teardown {
+        classify_removal(self.remove(false))
+    }
+
     /// Probe this container's running state, preserving the difference
     /// between a definitive "not running" and a transient inspection failure.
     ///

--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -169,7 +169,7 @@ pub fn is_dirty_worktree_error(error: &str) -> bool {
 ///
 /// Without this classifier the error fell through to the generic arm and the
 /// trash auto-purge failed on every hourly sweep forever, never draining the
-/// expired session (#3161).
+/// expired session (#3171).
 pub fn is_not_a_worktree_error(error: &str) -> bool {
     error.to_lowercase().contains("is not a working tree")
 }
@@ -603,7 +603,7 @@ pub fn remove_managed_worktree(
                 // `.git` pointer), so finish the job by hand exactly as the
                 // missing-`.git` branch above does. Checked before the
                 // permission/submodule fallbacks: those recover a live
-                // worktree, and this one is not one. See #3161.
+                // worktree, and this one is not one. See #3171.
                 if is_not_a_worktree_error(&err_str) {
                     tracing::info!(target: "git.worktree",
                         path = %worktree_path.display(),
@@ -1082,7 +1082,7 @@ mod tests {
     /// A trashed worktree whose git admin entry went missing (pruned, or the
     /// main repo re-cloned) keeps its checkout and a now-dangling `.git`
     /// pointer on disk. `git worktree remove` refuses with "is not a working
-    /// tree", which is unfixable by retrying: before #3161 that error fell
+    /// tree", which is unfixable by retrying: before #3171 that error fell
     /// through to the generic arm, so `remove_managed_worktree` failed and
     /// the hourly trash auto-purge re-failed on the same session forever
     /// (observed retrying every hour with no progress). The recovery is to

--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -157,6 +157,23 @@ pub fn is_dirty_worktree_error(error: &str) -> bool {
         || (lower.contains("--force") && lower.contains("contains"))
 }
 
+/// Returns true if a `git worktree` stderr indicates git has no admin entry
+/// for the path ("fatal: '<path>' is not a working tree").
+///
+/// This is the "already gone from git's point of view" case, not a failure to
+/// act on: the checkout can still be on disk with a dangling `.git` pointer
+/// (its `gitdir:` target under `.git/worktrees/` was pruned or the repo was
+/// re-cloned), so `git worktree remove` refuses while the directory itself is
+/// still ours to delete. Callers recover by removing the directory by hand and
+/// pruning, the same path a missing `.git` takes.
+///
+/// Without this classifier the error fell through to the generic arm and the
+/// trash auto-purge failed on every hourly sweep forever, never draining the
+/// expired session (#3161).
+pub fn is_not_a_worktree_error(error: &str) -> bool {
+    error.to_lowercase().contains("is not a working tree")
+}
+
 /// Enumerate modified, staged, and untracked files inside a worktree using
 /// libgit2. Returns a vec of `"<status> <path>"` entries (e.g.
 /// `"modified src/foo.rs"`, `"untracked debug.log"`).
@@ -580,10 +597,45 @@ pub fn remove_managed_worktree(
                     is_submodule = is_submodule_blocker(&err_str),
                     "git worktree remove failed"
                 );
+                // git has no admin entry for this path, so there is nothing
+                // for `git worktree remove` to do and re-running can never
+                // succeed. The checkout is still on disk (with a dangling
+                // `.git` pointer), so finish the job by hand exactly as the
+                // missing-`.git` branch above does. Checked before the
+                // permission/submodule fallbacks: those recover a live
+                // worktree, and this one is not one. See #3161.
+                if is_not_a_worktree_error(&err_str) {
+                    tracing::info!(target: "git.worktree",
+                        path = %worktree_path.display(),
+                        "git has no worktree entry for this path; removing the leftover directory by hand"
+                    );
+                    let effective_force = force || instance.is_sandboxed();
+                    match remove_worktree_dir(worktree_path, main_repo, effective_force) {
+                        Ok(()) => worktree_removed = true,
+                        Err(e2) if is_permission_error(&e2.to_string()) => {
+                            if try_sandbox_dir_cleanup(
+                                worktree_path,
+                                main_repo,
+                                instance,
+                                allow_container_removal,
+                            ) {
+                                worktree_removed = true;
+                            } else {
+                                errors.push(format!("Worktree: {}", e2));
+                            }
+                        }
+                        Err(e2) => errors.push(format!("Worktree: {}", e2)),
+                    }
+                    if worktree_removed {
+                        if let Err(e2) = git_wt.prune_worktrees() {
+                            errors.push(format!("Worktree: {}", e2));
+                        }
+                    }
+                }
                 // Container cleanup deletes everything including .git, so
                 // git worktree remove won't work afterward. Fall back to
                 // removing the directory and pruning stale references.
-                if is_permission_error(&err_str)
+                else if is_permission_error(&err_str)
                     && try_sandbox_dir_cleanup(
                         worktree_path,
                         main_repo,
@@ -1010,6 +1062,98 @@ mod tests {
         ));
         assert!(!is_dirty_worktree_error("permission denied"));
         assert!(!is_dirty_worktree_error("file not found"));
+    }
+
+    #[test]
+    fn test_is_not_a_worktree_error_matches_git_message() {
+        assert!(is_not_a_worktree_error(
+            "fatal: '/tmp/wt/.aoe-trash/abc' is not a working tree"
+        ));
+        // The wrapped form callers actually see through GitError.
+        assert!(is_not_a_worktree_error(
+            "Git worktree command failed: fatal: '/tmp/wt' is not a working tree"
+        ));
+        assert!(!is_not_a_worktree_error("permission denied"));
+        assert!(!is_not_a_worktree_error(
+            "fatal: '/tmp/wt' contains modified or untracked files"
+        ));
+    }
+
+    /// A trashed worktree whose git admin entry went missing (pruned, or the
+    /// main repo re-cloned) keeps its checkout and a now-dangling `.git`
+    /// pointer on disk. `git worktree remove` refuses with "is not a working
+    /// tree", which is unfixable by retrying: before #3161 that error fell
+    /// through to the generic arm, so `remove_managed_worktree` failed and
+    /// the hourly trash auto-purge re-failed on the same session forever
+    /// (observed retrying every hour with no progress). The recovery is to
+    /// delete the leftover directory by hand and prune, the same as a
+    /// missing `.git`.
+    #[test]
+    fn test_remove_managed_worktree_recovers_from_missing_admin_entry() {
+        use crate::session::Instance;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let main_repo = tmp.path().join("main");
+        let worktree_path = tmp.path().join("trashed");
+        std::fs::create_dir(&main_repo).unwrap();
+
+        let repo = git2::Repository::init(&main_repo).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+
+        let status = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "feature/orphaned-admin-entry",
+                worktree_path.to_str().unwrap(),
+            ])
+            .current_dir(&main_repo)
+            .output()
+            .unwrap();
+        assert!(
+            status.status.success(),
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&status.stderr)
+        );
+
+        // Orphan the checkout: drop git's admin entry while leaving the
+        // worktree (and its `.git` pointer file) on disk. This is the exact
+        // state that makes both `worktree unlock` and `worktree remove`
+        // report "is not a working tree".
+        let admin = main_repo.join(".git/worktrees");
+        std::fs::remove_dir_all(&admin).unwrap();
+        assert!(
+            worktree_path.join(".git").exists(),
+            "test must exercise the has_dot_git branch"
+        );
+
+        let instance = Instance::new("Test", worktree_path.to_str().unwrap());
+        let git_wt = GitWorktree::new(main_repo.clone()).unwrap();
+
+        // force=true mirrors the auto-purge, which forces removal so a dirty
+        // tree can't pin an expired session in the trash forever.
+        let result =
+            remove_managed_worktree(&git_wt, &worktree_path, &main_repo, &instance, true, false);
+
+        assert!(
+            result.is_ok(),
+            "orphaned admin entry must not fail removal: {:?}",
+            result
+        );
+        assert!(
+            !worktree_path.exists(),
+            "leftover worktree dir should be gone"
+        );
+
+        // Idempotent: the purge may re-run before its registry entry drains.
+        let again =
+            remove_managed_worktree(&git_wt, &worktree_path, &main_repo, &instance, true, false);
+        assert!(again.is_ok(), "second removal must be a no-op: {:?}", again);
     }
 
     fn init_repo_with_commit() -> (tempfile::TempDir, std::path::PathBuf) {

--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -158,7 +158,7 @@ pub fn is_dirty_worktree_error(error: &str) -> bool {
 }
 
 /// Returns true if a `git worktree` stderr indicates git has no admin entry
-/// for the path ("fatal: '<path>' is not a working tree").
+/// for the path (`fatal: '<path>' is not a working tree`).
 ///
 /// This is the "already gone from git's point of view" case, not a failure to
 /// act on: the checkout can still be on disk with a dangling `.git` pointer

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1140,10 +1140,18 @@ pub async fn rename_session(
         // while the agent is Idle, so the move would fail. The helper drops a
         // merely-stopped container to free the mount and only reports held for
         // a live one, which the user has to stop.
-        // Short-circuited on the status check: the helper removes a stopped
-        // container, so running it for a request we are about to reject would
-        // be a destructive side effect on a 409.
+        // Short-circuited twice, because the helper removes a stopped
+        // container: once on the status check, so a request about to be
+        // rejected never discards, and once on whether the directory is
+        // actually going to move, so a no-op or branch-only rename does not
+        // either. The tied leaf comes from the title, matching what is handed
+        // to `edit_worktree_workdir` below.
+        let moves_worktree = crate::session::worktree_edit::worktree_move_required(
+            std::path::Path::new(&current_path),
+            &crate::session::worktree_edit::worktree_leaf_from_title(&title),
+        );
         let container_holds = !status.blocks_worktree_edit()
+            && moves_worktree
             && ensure_sandbox_container_released_blocking(&id, is_sandboxed).await;
         if status.blocks_worktree_edit() || container_holds {
             return (
@@ -1428,10 +1436,16 @@ pub async fn set_worktree_name(
     // is Idle, so the move would fail. The helper drops a merely-stopped
     // container to free the mount and only reports held for a live one, which
     // the user has to stop, same as the active-status case.
-    // Short-circuited on the status check: the helper removes a stopped
-    // container, so running it for a request we are about to reject would be a
-    // destructive side effect on a 409.
+    // Short-circuited twice, because the helper removes a stopped container:
+    // once on the status check, so a request about to be rejected never
+    // discards, and once on whether the directory is actually going to move, so
+    // a no-op or branch-only edit does not either.
+    let moves_worktree = crate::session::worktree_edit::worktree_move_required(
+        std::path::Path::new(&current_path),
+        &name,
+    );
     let container_holds = !status.blocks_worktree_edit()
+        && moves_worktree
         && ensure_sandbox_container_released_blocking(&id, is_sandboxed).await;
     if status.blocks_worktree_edit() || container_holds {
         return (

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1032,21 +1032,23 @@ async fn quiesce_structured_worker_for_worktree_move(
     }
 }
 
-/// Probe whether a sandboxed session's container is still holding its
-/// worktree mount, on the blocking pool.
+/// Release a sandboxed session's hold on its worktree mount ahead of a
+/// `git worktree move`, on the blocking pool, and report whether the
+/// worktree is *still* held.
 ///
-/// A sandbox container runs `sleep infinity` for the life of the session
-/// and keeps the worktree dir bind-mounted even while the agent is Idle,
-/// so a `git worktree move` would fail with `EBUSY`. Callers gate the
-/// rename/workdir-edit endpoints on this probe.
+/// NOT a read-only probe: for a container that is merely stopped this
+/// removes it, because a surviving container keeps pinning the bind mount
+/// and the rename would fail. Only call it on a path that is about to
+/// perform the move. See `ensure_sandbox_container_released` for the
+/// running-vs-stopped split.
 ///
 /// Fails closed at the async boundary: a `spawn_blocking` panic or
 /// cancellation reports the worktree as held (with a `warn!` log), so
 /// the caller rejects the mutating request with `409 CONFLICT` rather
-/// than risk `EBUSY` against a possibly-live container mount. Sharing
+/// than risk renaming against a possibly-live container mount. Sharing
 /// this helper between `rename_session` and `set_worktree_name` keeps
 /// the fail-closed policy synchronized across the two endpoints (#2596).
-async fn probe_container_holds_worktree(id: &str, is_sandboxed: bool) -> bool {
+async fn ensure_sandbox_container_released_blocking(id: &str, is_sandboxed: bool) -> bool {
     let probe_id = id.to_string();
     let log_id = id.to_string();
     tokio::task::spawn_blocking(move || {
@@ -1058,7 +1060,7 @@ async fn probe_container_holds_worktree(id: &str, is_sandboxed: bool) -> bool {
             target: "server.api.sessions",
             session = %log_id,
             error = %e,
-            "sandbox container probe task failed at the async boundary; failing closed and reporting the worktree as held to prevent EBUSY against a possibly-live container"
+            "sandbox container release task failed at the async boundary; failing closed and reporting the worktree as held rather than renaming against a possibly-live container mount"
         );
         true
     })
@@ -1067,10 +1069,10 @@ async fn probe_container_holds_worktree(id: &str, is_sandboxed: bool) -> bool {
 /// Rename a session's title (and, when tied, its worktree directory).
 ///
 /// The sandbox container probe runs on the blocking pool via
-/// `probe_container_holds_worktree`, which fails closed on a
+/// `ensure_sandbox_container_released_blocking`, which fails closed on a
 /// `spawn_blocking` panic or cancellation so the rename is rejected
 /// with `409 CONFLICT` rather than proceeding against a possibly-live
-/// container mount and hitting `EBUSY`.
+/// container mount.
 pub async fn rename_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1135,9 +1137,14 @@ pub async fn rename_session(
         // standalone worktree-name edit. A running session must be stopped
         // first; the setting is the escape hatch for free-form relabeling.
         // A sandbox session's container keeps the worktree dir mounted even
-        // while the agent is Idle, so the move would fail with EBUSY; stopping
-        // the session tears the container down and releases the mount.
-        let container_holds = probe_container_holds_worktree(&id, is_sandboxed).await;
+        // while the agent is Idle, so the move would fail. The helper drops a
+        // merely-stopped container to free the mount and only reports held for
+        // a live one, which the user has to stop.
+        // Short-circuited on the status check: the helper removes a stopped
+        // container, so running it for a request we are about to reject would
+        // be a destructive side effect on a 409.
+        let container_holds = !status.blocks_worktree_edit()
+            && ensure_sandbox_container_released_blocking(&id, is_sandboxed).await;
         if status.blocks_worktree_edit() || container_holds {
             return (
                 StatusCode::CONFLICT,
@@ -1343,11 +1350,11 @@ fn worktree_edit_error_response(
 /// Edit a managed worktree session's workdir directory name (and optionally
 /// its git branch).
 ///
-/// The sandbox container probe runs on the blocking pool via
-/// `probe_container_holds_worktree`, which fails closed on a
+/// The sandbox container gate runs on the blocking pool via
+/// `ensure_sandbox_container_released_blocking`, which fails closed on a
 /// `spawn_blocking` panic or cancellation so the edit is rejected with
 /// `409 CONFLICT` rather than proceeding against a possibly-live container
-/// mount and hitting `EBUSY`.
+/// mount.
 pub async fn set_worktree_name(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1418,9 +1425,14 @@ pub async fn set_worktree_name(
             .into_response();
     }
     // A sandbox container keeps the worktree dir mounted even while the agent
-    // is Idle, so the move would fail with EBUSY; stopping the session releases
-    // the mount, same as the active-status case.
-    let container_holds = probe_container_holds_worktree(&id, is_sandboxed).await;
+    // is Idle, so the move would fail. The helper drops a merely-stopped
+    // container to free the mount and only reports held for a live one, which
+    // the user has to stop, same as the active-status case.
+    // Short-circuited on the status check: the helper removes a stopped
+    // container, so running it for a request we are about to reject would be a
+    // destructive side effect on a 409.
+    let container_holds = !status.blocks_worktree_edit()
+        && ensure_sandbox_container_released_blocking(&id, is_sandboxed).await;
     if status.blocks_worktree_edit() || container_holds {
         return (
             StatusCode::CONFLICT,
@@ -2488,9 +2500,12 @@ pub async fn trash_session(
     // The session is durably trashed; stop its sandbox container (so it doesn't
     // keep running for the whole retention window) and relocate its managed
     // worktree out of the active dir into the holding area, then persist the
-    // repointed project_path. Stopping the container also releases the worktree
-    // bind mount, without which the git move hits EBUSY. Both the container stop
-    // and the git move are blocking, so this runs on a blocking thread.
+    // repointed project_path. Stopping the container is not enough on its own
+    // to release the worktree bind mount (a stopped container keeps pinning it,
+    // which is why the rename gate discards it); the stop is here so the
+    // sandbox isn't left running for the whole retention window. Both the
+    // container stop and the git move are blocking, so this runs on a blocking
+    // thread.
     // Best-effort: a failure leaves the worktree in place and the daemon's
     // reconcile pass can move it later. Never blocks the trash itself, which
     // already landed above.

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1050,7 +1050,7 @@ async fn probe_container_holds_worktree(id: &str, is_sandboxed: bool) -> bool {
     let probe_id = id.to_string();
     let log_id = id.to_string();
     tokio::task::spawn_blocking(move || {
-        crate::session::worktree_edit::sandbox_container_holds_worktree(&probe_id, is_sandboxed)
+        crate::session::worktree_edit::ensure_sandbox_container_released(&probe_id, is_sandboxed)
     })
     .await
     .unwrap_or_else(|e| {

--- a/src/session/trash.rs
+++ b/src/session/trash.rs
@@ -17,7 +17,7 @@ use chrono::{DateTime, Utc};
 
 use crate::git::GitWorktree;
 use crate::session::worktree_edit::{
-    discard_sandbox_container_after_move, sandbox_container_holds_worktree,
+    discard_sandbox_container_after_move, ensure_sandbox_container_released,
 };
 use crate::session::Instance;
 
@@ -117,9 +117,10 @@ pub fn relocate_worktree_to_trash(inst: &mut Instance) -> RelocateOutcome {
             reason: format!("trash holding path {} already exists", target.display()),
         };
     }
-    if sandbox_container_holds_worktree(&inst.id, is_sandboxed(inst)) {
+    if ensure_sandbox_container_released(&inst.id, is_sandboxed(inst)) {
         return RelocateOutcome::Failed {
-            reason: "sandbox container is still running and holds the worktree".to_string(),
+            reason: "sandbox container still holds the worktree; stop the session first"
+                .to_string(),
         };
     }
 
@@ -391,9 +392,10 @@ pub fn restore_worktree_location(inst: &mut Instance) -> RestoreOutcome {
         inst.pre_trash_project_path = None;
         return RestoreOutcome::NoChange;
     }
-    if sandbox_container_holds_worktree(&inst.id, is_sandboxed(inst)) {
+    if ensure_sandbox_container_released(&inst.id, is_sandboxed(inst)) {
         return RestoreOutcome::Failed {
-            reason: "sandbox container is still running and holds the worktree".to_string(),
+            reason: "sandbox container still holds the worktree; stop the session first"
+                .to_string(),
         };
     }
     if original.exists() {

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -44,6 +44,45 @@ pub fn worktree_leaf_from_title(title: &str) -> String {
     sanitize_branch_name(&crate::session::builder::branch_name_from_title(title))
 }
 
+/// The path [`edit_worktree_workdir`] would relocate the worktree to for
+/// `new_name`, or `None` when `current_path` has no parent to rename within.
+///
+/// The single source of truth for the sanitizer chain (git-ref sanitizer, then
+/// the path-safe one) so [`worktree_move_required`] cannot drift from the
+/// operation it gates.
+fn target_worktree_path(current_path: &Path, new_name: &str) -> Option<PathBuf> {
+    let parent = current_path.parent()?;
+    let new_leaf = sanitize_branch_name(&git_sanitize_branch_name(new_name));
+    Some(parent.join(new_leaf))
+}
+
+/// Whether a workdir edit for `new_name` would actually move the worktree
+/// directory.
+///
+/// Callers must gate [`ensure_sandbox_container_released`] on this. That helper
+/// removes a stopped sandbox container to free the bind mount, which is only
+/// worth doing when the rename is going to `rename(2)` the directory. Three
+/// cases reach these endpoints without moving anything, and each one would
+/// otherwise destroy a container for no reason:
+///
+///   - a name that sanitizes to the leaf the worktree already has,
+///   - a no-op edit submitting the current name unchanged,
+///   - a branch-only edit (`rename_branch` with the title or name unchanged),
+///     which [`edit_worktree_workdir`] handles without touching the path.
+///
+/// The post-move `discard_sandbox_container_after_move` call already gates on
+/// `path != current_path` for the same reason; this is the pre-move half of
+/// that rule. See #3171 review.
+///
+/// An empty name is reported as "no move": `edit_worktree_workdir` rejects it
+/// with `EmptyName` before doing anything.
+pub fn worktree_move_required(current_path: &Path, new_name: &str) -> bool {
+    if new_name.trim().is_empty() {
+        return false;
+    }
+    target_worktree_path(current_path, new_name).is_some_and(|p| p != current_path)
+}
+
 /// Release a sandbox session's hold on its worktree directory ahead of a
 /// `git worktree move`, and report whether the worktree is *still* held.
 ///
@@ -298,13 +337,9 @@ pub fn edit_worktree_workdir(
     // directory leaf uses the path-safe sanitizer (slashes become dashes),
     // mirroring how `resolve_template` derives a leaf from a branch.
     let new_branch = git_sanitize_branch_name(req.new_name);
-    let new_leaf = sanitize_branch_name(&new_branch);
 
-    let parent = req
-        .current_path
-        .parent()
+    let new_path = target_worktree_path(req.current_path, req.new_name)
         .ok_or_else(|| WorktreeEditError::NoParent(req.current_path.to_path_buf()))?;
-    let new_path = parent.join(&new_leaf);
 
     let branch_changes = req.rename_branch && new_branch != req.worktree_info.branch;
     let path_changes = new_path != req.current_path;
@@ -380,6 +415,66 @@ mod tests {
             managed_by_aoe: managed,
             created_at: Utc::now(),
             base_branch: None,
+        }
+    }
+
+    /// The gate that keeps `ensure_sandbox_container_released` (which discards a
+    /// stopped container) from firing for a rename that never moves the
+    /// directory. Before this, a no-op or branch-only edit destroyed a stopped
+    /// sandbox container while leaving the worktree exactly where it was, on all
+    /// five gates. Flagged by CodeRabbit on #3171.
+    #[test]
+    fn worktree_move_required_only_when_the_leaf_changes() {
+        let cur = Path::new("/repos/wt/feature-login");
+
+        // A genuinely different name relocates the directory.
+        assert!(worktree_move_required(cur, "feature-logout"));
+
+        // The name the worktree already has: no move, so no container discard.
+        // This is also the branch-only shape, which reaches these endpoints with
+        // the name unchanged and `rename_branch` set; `edit_worktree_workdir`
+        // renames the ref without touching the path.
+        assert!(!worktree_move_required(cur, "feature-login"));
+
+        // Sanitizes to the current leaf, so still no move. This is the case a
+        // raw string comparison against the leaf would miss: the path-safe
+        // sanitizer folds '/' to '-', landing back on the leaf already on disk.
+        assert!(!worktree_move_required(cur, "feature/login"));
+
+        // Neither sanitizer lowercases (verified against the chain, not
+        // assumed), so a case change is a real relocation and must NOT be
+        // treated as a no-op.
+        assert!(worktree_move_required(cur, "Feature Login"));
+
+        // Empty is rejected upstream with `EmptyName`; nothing moves.
+        assert!(!worktree_move_required(cur, ""));
+        assert!(!worktree_move_required(cur, "   "));
+
+        // No parent to rename within.
+        assert!(!worktree_move_required(Path::new("/"), "anything"));
+    }
+
+    /// `worktree_move_required` must agree with `edit_worktree_workdir`'s own
+    /// `path_changes` decision, since it exists purely to predict it. Both now
+    /// route through `target_worktree_path`, and this pins that they stay
+    /// routed through it: a drift here silently re-opens the bug above.
+    #[test]
+    fn worktree_move_required_agrees_with_the_target_path_it_gates() {
+        let cur = Path::new("/repos/wt/feature-login");
+        for name in [
+            "feature-logout",
+            "feature-login",
+            "feature/login",
+            "Feature Login",
+            "wild  name",
+        ] {
+            let target = target_worktree_path(cur, name).expect("has a parent");
+            assert_eq!(
+                worktree_move_required(cur, name),
+                target != cur,
+                "disagreement for {name:?}: target resolved to {}",
+                target.display()
+            );
         }
     }
 

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -113,7 +113,7 @@ pub fn worktree_move_required(current_path: &Path, new_name: &str) -> bool {
 /// exists to prevent: trashing a stopped sandboxed session logged
 /// `trash worktree relocation skipped: ... Permission denied` and left the
 /// worktree in place until a later daemon reconcile happened to remove the
-/// container first. See #1927 follow-up, #2596, and #3161.
+/// container first. See #1927 follow-up, #2596, and #3171.
 ///
 /// `is_sandboxed` is taken so non-sandbox sessions skip the `docker inspect`
 /// subprocess entirely.
@@ -133,8 +133,12 @@ pub fn ensure_sandbox_container_released(session_id: &str, is_sandboxed: bool) -
         Probe::Running => true,
         Probe::NotRunning => {
             // Stopped, but a surviving container still pins the bind mount.
-            // Dropping it now is what makes the rename succeed.
-            match container.discard() {
+            // Dropping it now is what makes the rename succeed. Non-force, so a
+            // container that came back up between the probe above and here is
+            // refused rather than force-killed: only the two server callers hold
+            // `instance_lock`, and the CLI, TUI, and trash paths race a daemon
+            // reconcile or a Start from the dashboard.
+            match container.discard_if_stopped() {
                 Teardown::Removed => {
                     tracing::info!(
                         target: "containers.runtime",

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -44,38 +44,87 @@ pub fn worktree_leaf_from_title(title: &str) -> String {
     sanitize_branch_name(&crate::session::builder::branch_name_from_title(title))
 }
 
-/// Whether a sandbox session's container is still running and therefore
-/// bind-mounting its worktree directory.
+/// Release a sandbox session's hold on its worktree directory ahead of a
+/// `git worktree move`, and report whether the worktree is *still* held.
 ///
-/// A sandbox container runs `sleep infinity` for the life of the session
-/// (`src/containers/runtime_base.rs`), so it holds the worktree dir as an
-/// active mount source even while the agent is Idle. A `git worktree move`
-/// then `rename(2)`s that dir and the kernel refuses with `EBUSY`, surfaced
-/// as `fatal: failed to move`. Callers about to move the worktree must refuse
-/// and have the user stop the session first, which tears the container down
-/// and releases the mount. `is_sandboxed` is taken so non-sandbox sessions
-/// skip the `docker inspect` subprocess entirely. See #1927 follow-up.
+/// `true` means the caller must refuse the move.
+///
+/// A sandbox container bind-mounts the worktree dir. `git worktree move`
+/// `rename(2)`s that dir, and the mount holder makes the rename fail: as
+/// `EBUSY` on Linux, and as `EACCES` ("Permission denied") on Docker
+/// Desktop for macOS, where the bind is re-exported through the VM's
+/// file-sharing layer. Either way git surfaces `fatal: failed to move`.
+///
+/// Two cases, and the distinction is the whole point of this function:
+///
+///   - **Running.** The agent is live in there; we can't yank its mount out
+///     from under it. Report held and let the caller tell the user to stop
+///     the session first.
+///   - **Stopped but still present.** `docker stop` does *not* release the
+///     bind on Docker Desktop, so the rename fails exactly as it would
+///     against a live container, but there is nothing to protect. Discard
+///     the container here, which drops the mount, and report not-held. The
+///     container is recreated with the new path on next start (see
+///     [`discard_sandbox_container_after_move`], which the caller still
+///     invokes post-move and which no-ops as `AlreadyGone` when we got here
+///     first).
+///
+/// Before this, the gate tested `probe_running()` alone, so a session the
+/// user had just stopped sailed past it and hit the rename failure the gate
+/// exists to prevent: trashing a stopped sandboxed session logged
+/// `trash worktree relocation skipped: ... Permission denied` and left the
+/// worktree in place until a later daemon reconcile happened to remove the
+/// container first. See #1927 follow-up, #2596, and #3161.
+///
+/// `is_sandboxed` is taken so non-sandbox sessions skip the `docker inspect`
+/// subprocess entirely.
 ///
 /// Fails closed on a transient `docker inspect` failure: a [`Probe::Unknown`]
 /// answer is treated as "possibly running" and blocks the rename, rather
 /// than swallowing the failure into a false negative (`unwrap_or(false)`)
-/// that would let the rename proceed against a live container and hit
-/// `EBUSY`. Same swallowing-existence-probe class as #2596, on the more
-/// consequential gate path (this function is *the* barrier that stops the
-/// `EBUSY`, not a best-effort post-move cleanup).
-pub fn sandbox_container_holds_worktree(session_id: &str, is_sandboxed: bool) -> bool {
+/// that would let the rename proceed against a live container. This function
+/// is *the* barrier that stops the failed rename, not a best-effort post-move
+/// cleanup.
+pub fn ensure_sandbox_container_released(session_id: &str, is_sandboxed: bool) -> bool {
     if !is_sandboxed {
         return false;
     }
-    match DockerContainer::from_session_id(session_id).probe_running() {
+    let container = DockerContainer::from_session_id(session_id);
+    match container.probe_running() {
         Probe::Running => true,
-        Probe::NotRunning => false,
+        Probe::NotRunning => {
+            // Stopped, but a surviving container still pins the bind mount.
+            // Dropping it now is what makes the rename succeed.
+            match container.discard() {
+                Teardown::Removed => {
+                    tracing::info!(
+                        target: "containers.runtime",
+                        session = %session_id,
+                        "removed stopped sandbox container to release its bind mount before the worktree move"
+                    );
+                    false
+                }
+                Teardown::AlreadyGone => false,
+                // Couldn't drop it, so assume it still holds the mount and
+                // fail the rename with a real reason instead of letting git
+                // fail with a bare `Permission denied`.
+                Teardown::Failed(e) => {
+                    tracing::warn!(
+                        target: "containers.runtime",
+                        session = %session_id,
+                        error = %e,
+                        "failed to remove stopped sandbox container before the worktree move; reporting the worktree as held"
+                    );
+                    true
+                }
+            }
+        }
         Probe::Unknown(e) => {
             tracing::warn!(
                 target: "containers.runtime",
                 session = %session_id,
                 error = %e,
-                "docker inspect failed while probing sandbox container for the worktree rename gate; failing closed and reporting the worktree as held to prevent EBUSY against a possibly-live container"
+                "docker inspect failed while probing sandbox container for the worktree rename gate; failing closed and reporting the worktree as held to prevent a failed rename against a possibly-live container"
             );
             true
         }
@@ -94,9 +143,13 @@ pub fn sandbox_container_holds_worktree(session_id: &str, is_sandboxed: bool) ->
 /// the session's named ignore volumes (`target/`, `node_modules/`) so the
 /// recreated container re-attaches its build caches.
 ///
-/// No-op for non-sandbox sessions. The rename gate requires a stopped session
-/// (see [`sandbox_container_holds_worktree`]), so the container is not
-/// running here. Best-effort: a failure is logged, not surfaced, since the
+/// No-op for non-sandbox sessions, and commonly a no-op
+/// ([`Teardown::AlreadyGone`]) on the sandbox path too: the rename gate
+/// ([`ensure_sandbox_container_released`]) already discards a stopped
+/// container to free the bind mount, so this call is what covers the
+/// remaining case of a container that reappeared, plus callers that reach a
+/// rename without passing the gate. Best-effort: a failure is logged, not
+/// surfaced, since the
 /// rename itself has already succeeded. See #1927 follow-up and #2596.
 pub fn discard_sandbox_container_after_move(session_id: &str, is_sandboxed: bool) {
     if !is_sandboxed {
@@ -337,7 +390,7 @@ mod tests {
         // false before touching the container runtime, so a plain worktree
         // rename never pays a `docker inspect`. The live-container branch is the
         // same helper the tied-rename path already relies on.
-        assert!(!sandbox_container_holds_worktree("any-session-id", false));
+        assert!(!ensure_sandbox_container_released("any-session-id", false));
     }
 
     #[test]

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1024,7 +1024,7 @@ impl HomeView {
         // session is stopped, mirroring the tied-rename path. `status` alone is
         // insufficient: `blocks_worktree_edit` is false for an Idle session
         // whose container is still up. See #2117, #2414.
-        if crate::session::worktree_edit::sandbox_container_holds_worktree(&id, is_sandboxed) {
+        if crate::session::worktree_edit::ensure_sandbox_container_released(&id, is_sandboxed) {
             anyhow::bail!(
                 "Stop the session before editing its workdir name: its sandbox container is \
                  mounting the worktree directory"
@@ -1122,20 +1122,21 @@ impl HomeView {
                     // A sandbox session keeps its container alive (running
                     // `sleep infinity`) even while the agent is Idle, and that
                     // container bind-mounts the worktree directory. The move
-                    // below `git worktree move`s that dir, which the kernel
-                    // refuses while it is an active mount source (EBUSY ->
-                    // "fatal: failed to move"). Stopping the session tears the
-                    // container down and releases the mount. We only inspect
+                    // below `git worktree move`s that dir, which fails while it
+                    // is an active mount source ("fatal: failed to move"). The
+                    // gate releases a merely-stopped container itself and only
+                    // reports held when the agent is genuinely live, in which
+                    // case the user has to stop the session. We only inspect
                     // the container when the status check hasn't already
                     // blocked, so the common non-sandbox path spawns no
-                    // `docker inspect`. See #1927 follow-up.
-                    let container_running = !status.blocks_worktree_edit()
-                        && crate::session::worktree_edit::sandbox_container_holds_worktree(
+                    // `docker inspect`. See #1927 follow-up and #3161.
+                    let container_holds_worktree = !status.blocks_worktree_edit()
+                        && crate::session::worktree_edit::ensure_sandbox_container_released(
                             &id,
                             is_sandboxed,
                         );
                     if let Some(reason) =
-                        worktree_rename_block(status, is_sandboxed, container_running)
+                        worktree_rename_block(status, is_sandboxed, container_holds_worktree)
                     {
                         let body = match reason {
                             WorktreeRenameBlock::ActiveAgent => "This worktree session's directory moves to match the new name, which can't happen while it's running. Stop the session first, or disable \"Tie Worktree Directory to Session Name\" to relabel it freely.",

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1024,7 +1024,14 @@ impl HomeView {
         // session is stopped, mirroring the tied-rename path. `status` alone is
         // insufficient: `blocks_worktree_edit` is false for an Idle session
         // whose container is still up. See #2117, #2414.
-        if crate::session::worktree_edit::ensure_sandbox_container_released(&id, is_sandboxed) {
+        // Gated on the directory actually moving: the helper discards a
+        // stopped container, which is only worth doing for a real relocation.
+        // A no-op or branch-only edit leaves the mount valid.
+        if crate::session::worktree_edit::worktree_move_required(
+            std::path::Path::new(&project_path),
+            new_name,
+        ) && crate::session::worktree_edit::ensure_sandbox_container_released(&id, is_sandboxed)
+        {
             anyhow::bail!(
                 "Stop the session before editing its workdir name: its sandbox container is \
                  mounting the worktree directory"
@@ -1130,7 +1137,17 @@ impl HomeView {
                     // the container when the status check hasn't already
                     // blocked, so the common non-sandbox path spawns no
                     // `docker inspect`. See #1927 follow-up and #3161.
+                    // Gated on the directory actually moving, matching the
+                    // `dir_moved` guard on the post-move discard below: a
+                    // branch-only rename leaves the path, and thus the mount,
+                    // valid, so there is no container to release.
+                    let leaf =
+                        crate::session::worktree_edit::worktree_leaf_from_title(&effective_title);
                     let container_holds_worktree = !status.blocks_worktree_edit()
+                        && crate::session::worktree_edit::worktree_move_required(
+                            std::path::Path::new(&project_path),
+                            &leaf,
+                        )
                         && crate::session::worktree_edit::ensure_sandbox_container_released(
                             &id,
                             is_sandboxed,
@@ -1148,8 +1165,6 @@ impl HomeView {
                         ));
                         return Ok(());
                     }
-                    let leaf =
-                        crate::session::worktree_edit::worktree_leaf_from_title(&effective_title);
                     match crate::session::worktree_edit::edit_worktree_workdir(
                         crate::session::worktree_edit::WorktreeEditRequest {
                             worktree_info: &worktree_info,

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1136,7 +1136,7 @@ impl HomeView {
                     // case the user has to stop the session. We only inspect
                     // the container when the status check hasn't already
                     // blocked, so the common non-sandbox path spawns no
-                    // `docker inspect`. See #1927 follow-up and #3161.
+                    // `docker inspect`. See #1927 follow-up and #3171.
                     // Gated on the directory actually moving, matching the
                     // `dir_moved` guard on the post-move discard below: a
                     // branch-only rename leaves the path, and thus the mount,


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The investigation and decisions are his; the prose is Claude's._

## Description

Four independent bugs found by reading a `debug.log` from a live session. Each is a separate commit with its own regression test, so any one can be reverted alone.

**1. `fix(acp)`: the native TUI structured view dropped its WebSocket every 30 seconds.**

The daemon emits `{"kind":"heartbeat"}` on every ping tick (#2287, `PING_INTERVAL` = 30s). The Rust client's `parse_text` only probed for the `lagged` sentinel, so the heartbeat fell through to the `AcpBroadcastFrame` parse and failed on the missing `session_id` field. `tui::structured_view` treats a parse error as a dropped socket, so every quiet session showed an error toast, cleared `in_flight`, and reconnected, every 30 seconds, indefinitely:

```
WARN acp.client.ws: ws frame parse failed error=missing field `session_id` at line 1 column 20
WARN acp.tui.ws: ws disconnect: failed to parse websocket frame
```

`{"kind":"heartbeat"}` is 20 characters, which is where "column 20" comes from. The web client already handled this shape (`useAcpSession.ts`); only the Rust client was never taught about it. Note `heartbeat_frame_shape_is_stable` in `src/server/acp_ws.rs` guards the server's wire shape and its comment predicts this exact failure, but nothing guarded the Rust client's ability to read it. There is now a test on both sides.

**2. `fix(session)`: phantom `Running -> Idle` every 2 seconds on ACP sessions.**

Thousands of identical lines for a single session:

```
INFO session.status_change: aed2f79faaf04082 [claude] Running -> Idle (hook=None hook_age_ms=None pane=empty_capture)
```

These were not transitions. A structured session's status is owned by the ACP overlay, and `update_status_with_metadata_inner` returns early for those rows, so `status` on exit is the value loaded from disk while `live_status_baseline` is the overlay's live value. Diffing the two compares an overlay-derived value against a stale disk read, and `decide_passive_transition` returns `patch: None` for structured rows by design, so nothing reconciles disk and the mismatch is permanent.

Beyond log volume, the phantom `StatusChange` reached `push::handle_status_change`, which re-armed `idle_since` on every tick and raced the 2s `DWELL_TERMINAL_MS` it is meant to enforce. The "session went idle" push therefore fired or not depending on tick jitter. The idle reaper is unaffected; it already filters `is_structured()`.

Fixed at both exits. The `Error -> Idle` heal, the one change `_inner` genuinely makes for these rows, is still observed, and there is a test asserting that so the guard cannot regress into a blanket skip.

**3. `fix(git)`: trash auto-purge wedged in a permanent hourly retry.**

```
WARN http.api.sessions: auto-purge of expired trash failed: Worktree: Git worktree command failed:
  fatal: '.../.aoe-trash/822ece2dad8c46c5' is not a working tree
```

Same session, same failure, every hour, no progress. The checkout is on disk with a dangling `.git` pointer while git's admin entry is gone, so `git worktree remove` refuses and retrying can never help. The error fell through to the generic arm. Now classified by `is_not_a_worktree_error` and recovered the way a missing `.git` already is: remove the directory by hand, then prune.

**4. `fix(session)`: `git worktree move` failing with Permission denied.**

The rename gate tested `probe_running()` alone, but a stopped-but-not-removed container still pins its bind mount. On Docker Desktop for macOS the bind is re-exported through the VM's file-sharing layer, so `rename(2)` fails with `EACCES` rather than the `EBUSY` the gate's docstring predicted. Timeline from the log:

```
23:48:49  stopping container aoe-sandbox-aed2f79f
23:48:59  git worktree move -> fatal: failed to move ...: Permission denied
23:56:39  removing container
23:56:40  "removed stale sandbox container after worktree move" -> the same move succeeded
```

`sandbox_container_holds_worktree` becomes `ensure_sandbox_container_released`, splitting the two conflated cases: a running container still blocks (we cannot yank a live agent's mount), while a stopped one is discarded on the spot, which frees the mount. Renamed rather than given a new parameter so the compiler found every caller; all five gates shared the bug, including the workdir-rename flow in the TUI, CLI and web API.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A, no visual change; see the note below)

On tests: `cargo fmt --check` clean, `cargo clippy --features serve --all-targets` adds no new warnings (the 7 reported all reproduce on a clean `main`), `cargo test --features serve` is 5845 passed / 2 failed. The 2 failures are pre-existing and environmental, not from this branch: `shutdown_and_wait_degrades_when_load_errs_without_peer` and `pid_source_for_falls_back_to_peer_pid_on_load_err` both force a read error with `chmod 0o000`, which is a no-op when the test runs as uid 0. Both fail identically on a clean checkout of `main` in the same container.

Each of the four regression tests was verified to fail without its fix. Two of them reproduce the logged error string verbatim: the heartbeat test panics with `Parse("missing field \`session_id\` at line 1 column 20")` and the trash test with `fatal: '...' is not a working tree`.

Documentation: no user-facing docs changed. The reasoning for each fix lives in the code, on the functions whose contracts changed.

On the screenshot box: nothing renders differently. The one visible effect is the *absence* of a recurring error toast in the TUI structured view, which needs a live daemon and a 30s ping tick to demonstrate, so a recording would be 30 seconds of a session correctly doing nothing. Say the word if you want it anyway.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: no `web/` files change, so the matrix gate does not apply, and the dashboard renders the same status either way (the web session list reads the ACP overlay, which is untouched). What commit 2 does change is push-notification timing, which needs a real push subscription and a dwell window to observe and is not reachable from Playwright. Flagging it rather than claiming N/A because the notifications surface is on the mandate list.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the natural e2e for the heartbeat fix is "attach the structured view to a live daemon and assert no disconnect toast appears", which needs 30+ seconds of wall clock to see the first ping tick. Covered instead from both ends by unit tests pinned to the same literal wire bytes: `heartbeat_frame_shape_is_stable` on the server and `parse_text_heartbeat_is_ignored_not_an_error` on the client, so drift on either side fails one of them. Happy to add the slow e2e if you would rather pay the 30s.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Starting point was a pasted `debug.log`. Every root cause was traced to specific code and confirmed there rather than inferred from the log text, and every fix has a regression test that was checked to fail without it. Worth a close look from a human on two points: whether skipping structured rows in the `status_poll_loop` diff loses a `StatusChange` consumer I did not account for (I traced `apply_status_intent` as the ACP-driven broadcaster that covers those rows), and whether discarding a stopped container inside the rename gate is acceptable in the workdir-rename flows, not just the trash flows, since the rename made it apply to all five call sites.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Ignored ACP WebSocket heartbeat frames without causing parse errors or reconnects.
- Removed orphaned worktree directories during trash cleanup.
- Released stopped sandbox containers only when a worktree move is required.
- Avoided force-removing containers that may restart during cleanup.
- Added regression tests for the fixes.

## Benefits

These changes reduce unnecessary reconnects and cleanup retries. They also make worktree operations safer and more predictable. Formatting, clippy, and documented tests pass. Two permission-test failures remain due to the test environment running as root.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->