### PR TITLE
fix(acp): release instance_lock before awaiting the worker, and withhold the publish until it is ready

### DIFF
--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -2192,6 +2192,17 @@ impl<S: BroadcastSink> Supervisor<S> {
         self.client_for_session(session_id).await
     }
 
+    /// Await worker readiness without resolving a client, so a caller can
+    /// gate a durable side effect on the worker actually being there. Used
+    /// by `send_turn` to hold back the `UserPromptSent` publish until the
+    /// resume it kicked has landed: publishing first and only then
+    /// discovering the worker never arrived is what leaves a session
+    /// rendering "running" forever with no agent behind it (#3172). Costs a
+    /// single worker-map lookup when the worker is already live.
+    pub async fn wait_until_ready(&self, session_id: &str) -> Result<(), SupervisorError> {
+        self.ready_client(session_id).await.map(|_| ())
+    }
+
     /// Send a user prompt (with optional attachments) to a running
     /// structured view worker.
     pub async fn send_prompt(

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -1435,9 +1435,9 @@ async fn resume_target_for_session(
 ) -> Option<ResumeTarget> {
     let instances = service.instances.read().await;
     // Filter the same triage states the reconciler skips everywhere else.
-    // The wake path drops `instance_lock` before calling this, so an archive
-    // or snooze can win the race after dormancy was cleared; resolving to
-    // None (then NotFound) keeps us from respawning a session the reconciler
+    // This runs without `instance_lock` held, so an archive or snooze can
+    // win the race after dormancy was cleared; resolving to None (then
+    // NotFound) keeps us from respawning a session the reconciler
     // intentionally leaves sunk. See #1748.
     let inst = instances.iter().find(|i| {
         i.id == id
@@ -1481,6 +1481,11 @@ pub(crate) enum ResumeTrigger {
 /// reconciler tick sees the reservation via `is_running` and skips the
 /// session, so there is no double-spawn. Returns `Err(CapacityFull)` when
 /// the worker cap is reached so the handler can surface 503. See #1748.
+///
+/// Callers MUST NOT hold the session's `instance_lock` while awaiting the
+/// worker this kicks: the detached task takes that same lock inside
+/// `build_spawn_request`, so a caller that holds it stalls the spawn for
+/// its whole `WORKER_READY_TIMEOUT` wait and then gives up. See #3172.
 pub(crate) async fn trigger_resume_background(
     service: &Arc<SessionService>,
     id: &str,

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1197,28 +1197,36 @@ pub async fn acp_prompt(
     // A fresh user prompt supersedes any queued rate-limit resume
     // continuation, so drop it before sending: otherwise the reconciler could
     // later replay the older interrupted prompt after this newer one (#3028).
-    // The clear + send run under the per-session `instance_lock` because the
-    // pending-turn drain holds that same lock across its whole snapshot ->
-    // reload -> send -> clear; without it a drain mid-await could deliver the
-    // stale continuation *after* this newer prompt. `send_turn` does not take
-    // `instance_lock` (the drain calls it while holding the lock), so this
-    // cannot deadlock. Resume + publish + forward all live in the shared
-    // service so the plugin host delivers turns through the same path (#2897).
-    let outcome = {
+    // The clear alone runs under the per-session `instance_lock`, and the
+    // guard is dropped before `send_turn`. Mutual exclusion with the
+    // pending-turn drain is enough to keep the #3028 ordering: the drain
+    // holds this same lock across its whole snapshot -> reload -> send ->
+    // clear, so whichever side wins the lock, the stale continuation can
+    // never be published after this newer prompt. If the drain wins it
+    // delivers first; if we win, the drain then reads None and returns.
+    //
+    // Holding the guard across `send_turn` is what broke #3172:
+    // `send_turn` -> `trigger_resume_background` detaches a task that calls
+    // `build_spawn_request`, which takes this very lock, so the spawn could
+    // not start until this handler released it, and the handler was busy
+    // burning `WORKER_READY_TIMEOUT` waiting for that spawn. Resume +
+    // publish + forward still live in the shared service so the plugin host
+    // delivers turns through the same path (#2897).
+    {
         let inst_lock = state.instance_lock(&id).await;
         let _serialized = inst_lock.lock().await;
         state.session_service.clear_pending_initial_turn(&id).await;
-        state
-            .session_service
-            .send_turn(
-                &SessionCaller::User,
-                &id,
-                &req.text,
-                &attachments,
-                woke_idle_dormant,
-            )
-            .await
-    };
+    }
+    let outcome = state
+        .session_service
+        .send_turn(
+            &SessionCaller::User,
+            &id,
+            &req.text,
+            &attachments,
+            woke_idle_dormant,
+        )
+        .await;
     // Smart-rename fires from `acp_event_listener` on the first clean
     // `prompt_complete` `Event::Stopped` (turn-end), so the one-shot never
     // races this handler's live worker for the provider API. See
@@ -2931,6 +2939,92 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
         assert!(state.instance_locks.read().await.is_empty());
+    }
+
+    /// #3172: two invariants of the idle-dormant prompt-wake path, both of
+    /// which the pre-fix tree violates.
+    ///
+    /// 1. `acp_prompt` must release `instance_lock` before it awaits the
+    ///    worker. The detached spawn task the wake kicks needs that same
+    ///    lock inside `build_spawn_request`, so a handler that keeps it
+    ///    stalls its own resume for the whole `WORKER_READY_TIMEOUT` and
+    ///    then reports the worker never arrived.
+    /// 2. A prompt that never reaches a worker must not be published. A
+    ///    `UserPromptSent` with no turn behind it renders as a session
+    ///    stuck on "running" that only a stop plus re-send clears.
+    ///
+    /// A held `ResumeReservation` stands in for a spawn in flight: it makes
+    /// `wait_for_worker` park exactly as it does mid-respawn, with no
+    /// process, sandbox, or agent involved.
+    #[tokio::test]
+    async fn wake_prompt_frees_instance_lock_and_publishes_nothing_without_a_worker() {
+        use crate::acp::supervisor::{ResumeKind, ResumeReservationOutcome};
+        use std::time::Duration;
+
+        let mut inst = crate::session::Instance::new("wake-3172", "/tmp/aoe-3172-project");
+        inst.id = "sess-3172".to_string();
+        inst.view = crate::session::View::Structured;
+        let id = inst.id.clone();
+        let state = crate::server::test_support::build_test_app_state(vec![inst]);
+
+        // Hold the reservation for the whole probe so no worker can land.
+        let reservation = match state
+            .acp_supervisor
+            .begin_resume(&id, ResumeKind::Spawn)
+            .await
+            .expect("begin_resume must not error under capacity")
+        {
+            ResumeReservationOutcome::Reserved(r) => r,
+            ResumeReservationOutcome::AlreadyPresent => panic!("expected a fresh reservation"),
+        };
+
+        let handler = tokio::spawn({
+            let state = Arc::clone(&state);
+            let id = id.clone();
+            async move {
+                acp_prompt(
+                    State(state),
+                    Path(id),
+                    Ok(Json(PromptRequest {
+                        text: "lgtm".to_string(),
+                        attachments: Vec::new(),
+                    })),
+                )
+                .await
+                .into_response()
+            }
+        });
+
+        // Let the handler reach its parked wait. It cannot return until the
+        // reservation drops, so anything past the lock scope is enough.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // The 2s budget is far under the 10s `WORKER_READY_TIMEOUT` the
+        // pre-fix handler holds the lock for, and far over the microseconds
+        // the fixed one needs to clear and release.
+        let inst_lock = state.instance_lock(&id).await;
+        let acquired = tokio::time::timeout(Duration::from_secs(2), inst_lock.lock()).await;
+        assert!(
+            acquired.is_ok(),
+            "acp_prompt must not hold instance_lock while it waits for the worker"
+        );
+        drop(acquired);
+
+        drop(reservation);
+        let response = tokio::time::timeout(Duration::from_secs(30), handler)
+            .await
+            .expect("handler must finish once the reservation drops")
+            .expect("handler task must not panic");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        assert!(
+            !state
+                .acp_event_store
+                .replay_from(&id, 0)
+                .iter()
+                .any(|(_, e)| matches!(e, Event::UserPromptSent { .. })),
+            "a prompt no worker ever received must not reach the event store"
+        );
     }
 
     #[tokio::test]

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -2955,7 +2955,12 @@ mod tests {
     ///
     /// A held `ResumeReservation` stands in for a spawn in flight: it makes
     /// `wait_for_worker` park exactly as it does mid-respawn, with no
-    /// process, sandbox, or agent involved.
+    /// process, sandbox, or agent involved. It also pins the subtler of the
+    /// two publish branches, because a reservation counts as `is_running`:
+    /// `needs_resume` is false here even though no worker exists, so only
+    /// an unconditional readiness gate catches it. Pre-fix that combination
+    /// published the prompt and then answered 404; it is now a retryable
+    /// 503 with nothing written.
     #[tokio::test]
     async fn wake_prompt_frees_instance_lock_and_publishes_nothing_without_a_worker() {
         use crate::acp::supervisor::{ResumeKind, ResumeReservationOutcome};

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -142,9 +142,10 @@ pub(crate) enum SendTurnError {
     /// Pre-publish: reserving the resume slot failed (includes
     /// `SupervisorError::CapacityFull`). Nothing was published.
     ResumeFailed(crate::acp::supervisor::SupervisorError),
-    /// Post-publish: the respawn kicked by this call did not finish within
-    /// `send_prompt`'s wait window (slow sandbox / spawn). The worker is
-    /// still coming; retryable. See #1748.
+    /// Pre-publish: the worker did not become ready within
+    /// `WORKER_READY_TIMEOUT` (slow sandbox / spawn). The worker is still
+    /// coming; retryable, and nothing was published, so the transcript is
+    /// not left with a prompt no agent ever received. See #1748 and #3172.
     WorkerNotReady,
     /// Post-publish: the forward to the agent failed.
     Send(crate::acp::supervisor::SupervisorError),
@@ -423,6 +424,27 @@ impl SessionService {
                 Err(e) => return Err(SendTurnError::ResumeFailed(e)),
             }
         }
+        // Gate the publish below on the worker actually being there. Without
+        // this the prompt lands in the durable event stream and only THEN
+        // does `send_prompt` discover the respawn never finished, leaving a
+        // `UserPromptSent` with no turn behind it and a UI stuck on
+        // "running" until someone stops the session and re-sends (#3172).
+        // Failing here instead returns a 503 the frontend already treats as
+        // transient: it rolls the optimistic row back and re-queues for the
+        // drain to re-fire on the next `AcpSessionAssigned` (#3094).
+        //
+        // Unconditional, not gated on `needs_resume`: `is_running` is also
+        // true for a resume another caller already reserved, so a false
+        // `needs_resume` does not imply a live worker. For one that is live
+        // this is a single worker-map lookup.
+        if let Err(e) = self.acp_supervisor.wait_until_ready(id).await {
+            return match e {
+                crate::acp::supervisor::SupervisorError::UnknownSession(_) => {
+                    Err(SendTurnError::WorkerNotReady)
+                }
+                other => Err(SendTurnError::ResumeFailed(other)),
+            };
+        }
         // A plugin-delivered turn must run under the session's persisted
         // explicit mode: re-assert it before publishing, and withhold the
         // prompt when the assertion fails (#2897). set_mode waits on the
@@ -466,8 +488,10 @@ impl SessionService {
         match outcome {
             Ok(()) => Ok(()),
             // Intentional override of the canonical UnknownSession 404: the
-            // respawn we kicked above did not finish within `send_prompt`'s
-            // wait window. See the `WorkerNotReady` variant doc.
+            // readiness barrier above passed, so the worker was alive a
+            // moment ago and died in the gap. Retryable rather than a 404,
+            // same as before. This one IS post-publish; closing that window
+            // needs delivery acknowledgements, not a longer timeout.
             Err(crate::acp::supervisor::SupervisorError::UnknownSession(_)) if needs_resume => {
                 Err(SendTurnError::WorkerNotReady)
             }


### PR DESCRIPTION
**Note:** Claude handled the investigation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Since v1.13.2, a prompt sent to an idle-dormant structured session gets written to the event store and then never reaches the agent. The worker spawns exactly 10 seconds late, the session renders as "running" forever, and the only way out is to stop it and re-send. It reproduces several times per session on a machine that lets sessions go dormant.

The cause is a lock-ordering stall. `acp_prompt` held the per-session `instance_lock` across the whole `send_turn` call. For a dormant session `send_turn` calls `trigger_resume_background`, which detaches a task that takes that same lock inside `build_spawn_request` (and again inside `ensure_container_for_session`). So the spawn could not start until the handler released the lock, while the handler sat in `wait_for_worker` burning the full 10s `WORKER_READY_TIMEOUT` waiting for precisely that spawn. It then returned 503, dropped the lock, and the worker came up 10s late with nobody left to forward the text. Introduced by b8c2bea8 (#3061), which added the lock wrap so a fresh prompt supersedes a queued rate-limit continuation (#3028).

Two changes:

1. **Scope the handler's guard to `clear_pending_initial_turn`.** Mutual exclusion with the pending-turn drain is all the lock was ever for, and the drain holds it across its whole snapshot-to-publish sequence, so the #3028 ordering survives either way the race lands: if the drain wins it delivers first, and if the handler wins the drain then reads `None` and returns.

2. **Withhold the publish until the worker is ready.** `send_turn` used to publish `UserPromptSent` and only then discover, inside `send_prompt`, that no worker had arrived. A durable prompt with no turn behind it is what the frontend reads as authoritative and renders as a stuck spinner. A readiness wait before the publish makes `WorkerNotReady` a pre-publish failure, so a slow cold resume now leaves nothing behind. The wait is unconditional rather than gated on `needs_resume`, because `is_running` is also true for a resume another caller already reserved, so a false `needs_resume` does not imply a live worker.

No frontend change is needed. `useAcpSession.ts` already treats `503 worker_not_ready` as transient: it rolls the optimistic row back by id and re-queues the prompt for the drain to re-fire on the next `AcpSessionAssigned` (#3094, #1748).

One incidental behavior change worth calling out: a prompt that races a resume another caller already reserved used to publish and then answer 404, which the dashboard classifies as a non-retryable rejection and drops from the queue. It now answers a retryable 503 with nothing published, so that prompt is re-queued instead of lost.

Fixing `drain_pending_initial_turn`, which has the same lock-across-`send_turn` shape since #2897, is deliberately out of scope. It is pre-existing, it self-heals because a failed drain leaves `pending_initial_turn` set for the reconciler to retry, and change 2 already stops it publishing phantom prompts. What is left there is lock duration, not correctness. Happy to file that as a follow-up.

Design was debated across two models. Both rejected threading a "caller already holds the lock" flag into the resume path, since the detached task outlives the caller's guard, and both landed on this shape over a larger `prepare_turn` / `commit_turn` split.

Closes #3172

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] Set `auto_stop_idle_secs` to something short in the profile config that actually applies (note that `~/.agent-of-empires/profiles/<profile>/config.toml` overrides the global `~/.agent-of-empires/config.toml`), then let a structured session go idle-dormant and confirm `Stopped { reason: "idle_auto_stop" }` lands in the transcript.
- [ ] Send a prompt to that dormant session from the dashboard. Confirm the agent picks it up and replies, rather than the session sitting on "running" with no output.
- [ ] Check the worker log at `~/.agent-of-empires/acp-workers/<id>.log`: the gap between `waking idle-dormant structured view session` and `resuming session via session/load` should be well under a second, not the ~10s it was before, and a `sending prompt` line must appear.
- [ ] Repeat the dormant-wake prompt a few times in one session. Previously this failed intermittently and often more than once per session.
- [ ] Confirm a normal prompt to a live, already-running session is unaffected and shows no added latency.
- [ ] Confirm no `UserPromptSent` is left behind on a failed wake: if you do manage to hit a `worker_not_ready` 503, the composer should roll the message back and re-queue it rather than leaving a prompt bubble with a spinner that never resolves.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The change is server-side. The client's `503 worker_not_ready` handling already exists and is already covered by `web/src/hooks/useAcpSession.queue.test.ts`.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: a Rust unit test pins this deterministically in 2.4s with no process, sandbox, or agent involved. `wake_prompt_frees_instance_lock_and_publishes_nothing_without_a_worker` in `src/server/api/acp.rs` holds a `ResumeReservation` to make `wait_for_worker` park exactly as it does mid-respawn, then asserts both halves of the bug: that the handler is not sitting on `instance_lock` while it waits, and that a prompt no worker received leaves nothing in the event store. Verified red on the pre-fix tree (`eeabc4d3`) in a throwaway worktree, on both assertions independently: the lock probe fails its 2s budget because the pre-fix handler holds the mutex for the full 10s, and with that assertion neutralised the response is a 404 with `UserPromptSent` already persisted. An e2e would add process and socket nondeterminism without covering anything more.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-investigate` and `/aoe-implement`), with the fix design debated against gemini-3.1-pro-preview and gpt-5.6-sol.

**Any Additional AI Details you'd like to share:**

I hit this bug repeatedly on my own machine and pointed Claude at the session that was stuck. It traced the root cause from the event store and worker logs, found the issue was already filed as #3172, and drafted the fix. I made the scoping calls: A plus the readiness gate over the larger `prepare_turn` / `commit_turn` refactor, and deferring the drain. I reviewed each commit and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents deadlocks when prompts wake idle-dormant sessions.
- Releases `instance_lock` before waiting for the worker.
- Waits for worker readiness before publishing or forwarding prompts.
- Adds `Supervisor::wait_until_ready`.
- Adds regression coverage for lock release and unpublished failed prompts.
- Documents the locking requirements for background resume tasks.

## Benefits

Prompts now reach dormant sessions after the worker starts. Failed wake attempts remain retryable, and the event store does not retain prompts that no worker accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->