### PR TITLE
fix(cli): capture agent_session_id after CLI launch (#3169)

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1179,9 +1179,9 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 let tmux_session = crate::tmux::Session::new(&instance.id, &instance.title)?;
                 tmux_session.attach()?;
 
-                // #3169: the poller ran throughout the attached session but the
-                // CLI never drained it, dropping the observed id on detach. Drain
-                // it now (short bound: it is almost always already queued).
+                // The poller ran throughout the attached session but the CLI
+                // never drained it, dropping the observed id on detach. Drain it
+                // now (short bound: it is almost always already queued).
                 let file_watch = crate::file_watch::FileWatchService::noop();
                 crate::session::sync::capture_launched_session_id_blocking(
                     &mut instance,

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1178,6 +1178,16 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
 
                 let tmux_session = crate::tmux::Session::new(&instance.id, &instance.title)?;
                 tmux_session.attach()?;
+
+                // #3169: the poller ran throughout the attached session but the
+                // CLI never drained it, dropping the observed id on detach. Drain
+                // it now (short bound: it is almost always already queued).
+                let file_watch = crate::file_watch::FileWatchService::noop();
+                crate::session::sync::capture_launched_session_id_blocking(
+                    &mut instance,
+                    &file_watch,
+                    crate::session::sync::CLI_ATTACHED_SESSION_ID_CAPTURE_TIMEOUT,
+                );
             }
             Err(e) => {
                 if let Err(rollback_err) = storage.update(|all_instances, _groups| {

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1187,6 +1187,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                     &mut instance,
                     &file_watch,
                     crate::session::sync::CLI_ATTACHED_SESSION_ID_CAPTURE_TIMEOUT,
+                    true,
                 );
             }
             Err(e) => {

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -752,6 +752,18 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     // so a slow agent startup does not block peer mutators on the same
     // profile (daemon poller, sibling CLI invocations).
     working.start_with_size(crate::terminal::get_size())?;
+
+    // #3169: the CLI has no long-lived loop to drain the just-started session-id
+    // poller, so a capture-deferred agent would exit with agent_session_id unset
+    // and silently lose resume. Wait briefly for the poller and persist via the
+    // same drain the TUI/daemon use.
+    let file_watch = crate::file_watch::FileWatchService::noop();
+    crate::session::sync::capture_launched_session_id_blocking(
+        &mut working,
+        &file_watch,
+        crate::session::sync::CLI_SESSION_ID_CAPTURE_TIMEOUT,
+    );
+
     let title = working.title.clone();
     let id = working.id.clone();
 
@@ -1023,6 +1035,7 @@ async fn import_sessions(profile: &str, args: ImportArgs) -> Result<()> {
 /// do not abort the rest.
 fn launch_imported(profile: &str, ids: &[String]) -> Result<()> {
     let storage = Storage::open_unwatched(profile)?;
+    let file_watch = crate::file_watch::FileWatchService::noop();
     for id in ids {
         let (instances, _groups) = storage.load_with_groups()?;
         let Some(inst) = instances.iter().find(|i| &i.id == id) else {
@@ -1034,6 +1047,12 @@ fn launch_imported(profile: &str, ids: &[String]) -> Result<()> {
             eprintln!("Warning: failed to start {}: {e}", working.title);
             continue;
         }
+        // #3169: persist the poller-observed id before exit (see start_session).
+        crate::session::sync::capture_launched_session_id_blocking(
+            &mut working,
+            &file_watch,
+            crate::session::sync::CLI_SESSION_ID_CAPTURE_TIMEOUT,
+        );
         let wid = working.id.clone();
         storage.update(|instances, _groups| {
             if let Some(stored) = instances.iter_mut().find(|i| i.id == wid) {

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -753,7 +753,7 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     // profile (daemon poller, sibling CLI invocations).
     working.start_with_size(crate::terminal::get_size())?;
 
-    // #3169: the CLI has no long-lived loop to drain the just-started session-id
+    // The CLI has no long-lived loop to drain the just-started session-id
     // poller, so a capture-deferred agent would exit with agent_session_id unset
     // and silently lose resume. Wait briefly for the poller and persist via the
     // same drain the TUI/daemon use.
@@ -1047,7 +1047,7 @@ fn launch_imported(profile: &str, ids: &[String]) -> Result<()> {
             eprintln!("Warning: failed to start {}: {e}", working.title);
             continue;
         }
-        // #3169: persist the poller-observed id before exit (see start_session).
+        // Persist the poller-observed id before exit (see start_session).
         crate::session::sync::capture_launched_session_id_blocking(
             &mut working,
             &file_watch,
@@ -1183,6 +1183,18 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
             let title = inst.title.clone();
             let res = tokio::task::spawn_blocking(move || {
                 let result = inst.restart_with_size(size);
+                // Drain the fresh poller so a fresh-relaunched capture-deferred
+                // agent persists its new agent_session_id. No-op for Resumed /
+                // ResumeFailed. In spawn_blocking: off the runtime, parallel,
+                // bounded by the semaphore.
+                if result.is_ok() {
+                    let file_watch = crate::file_watch::FileWatchService::noop();
+                    crate::session::sync::capture_launched_session_id_blocking(
+                        &mut inst,
+                        &file_watch,
+                        crate::session::sync::CLI_SESSION_ID_CAPTURE_TIMEOUT,
+                    );
+                }
                 (inst, result)
             })
             .await;
@@ -1353,6 +1365,17 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
             }
         }
     }
+
+    // Restart starts a fresh session-id poller; a capture-deferred agent that
+    // relaunches fresh mints a new agent_session_id no CLI loop would drain.
+    // Same drain as `session start`; no-op for Resumed (sid kept) and
+    // ResumeFailed (poller cleared). After the wake wait, so it is usually ready.
+    let file_watch = crate::file_watch::FileWatchService::noop();
+    crate::session::sync::capture_launched_session_id_blocking(
+        &mut working,
+        &file_watch,
+        crate::session::sync::CLI_SESSION_ID_CAPTURE_TIMEOUT,
+    );
 
     // touch_last_accessed runs on `stored`, not `working`: its fields are
     // peer-mutable and do not belong in `merge_post_restart`.

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -748,10 +748,25 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let mut working = inst.clone();
     working.source_profile = profile.to_string();
 
+    // Snapshot the sid for the same reason `restart_session` does: a persisted
+    // `ResumeIntent::Cleared` (from `aoe session set-session-id <id> ""`) makes
+    // `acquire_session_id` drop it on this launch, but the abandoned rollout
+    // lingers and stays newest-by-mtime, so the fresh poller's immediate first
+    // poll can re-observe it and the drain below would silently revert the
+    // user's clear.
+    let prior_sid = working.agent_session_id.clone();
+
     // Phase 2 (unlocked): tmux work happens outside the cross-process flock
     // so a slow agent startup does not block peer mutators on the same
     // profile (daemon poller, sibling CLI invocations).
     working.start_with_size(crate::terminal::get_size())?;
+
+    // Cleared on this launch, so the sid we came in with is abandoned.
+    if working.agent_session_id.is_none() {
+        if let Some(sid) = prior_sid {
+            working.retroactive_capture_excludes.insert(sid);
+        }
+    }
 
     // The CLI has no long-lived loop to drain the just-started session-id
     // poller, so a capture-deferred agent would exit with agent_session_id unset
@@ -1044,9 +1059,17 @@ fn launch_imported(profile: &str, ids: &[String]) -> Result<()> {
         };
         let mut working = inst.clone();
         working.source_profile = profile.to_string();
+        // See `start_session`: a cleared sid whose rollout is still newest on
+        // disk would be re-adopted by the drain below.
+        let prior_sid = working.agent_session_id.clone();
         if let Err(e) = working.start_with_size(crate::terminal::get_size()) {
             eprintln!("Warning: failed to start {}: {e}", working.title);
             continue;
+        }
+        if working.agent_session_id.is_none() {
+            if let Some(sid) = prior_sid {
+                working.retroactive_capture_excludes.insert(sid);
+            }
         }
         // Persist the poller-observed id before exit (see start_session).
         crate::session::sync::capture_launched_session_id_blocking(

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -762,6 +762,7 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         &mut working,
         &file_watch,
         crate::session::sync::CLI_SESSION_ID_CAPTURE_TIMEOUT,
+        true,
     );
 
     let title = working.title.clone();
@@ -1052,6 +1053,7 @@ fn launch_imported(profile: &str, ids: &[String]) -> Result<()> {
             &mut working,
             &file_watch,
             crate::session::sync::CLI_SESSION_ID_CAPTURE_TIMEOUT,
+            true,
         );
         let wid = working.id.clone();
         storage.update(|instances, _groups| {
@@ -1202,6 +1204,7 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
                         &mut inst,
                         &file_watch,
                         crate::session::sync::CLI_SESSION_ID_CAPTURE_TIMEOUT,
+                        false,
                     );
                 }
                 (inst, result)
@@ -1397,6 +1400,7 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         &mut working,
         &file_watch,
         crate::session::sync::CLI_SESSION_ID_CAPTURE_TIMEOUT,
+        true,
     );
 
     // touch_last_accessed runs on `stored`, not `working`: its fields are

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1182,12 +1182,21 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
                 .expect("semaphore not closed");
             let title = inst.title.clone();
             let res = tokio::task::spawn_blocking(move || {
+                let prior_sid = inst.agent_session_id.clone();
                 let result = inst.restart_with_size(size);
                 // Drain the fresh poller so a fresh-relaunched capture-deferred
                 // agent persists its new agent_session_id. No-op for Resumed /
                 // ResumeFailed. In spawn_blocking: off the runtime, parallel,
                 // bounded by the semaphore.
                 if result.is_ok() {
+                    if matches!(
+                        result,
+                        Ok(StartOutcome::Fresh) | Ok(StartOutcome::FreshAfterFailedResume { .. })
+                    ) {
+                        if let Some(sid) = prior_sid {
+                            inst.retroactive_capture_excludes.insert(sid);
+                        }
+                    }
                     let file_watch = crate::file_watch::FileWatchService::noop();
                     crate::session::sync::capture_launched_session_id_blocking(
                         &mut inst,
@@ -1329,6 +1338,11 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let mut working = inst.clone();
     working.source_profile = profile.to_string();
 
+    // Snapshot the sid before `restart_with_size` clears it on a forced-fresh
+    // path: the abandoned rollout lingers and stays newest-by-mtime, so the
+    // fresh poller can re-observe it. Excluded below so the drain rejects it.
+    let prior_sid = working.agent_session_id.clone();
+
     // Phase 2 (unlocked): tmux restart, agent boot, optional wake-up
     // send-keys. Slow; the cross-process flock is not held here so peer
     // mutators on this profile are not starved.
@@ -1370,6 +1384,14 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     // relaunches fresh mints a new agent_session_id no CLI loop would drain.
     // Same drain as `session start`; no-op for Resumed (sid kept) and
     // ResumeFailed (poller cleared). After the wake wait, so it is usually ready.
+    if matches!(
+        outcome,
+        StartOutcome::Fresh | StartOutcome::FreshAfterFailedResume { .. }
+    ) {
+        if let Some(sid) = prior_sid {
+            working.retroactive_capture_excludes.insert(sid);
+        }
+    }
     let file_watch = crate::file_watch::FileWatchService::noop();
     crate::session::sync::capture_launched_session_id_blocking(
         &mut working,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -5952,7 +5952,7 @@ mod tests {
         assert!(inst.last_error_check.is_some());
     }
 
-    /// R2: the poller / serve / ps loops resolve the session's live tmux name
+    /// the poller / serve / ps loops resolve the session's live tmux name
     /// once against the batch snapshot; the status probe must act on that name
     /// instead of resolving the id a second time from the (possibly stale)
     /// title. A live name the title could never derive proves which path ran:

--- a/src/session/sync.rs
+++ b/src/session/sync.rs
@@ -305,8 +305,8 @@ pub(crate) fn capture_launched_session_id_blocking(
         }
         if Instant::now() >= deadline {
             eprintln!(
-                "Note: {} did not report a session id in time; resume stays unavailable until the TUI or `aoe serve` observes it.",
-                inst.tool
+                "Note: session \"{}\" ({}) did not report a session id in time; resume stays unavailable until the TUI or `aoe serve` observes it.",
+                inst.title, inst.tool
             );
             tracing::warn!(
                 target: "session.sync",

--- a/src/session/sync.rs
+++ b/src/session/sync.rs
@@ -16,6 +16,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use crate::file_watch::FileWatchService;
 use crate::session::capture::validated_session_id;
@@ -236,6 +237,64 @@ pub(crate) fn drain_and_persist_session_ids(
         applied: to_apply.into_iter().map(|(id, _)| id).collect(),
         rolled_back: to_rollback.into_iter().map(|r| r.id).collect(),
         filtered: filtered_ids.into_iter().collect(),
+    }
+}
+
+/// Bound for a non-attaching CLI launch (`aoe session start` / import
+/// `--launch`) to wait for its poller. Covers the poller's first few ~2s
+/// ticks (`POLL_INITIAL_INTERVAL`) while keeping the foreground bounded.
+pub(crate) const CLI_SESSION_ID_CAPTURE_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// Bound for `aoe add --launch`, which drains only after `tmux attach`
+/// returns: the poller observed for the whole attached session, so the id is
+/// almost always already queued and this only covers a detach before tick 1.
+pub(crate) const CLI_ATTACHED_SESSION_ID_CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Bounded, blocking post-launch capture of `agent_session_id` for the CLI
+/// one-shot launch paths (#3169).
+///
+/// The TUI event loop and the `aoe serve` daemon drain each instance's
+/// session-id poller on every tick; a bare CLI launch has no such loop, so for
+/// a capture-deferred agent (every resume-capable agent except claude and
+/// preassigned opencode) the poller-observed id was never persisted and
+/// resume/recovery silently broke. `finalize_launch` has already started the
+/// poller by the time this runs, so this simply drives the SAME
+/// [`drain_and_persist_session_ids`] path the TUI/daemon use, on a
+/// single-instance slice, until the id lands or `timeout` elapses.
+///
+/// Returns `true` if `inst` has an `agent_session_id` on return (already had
+/// one, or one was captured+persisted). Instances that already carry an id, or
+/// that run no poller (`ResumeStrategy::Unsupported`, a sandboxed agent whose
+/// container is not up, or a budget-exhausted poller), impose no wait.
+pub(crate) fn capture_launched_session_id_blocking(
+    inst: &mut Instance,
+    file_watch: &Arc<FileWatchService>,
+    timeout: Duration,
+) -> bool {
+    if inst.agent_session_id.is_some() || inst.session_id_poller.is_none() {
+        return inst.agent_session_id.is_some();
+    }
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        // Reuse the fleet drain on a one-element slice: the cross-instance
+        // collision arbitration is a no-op for a single session, and the
+        // authoritative same-cwd guard (`foreign_sid_holder`) runs under the
+        // storage flock inside `persist_session_to_storage` regardless.
+        drain_and_persist_session_ids(std::slice::from_mut(inst), file_watch);
+        if inst.agent_session_id.is_some() {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            tracing::info!(
+                target: "session.sync",
+                instance = %inst.id,
+                tool = %inst.tool,
+                "CLI launch timed out waiting for agent_session_id; capture deferred to the next TUI/daemon drain",
+            );
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(200));
     }
 }
 
@@ -644,5 +703,104 @@ mod tests {
         assert!(outcome.filtered.contains(&instances[1].id));
         assert_eq!(instances[0].agent_session_id, None);
         assert_eq!(instances[1].agent_session_id, None);
+    }
+
+    #[test]
+    #[serial]
+    fn cli_capture_persists_poller_observation_to_disk() {
+        let temp = tempdir().unwrap();
+        let _guard = storage_home_guard(&temp);
+
+        let profile = "sync-cli-capture";
+        let mut inst = Instance::new("cli-capture-title", "/tmp/x");
+        inst.source_profile = profile.to_string();
+        inst.agent_session_id = None;
+        seed_instance_on_disk(profile, &inst);
+
+        let fresh = "019342ab-1234-7def-8901-abcdef012345";
+        attach_poller_with_update(&mut inst, fresh);
+
+        let file_watch = FileWatchService::noop();
+        let captured =
+            capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(2));
+
+        assert!(captured);
+        assert_eq!(inst.agent_session_id.as_deref(), Some(fresh));
+
+        let storage = Storage::new_unwatched(profile).unwrap();
+        let loaded = storage.load().unwrap();
+        assert_eq!(loaded[0].agent_session_id.as_deref(), Some(fresh));
+    }
+
+    #[test]
+    #[serial]
+    fn cli_capture_returns_immediately_when_already_captured() {
+        let temp = tempdir().unwrap();
+        let _guard = storage_home_guard(&temp);
+
+        let mut inst = Instance::new("cli-capture-noop-title", "/tmp/x");
+        inst.source_profile = "sync-cli-noop".to_string();
+        inst.agent_session_id = Some("already-here".to_string());
+
+        let file_watch = FileWatchService::noop();
+        let start = Instant::now();
+        let captured =
+            capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(30));
+
+        assert!(captured);
+        assert!(start.elapsed() < Duration::from_secs(1));
+        assert_eq!(inst.agent_session_id.as_deref(), Some("already-here"));
+    }
+
+    #[test]
+    #[serial]
+    fn cli_capture_returns_immediately_without_a_poller() {
+        let temp = tempdir().unwrap();
+        let _guard = storage_home_guard(&temp);
+
+        let mut inst = Instance::new("cli-capture-nopoller-title", "/tmp/x");
+        inst.source_profile = "sync-cli-nopoller".to_string();
+        inst.agent_session_id = None;
+
+        let file_watch = FileWatchService::noop();
+        let start = Instant::now();
+        let captured =
+            capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(30));
+
+        assert!(!captured);
+        assert!(start.elapsed() < Duration::from_secs(1));
+        assert_eq!(inst.agent_session_id, None);
+    }
+
+    #[test]
+    #[serial]
+    fn cli_capture_waits_for_a_late_poller_observation() {
+        let temp = tempdir().unwrap();
+        let _guard = storage_home_guard(&temp);
+
+        let profile = "sync-cli-late";
+        let mut inst = Instance::new("cli-capture-late-title", "/tmp/x");
+        inst.source_profile = profile.to_string();
+        inst.agent_session_id = None;
+        seed_instance_on_disk(profile, &inst);
+
+        let fresh = "019342ab-1234-7def-8901-abcdef999999";
+        let poller = SessionPoller::new(format!("test-tmux-{}", inst.id));
+        let poller = Arc::new(Mutex::new(poller));
+        inst.session_id_poller = Some(poller.clone());
+
+        let inst_id = inst.id.clone();
+        let injector = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(400));
+            poller.lock().unwrap().inject_test_update(&inst_id, fresh);
+        });
+
+        let file_watch = FileWatchService::noop();
+        let captured =
+            capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(5));
+        injector.join().unwrap();
+
+        assert!(captured);
+        assert_eq!(inst.agent_session_id.as_deref(), Some(fresh));
     }
 }

--- a/src/session/sync.rs
+++ b/src/session/sync.rs
@@ -267,37 +267,55 @@ const CLI_CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(200);
 /// [`drain_and_persist_session_ids`] path the TUI/daemon use, on a
 /// single-instance slice, until the id lands or `timeout` elapses.
 ///
-/// Returns `true` if `inst` has an `agent_session_id` on return (already had
-/// one, or one was captured+persisted). Instances that already carry an id, or
-/// that run no poller (`ResumeStrategy::Unsupported`, a sandboxed agent whose
-/// container is not up, or a budget-exhausted poller), impose no wait.
+/// Instances that already carry an id, or that run no poller
+/// (`ResumeStrategy::Unsupported`, a sandboxed agent whose container is not up,
+/// or a budget-exhausted poller), impose no wait. Called only from CLI
+/// one-shot paths, so it prints its wait/timeout state to stderr.
 pub(crate) fn capture_launched_session_id_blocking(
     inst: &mut Instance,
     file_watch: &Arc<FileWatchService>,
     timeout: Duration,
-) -> bool {
+) {
     if inst.agent_session_id.is_some() || inst.session_id_poller.is_none() {
-        return inst.agent_session_id.is_some();
+        return;
     }
 
-    let deadline = Instant::now() + timeout;
+    let start = Instant::now();
+    let deadline = start + timeout;
+    let mut notified = false;
     loop {
         // Reuse the fleet drain on a one-element slice: the cross-instance
         // collision arbitration is a no-op for a single session, and the
         // authoritative same-cwd guard (`foreign_sid_holder`) runs under the
-        // storage flock inside `persist_session_to_storage` regardless.
-        drain_and_persist_session_ids(std::slice::from_mut(inst), file_watch);
+        // storage flock inside `persist_session_to_storage` regardless. Drain
+        // the whole backlog this tick (while `touched`) so a late correction
+        // already queued behind an earlier observation wins the CAS, bounded
+        // by the deadline so a peer-driven rollback loop cannot spin.
+        while drain_and_persist_session_ids(std::slice::from_mut(inst), file_watch).touched()
+            && Instant::now() < deadline
+        {}
         if inst.agent_session_id.is_some() {
-            return true;
+            return;
         }
         if Instant::now() >= deadline {
+            eprintln!(
+                "Note: {} did not report a session id in time; resume stays unavailable until the TUI or `aoe serve` observes it.",
+                inst.tool
+            );
             tracing::warn!(
                 target: "session.sync",
                 instance = %inst.id,
                 tool = %inst.tool,
                 "CLI launch timed out waiting for agent_session_id; resume stays unavailable until a TUI or daemon re-observes it via its own poller",
             );
-            return false;
+            return;
+        }
+        if !notified && start.elapsed() >= Duration::from_secs(1) {
+            eprintln!(
+                "Waiting for {} to report its session id (Ctrl-C to skip)…",
+                inst.tool
+            );
+            notified = true;
         }
         std::thread::sleep(CLI_CAPTURE_POLL_INTERVAL);
     }
@@ -726,10 +744,8 @@ mod tests {
         attach_poller_with_update(&mut inst, fresh);
 
         let file_watch = FileWatchService::noop();
-        let captured =
-            capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(2));
+        capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(2));
 
-        assert!(captured);
         assert_eq!(inst.agent_session_id.as_deref(), Some(fresh));
 
         let storage = Storage::new_unwatched(profile).unwrap();
@@ -749,10 +765,8 @@ mod tests {
 
         let file_watch = FileWatchService::noop();
         let start = Instant::now();
-        let captured =
-            capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(30));
+        capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(30));
 
-        assert!(captured);
         assert!(start.elapsed() < Duration::from_secs(1));
         assert_eq!(inst.agent_session_id.as_deref(), Some("already-here"));
     }
@@ -769,10 +783,8 @@ mod tests {
 
         let file_watch = FileWatchService::noop();
         let start = Instant::now();
-        let captured =
-            capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(30));
+        capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(30));
 
-        assert!(!captured);
         assert!(start.elapsed() < Duration::from_secs(1));
         assert_eq!(inst.agent_session_id, None);
     }
