### PR TITLE
fix(tmux): unstick stale-running Claude sessions with typed prompt text

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -355,28 +355,44 @@ fn claude_word_is_duration(word: &str) -> bool {
     digits_end > 0 && matches!(&word[digits_end..], "s" | "m" | "h")
 }
 
-/// The input box holds unsubmitted typed text and nothing above it positively
-/// marks the turn as over. This pane state is statically ambiguous between
-/// running and parked: typed text repurposes Esc to "clear input", so Claude
-/// (verified on 2.1.212) drops the footer's `esc to interrupt` hint, and no
-/// spinner line renders while response prose streams, leaving an actively
-/// working session with zero running signals. The parked variant of the same
-/// pane differs only by the past-tense completion line (or the Esc-interrupt
-/// banner) sitting directly above the input box, so that is the evidence this
-/// check requires before letting the pane read as parked.
+/// What the input box's unsubmitted typed text says about the pane. The pane
+/// state is statically ambiguous between running and parked: typed text
+/// repurposes Esc to "clear input", so Claude (verified on 2.1.212) drops the
+/// footer's `esc to interrupt` hint, and no spinner line renders while
+/// response prose streams, leaving an actively working session with zero
+/// running signals. The parked variant of the same pane differs only by the
+/// past-tense completion line (or the Esc-interrupt banner) sitting directly
+/// above the input box, so that evidence is what splits `Parked` from
+/// `Ambiguous`.
 ///
 /// Ghost suggestion text also occupies the `❯` line (#2919), but it only
 /// renders after a finished turn, i.e. with the completion line above the box
-/// (see `test_claude_ready_prompt_footer_variants`), so it keeps its parked
-/// verdict; only text over a still-streaming transcript is held back.
-fn claude_typed_prompt_without_parked_evidence(recent: &[&str]) -> bool {
+/// (see `test_claude_ready_prompt_footer_variants`), so it reads `Parked`;
+/// only text over a still-streaming transcript is `Ambiguous`.
+enum TypedPromptVerdict {
+    /// No unsubmitted typed text: the `❯` line is absent, empty, or a
+    /// numbered menu. The other pane markers decide on their own.
+    NoTypedText,
+    /// Typed text with parked evidence directly above the input box:
+    /// positive evidence the turn is over. This is a parked marker in its
+    /// own right, since typed text simultaneously defeats the bare-`❯`
+    /// marker and (on footers without a recognized idle suffix) leaves
+    /// `claude_pane_shows_ready_prompt` with nothing else to match, which
+    /// pinned a stale `running` hook write on Running with no recovery.
+    Parked,
+    /// Typed text over a transcript with no parked evidence: hold the last
+    /// observed state rather than guessing.
+    Ambiguous,
+}
+
+fn claude_typed_prompt_verdict(recent: &[&str]) -> TypedPromptVerdict {
     let Some(prompt_idx) = recent.iter().rposition(|l| l.trim_start().starts_with('❯')) else {
-        return false;
+        return TypedPromptVerdict::NoTypedText;
     };
     let prompt_line = recent[prompt_idx].trim_start();
     let typed = prompt_line.trim_start_matches('❯').trim();
     if typed.is_empty() || claude_line_is_numbered_choice(prompt_line) {
-        return false;
+        return TypedPromptVerdict::NoTypedText;
     }
     // Walk up past the input box's top separator and any `⎿ Tip:` rows to the
     // last transcript line.
@@ -388,22 +404,30 @@ fn claude_typed_prompt_without_parked_evidence(recent: &[&str]) -> bool {
     });
     let Some(above) = above else {
         // Nothing above the typed prompt carries parked evidence either.
-        return true;
+        return TypedPromptVerdict::Ambiguous;
     };
-    !(claude_line_is_completed_turn(above)
-        || above.to_lowercase().contains(CLAUDE_INTERRUPT_MARKER))
+    if claude_line_is_completed_turn(above)
+        || above.to_lowercase().contains(CLAUDE_INTERRUPT_MARKER)
+    {
+        TypedPromptVerdict::Parked
+    } else {
+        TypedPromptVerdict::Ambiguous
+    }
 }
 
 /// A Claude pane whose only verdict would be "parked" but whose input box
 /// holds unsubmitted typed text with no parked evidence above it (see
