### PR TITLE
fix(web): guard crypto.randomUUID for insecure-context prompt sends

### DIFF
--- a/web/src/hooks/useAcpSession.queue.test.ts
+++ b/web/src/hooks/useAcpSession.queue.test.ts
@@ -397,6 +397,26 @@ describe("useAcpSession drain race (#1144)", () => {
     expect(reportAcpInteraction).not.toHaveBeenCalled();
   });
 
+  // #3173: aoe serve --host <LAN-IP> is plain HTTP on a non-loopback host,
+  // which is not a secure context, so crypto.randomUUID is undefined there.
+  // sendPrompt must not throw building the optimistic id; it should still
+  // POST the prompt.
+  it("still POSTs when crypto.randomUUID is unavailable (insecure context, #3173)", async () => {
+    vi.stubGlobal("crypto", { ...globalThis.crypto, randomUUID: undefined });
+    const { result } = renderHook(() => useAcpSession("sess-insecure-context"));
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+    await act(async () => {
+      await result.current.sendPrompt("sent over plain http");
+    });
+    expect(promptPostCount).toBe(1);
+  });
+
   it("reports a prompt_queued interaction on the retryable-failure requeue path (#1888)", async () => {
     // Idle-dormant wake: the worker was reaped, so sendPrompt POSTs directly
     // to wake it. When that POST fails retryably (worker_not_ready 503), the

--- a/web/src/hooks/useAcpSession.queue.test.ts
+++ b/web/src/hooks/useAcpSession.queue.test.ts
@@ -402,19 +402,31 @@ describe("useAcpSession drain race (#1144)", () => {
   // sendPrompt must not throw building the optimistic id; it should still
   // POST the prompt.
   it("still POSTs when crypto.randomUUID is unavailable (insecure context, #3173)", async () => {
-    vi.stubGlobal("crypto", { ...globalThis.crypto, randomUUID: undefined });
-    const { result } = renderHook(() => useAcpSession("sess-insecure-context"));
-    await flushAsync();
-    const ws = sockets[0]!;
-    act(() => {
-      ws.readyState = FakeWebSocket.OPEN;
-      ws.onopen?.({} as Event);
-    });
-    await flushAsync();
-    await act(async () => {
-      await result.current.sendPrompt("sent over plain http");
-    });
-    expect(promptPostCount).toBe(1);
+    // Shadow only randomUUID on the real crypto instance; a full stub
+    // object (e.g. `{...globalThis.crypto}`) drops inherited members
+    // like getRandomValues, which would mask this test behind an
+    // unrelated getOrCreateDeviceBindingSecret failure path.
+    const originalRandomUUID = globalThis.crypto.randomUUID;
+    Object.defineProperty(globalThis.crypto, "randomUUID", { value: undefined, configurable: true });
+    try {
+      const { result } = renderHook(() => useAcpSession("sess-insecure-context"));
+      await flushAsync();
+      const ws = sockets[0]!;
+      act(() => {
+        ws.readyState = FakeWebSocket.OPEN;
+        ws.onopen?.({} as Event);
+      });
+      await flushAsync();
+      await act(async () => {
+        await result.current.sendPrompt("sent over plain http");
+      });
+      expect(promptPostCount).toBe(1);
+    } finally {
+      Object.defineProperty(globalThis.crypto, "randomUUID", {
+        value: originalRandomUUID,
+        configurable: true,
+      });
+    }
   });
 
   it("reports a prompt_queued interaction on the retryable-failure requeue path (#1888)", async () => {

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -767,6 +767,25 @@ export const ACP_MAX_RETRIES_EXPORT = ACP_MAX_RETRIES;
 const ACP_WS_WATCHDOG_INTERVAL_MS = 15000;
 export const ACP_WS_STALE_MS = 75000;
 
+/** A real UUID v4 for the optimistic prompt id (#3173). `crypto.randomUUID`
+ *  is restricted to secure contexts (HTTPS or localhost); `aoe serve
+ *  --host <LAN-IP>` is plain HTTP on a non-loopback host, where it is
+ *  undefined. `crypto.getRandomValues` has no such restriction, so build
+ *  the UUID from that instead of falling back to a non-UUID string. Only
+ *  when crypto itself is entirely unavailable (older webviews, jsdom) does
+ *  this fall back to a Date.now/Math.random id, same as StructuredWidgets.tsx's
+ *  `newItemId()`. */
+function optimisticPromptId(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") return c.randomUUID();
+  if (c && typeof c.getRandomValues === "function") {
+    return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (digit) =>
+      (Number(digit) ^ (c.getRandomValues(new Uint8Array(1))[0]! & (15 >> (Number(digit) / 4)))).toString(16),
+    );
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
 export function useAcpSession(
   sessionId: string | null,
   /** Live structured view worker lifecycle from `SessionResponse.acp_worker_state`.
@@ -1558,14 +1577,7 @@ export function useAcpSession(
       // they tried to send; a transient worker_not_ready 503 rolls this
       // exact row back (by id) because the prompt is re-queued and the
       // drain would otherwise echo a duplicate. See #3094 / #3087.
-      // crypto.randomUUID is restricted to secure contexts (HTTPS or
-      // localhost); `aoe serve --host <LAN-IP>` is plain HTTP on a
-      // non-loopback host, where it is undefined. See #3173.
-      const optimisticId = `user-opt-${
-        globalThis.crypto && typeof globalThis.crypto.randomUUID === "function"
-          ? globalThis.crypto.randomUUID()
-          : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
-      }`;
+      const optimisticId = `user-opt-${optimisticPromptId()}`;
       dispatch({
         kind: "user_prompt",
         id: optimisticId,

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -1558,7 +1558,14 @@ export function useAcpSession(
       // they tried to send; a transient worker_not_ready 503 rolls this
       // exact row back (by id) because the prompt is re-queued and the
       // drain would otherwise echo a duplicate. See #3094 / #3087.
-      const optimisticId = `user-opt-${crypto.randomUUID()}`;
+      // crypto.randomUUID is restricted to secure contexts (HTTPS or
+      // localhost); `aoe serve --host <LAN-IP>` is plain HTTP on a
+      // non-loopback host, where it is undefined. See #3173.
+      const optimisticId = `user-opt-${
+        globalThis.crypto && typeof globalThis.crypto.randomUUID === "function"
+          ? globalThis.crypto.randomUUID()
+          : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+      }`;
       dispatch({
         kind: "user_prompt",
         id: optimisticId,


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On `1.13.2`, the structured-view web composer's Send action silently no-oped (no error toast, no network request, no server-side log entry) when `aoe serve` is bound to a non-loopback, non-HTTPS host (e.g. `--host 192.168.1.x` on a LAN). Sending via `aoe acp prompt` (CLI) worked fine, confirming the daemon/agent were healthy; only the browser composer's send path was affected.

Root cause: `useAcpSession.ts`'s `sendPrompt` built its optimistic-row id with an unguarded `crypto.randomUUID()` call. `crypto.randomUUID` is restricted to [secure contexts](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) (HTTPS, or `localhost`/`127.0.0.1`). `aoe serve --host <LAN-IP>` serves plain HTTP on a non-loopback address, which is not a secure context in any standards-compliant browser, so `crypto.randomUUID` is `undefined` there, and calling it threw a synchronous `TypeError` that aborted `submitComposer` before the fetch was ever issued.

The codebase already had a guarded fallback for exactly this case elsewhere (`StructuredWidgets.tsx`'s `newItemId()`). This PR applies the same guard to the `sendPrompt` call site: check `typeof globalThis.crypto.randomUUID === "function"` and fall back to a `Date.now()`/`Math.random()` id when it is not available.

Closes #3173

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] `aoe serve --host <LAN-IP>` (plain HTTP, no `--remote`/tunnel), open the dashboard from another device via `http://<LAN-IP>:8080/?token=...`
- [ ] Open a structured-view (ACP) session, type a message, hit Send: the message now sends (POST fires, agent responds), where before it silently did nothing
- [ ] Confirm the existing `localhost`/HTTPS composer send flow is unaffected

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: this is a browser-API compatibility guard inside a hook, not a new/changed dashboard flow from the coverage-matrix mandate list (auth, wizard, settings, sessions, etc.). Added a Vitest regression test (`web/src/hooks/useAcpSession.queue.test.ts`) that stubs `crypto.randomUUID` away and asserts `sendPrompt` still POSTs instead of throwing; confirmed it fails on the pre-fix code and passes post-fix.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. The issue report already included the root cause and suggested fix; I reviewed the guard placement, the regression test, and confirmed the red-to-green transition before committing.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed prompt sending over plain HTTP on non-loopback hosts.
- Added UUID v4 generation with `crypto.getRandomValues` and a timestamp/random fallback.
- Added a regression test for insecure-context behavior.

## Benefits

- Prompts now reach the server in LAN HTTP deployments.
- Existing behavior remains unchanged for HTTPS and localhost contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->