@@ -801,11 +813,34 @@ mod tests {
         });
 
         let file_watch = FileWatchService::noop();
-        let captured =
-            capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(5));
+        capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(5));
         injector.join().unwrap();
 
-        assert!(captured);
         assert_eq!(inst.agent_session_id.as_deref(), Some(fresh));
+    }
+
+    #[test]
+    #[serial]
+    fn cli_capture_prefers_newest_of_multiple_queued_observations() {
+        let temp = tempdir().unwrap();
+        let _guard = storage_home_guard(&temp);
+
+        let profile = "sync-cli-newest";
+        let mut inst = Instance::new("cli-capture-newest-title", "/tmp/x");
+        inst.source_profile = profile.to_string();
+        inst.agent_session_id = None;
+        seed_instance_on_disk(profile, &inst);
+
+        let older = "019342ab-1234-7def-8901-aaaaaaaaaaaa";
+        let newer = "019342ab-1234-7def-8901-bbbbbbbbbbbb";
+        let poller = SessionPoller::new(format!("test-tmux-{}", inst.id));
+        poller.inject_test_update(&inst.id, older);
+        poller.inject_test_update(&inst.id, newer);
+        inst.session_id_poller = Some(Arc::new(Mutex::new(poller)));
+
+        let file_watch = FileWatchService::noop();
+        capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(2));
+
+        assert_eq!(inst.agent_session_id.as_deref(), Some(newer));
     }
 }

