### PR TITLE
feat(acp): add Atlas Cloud model provider

### DIFF
--- a/acp-worker/aoe-agent/src/index.ts
+++ b/acp-worker/aoe-agent/src/index.ts
@@ -17,10 +17,8 @@
 import * as acp from "@agentclientprotocol/sdk";
 import { Readable, Writable } from "node:stream";
 import { streamText, tool, stepCountIs, type ModelMessage } from "ai";
-import { anthropic } from "@ai-sdk/anthropic";
-import { openai } from "@ai-sdk/openai";
-import { google } from "@ai-sdk/google";
 import { z } from "zod";
+import { pickModel } from "./models.ts";
 import { appendTurn, loadTranscript } from "./transcript.ts";
 
 const DEFAULT_MODEL = "claude-opus-4-7";
@@ -286,19 +284,6 @@ function serialiseToolOutput(output: unknown): Record<string, unknown> {
     return output as Record<string, unknown>;
   }
   return { value: output };
-}
-
-function pickModel(modelId: string) {
-  if (modelId.startsWith("claude-") || modelId.startsWith("anthropic:")) {
-    return anthropic(modelId.replace(/^anthropic:/, ""));
-  }
-  if (modelId.startsWith("gpt-") || modelId.startsWith("openai:")) {
-    return openai(modelId.replace(/^openai:/, ""));
-  }
-  if (modelId.startsWith("gemini-") || modelId.startsWith("google:")) {
-    return google(modelId.replace(/^google:/, ""));
-  }
-  return anthropic(modelId);
 }
 
 function randomHexId(): string {

--- a/acp-worker/aoe-agent/src/models.ts
+++ b/acp-worker/aoe-agent/src/models.ts
@@ -1,0 +1,26 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { google } from "@ai-sdk/google";
+import { openai } from "@ai-sdk/openai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+
+const atlasCloud = createOpenAICompatible({
+  name: "atlas-cloud",
+  apiKey: process.env.ATLASCLOUD_API_KEY,
+  baseURL: "https://api.atlascloud.ai/v1",
+});
+
+export function pickModel(modelId: string) {
+  if (modelId.startsWith("atlas:")) {
+    return atlasCloud.chatModel(modelId.replace(/^atlas:/, ""));
+  }
+  if (modelId.startsWith("claude-") || modelId.startsWith("anthropic:")) {
+    return anthropic(modelId.replace(/^anthropic:/, ""));
+  }
+  if (modelId.startsWith("gpt-") || modelId.startsWith("openai:")) {
+    return openai(modelId.replace(/^openai:/, ""));
+  }
+  if (modelId.startsWith("gemini-") || modelId.startsWith("google:")) {
+    return google(modelId.replace(/^google:/, ""));
+  }
+  return anthropic(modelId);
+}

--- a/acp-worker/aoe-agent/test/models.test.ts
+++ b/acp-worker/aoe-agent/test/models.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { pickModel } from "../src/models.ts";
+
+test("routes Atlas Cloud models through the OpenAI-compatible provider", () => {
+  const model = pickModel("atlas:deepseek-ai/deepseek-v4-pro");
+
+  assert.equal(model.provider, "atlas-cloud.chat");
+  assert.equal(model.modelId, "deepseek-ai/deepseek-v4-pro");
+});
+
+test("preserves existing provider routing", () => {
+  assert.equal(pickModel("openai:gpt-5").provider, "openai.responses");
+  assert.equal(
+    pickModel("google:gemini-2.5-pro").provider,
+    "google.generative-ai",
+  );
+  assert.equal(
+    pickModel("anthropic:claude-sonnet-4-5").provider,
+    "anthropic.messages",
+  );
+});


### PR DESCRIPTION
## Description

Add Atlas Cloud as an OpenAI-compatible model route for the bundled `aoe-agent` worker. Models prefixed with `atlas:` now use `https://api.atlascloud.ai/v1` and `ATLASCLOUD_API_KEY`, while preserving nested model IDs such as `deepseek-ai/deepseek-v4-pro`.

The model selection logic is moved into a focused module so provider routing can be tested without starting an ACP session.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No documentation or UI change is required; the new `atlas:` runtime route and its environment variable are covered by focused tests.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex

**Any Additional AI Details you'd like to share:** The implementation was authored with Codex and verified with focused Node tests, TypeScript checks, formatting checks, and a live Atlas Cloud request.

- [x] I am an AI Agent filling out this form (check box if true)

## Verification

- `npm test` (7 passed)
- TypeScript check with transient `typescript` and `@types/node` packages, because the package does not currently declare its build-time TypeScript dependencies
- `cargo fmt --check`
- `git diff --check`
- Live Atlas Cloud model catalog: default model present
- Live `generateText` through `pickModel("atlas:deepseek-ai/deepseek-v4-pro")`: non-empty response, `finishReason=stop`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added Atlas Cloud as an OpenAI-compatible provider for `aoe-agent`.
- Routed `atlas:` model identifiers to Atlas Cloud while preserving nested model IDs.
- Moved model selection into the reusable `models.ts` module.
- Removed provider-selection logic and imports from `index.ts`.
- Added tests for Atlas, OpenAI, Google, and Anthropic routing.

## Benefits

- Enables Atlas Cloud model usage through `ATLASCLOUD_API_KEY`.
- Makes provider routing easier to test and maintain.
- Preserves existing provider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->