-/// `claude_typed_prompt_without_parked_evidence`). Used by the hookless
-/// status fallback to hold an already-observed Running instead of flapping a
-/// working session to Idle the moment the user pre-types their next prompt.
+/// `TypedPromptVerdict::Ambiguous`). Used by the hookless status fallback to
+/// hold an already-observed Running instead of flapping a working session to
+/// Idle the moment the user pre-types their next prompt.
 pub(crate) fn claude_pane_is_ambiguous_typed_prompt(raw_content: &str) -> bool {
     with_claude_recent_pane(raw_content, |recent, recent_joined, recent_lower| {
         claude_blocking_prompt_rule(recent, recent_lower).is_none()
             && !claude_pane_has_running_signal(recent, recent_joined, recent_lower)
-            && claude_typed_prompt_without_parked_evidence(recent)
+            && matches!(
+                claude_typed_prompt_verdict(recent),
+                TypedPromptVerdict::Ambiguous
+            )
     })
 }
 
@@ -506,53 +530,81 @@ fn claude_pane_shows_interrupted_turn(
 /// the next unrecognized running state.
 const IDLE_RECONCILE_MIN_RUNNING_AGE: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// The mode names Claude's mode-cycle footer leads with. 2.1.211 renders each
+/// with a `(shift+tab to cycle)` suffix; newer builds drop the suffix when
+/// extra footer segments (a statusline, background-task counts,
+/// `← for agents`) are appended, so the mode name itself is the stable marker.
+const CLAUDE_MODE_FOOTER_MODES: &[&str] = &[
+    "accept edits on",
+    "plan mode on",
+    "auto mode on",
+    "bypass permissions on",
+];
+
+/// One of Claude's idle input-box footers is on screen: manual mode's
+/// `? for shortcuts`, or a mode-cycle footer line, matched by its
+/// `(shift+tab to cycle)` suffix or by a mode name from
+/// `CLAUDE_MODE_FOOTER_MODES` (the suffix check stays for any future mode
+/// name not in the list). The mode-cycle marker is anchored to a line
+/// starting with the footer's `⏵`/`⏸` glyph rather than matched as a bare
+/// substring, so panes merely echoing the footer text (a `git diff` of this
+/// file, quoted docs, this repo's own test fixtures in tool output) don't
+/// read as parked. The footer text is identical while running and while
+/// parked: the running variant only appends `esc to interrupt`, which the
+/// running-signal check catches first.
+fn claude_has_idle_footer(recent: &[&str], recent_lower: &str) -> bool {
+    if recent_lower.contains("? for shortcuts") {
+        return true;
+    }
+    recent.iter().any(|line| {
+        let trimmed = line.trim_start();
+        if !(trimmed.starts_with('⏵') || trimmed.starts_with('⏸')) {
+            return false;
+        }
+        let lower = trimmed.to_lowercase();
+        lower.contains("shift+tab to cycle")
+            || CLAUDE_MODE_FOOTER_MODES.iter().any(|m| lower.contains(m))
+    })
+}
+
 /// Claude has finished a turn and parked at the idle ready prompt, but no idle
 /// hook fired (the "silent tool stop" path: a tool result followed by no text
 /// fires neither `Stop` nor `idle_prompt`), so the status file is stuck on
 /// `running`. The positive marker is Claude's empty input prompt (a bare `❯`
-/// line, distinct from a numbered `❯ 1.` menu) or one of its input-box
-/// footers, combined with the absence of any active-turn signal. Requiring a
-/// positive ready-prompt marker (not merely "no spinner") keeps a blank or
-/// mid-redraw capture from reading as Idle.
+/// line, distinct from a numbered `❯ 1.` menu), one of its input-box footers
+/// (`claude_has_idle_footer`), or unsubmitted typed text whose transcript
+/// line above is parked evidence (`TypedPromptVerdict::Parked`), combined
+/// with the absence of any active-turn signal. Requiring a positive
+/// ready-prompt marker (not merely "no spinner") keeps a blank or mid-redraw
+/// capture from reading as Idle.
 ///
-/// Two footer markers are needed because the footer varies by permission
-/// mode: manual mode shows `? for shortcuts`, while the mode-cycle footers
-/// drop it (all verified against 2.1.211: `⏵⏵ accept edits on`,
-/// `⏸ plan mode on`, `⏵⏵ auto mode on`, and `⏵⏵ bypass permissions on`, each
-/// with `(shift+tab to cycle)`). Without the second marker, bypass-mode
-/// sessions had no footer match, and ghost suggestion text (a pre-filled
+/// The footer marker exists because ghost suggestion text (a pre-filled
 /// follow-up rendered on the `❯` line within a couple seconds of turn end)
-/// defeats the bare-prompt marker, so silent stops stayed stuck on Running.
-/// The marker text is identical while running and while parked: the running
-/// variant only appends `esc to interrupt`, which the running-signal check
-/// catches first.
+/// defeats the bare-prompt marker, so silent stops stayed stuck on Running
+/// without it. The typed-prompt marker exists because typed text defeats the
+/// bare-prompt marker the same way while the visible footer may carry no
+/// recognized idle suffix at all; the completion line (or interrupt banner)
+/// directly above the input box is then the only parked evidence on screen.
 ///
-/// The mode-cycle marker is anchored to a line starting with the footer's
-/// `⏵`/`⏸` glyph rather than matched as a bare substring, so panes merely
-/// echoing the footer text (a `git diff` of this file, quoted docs, this
-/// repo's own test fixtures in tool output) don't read as parked.
-///
-/// Unsubmitted typed text in the input box vetoes the footer marker: typing
-/// suppresses the `esc to interrupt` hint (Esc now clears the input), and no
-/// spinner renders while prose streams, so a mid-turn pane with typed text
-/// carries the mode-cycle footer and no running signal, identical to the
-/// parked pane except for the completion line above the box. Without the
-/// veto, pre-typing the next prompt flipped a working session to Idle.
+/// Ambiguous typed text (no parked evidence above it) vetoes the other
+/// markers: typing suppresses the `esc to interrupt` hint (Esc now clears the
+/// input), and no spinner renders while prose streams, so a mid-turn pane
+/// with typed text carries the mode-cycle footer and no running signal,
+/// identical to the parked pane except for the completion line above the box.
+/// Without the veto, pre-typing the next prompt flipped a working session to
+/// Idle.
 fn claude_pane_shows_ready_prompt(
     recent: &[&str],
     recent_joined: &str,
     recent_lower: &str,
 ) -> bool {
     let has_empty_prompt = recent.iter().any(|line| line.trim() == "❯");
-    let has_idle_footer = recent_lower.contains("? for shortcuts")
-        || recent.iter().any(|line| {
-            let trimmed = line.trim_start();
-            (trimmed.starts_with('⏵') || trimmed.starts_with('⏸'))
-                && trimmed.to_lowercase().contains("shift+tab to cycle")
-        });
-    (has_empty_prompt || has_idle_footer)
+    let typed_prompt = claude_typed_prompt_verdict(recent);
+    (has_empty_prompt
+        || claude_has_idle_footer(recent, recent_lower)
+        || matches!(typed_prompt, TypedPromptVerdict::Parked))
+        && !matches!(typed_prompt, TypedPromptVerdict::Ambiguous)
         && !claude_pane_has_running_signal(recent, recent_joined, recent_lower)
-        && !claude_typed_prompt_without_parked_evidence(recent)
 }
 
 /// When Claude's status hook reports Running, the pane is consulted to catch two
@@ -750,13 +802,7 @@ pub(crate) fn claude_pane_marker_fingerprint(raw_content: &str) -> String {
         if recent.iter().any(|line| line.trim() == "❯") {
             markers.push("empty_prompt");
         }
-        if recent_lower.contains("? for shortcuts")
-            || recent.iter().any(|line| {
-                let trimmed = line.trim_start();
-                (trimmed.starts_with('⏵') || trimmed.starts_with('⏸'))
-                    && trimmed.to_lowercase().contains("shift+tab to cycle")
-            })
-        {
+        if claude_has_idle_footer(recent, recent_lower) {
             markers.push("idle_footer");
         }
         if recent
@@ -768,8 +814,10 @@ pub(crate) fn claude_pane_marker_fingerprint(raw_content: &str) -> String {
         if recent_lower.contains(CLAUDE_INTERRUPT_MARKER) {
             markers.push("interrupt_banner");
         }
-        if claude_typed_prompt_without_parked_evidence(recent) {
-            markers.push("typed_prompt_ambiguous");
+        match claude_typed_prompt_verdict(recent) {
+            TypedPromptVerdict::Parked => markers.push("typed_prompt_parked"),
+            TypedPromptVerdict::Ambiguous => markers.push("typed_prompt_ambiguous"),
+            TypedPromptVerdict::NoTypedText => {}
         }
         if markers.is_empty() {
             "no_markers".to_string()
@@ -2548,6 +2596,15 @@ enter to select · esc to cancel";
             claude_pane_marker_fingerprint(pane),
             "empty_prompt+idle_footer+completed_turn"
         );
+        // Typed text over a completion line: the parked typed-prompt marker.
+        let typed = "\
+✻ Worked for 1m 52s\n\
+❯ half-typed next prompt\n\
+  ? for shortcuts\n";
+        assert_eq!(
+            claude_pane_marker_fingerprint(typed),
+            "idle_footer+completed_turn+typed_prompt_parked"
+        );
     }
 
     #[test]
@@ -3087,23 +3144,71 @@ Do you want to proceed?\n\
     }
 
     #[test]
+    fn test_reconcile_claude_hook_status_stale_running_typed_prompt_over_completion_line() {
+        // Regression for a session pinned on Running: the turn ended but no
+        // idle hook fired, and the parked pane offered neither of the old
+        // positive markers. Typed unsubmitted text defeats the bare-`❯`
+        // marker, and this newer footer drops `(shift+tab to cycle)` (extra
+        // segments take its place), so the stale `running` write was trusted
+        // forever. The completion line directly above the typed prompt is
+        // the parked evidence; pane captured verbatim from the hung session.
+        let parked = "\
+✻ Sautéed for 39s · 1 monitor still running\n\
+──────────────────────────────\n\
+❯ stop the monitor\n\
+──────────────────────────────\n\
+  ⏵⏵ bypass permissions on · PR #444 · 1 monitor · ← for agents · ↓ to manage";
+        // The same box over a still-streaming transcript stays ambiguous:
+        // the footer alone must not downgrade a pre-typed working session.
+        let streaming = "\
+  prose still being generated by the model\n\
+──────────────────────────────\n\
+❯ stop the monitor\n\
+──────────────────────────────\n\
+  ⏵⏵ bypass permissions on · PR #444 · 1 monitor · ← for agents · ↓ to manage";
+        let cases = [(parked, Status::Idle), (streaming, Status::Running)];
+        for (pane, expected) in cases {
+            assert_eq!(
+                reconcile_claude_hook_status(
+                    Status::Running,
+                    pane,
+                    Some(std::time::Duration::from_secs(120))
+                ),
+                expected,
+                "pane:\n{pane}"
+            );
+        }
+    }
+
+    #[test]
     fn test_claude_ready_prompt_footer_variants() {
-        // Parked footers captured from 2.1.211 by cycling shift+tab, each
-        // with ghost suggestion text defeating the bare-prompt marker. All
-        // four mode-cycle variants must read as parked; an echoed footer
-        // (diff/tool output, so the line doesn't start with the footer
-        // glyph) and the running footer variant must not.
+        // Parked footers captured from 2.1.211 by cycling shift+tab, plus
+        // the newer variant that drops the shift+tab suffix for extra
+        // segments; each pane has ghost suggestion text defeating the
+        // bare-prompt marker. Every variant must read as parked end-to-end
+        // AND match the footer marker itself (the ghost-text pane also
+        // carries the typed-prompt parked marker, so only the direct check
+        // pins the footer matcher); an echoed footer (diff/tool output, so
+        // the line doesn't start with the footer glyph) and the running
+        // footer variant must not.
         for footer in [
             "  ⏵⏵ accept edits on (shift+tab to cycle) · ← for agents",
             "  ⏸ plan mode on (shift+tab to cycle) · ← for agents",
             "  ⏵⏵ auto mode on (shift+tab to cycle) · ← for agents",
             "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents",
             "  ⏸ manual mode on · ? for shortcuts · ← for agents",
+            "  ⏵⏵ bypass permissions on · PR #444 · 1 monitor · ← for agents · ↓ to manage",
         ] {
             let pane = format!("✻ Churned for 10s\n❯ ghost suggestion text\n{footer}");
             assert!(
                 with_claude_recent_pane(&pane, claude_pane_shows_ready_prompt),
                 "expected parked for footer: {footer}"
+            );
+            assert!(
+                with_claude_recent_pane(footer, |recent, _, lower| claude_has_idle_footer(
+                    recent, lower
+                )),
+                "expected idle-footer match for: {footer}"
             );
         }
         let echoed = "\


### PR DESCRIPTION
## Description

A Claude session was stuck showing **Running** in aoe while the agent was actually parked idle at its prompt. Debugged live against the hung session (`fix-443-ssrf-write-path-gate`):

- The turn ended but no idle hook fired, leaving the hook status file on `running` (the known "silent stop" gap that `reconcile_claude_hook_status` exists to repair).
- The stale-running downgrade requires a *positive* parked marker, and the pane defeated both of them at once:
  1. The user had typed unsubmitted text into the input box, so there was no bare `❯` line.
  2. The footer rendered as `⏵⏵ bypass permissions on · PR #444 · 1 monitor · ← for agents · ↓ to manage`; newer Claude Code builds drop the `(shift+tab to cycle)` suffix when extra segments are shown, so the idle-footer matcher missed it.
- Result: the reconciler trusted the 10-minute-stale `running` write indefinitely. The `debug.log` fingerprint showed the flip pin itself the moment the user typed into the box: `Running -> Idle (pane=empty_prompt+completed_turn)` followed 3s later by `Idle -> Running (pane=completed_turn)`.

The irony: the detector already *proved* the pane was parked. `claude_typed_prompt_without_parked_evidence` recognizes "typed text with a completion line directly above the box = parked", but that recognition was only wired in as a veto, never as a positive marker.

### Changes

- Refactor the typed-prompt check into a three-way `TypedPromptVerdict` (`NoTypedText` / `Parked` / `Ambiguous`). `Parked` (typed text with a completion line or interrupt banner directly above the input box) now counts as a positive parked marker in `claude_pane_shows_ready_prompt`; `Ambiguous` still vetoes, so pre-typing during a live turn keeps holding Running.
- New `claude_has_idle_footer` helper (also deduplicates the fingerprint's copy): matches the mode-cycle footer by its `⏵`/`⏸`-anchored mode name (`accept edits on`, `plan mode on`, `auto mode on`, `bypass permissions on`) in addition to the old `shift+tab to cycle` suffix, covering the suffix-less newer footer. Echo-resistance is unchanged (line must start with the footer glyph).
- Status-transition fingerprint now emits `typed_prompt_parked`, so this failure mode is identifiable from `debug.log` without a live repro.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: pure pane-text detection logic; covered by unit regression tests using the hung session's pane captured verbatim (`test_reconcile_claude_hook_status_stale_running_typed_prompt_over_completion_line`, extended `test_claude_ready_prompt_footer_variants` and fingerprint tests). Verified with `cargo fmt`, `cargo clippy`, `cargo test --lib` (4308 passed).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Fable 5)

**Any Additional AI Details you'd like to share:**
Investigated the live hung session (tmux pane capture, hook status file mtime, debug.log fingerprints), implemented the fix, and wrote the regression tests.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Improved tmux detection for Claude sessions with typed text at an idle prompt.
- Added clear classifications for typed input: `NoTypedText`, `Parked`, and `Ambiguous`.
- Recognized completion lines and interrupt banners as evidence that a session is parked.
- Preserved ambiguous typed input as a safety veto during active turns.
- Added support for newer Claude idle-footer formats.
- Added `typed_prompt_parked` to status fingerprints for better debugging.
- Added regression tests for captured stale sessions and newer footer formats.

These changes reduce false “running” states and improve recovery of stale Claude sessions while keeping uncertain input handling safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->