--- a/src/session/sync.rs
+++ b/src/session/sync.rs
@@ -256,7 +256,7 @@ pub(crate) const CLI_ATTACHED_SESSION_ID_CAPTURE_TIMEOUT: Duration = Duration::f
 const CLI_CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 /// Bounded, blocking post-launch capture of `agent_session_id` for the CLI
-/// one-shot launch paths (#3169).
+/// one-shot launch paths.
 ///
 /// The TUI event loop and the `aoe serve` daemon drain each instance's
 /// session-id poller on every tick; a bare CLI launch has no such loop, so for

--- a/src/session/sync.rs
+++ b/src/session/sync.rs
@@ -318,8 +318,13 @@ pub(crate) fn capture_launched_session_id_blocking(
             return;
         }
         if notify && !notified && start.elapsed() >= Duration::from_secs(1) {
+            // Deliberately does not offer Ctrl-C as a way out. In the CLI start
+            // and restart paths this wait sits between the tmux launch and the
+            // phase-3 storage merge, so interrupting here leaves the pane
+            // running with the row never merged. The session is already up;
+            // only the resume id is still pending.
             eprintln!(
-                "Waiting for {} to report its session id (Ctrl-C to skip)…",
+                "{} is up; waiting for it to report its session id…",
                 inst.tool
             );
             notified = true;

--- a/src/session/sync.rs
+++ b/src/session/sync.rs
@@ -304,9 +304,10 @@ pub(crate) fn capture_launched_session_id_blocking(
             return;
         }
         if Instant::now() >= deadline {
+            let title: String = inst.title.chars().filter(|c| !c.is_control()).collect();
             eprintln!(
                 "Note: session \"{}\" ({}) did not report a session id in time; resume stays unavailable until the TUI or `aoe serve` observes it.",
-                inst.title, inst.tool
+                title, inst.tool
             );
             tracing::warn!(
                 target: "session.sync",

--- a/src/session/sync.rs
+++ b/src/session/sync.rs
@@ -270,11 +270,15 @@ const CLI_CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(200);
 /// Instances that already carry an id, or that run no poller
 /// (`ResumeStrategy::Unsupported`, a sandboxed agent whose container is not up,
 /// or a budget-exhausted poller), impose no wait. Called only from CLI
-/// one-shot paths, so it prints its wait/timeout state to stderr.
+/// one-shot paths. When `notify` is set it prints a one-line "waiting" notice
+/// to stderr once it has actually waited ~1s; the parallel `restart --all`
+/// workers pass `false` so their concurrent waits do not interleave that line.
+/// The timeout note is always printed.
 pub(crate) fn capture_launched_session_id_blocking(
     inst: &mut Instance,
     file_watch: &Arc<FileWatchService>,
     timeout: Duration,
+    notify: bool,
 ) {
     if inst.agent_session_id.is_some() || inst.session_id_poller.is_none() {
         return;
@@ -289,8 +293,10 @@ pub(crate) fn capture_launched_session_id_blocking(
         // authoritative same-cwd guard (`foreign_sid_holder`) runs under the
         // storage flock inside `persist_session_to_storage` regardless. Drain
         // the whole backlog this tick (while `touched`) so a late correction
-        // already queued behind an earlier observation wins the CAS, bounded
-        // by the deadline so a peer-driven rollback loop cannot spin.
+        // already queued behind an earlier observation wins the CAS. The loop
+        // cannot run past the deadline, and each pass consumes one queued
+        // observation (the poller only enqueues on change, ~2s apart), so it
+        // cannot spin unbounded.
         while drain_and_persist_session_ids(std::slice::from_mut(inst), file_watch).touched()
             && Instant::now() < deadline
         {}
@@ -310,7 +316,7 @@ pub(crate) fn capture_launched_session_id_blocking(
             );
             return;
         }
-        if !notified && start.elapsed() >= Duration::from_secs(1) {
+        if notify && !notified && start.elapsed() >= Duration::from_secs(1) {
             eprintln!(
                 "Waiting for {} to report its session id (Ctrl-C to skip)…",
                 inst.tool
@@ -744,7 +750,7 @@ mod tests {
         attach_poller_with_update(&mut inst, fresh);
 
         let file_watch = FileWatchService::noop();
-        capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(2));
+        capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(2), false);
 
         assert_eq!(inst.agent_session_id.as_deref(), Some(fresh));
 
@@ -765,7 +771,12 @@ mod tests {
 
         let file_watch = FileWatchService::noop();
         let start = Instant::now();
-        capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(30));
+        capture_launched_session_id_blocking(
+            &mut inst,
+            &file_watch,
+            Duration::from_secs(30),
+            false,
+        );
 
         assert!(start.elapsed() < Duration::from_secs(1));
         assert_eq!(inst.agent_session_id.as_deref(), Some("already-here"));
@@ -783,7 +794,12 @@ mod tests {
 
         let file_watch = FileWatchService::noop();
         let start = Instant::now();
-        capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(30));
+        capture_launched_session_id_blocking(
+            &mut inst,
+            &file_watch,
+            Duration::from_secs(30),
+            false,
+        );
 
         assert!(start.elapsed() < Duration::from_secs(1));
         assert_eq!(inst.agent_session_id, None);
@@ -813,7 +829,7 @@ mod tests {
         });
 
         let file_watch = FileWatchService::noop();
-        capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(5));
+        capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(5), false);
         injector.join().unwrap();
 
         assert_eq!(inst.agent_session_id.as_deref(), Some(fresh));
@@ -839,7 +855,7 @@ mod tests {
         inst.session_id_poller = Some(Arc::new(Mutex::new(poller)));
 
         let file_watch = FileWatchService::noop();
-        capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(2));
+        capture_launched_session_id_blocking(&mut inst, &file_watch, Duration::from_secs(2), false);
 
         assert_eq!(inst.agent_session_id.as_deref(), Some(newer));
     }

--- a/src/session/sync.rs
+++ b/src/session/sync.rs
@@ -250,6 +250,11 @@ pub(crate) const CLI_SESSION_ID_CAPTURE_TIMEOUT: Duration = Duration::from_secs(
 /// almost always already queued and this only covers a detach before tick 1.
 pub(crate) const CLI_ATTACHED_SESSION_ID_CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// How often the bounded CLI capture re-drains the poller while waiting. Short
+/// enough to land the id promptly once the poller observes it, coarse enough
+/// not to busy-spin the storage flock between the poller's ~2s ticks.
+const CLI_CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
 /// Bounded, blocking post-launch capture of `agent_session_id` for the CLI
 /// one-shot launch paths (#3169).
 ///
@@ -286,15 +291,15 @@ pub(crate) fn capture_launched_session_id_blocking(
             return true;
         }
         if Instant::now() >= deadline {
-            tracing::info!(
+            tracing::warn!(
                 target: "session.sync",
                 instance = %inst.id,
                 tool = %inst.tool,
-                "CLI launch timed out waiting for agent_session_id; capture deferred to the next TUI/daemon drain",
+                "CLI launch timed out waiting for agent_session_id; resume stays unavailable until a TUI or daemon re-observes it via its own poller",
             );
             return false;
         }
-        std::thread::sleep(Duration::from_millis(200));
+        std::thread::sleep(CLI_CAPTURE_POLL_INTERVAL);
     }
 }
 

--- a/tests/e2e/cli_session_id_capture.rs
+++ b/tests/e2e/cli_session_id_capture.rs
@@ -1,5 +1,5 @@
 //! E2E: a CLI-launched, capture-deferred agent must persist
-//! `agent_session_id` with no `aoe serve` daemon and no TUI running (#3169).
+//! `agent_session_id` with no `aoe serve` daemon and no TUI running.
 //!
 //! Uses a fake `codex` (a capture-deferred agent) that, on launch, writes a
 //! rollout file the codex poller scans, then idles so its tmux pane stays
@@ -70,11 +70,12 @@ fn install_fake_codex(h: &mut TuiTestHarness, codex_home: &Path, project: &Path)
 
 struct StopSessionOnDrop<'a> {
     h: &'a TuiTestHarness,
+    title: &'a str,
 }
 
 impl Drop for StopSessionOnDrop<'_> {
     fn drop(&mut self) {
-        let _ = self.h.run_cli(&["session", "stop", TITLE]);
+        let _ = self.h.run_cli(&["session", "stop", self.title]);
     }
 }
 
@@ -102,7 +103,10 @@ fn cli_session_start_persists_agent_session_id_without_daemon() {
         "agent_session_id must be unset before launch"
     );
 
-    let _stop = StopSessionOnDrop { h: &h };
+    let _stop = StopSessionOnDrop {
+        h: &h,
+        title: TITLE,
+    };
     let start = h.run_cli(&["session", "start", TITLE]);
     assert!(
         start.status.success(),
@@ -113,7 +117,113 @@ fn cli_session_start_persists_agent_session_id_without_daemon() {
     assert_eq!(
         agent_session_id(&h, TITLE).as_deref(),
         Some(FAKE_SID),
-        "#3169: CLI launch must drain the poller and persist agent_session_id \
+        "CLI launch must drain the poller and persist agent_session_id \
          without a daemon or TUI"
+    );
+}
+
+const RESTART_TITLE: &str = "CliSidRestartE2E";
+const RESTART_SID_FIRST: &str = "019342ab-1234-7def-8901-aaaaaaaaaaaa";
+const RESTART_SID_SECOND: &str = "019342ab-1234-7def-8901-bbbbbbbbbbbb";
+
+/// Fake codex that mints `RESTART_SID_FIRST` on its first launch and
+/// `RESTART_SID_SECOND` on every launch after (tracked by a marker file). The
+/// second rollout carries a strictly later filename timestamp so the codex
+/// poller ranks it as the newest rollout for this cwd regardless of whether it
+/// sorts by mtime or by the name-embedded date.
+fn install_toggling_fake_codex(h: &mut TuiTestHarness, codex_home: &Path, project: &Path) {
+    let bin = h.install_path_command("codex");
+    let sessions_dir = codex_home.join("sessions");
+    let marker = codex_home.join(".launched");
+    let rollout_first = sessions_dir.join(format!(
+        "rollout-2025-01-01T00-00-00-{RESTART_SID_FIRST}.jsonl"
+    ));
+    let rollout_second = sessions_dir.join(format!(
+        "rollout-2025-01-02T00-00-00-{RESTART_SID_SECOND}.jsonl"
+    ));
+    let script = format!(
+        "#!/bin/sh\nmkdir -p {dir}\nif [ -f {marker} ]; then\n  \
+         printf '{{\"payload\":{{\"cwd\":\"%s\"}}}}\\n' {cwd} > {second}\nelse\n  \
+         : > {marker}\n  printf '{{\"payload\":{{\"cwd\":\"%s\"}}}}\\n' {cwd} > {first}\nfi\n\
+         exec sleep 300\n",
+        dir = sh_quote(&sessions_dir),
+        marker = sh_quote(&marker),
+        cwd = sh_quote(project),
+        first = sh_quote(&rollout_first),
+        second = sh_quote(&rollout_second),
+    );
+    let script_path = bin.join("codex");
+    fs::write(&script_path, script).expect("write fake codex");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod codex");
+    }
+}
+
+/// Force `session restart` down the fresh-launch path (no `--resume <sid>`), so
+/// the restarted agent mints a new capture-deferred sid the restart path must
+/// drain. Without this the restart resumes the existing sid and never observes
+/// a new one, so it could not distinguish the fix from its absence.
+fn disable_auto_resume_on_restart(h: &TuiTestHarness) {
+    let config = app_dir_in(h.home_path()).join("config.toml");
+    let mut content = fs::read_to_string(&config).unwrap_or_default();
+    content.push_str("\n[session]\nauto_resume_on_restart = false\n");
+    fs::write(&config, content).expect("write config.toml");
+}
+
+#[test]
+#[serial]
+fn cli_session_restart_persists_new_agent_session_id_without_daemon() {
+    require_tmux!();
+    let mut h = new_harness("cli_sid_restart");
+    let project = h.project_path();
+    let codex_home = h.home_path().join("codex-home");
+    fs::create_dir_all(&codex_home).expect("create codex home");
+    h.set_env("CODEX_HOME", codex_home.to_str().expect("utf8 codex home"));
+    install_toggling_fake_codex(&mut h, &codex_home, &project);
+    disable_auto_resume_on_restart(&h);
+
+    let add = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-c",
+        "codex",
+        "-t",
+        RESTART_TITLE,
+    ]);
+    assert!(
+        add.status.success(),
+        "add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    let _stop = StopSessionOnDrop {
+        h: &h,
+        title: RESTART_TITLE,
+    };
+    let start = h.run_cli(&["session", "start", RESTART_TITLE]);
+    assert!(
+        start.status.success(),
+        "start failed: {}",
+        String::from_utf8_lossy(&start.stderr)
+    );
+    assert_eq!(
+        agent_session_id(&h, RESTART_TITLE).as_deref(),
+        Some(RESTART_SID_FIRST),
+        "start must capture the first sid"
+    );
+
+    let restart = h.run_cli(&["session", "restart", RESTART_TITLE]);
+    assert!(
+        restart.status.success(),
+        "restart failed: {}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    assert_eq!(
+        agent_session_id(&h, RESTART_TITLE).as_deref(),
+        Some(RESTART_SID_SECOND),
+        "`session restart` must drain the fresh poller and persist the new \
+         agent_session_id without a daemon or TUI"
     );
 }

--- a/tests/e2e/cli_session_id_capture.rs
+++ b/tests/e2e/cli_session_id_capture.rs
@@ -1,0 +1,119 @@
+//! E2E: a CLI-launched, capture-deferred agent must persist
+//! `agent_session_id` with no `aoe serve` daemon and no TUI running (#3169).
+//!
+//! Uses a fake `codex` (a capture-deferred agent) that, on launch, writes a
+//! rollout file the codex poller scans, then idles so its tmux pane stays
+//! alive. Before the fix, `aoe session start` returned before draining the
+//! poller, so the observed id was dropped and `sessions.json` kept
+//! `agent_session_id: null`, silently breaking resume.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use serial_test::serial;
+
+use crate::harness::{app_dir_in, require_tmux, TuiTestHarness};
+
+const TITLE: &str = "CliSidCaptureE2E";
+const FAKE_SID: &str = "019342ab-1234-7def-8901-abcdef012345";
+
+fn new_harness(name: &str) -> TuiTestHarness {
+    #[cfg(unix)]
+    {
+        TuiTestHarness::new_in_tmp(name)
+    }
+    #[cfg(not(unix))]
+    {
+        TuiTestHarness::new(name)
+    }
+}
+
+fn sessions_path(h: &TuiTestHarness) -> PathBuf {
+    app_dir_in(h.home_path()).join("profiles/default/sessions.json")
+}
+
+fn agent_session_id(h: &TuiTestHarness, title: &str) -> Option<String> {
+    let content = fs::read_to_string(sessions_path(h)).ok()?;
+    let sessions: Value = serde_json::from_str(&content).ok()?;
+    sessions
+        .as_array()?
+        .iter()
+        .find(|s| s["title"].as_str() == Some(title))?
+        .get("agent_session_id")?
+        .as_str()
+        .map(str::to_owned)
+}
+
+fn sh_quote(path: &Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
+}
+
+fn install_fake_codex(h: &mut TuiTestHarness, codex_home: &Path, project: &Path) {
+    let bin = h.install_path_command("codex");
+    let sessions_dir = codex_home.join("sessions");
+    let rollout = sessions_dir.join(format!("rollout-2025-01-01T00-00-00-{FAKE_SID}.jsonl"));
+    let script = format!(
+        "#!/bin/sh\nmkdir -p {dir}\nprintf '{{\"payload\":{{\"cwd\":\"%s\"}}}}\\n' {cwd} > {file}\nexec sleep 300\n",
+        dir = sh_quote(&sessions_dir),
+        cwd = sh_quote(project),
+        file = sh_quote(&rollout),
+    );
+    let script_path = bin.join("codex");
+    fs::write(&script_path, script).expect("write fake codex");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).expect("chmod codex");
+    }
+}
+
+struct StopSessionOnDrop<'a> {
+    h: &'a TuiTestHarness,
+}
+
+impl Drop for StopSessionOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.h.run_cli(&["session", "stop", TITLE]);
+    }
+}
+
+#[test]
+#[serial]
+fn cli_session_start_persists_agent_session_id_without_daemon() {
+    require_tmux!();
+    let mut h = new_harness("cli_sid_capture");
+    let project = h.project_path();
+    let codex_home = h.home_path().join("codex-home");
+    fs::create_dir_all(&codex_home).expect("create codex home");
+    h.set_env("CODEX_HOME", codex_home.to_str().expect("utf8 codex home"));
+    install_fake_codex(&mut h, &codex_home, &project);
+
+    let add = h.run_cli(&["add", project.to_str().unwrap(), "-c", "codex", "-t", TITLE]);
+    assert!(
+        add.status.success(),
+        "add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    assert_eq!(
+        agent_session_id(&h, TITLE),
+        None,
+        "agent_session_id must be unset before launch"
+    );
+
+    let _stop = StopSessionOnDrop { h: &h };
+    let start = h.run_cli(&["session", "start", TITLE]);
+    assert!(
+        start.status.success(),
+        "start failed: {}",
+        String::from_utf8_lossy(&start.stderr)
+    );
+
+    assert_eq!(
+        agent_session_id(&h, TITLE).as_deref(),
+        Some(FAKE_SID),
+        "#3169: CLI launch must drain the poller and persist agent_session_id \
+         without a daemon or TUI"
+    );
+}

--- a/tests/e2e/cli_session_id_capture.rs
+++ b/tests/e2e/cli_session_id_capture.rs
@@ -128,8 +128,12 @@ const RESTART_SID_SECOND: &str = "019342ab-1234-7def-8901-bbbbbbbbbbbb";
 
 /// Fake codex that mints `RESTART_SID_FIRST` on its first launch and
 /// `RESTART_SID_SECOND` on every launch after (tracked by a marker file). The
-/// codex poller picks the newest rollout by mtime; the second rollout is
-/// written later, on restart, so its mtime is strictly newer and it wins.
+/// codex poller picks the newest rollout by mtime. On restart the second
+/// rollout is written after a 1s delay, so the freshly-started poller's
+/// immediate first poll sees only the lingering first rollout: without the
+/// forced-fresh exclusion the restart drain would capture and persist the
+/// stale `RESTART_SID_FIRST` and stop waiting; the exclusion makes it reject
+/// that and wait for the second rollout, which lands well inside the bound.
 fn install_toggling_fake_codex(h: &mut TuiTestHarness, codex_home: &Path, project: &Path) {
     let bin = h.install_path_command("codex");
     let sessions_dir = codex_home.join("sessions");
@@ -141,7 +145,7 @@ fn install_toggling_fake_codex(h: &mut TuiTestHarness, codex_home: &Path, projec
         "rollout-2025-01-02T00-00-00-{RESTART_SID_SECOND}.jsonl"
     ));
     let script = format!(
-        "#!/bin/sh\nmkdir -p {dir}\nif [ -f {marker} ]; then\n  \
+        "#!/bin/sh\nmkdir -p {dir}\nif [ -f {marker} ]; then\n  sleep 1\n  \
          printf '{{\"payload\":{{\"cwd\":\"%s\"}}}}\\n' {cwd} > {second}\nelse\n  \
          : > {marker}\n  printf '{{\"payload\":{{\"cwd\":\"%s\"}}}}\\n' {cwd} > {first}\nfi\n\
          exec sleep 300\n",
@@ -164,11 +168,28 @@ fn install_toggling_fake_codex(h: &mut TuiTestHarness, codex_home: &Path, projec
 /// the restarted agent mints a new capture-deferred sid the restart path must
 /// drain. Without this the restart resumes the existing sid and never observes
 /// a new one, so it could not distinguish the fix from its absence.
-fn disable_auto_resume_on_restart(h: &TuiTestHarness) {
+/// Force `session restart` down the fresh-launch path (no `--resume <sid>`), so
+/// the restarted agent mints a new capture-deferred sid the restart path must
+/// drain. Without `auto_resume_on_restart = false` the restart resumes the
+/// existing sid and never observes a new one.
+///
+/// Also blanks `restart_wake_message`, which removes the pre-capture
+/// `wait_for_pane_ready` wake wait. Without that, the capture helper drains the
+/// fresh poller immediately after relaunch, while only the lingering first
+/// rollout exists (the second is written 1s later), so the forced-fresh
+/// exclusion is load-bearing: without it the drain persists the stale
+/// `RESTART_SID_FIRST` and returns. With the wake wait in place the poller
+/// would observe both rollouts before the drain and pick the newest anyway,
+/// masking the exclusion.
+fn configure_fresh_restart_capture(h: &TuiTestHarness) {
     let config = app_dir_in(h.home_path()).join("config.toml");
-    let mut content = fs::read_to_string(&config).unwrap_or_default();
-    content.push_str("\n[session]\nauto_resume_on_restart = false\n");
-    fs::write(&config, content).expect("write config.toml");
+    let mut doc = fs::read_to_string(&config)
+        .unwrap_or_default()
+        .parse::<toml_edit::DocumentMut>()
+        .expect("parse config.toml");
+    doc["session"]["auto_resume_on_restart"] = toml_edit::value(false);
+    doc["session"]["restart_wake_message"] = toml_edit::value("");
+    fs::write(&config, doc.to_string()).expect("write config.toml");
 }
 
 #[test]
@@ -181,7 +202,7 @@ fn cli_session_restart_persists_new_agent_session_id_without_daemon() {
     fs::create_dir_all(&codex_home).expect("create codex home");
     h.set_env("CODEX_HOME", codex_home.to_str().expect("utf8 codex home"));
     install_toggling_fake_codex(&mut h, &codex_home, &project);
-    disable_auto_resume_on_restart(&h);
+    configure_fresh_restart_capture(&h);
 
     let add = h.run_cli(&[
         "add",

--- a/tests/e2e/cli_session_id_capture.rs
+++ b/tests/e2e/cli_session_id_capture.rs
@@ -166,10 +166,6 @@ fn install_toggling_fake_codex(h: &mut TuiTestHarness, codex_home: &Path, projec
 
 /// Force `session restart` down the fresh-launch path (no `--resume <sid>`), so
 /// the restarted agent mints a new capture-deferred sid the restart path must
-/// drain. Without this the restart resumes the existing sid and never observes
-/// a new one, so it could not distinguish the fix from its absence.
-/// Force `session restart` down the fresh-launch path (no `--resume <sid>`), so
-/// the restarted agent mints a new capture-deferred sid the restart path must
 /// drain. Without `auto_resume_on_restart = false` the restart resumes the
 /// existing sid and never observes a new one.
 ///

--- a/tests/e2e/cli_session_id_capture.rs
+++ b/tests/e2e/cli_session_id_capture.rs
@@ -11,7 +11,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
-use serial_test::serial;
+use serial_test::parallel;
 
 use crate::harness::{app_dir_in, require_tmux, TuiTestHarness};
 
@@ -80,7 +80,7 @@ impl Drop for StopSessionOnDrop<'_> {
 }
 
 #[test]
-#[serial]
+#[parallel]
 fn cli_session_start_persists_agent_session_id_without_daemon() {
     require_tmux!();
     let mut h = new_harness("cli_sid_capture");
@@ -193,7 +193,7 @@ fn configure_fresh_restart_capture(h: &TuiTestHarness) {
 }
 
 #[test]
-#[serial]
+#[parallel]
 fn cli_session_restart_persists_new_agent_session_id_without_daemon() {
     require_tmux!();
     let mut h = new_harness("cli_sid_restart");

--- a/tests/e2e/cli_session_id_capture.rs
+++ b/tests/e2e/cli_session_id_capture.rs
@@ -128,9 +128,8 @@ const RESTART_SID_SECOND: &str = "019342ab-1234-7def-8901-bbbbbbbbbbbb";
 
 /// Fake codex that mints `RESTART_SID_FIRST` on its first launch and
 /// `RESTART_SID_SECOND` on every launch after (tracked by a marker file). The
-/// second rollout carries a strictly later filename timestamp so the codex
-/// poller ranks it as the newest rollout for this cwd regardless of whether it
-/// sorts by mtime or by the name-embedded date.
+/// codex poller picks the newest rollout by mtime; the second rollout is
+/// written later, on restart, so its mtime is strictly newer and it wins.
 fn install_toggling_fake_codex(h: &mut TuiTestHarness, codex_home: &Path, project: &Path) {
     let bin = h.install_path_command("codex");
     let sessions_dir = codex_home.join("sessions");

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -26,6 +26,7 @@ mod archive_restore;
 mod archive_structured;
 mod claude_shared_project_correlation_e2e;
 mod cli;
+mod cli_session_id_capture;
 mod command_palette;
 mod errors;
 mod filewatch_config_malformed;


### PR DESCRIPTION
## Description

Fixes #3169.

A session launched purely through the CLI never persisted `agent_session_id` for **capture-deferred agents** (every resume-capable agent except `claude` and preassigned-`opencode`) as long as no `aoe serve` daemon and no TUI were running. Resume, resume-after-reboot, and `--resume` continuity then silently broke for those sessions, with no error surfaced.

### Root cause (verified in code)

- `agent_session_id` is set at launch by `Instance::acquire_session_id` -> `fresh_launch_session_id` (`src/session/instance.rs`): `claude` pre-mints a UUID, `opencode` optionally preassigns (off by default), **every other agent returns `None`** and is captured post-launch.
- That post-launch capture is done by the per-instance `session_id_poller`, started in `finalize_launch` (`src/session/instance.rs`). The poller only accumulates the observation on an in-memory mpsc channel; its `on_change` is log-only.
- Persisting the observation requires an external drain, `drain_and_persist_session_ids` (`src/session/sync.rs`), which is invoked **only** by the TUI event loop (`src/tui/home/mod.rs`) and the `aoe serve` daemon (`drain_session_id_updates_in_state`, `src/server/mod.rs`).
- **No CLI path drained it.** Four one-shot CLI launch surfaces start (or restart) the poller and exit without draining: `aoe session start`, `aoe session import --launch`, `aoe add --launch`, and `aoe session restart` (single and `--all`). `session start` returns before the poller's first (~2s) tick; `add --launch` blocks on `tmux attach` while nothing reads the channel; `restart` re-execs the agent, starting a fresh poller, then merges without draining.
- Impact: `is_recovery_candidate` (`src/session/recovery.rs`) requires `should_attempt_resume(agent_session_id, tool)`, which is false for an empty id, so resume/recovery/`--resume` never fired for these sessions.

### Evidence (before/after)

Two e2e regressions in `tests/e2e/cli_session_id_capture.rs`, each with no daemon/TUI and a fake capture-deferred `codex`:

- `session start`: **before**, `sessions.json` keeps `agent_session_id: null` (test asserts `None`, fails); **after**, the id is persisted before the CLI exits (passes).
- `session restart` (with `auto_resume_on_restart = false` forcing a fresh relaunch, and a toggling fake codex minting a second sid): **before**, restart leaves `agent_session_id` unset (`left: None`); **after**, the new sid is persisted (`Some(...)`). Verified locally: red before the restart change, green after.

### Fix

Add `capture_launched_session_id_blocking` in `src/session/sync.rs`: a bounded wait that reuses the **same** `drain_and_persist_session_ids` CAS path the TUI/daemon use (no parallel persistence logic), and call it from every CLI launch site before the process exits:

- `aoe session start` and `aoe session import --launch`: wait after `start_with_size`, bounded by `CLI_SESSION_ID_CAPTURE_TIMEOUT` (8s), exiting as soon as the id lands.
- `aoe add --launch`: drain after `tmux attach` returns, with a short bound (`CLI_ATTACHED_SESSION_ID_CAPTURE_TIMEOUT`, 2s) since the poller has already been observing throughout the attached session.
- `aoe session restart` (single and `--all`): drain after the relaunch (single: after the wake wait; `--all`: inside each worker's `spawn_blocking`, parallel and bounded by the `--all` semaphore), 8s bound. `merge_post_restart` is left untouched; the drain persists directly and phase 3 preserves it.

The helper is a no-op (zero added latency) for sessions that already have an id (`claude`, preassigned-`opencode`, and `restart` outcomes `Resumed`) or that run no poller (`ResumeStrategy::Unsupported`: `cursor`/`droid`/`settl`/`antigravity`; sandboxed agents with no container; `restart` outcome `ResumeFailed`, which clears the poller).

### Risks / limitations

- `aoe session start` and `aoe session restart` for a capture-deferred agent now block up to 8s (typically ~2s, or near-zero on restart since the wake wait already overlaps the poller; exits early on capture). Correctness of resume is worth the bounded wait.
 - `aoe session import --launch` applies the 8s bound **per launched session, serially**, so importing N slow-to-emit sessions can add up to N×8s in the foreground. Bounded and best-effort (a session that never emits within the window is still captured by the next TUI/daemon poller). Parallelization was not retained: it would duplicate the `--all` JoinSet/semaphore machinery for a cold path where the worst case only occurs if the agent writes no transcript at all.
 - `aoe session restart --all` runs the same 8s bounded capture inside each worker's `spawn_blocking`, parallelized under the `--parallel` semaphore (default 3), so M capture-deferred sessions that never emit cost at most ⌈M/parallel⌉×8s in the foreground rather than M×8s. Bounded and best-effort like the import path (each is still captured by the next TUI/daemon drain). Not short-circuited on a dead pane: the cost comes from a freshly relaunched pane that is alive but has not yet written a session id, which within a finite bound is indistinguishable from one about to; a liveness check would not help, and coupling the protocol-agnostic drain helper to tmux was rejected on review. Raise `--parallel` to amortize a large fan-out.
 - The single CLI paths (`session start`, `session restart`) run the bounded capture on the runtime thread, consistent with the already-inline `start_with_size`; acceptable for a one-shot command with no concurrent work. `restart --all` runs it inside `spawn_blocking`.
- `aoe add --launch` can still miss capture if the user kills the terminal without detaching (the process dies before the post-attach drain); it then spins the 2s bound to no effect. Unfixable without a daemon and out of scope; the id is still captured on the next TUI/`aoe serve` drain.
- On timeout the helper logs at `warn` and the message no longer implies a pending in-memory drain: the CLI poller thread dies on exit, so recovery depends on a future TUI/daemon re-observing the id via its own poller.
- No change to the TUI/daemon drain path or to `drain_and_persist_session_ids` itself; concurrent daemon/CLI drains stay race-safe via the existing CAS + flock-scoped `foreign_sid_holder` guard (also true for the parallel `restart --all` workers, which each write a distinct instance under the flock).

Also drops an internal `R2:` label from a test doc comment in `src/session/instance.rs` (separate commit; the label referenced nothing in the code).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

Added `tests/e2e/cli_session_id_capture.rs` with two e2e tests (fake capture-deferred agent, no daemon/TUI): one asserts `aoe session start` persists `agent_session_id`, the other asserts `aoe session restart` persists the new id after a forced fresh relaunch. Plus 4 in-module unit tests in `src/session/sync.rs` locking the wait/drain/persist behaviour of `capture_launched_session_id_blocking` (persist-to-disk, already-captured fast path, no-poller fast path, late-observation wait).

**Coverage scope, stated honestly:** the e2e exercises the `aoe session start` and `aoe session restart` launch sites end-to-end. The `aoe add --launch` and `aoe session import --launch` sites call the **same** unit-tested helper (only the timeout constant / parallelism differs); their post-`tmux attach` / per-item wiring is not exercised by a dedicated e2e, since driving an interactive `tmux attach` in the harness is impractical and prone to flakiness.

Validated locally: `cargo fmt --check`, `cargo clippy --all-targets --features e2e-tests` (no new warnings; pre-existing `useless_vec`/`dead_code` warnings are outside this diff), `cargo test --lib session::sync` (12 pass), `cargo test --features e2e-tests --test e2e cli_session_id_capture` (2 pass; restart test verified red before the restart change), and `cargo check --features serve`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via opencode)

**Any Additional AI Details you'd like to share:**
Root-cause investigation, design, and implementation were AI-assisted under my direction and cross-checked by independent review passes; every claim above is code-referenced and the fix is locked by regression e2e tests that fail before the change and pass after. I have reviewed and understand every line.

- [x] I am an AI Agent filling out this form (check box if true)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added bounded session ID capture for CLI-launched sessions.
- Applied capture to session start, session import, add, and restart flows.
- Added timeout notices for delayed capture during parallel restarts.
- Sanitized control characters in capture-timeout notes.
- Added unit and end-to-end tests for session ID persistence.
- Removed an obsolete test comment label.

## Benefits

CLI-launched sessions now persist session IDs without `aoe serve` or the TUI. This restores resume and recovery behavior while keeping capture waits bounded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->