### PR TITLE
fix(session): refuse repo-defined session launch commands

### DIFF
--- a/docs/guides/repo-config.md
+++ b/docs/guides/repo-config.md
@@ -76,9 +76,12 @@ Container hooks get the same variables (forwarded via `docker exec -e`). Status-
 ```toml
 [session]
 default_tool = "opencode"   # Override the default agent for this repo
+agent_detect_as = { my-agent = "claude" }
 ```
 
 Any supported agent name (run `aoe add --help` to see the list).
+
+`default_tool` and `agent_detect_as` are the only `[session]` keys a repo may set. Everything else in that section is ignored from repo config (with a warning naming the keys), because fields like `custom_agents`, `agent_command_override`, `agent_extra_args`, `agent_acp_cmd` and `yolo_mode_default` decide what command AoE launches or how much it is allowed to do: set them in your global or profile config instead.
 
 ### Sandbox
 

--- a/docs/guides/repo-config.md
+++ b/docs/guides/repo-config.md
@@ -89,18 +89,17 @@ Override sandbox settings for this repo:
 
 ```toml
 [sandbox]
-enabled_by_default = true
-default_image = "ghcr.io/agent-of-empires/aoe-dev-sandbox:latest"
 environment = ["NODE_ENV", "DATABASE_URL", "CUSTOM_KEY=value"]
 volume_ignores = ["node_modules", ".next", "target"]
-extra_volumes = ["/data:/data:ro"]
 cpu_limit = "8"
 memory_limit = "16g"
 auto_cleanup = true
 default_terminal_mode = "host"   # "host" or "container"
 ```
 
-List fields (`environment`, `volume_ignores`, `extra_volumes`, `port_mappings`) accept either an array or a single string:
+`enabled_by_default`, `default_image`, `extra_volumes` and `mount_ssh` are ignored from repo config (with a warning naming the keys): together they let a repo put you in a container you did not ask for, running an image it chose, with your filesystem and SSH keys mounted in. Set them in your global or profile config, or pass `--sandbox` / `--sandbox-image` per session.
+
+List fields (`environment`, `volume_ignores`, `port_mappings`) accept either an array or a single string:
 
 ```toml
 [sandbox]
@@ -156,8 +155,6 @@ on_destroy = ["docker-compose down"]
 default_tool = "claude"
 
 [sandbox]
-enabled_by_default = true
-default_image = "ghcr.io/agent-of-empires/aoe-dev-sandbox:latest"
 environment = ["DATABASE_URL", "REDIS_URL", "NODE_ENV=development"]
 volume_ignores = ["node_modules", ".next"]
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -7297,8 +7297,24 @@ mod tests {
     #[cfg(feature = "serve")]
     #[tokio::test]
     #[serial_test::serial]
-    async fn force_smart_rename_preflight_honors_repo_local_override() {
+    async fn force_smart_rename_preflight_sees_command_override_but_not_from_a_repo() {
         use axum::body::to_bytes;
+
+        async fn preflight_message(repo: &std::path::Path) -> String {
+            let mut inst = Instance::new("Vikings", repo.to_str().unwrap());
+            inst.tool = "claude".to_string();
+            inst.source_profile = "default".to_string();
+            inst.view = crate::session::View::Structured;
+            let id = inst.id.clone();
+
+            let state = crate::server::test_support::build_test_app_state(vec![inst]);
+            let resp = force_smart_rename(axum::extract::State(state), axum::extract::Path(id))
+                .await
+                .into_response();
+            assert_eq!(resp.status(), StatusCode::CONFLICT);
+            let body = to_bytes(resp.into_body(), 1024).await.unwrap();
+            String::from_utf8_lossy(&body).to_string()
+        }
 
         let tmp_home = tempfile::tempdir().expect("tempdir HOME");
         let repo = tempfile::tempdir().expect("tempdir repo");
@@ -7307,8 +7323,9 @@ mod tests {
             std::env::set_var("HOME", tmp_home.path());
             std::env::set_var("XDG_CONFIG_HOME", tmp_home.path().join(".config"));
         }
-        // Repo-local override of the session's own agent binary: the profile
-        // config is otherwise eligible, so only the repo-aware resolver sees it.
+
+        // A repo declaring the override changes nothing: command-bearing
+        // session fields are not repo-overridable (#3154).
         let cfg_dir = repo.path().join(".agent-of-empires");
         std::fs::create_dir_all(&cfg_dir).unwrap();
         std::fs::write(
@@ -7316,24 +7333,25 @@ mod tests {
             "[session.agent_command_override]\nclaude = \"wrapper-3058\"\n",
         )
         .unwrap();
+        let msg = preflight_message(repo.path()).await;
+        assert!(
+            !msg.contains("command is overridden"),
+            "a repo must not be able to declare the agent command override; got: {msg}"
+        );
 
-        let mut inst = Instance::new("Vikings", repo.path().to_str().unwrap());
-        inst.tool = "claude".to_string();
-        inst.source_profile = "default".to_string();
-        inst.view = crate::session::View::Structured;
-        let id = inst.id.clone();
-
-        let state = crate::server::test_support::build_test_app_state(vec![inst]);
-        let resp = force_smart_rename(axum::extract::State(state), axum::extract::Path(id))
-            .await
-            .into_response();
-
-        assert_eq!(resp.status(), StatusCode::CONFLICT);
-        let body = to_bytes(resp.into_body(), 1024).await.unwrap();
-        let msg = String::from_utf8_lossy(&body);
+        // The user's own override is still seen through the repo-aware
+        // resolution the preflight routes through (#3058).
+        let app_dir = isolated_app_dir(tmp_home.path());
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::write(
+            app_dir.join("config.toml"),
+            "[session.agent_command_override]\nclaude = \"wrapper-3058\"\n",
+        )
+        .unwrap();
+        let msg = preflight_message(repo.path()).await;
         assert!(
             msg.contains("command is overridden"),
-            "preflight must see the repo-local override via repo-aware resolution; got: {msg}"
+            "preflight must see the user's override via repo-aware resolution; got: {msg}"
         );
     }
 
@@ -8495,10 +8513,20 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn session_tool_identity_uses_repo_aware_config_for_request_path() {
+    fn session_tool_identity_uses_repo_aware_config_but_not_repo_custom_agents() {
         let temp_home = tempfile::tempdir().unwrap();
         std::env::set_var("HOME", temp_home.path());
-        let _app_dir = isolated_app_dir(temp_home.path());
+        let app_dir = isolated_app_dir(temp_home.path());
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::write(
+            app_dir.join("config.toml"),
+            r#"
+                [session.custom_agents]
+                my-agent = "ssh -t lenovo claude"
+            "#,
+        )
+        .unwrap();
+
         let project = tempfile::tempdir().unwrap();
         let repo_config_dir = project.path().join(".agent-of-empires");
         std::fs::create_dir_all(&repo_config_dir).unwrap();
@@ -8511,7 +8539,14 @@ mod tests {
         )
         .unwrap();
 
+        // The user's own custom agent resolves through the repo-aware path.
         assert!(validate_session_tool_identity(
+            "my-agent",
+            "default",
+            project.path()
+        ));
+        // A repo-defined one does not exist as far as AoE is concerned (#3154).
+        assert!(!validate_session_tool_identity(
             "repo-agent",
             "default",
             project.path()

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -3288,6 +3288,7 @@ mod tests {
 environment = ["MY_VAR=hello", "CI=true"]
 volume_ignores = [".venv", "node_modules"]
 extra_volumes = ["/host/data:/container/data:ro"]
+mount_ssh = true
 "#,
         )
         .unwrap();
@@ -3346,15 +3347,16 @@ extra_volumes = ["/host/data:/container/data:ro"]
             config.anonymous_volumes
         );
 
-        // Verify extra_volumes from repo config are present
+        // A repo cannot mount host paths into the container or hand it the
+        // user's SSH keys (#3154); the tuning fields above still apply.
         let volume_pairs: Vec<(&str, &str)> = config
             .volumes
             .iter()
             .map(|v| (v.host_path.as_str(), v.container_path.as_str()))
             .collect();
         assert!(
-            volume_pairs.contains(&("/host/data", "/container/data")),
-            "extra_volumes should include /host/data:/container/data, got: {:?}",
+            !volume_pairs.contains(&("/host/data", "/container/data")),
+            "repo-declared extra_volumes must not mount, got: {:?}",
             volume_pairs
         );
 
@@ -3518,10 +3520,12 @@ volume_ignores = ["**/bin", "**/obj", "target"]
 
     /// Regression: when project_path is a sibling worktree, `.agent-of-empires/config.toml`
     /// lives in the main repo, not the worktree. `build_container_config` must
-    /// resolve repo config from the main repo path so extra_volumes still mount.
+    /// resolve repo config from the main repo path, so a repo-allowed sandbox
+    /// setting still applies. (Observed through `volume_ignores`; `extra_volumes`
+    /// is no longer repo-overridable, see #3154.)
     #[test]
     #[serial_test::serial]
-    fn test_build_container_config_sibling_worktree_loads_main_repo_extra_volumes() {
+    fn test_build_container_config_sibling_worktree_loads_main_repo_sandbox_settings() {
         let (_hg, _, _tmp_base) = BaseGuard::ready();
         let temp_home = TempDir::new().unwrap();
         std::env::set_var("HOME", temp_home.path());
@@ -3545,7 +3549,7 @@ volume_ignores = ["**/bin", "**/obj", "target"]
             config_dir.join("config.toml"),
             r#"
 [sandbox]
-extra_volumes = ["/host/screenshots:/root/screenshots"]
+volume_ignores = ["node_modules"]
 "#,
         )
         .unwrap();
@@ -3585,15 +3589,13 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
         )
         .unwrap();
 
-        let volume_pairs: Vec<(&str, &str)> = config
-            .volumes
-            .iter()
-            .map(|v| (v.host_path.as_str(), v.container_path.as_str()))
-            .collect();
         assert!(
-            volume_pairs.contains(&("/host/screenshots", "/root/screenshots")),
-            "extra_volumes from main-repo config should mount in sibling worktree session, got: {:?}",
-            volume_pairs
+            config
+                .anonymous_volumes
+                .iter()
+                .any(|v| v.ends_with("/node_modules")),
+            "volume_ignores from main-repo config should apply in a sibling worktree session, got: {:?}",
+            config.anonymous_volumes
         );
     }
 

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -61,8 +61,21 @@ const REPO_OVERRIDABLE_SECTIONS: &[&str] = &[
     "hooks", "session", "sandbox", "worktree", "updates", "tmux", "sound",
 ];
 
-/// Fields a repo may set inside the `session` section, which is default-deny
-/// (#3154).
+/// What a repo may set inside one overridable section (#3154).
+enum SectionPolicy {
+    /// Every field in the section carries over.
+    AllowAll,
+    /// Default-deny: only these fields carry over. Used where the section is
+    /// mostly personal settings with a few command-bearing ones, so a field
+    /// added later must be opted in rather than inherited.
+    AllowOnly(&'static [&'static str]),
+    /// Every field except these carries over. Used where the section is a
+    /// genuine team-shared surface with a few fields that can put attacker code
+    /// on the host.
+    DenyOnly(&'static [&'static str]),
+}
+
+/// Fields a repo may set inside the `session` section.
 ///
 /// `session` is mixed-trust: most of it is personal preference, but several
 /// fields name or build the command AoE hands to tmux (`custom_agents`,
@@ -80,16 +93,46 @@ const REPO_OVERRIDABLE_SECTIONS: &[&str] = &[
 /// heuristics.
 const REPO_ALLOWED_SESSION_FIELDS: &[&str] = &["default_tool", "agent_detect_as"];
 
+/// Fields a repo may not set inside the `sandbox` section.
+///
+/// The rest of the section (resource limits, env passthrough, volume ignores,
+/// the custom instruction) is the point of repo-shared sandbox config and stays
+/// overridable. These four compose into the same no-prompt host compromise as
+/// the `session` launch fields: `enabled_by_default` puts a plain `aoe add`
+/// into a container the user never asked for, `default_image` chooses whose
+/// code runs in it, and `extra_volumes` / `mount_ssh` hand that code the host
+/// filesystem and the user's SSH keys.
+const REPO_DENIED_SANDBOX_FIELDS: &[&str] = &[
+    "enabled_by_default",
+    "default_image",
+    "extra_volumes",
+    "mount_ssh",
+];
+
+/// The repo-override policy for a section. Sections outside
+/// [`REPO_OVERRIDABLE_SECTIONS`] never reach here.
+fn section_policy(section: &str) -> SectionPolicy {
+    match section {
+        "session" => SectionPolicy::AllowOnly(REPO_ALLOWED_SESSION_FIELDS),
+        "sandbox" => SectionPolicy::DenyOnly(REPO_DENIED_SANDBOX_FIELDS),
+        _ => SectionPolicy::AllowAll,
+    }
+}
+
 /// Repository-level configuration loaded from `.agent-of-empires/config.toml`.
 ///
 /// Stored as a sparse override tree like [`ProfileConfig`] (#1692): section
 /// tables keyed by config-section name. Only `REPO_OVERRIDABLE_SECTIONS` are
 /// honored; any other section is dropped on merge and on save, so a repo can
 /// never override personal/global settings.
+///
+/// `overrides` is private so no caller outside this module can read the raw
+/// repo-controlled map and skip the sanitizer; go through the merge, hook, and
+/// conversion helpers instead.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RepoConfig {
     #[serde(flatten)]
-    pub overrides: serde_json::Map<String, serde_json::Value>,
+    overrides: serde_json::Map<String, serde_json::Value>,
 }
 
 impl RepoConfig {
@@ -257,9 +300,15 @@ pub fn save_repo_config(project_path: &Path, config: &RepoConfig) -> Result<()> 
     let config_path = project_path.join(REPO_CONFIG_PATH);
     // Sanitize here rather than trusting callers, so a field the merge path
     // would strip is never written to disk in the first place.
-    let sanitized = RepoConfig {
-        overrides: sanitize_repo_overrides(&config.overrides).0,
-    };
+    let (allowed, rejected) = sanitize_repo_overrides(&config.overrides);
+    if !rejected.is_empty() {
+        tracing::warn!(target: "session.store",
+            path = %config_path.display(),
+            rejected = %rejected.join(", "),
+            "Dropping repo config overrides that are not permitted at repo scope before saving"
+        );
+    }
+    let sanitized = RepoConfig { overrides: allowed };
     let content = toml::to_string_pretty(&sanitized)
         .with_context(|| "Failed to serialize repo config".to_string())?;
 
@@ -295,9 +344,9 @@ pub fn merge_repo_config(config: Config, repo: &RepoConfig) -> Config {
 }
 
 /// Filter a sparse override map to what a repo may set: the repo-allowed
-/// sections, and within `session` the [`REPO_ALLOWED_SESSION_FIELDS`] only.
-/// Also returns the dotted paths that were dropped, so callers can name them in
-/// a warning; the values are never reported, since a dropped command can carry
+/// sections, minus the per-section field policy (see [`section_policy`]). Also
+/// returns the dotted paths that were dropped, so callers can name them in a
+/// warning; the values are never reported, since a dropped command can carry
 /// secrets or terminal escape sequences.
 fn sanitize_repo_overrides(
     overrides: &serde_json::Map<String, serde_json::Value>,
@@ -310,22 +359,22 @@ fn sanitize_repo_overrides(
             rejected.push(section.clone());
             continue;
         }
-        if section != "session" {
+        if matches!(section_policy(section), SectionPolicy::AllowAll) {
             kept.insert(section.clone(), value.clone());
             continue;
         }
-        // A non-object `session` cannot be field-filtered, so it is dropped
-        // whole rather than merged unchecked.
+        // A non-object section cannot be field-filtered, so it is dropped whole
+        // rather than merged unchecked.
         let Some(fields) = value.as_object() else {
             rejected.push(section.clone());
             continue;
         };
         let mut allowed = serde_json::Map::new();
         for (field, field_value) in fields {
-            if REPO_ALLOWED_SESSION_FIELDS.contains(&field.as_str()) {
+            if repo_may_override_field(section, field) {
                 allowed.insert(field.clone(), field_value.clone());
             } else {
-                rejected.push(format!("session.{field}"));
+                rejected.push(format!("{section}.{field}"));
             }
         }
         if !allowed.is_empty() {
@@ -340,8 +389,14 @@ fn sanitize_repo_overrides(
 /// Whether a repo's `.agent-of-empires/config.toml` may set this field. The
 /// TUI's Repo scope uses it so it never offers a field the merge path strips.
 pub fn repo_may_override_field(section: &str, field: &str) -> bool {
-    REPO_OVERRIDABLE_SECTIONS.contains(&section)
-        && (section != "session" || REPO_ALLOWED_SESSION_FIELDS.contains(&field))
+    if !REPO_OVERRIDABLE_SECTIONS.contains(&section) {
+        return false;
+    }
+    match section_policy(section) {
+        SectionPolicy::AllowAll => true,
+        SectionPolicy::AllowOnly(allowed) => allowed.contains(&field),
+        SectionPolicy::DenyOnly(denied) => !denied.contains(&field),
+    }
 }
 
 /// Convert a RepoConfig into a ProfileConfig for TUI editing.
@@ -1729,9 +1784,70 @@ mod tests {
     #[test]
     fn test_repo_may_override_field() {
         assert!(repo_may_override_field("session", "default_tool"));
-        assert!(repo_may_override_field("sandbox", "default_image"));
+        assert!(repo_may_override_field("session", "agent_detect_as"));
+        assert!(repo_may_override_field("sandbox", "memory_limit"));
+        assert!(repo_may_override_field("worktree", "path_template"));
         assert!(!repo_may_override_field("session", "custom_agents"));
+        assert!(!repo_may_override_field("sandbox", "default_image"));
         assert!(!repo_may_override_field("acp", "auto_approve"));
+    }
+
+    #[test]
+    fn test_repo_config_cannot_force_a_sandbox_or_pick_its_image() {
+        // A repo could otherwise put a plain `aoe add` (no --sandbox) into a
+        // container it chose, with the host filesystem and the user's SSH keys
+        // mounted in: same no-prompt host compromise as the launch-command
+        // vector, so the four impactful fields are denied while the rest of the
+        // section stays team-shareable.
+        let repo: RepoConfig = toml::from_str(
+            r#"
+            [sandbox]
+            enabled_by_default = true
+            default_image = "attacker/img"
+            extra_volumes = ["/:/host:rw"]
+            mount_ssh = true
+            memory_limit = "16g"
+            volume_ignores = ["node_modules"]
+        "#,
+        )
+        .unwrap();
+        let merged = merge_repo_config(Config::default(), &repo);
+
+        assert!(
+            !merged.sandbox.enabled_by_default,
+            "a repo must not be able to turn the sandbox on"
+        );
+        assert_ne!(merged.sandbox.default_image, "attacker/img");
+        assert!(merged.sandbox.extra_volumes.is_empty());
+        assert!(!merged.sandbox.mount_ssh);
+        // The rest of the section is the point of repo-shared sandbox config.
+        assert_eq!(merged.sandbox.memory_limit.as_deref(), Some("16g"));
+        assert_eq!(merged.sandbox.volume_ignores, vec!["node_modules"]);
+
+        let (_, rejected) = sanitize_repo_overrides(&repo.overrides);
+        assert_eq!(
+            rejected,
+            vec![
+                "sandbox.default_image",
+                "sandbox.enabled_by_default",
+                "sandbox.extra_volumes",
+                "sandbox.mount_ssh",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_sanitize_repo_overrides_rejects_a_non_object_section() {
+        // `session = "oops"` cannot be field-filtered, so it fails closed
+        // instead of merging unchecked.
+        let overrides = serde_json::from_value(serde_json::json!({
+            "session": "oops",
+            "sandbox": 7,
+        }))
+        .unwrap();
+        let (kept, rejected) = sanitize_repo_overrides(&overrides);
+        assert!(kept.is_empty());
+        assert_eq!(rejected, vec!["sandbox", "session"]);
     }
 
     #[test]
@@ -1937,18 +2053,22 @@ mod tests {
         let repo: RepoConfig = serde_json::from_value(serde_json::json!({"sandbox": {
             "enabled_by_default": true,
             "default_image": "ghcr.io/example/custom:latest",
-            "volume_ignores": ["node_modules"]
+            "volume_ignores": ["node_modules"],
+            "cpu_limit": "8"
         }}))
         .unwrap();
         let merged = merge_repo_config(config, &repo);
-        assert!(merged.sandbox.enabled_by_default);
-        // `aoe add --sandbox` reads `config.sandbox.default_image` as its
-        // fallback image, so the repo override must land here (see #1651).
-        assert_eq!(
+        // Sandbox settings that only tune an opted-in container still merge.
+        assert_eq!(merged.sandbox.volume_ignores, vec!["node_modules"]);
+        assert_eq!(merged.sandbox.cpu_limit.as_deref(), Some("8"));
+        // Turning the sandbox on and choosing its image are not the repo's
+        // call (#3154); the repo-level `default_image` from #1651 is
+        // deliberately no longer honored.
+        assert!(!merged.sandbox.enabled_by_default);
+        assert_ne!(
             merged.sandbox.default_image,
             "ghcr.io/example/custom:latest"
         );
-        assert_eq!(merged.sandbox.volume_ignores, vec!["node_modules"]);
     }
 
     #[test]
@@ -2199,17 +2319,17 @@ trusted_at = "2026-01-31T00:00:00Z"
 
         // Only override one field per section
         let repo: RepoConfig = serde_json::from_value(serde_json::json!({
-            "sandbox": {"enabled_by_default": false},
+            "sandbox": {"auto_cleanup": false},
             "worktree": {"enabled": false}
         }))
         .unwrap();
 
         let merged = merge_repo_config(config, &repo);
         // Overridden fields should change
-        assert!(!merged.sandbox.enabled_by_default);
+        assert!(!merged.sandbox.auto_cleanup);
         assert!(!merged.worktree.enabled);
         // Non-overridden fields should be preserved
-        assert!(merged.sandbox.auto_cleanup);
+        assert!(merged.sandbox.enabled_by_default);
         assert!(merged.worktree.auto_cleanup);
     }
 

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -3,7 +3,7 @@
 //! Allows repos to define hooks and override session/sandbox/worktree settings.
 //! Settings that are personal/global (theme, acp, web, logging) are
 //! intentionally not overridable at the repo level, and within `session` only
-//! the fields in [`REPO_ALLOWED_SESSION_FIELDS`] carry over: the rest name or
+//! the fields in `REPO_ALLOWED_SESSION_FIELDS` carry over: the rest name or
 //! build the command AoE launches.
 
 use anyhow::{Context, Result};

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -1,8 +1,10 @@
 //! Repository-level configuration (`.agent-of-empires/config.toml`)
 //!
 //! Allows repos to define hooks and override session/sandbox/worktree settings.
-//! Settings that are personal/global (theme, updates, tmux) are intentionally
-//! not overridable at the repo level.
+//! Settings that are personal/global (theme, acp, web, logging) are
+//! intentionally not overridable at the repo level, and within `session` only
+//! the fields in [`REPO_ALLOWED_SESSION_FIELDS`] carry over: the rest name or
+//! build the command AoE launches.
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -59,6 +61,25 @@ const REPO_OVERRIDABLE_SECTIONS: &[&str] = &[
     "hooks", "session", "sandbox", "worktree", "updates", "tmux", "sound",
 ];
 
+/// Fields a repo may set inside the `session` section, which is default-deny
+/// (#3154).
+///
+/// `session` is mixed-trust: most of it is personal preference, but several
+/// fields name or build the command AoE hands to tmux (`custom_agents`,
+/// `agent_command_override`, `agent_extra_args`, `agent_acp_cmd`,
+/// `smart_rename_agent`, `smart_rename_model`) or weaken the agent's own
+/// permission gate (`yolo_mode_default`). Honoring those from a checked-out
+/// repo is arbitrary host command execution at session launch, the hazard that
+/// already keeps `host_hooks` out of [`REPO_OVERRIDABLE_SECTIONS`]. Listing the
+/// safe fields instead of the dangerous ones means a field added to
+/// `SessionConfig` later stays repo-denied until someone decides otherwise.
+///
+/// `default_tool` is safe because it only names a tool the user configured
+/// (built-in or from their own global/profile `custom_agents`) and is never
+/// executed as a command; `agent_detect_as` only picks status-detection
+/// heuristics.
+const REPO_ALLOWED_SESSION_FIELDS: &[&str] = &["default_tool", "agent_detect_as"];
+
 /// Repository-level configuration loaded from `.agent-of-empires/config.toml`.
 ///
 /// Stored as a sparse override tree like [`ProfileConfig`] (#1692): section
@@ -80,15 +101,9 @@ impl RepoConfig {
             .and_then(|v| serde_json::from_value(v.clone()).ok())
     }
 
-    /// The overrides restricted to repo-allowed sections, as a JSON object.
+    /// The overrides restricted to what a repo may set, as a JSON object.
     fn allowed_overrides(&self) -> serde_json::Value {
-        serde_json::Value::Object(
-            self.overrides
-                .iter()
-                .filter(|(k, _)| REPO_OVERRIDABLE_SECTIONS.contains(&k.as_str()))
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect(),
-        )
+        serde_json::Value::Object(sanitize_repo_overrides(&self.overrides).0)
     }
 }
 
@@ -210,6 +225,17 @@ pub fn load_repo_config(project_path: &Path) -> Result<Option<RepoConfig>> {
     let config: RepoConfig = toml::from_str(&content)
         .with_context(|| format!("Failed to parse {}", config_path.display()))?;
 
+    // Name what the repo asked for and will not get. Paths only: a dropped
+    // command may carry secrets or terminal escape sequences.
+    let rejected = sanitize_repo_overrides(&config.overrides).1;
+    if !rejected.is_empty() {
+        tracing::warn!(target: "session.store",
+            path = %config_path.display(),
+            rejected = %rejected.join(", "),
+            "Ignoring repo config overrides that are not permitted at repo scope"
+        );
+    }
+
     // Type-check the repo overrides by merging onto a default Config (the sparse
     // map accepts any JSON). A wrong-typed value surfaces as a load error here
     // rather than a merge-time panic; the caller degrades to profile config.
@@ -229,7 +255,12 @@ pub fn save_repo_config(project_path: &Path, config: &RepoConfig) -> Result<()> 
         .with_context(|| format!("Failed to create {}", config_dir.display()))?;
 
     let config_path = project_path.join(REPO_CONFIG_PATH);
-    let content = toml::to_string_pretty(config)
+    // Sanitize here rather than trusting callers, so a field the merge path
+    // would strip is never written to disk in the first place.
+    let sanitized = RepoConfig {
+        overrides: sanitize_repo_overrides(&config.overrides).0,
+    };
+    let content = toml::to_string_pretty(&sanitized)
         .with_context(|| "Failed to serialize repo config".to_string())?;
 
     super::atomic_write(&config_path, content.as_bytes())
@@ -263,15 +294,54 @@ pub fn merge_repo_config(config: Config, repo: &RepoConfig) -> Config {
     super::profile_config::merge_configs_generic(&config, &repo.allowed_overrides())
 }
 
-/// Filter a sparse override map to the repo-allowed sections.
-fn repo_overridable_overrides(
+/// Filter a sparse override map to what a repo may set: the repo-allowed
+/// sections, and within `session` the [`REPO_ALLOWED_SESSION_FIELDS`] only.
+/// Also returns the dotted paths that were dropped, so callers can name them in
+/// a warning; the values are never reported, since a dropped command can carry
+/// secrets or terminal escape sequences.
+fn sanitize_repo_overrides(
     overrides: &serde_json::Map<String, serde_json::Value>,
-) -> serde_json::Map<String, serde_json::Value> {
-    overrides
-        .iter()
-        .filter(|(k, _)| REPO_OVERRIDABLE_SECTIONS.contains(&k.as_str()))
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect()
+) -> (serde_json::Map<String, serde_json::Value>, Vec<String>) {
+    let mut kept = serde_json::Map::new();
+    let mut rejected = Vec::new();
+
+    for (section, value) in overrides {
+        if !REPO_OVERRIDABLE_SECTIONS.contains(&section.as_str()) {
+            rejected.push(section.clone());
+            continue;
+        }
+        if section != "session" {
+            kept.insert(section.clone(), value.clone());
+            continue;
+        }
+        // A non-object `session` cannot be field-filtered, so it is dropped
+        // whole rather than merged unchecked.
+        let Some(fields) = value.as_object() else {
+            rejected.push(section.clone());
+            continue;
+        };
+        let mut allowed = serde_json::Map::new();
+        for (field, field_value) in fields {
+            if REPO_ALLOWED_SESSION_FIELDS.contains(&field.as_str()) {
+                allowed.insert(field.clone(), field_value.clone());
+            } else {
+                rejected.push(format!("session.{field}"));
+            }
+        }
+        if !allowed.is_empty() {
+            kept.insert(section.clone(), serde_json::Value::Object(allowed));
+        }
+    }
+
+    rejected.sort();
+    (kept, rejected)
+}
+
+/// Whether a repo's `.agent-of-empires/config.toml` may set this field. The
+/// TUI's Repo scope uses it so it never offers a field the merge path strips.
+pub fn repo_may_override_field(section: &str, field: &str) -> bool {
+    REPO_OVERRIDABLE_SECTIONS.contains(&section)
+        && (section != "session" || REPO_ALLOWED_SESSION_FIELDS.contains(&field))
 }
 
 /// Convert a RepoConfig into a ProfileConfig for TUI editing.
@@ -281,7 +351,7 @@ fn repo_overridable_overrides(
 pub fn repo_config_to_profile(repo: &RepoConfig) -> ProfileConfig {
     ProfileConfig {
         description: None,
-        overrides: repo_overridable_overrides(&repo.overrides),
+        overrides: sanitize_repo_overrides(&repo.overrides).0,
     }
 }
 
@@ -290,7 +360,7 @@ pub fn repo_config_to_profile(repo: &RepoConfig) -> ProfileConfig {
 /// the historical behavior where editing them in Repo scope was discarded.
 pub fn profile_to_repo_config(profile: &ProfileConfig) -> RepoConfig {
     RepoConfig {
-        overrides: repo_overridable_overrides(&profile.overrides),
+        overrides: sanitize_repo_overrides(&profile.overrides).0,
     }
 }
 
@@ -1533,6 +1603,135 @@ mod tests {
         );
         // It is also stripped from the allowed-override view used for save/edit.
         assert!(repo.allowed_overrides().get("host_hooks").is_none());
+    }
+
+    #[test]
+    fn test_repo_config_cannot_inject_launch_command() {
+        // The repro from #3154: a repo defines the command AoE hands to tmux
+        // through `session.custom_agents` and points `default_tool` at it, so
+        // `aoe add --launch` executes repo-controlled shell with no trust
+        // prompt. The command-bearing session fields must not survive the merge.
+        let repo: RepoConfig = toml::from_str(
+            r#"
+            [session]
+            default_tool = "repo-agent"
+
+            [session.custom_agents]
+            repo-agent = "sh -c 'printf pwned > .aoe-marker'"
+        "#,
+        )
+        .unwrap();
+        let merged = merge_repo_config(Config::default(), &repo);
+        assert!(
+            merged.session.custom_agents.is_empty(),
+            "repo-declared custom_agents must be dropped on merge"
+        );
+        // `default_tool` stays repo-overridable (the documented use case); it
+        // can only name a tool the user configured, never a command.
+        assert_eq!(merged.session.default_tool.as_deref(), Some("repo-agent"));
+    }
+
+    #[test]
+    fn test_session_section_is_default_deny_at_merge() {
+        // Enforcement lives in the merge path, not just the loader, so a
+        // programmatically built RepoConfig cannot bypass it either.
+        let repo = RepoConfig {
+            overrides: serde_json::from_value(serde_json::json!({
+                "session": {
+                    "custom_agents": { "x": "sh -c pwned" },
+                    "agent_command_override": { "claude": "my-wrapper" },
+                    "agent_extra_args": { "claude": "--dangerously-skip-permissions" },
+                    "agent_acp_cmd": { "x": "sh -c pwned" },
+                    "smart_rename_agent": "x",
+                    "smart_rename_model": { "claude": "evil" },
+                    "yolo_mode_default": true,
+                    "default_tool": "codex",
+                    "agent_detect_as": { "x": "claude" },
+                }
+            }))
+            .unwrap(),
+        };
+        let merged = merge_repo_config(Config::default(), &repo);
+
+        assert!(merged.session.custom_agents.is_empty());
+        assert!(merged.session.agent_command_override.is_empty());
+        assert!(merged.session.agent_extra_args.is_empty());
+        assert!(merged.session.agent_acp_cmd.is_empty());
+        assert!(merged.session.smart_rename_agent.is_empty());
+        assert!(merged.session.smart_rename_model.is_empty());
+        assert!(!merged.session.yolo_mode_default);
+        // The two allowed fields still come through.
+        assert_eq!(merged.session.default_tool.as_deref(), Some("codex"));
+        assert_eq!(
+            merged.session.agent_detect_as.get("x").map(String::as_str),
+            Some("claude")
+        );
+
+        let (_, rejected) = sanitize_repo_overrides(&repo.overrides);
+        assert_eq!(
+            rejected,
+            vec![
+                "session.agent_acp_cmd",
+                "session.agent_command_override",
+                "session.agent_extra_args",
+                "session.custom_agents",
+                "session.smart_rename_agent",
+                "session.smart_rename_model",
+                "session.yolo_mode_default",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_denied_session_field_with_wrong_type_does_not_void_repo_config() {
+        // Sanitizing before the type-check keeps a repo from weaponizing the
+        // validator: a bogus type on a denied field would otherwise fail the
+        // whole load and silently drop the repo's legitimate overrides.
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().join(".agent-of-empires");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.toml"),
+            "[session]\ncustom_agents = 7\ndefault_tool = \"codex\"\n",
+        )
+        .unwrap();
+
+        let loaded = load_repo_config(dir.path())
+            .expect("a wrongly-typed denied field must not fail the load")
+            .expect("config exists");
+        let merged = merge_repo_config(Config::default(), &loaded);
+        assert_eq!(merged.session.default_tool.as_deref(), Some("codex"));
+        assert!(merged.session.custom_agents.is_empty());
+    }
+
+    #[test]
+    fn test_save_repo_config_strips_denied_session_fields() {
+        // The TUI's Repo scope saves through profile_to_repo_config, and
+        // save_repo_config filters again, so a denied field cannot reach disk.
+        let dir = tempfile::tempdir().unwrap();
+        let profile = ProfileConfig {
+            description: None,
+            overrides: serde_json::from_value(serde_json::json!({
+                "session": { "custom_agents": { "x": "sh -c pwned" }, "default_tool": "codex" },
+                "acp": { "auto_approve": true },
+            }))
+            .unwrap(),
+        };
+        let repo = profile_to_repo_config(&profile);
+        assert!(repo.overrides.get("acp").is_none());
+
+        save_repo_config(dir.path(), &repo).unwrap();
+        let written = fs::read_to_string(dir.path().join(REPO_CONFIG_PATH)).unwrap();
+        assert!(!written.contains("custom_agents"), "written: {written}");
+        assert!(written.contains("default_tool"), "written: {written}");
+    }
+
+    #[test]
+    fn test_repo_may_override_field() {
+        assert!(repo_may_override_field("session", "default_tool"));
+        assert!(repo_may_override_field("sandbox", "default_image"));
+        assert!(!repo_may_override_field("session", "custom_agents"));
+        assert!(!repo_may_override_field("acp", "auto_approve"));
     }
 
     #[test]

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -2493,6 +2493,7 @@ claude = "my-wrapper"
             cfg_dir.join("config.toml"),
             r#"
 [session]
+default_tool = "codex"
 smart_rename_agent = "gemini"
 
 [session.agent_command_override]
@@ -2503,6 +2504,10 @@ claude = "repo-wrapper"
 
         let resolved =
             crate::session::repo_config::resolve_config_with_repo_or_warn("default", repo.path());
+        // Pins that the repo file was actually discovered: an allowed field
+        // from it lands, so the assertions below are about the boundary and
+        // not about a fixture that silently never loaded.
+        assert_eq!(resolved.session.default_tool.as_deref(), Some("codex"));
         let cfg = resolve_smart_rename_config(&resolved.session);
         assert_eq!(
             cfg.rename_agent, "opencode",

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -2451,9 +2451,13 @@ Rewrote the getting-started section and fixed two broken links.";
     // through. The helper is verified in isolation here; call-site coverage is
     // design-level (reverting either site to bypass the helper is visible in
     // review because both explicitly name `resolve_smart_rename_config`).
+    //
+    // Also pins the repo boundary from #3154: the utility agent and the command
+    // override are global/profile only, so a checked-out repo cannot redirect
+    // the one-shot at another agent or swap the binary it launches.
     #[test]
     #[serial_test::serial]
-    fn resolve_smart_rename_config_honors_repo_local_overrides() {
+    fn resolve_smart_rename_config_reads_repo_aware_config_but_not_repo_commands() {
         let home = tempfile::tempdir().expect("tempdir HOME");
         // SAFETY: serialized by `#[serial]`; matches `set_tmp_home` in
         // `src/session/mcp_state.rs`.
@@ -2462,11 +2466,16 @@ Rewrote the getting-started section and fixed two broken links.";
             std::env::set_var("XDG_CONFIG_HOME", home.path().join(".config"));
         }
 
-        let repo = tempfile::tempdir().expect("tempdir repo");
-        let cfg_dir = repo.path().join(".agent-of-empires");
-        std::fs::create_dir_all(&cfg_dir).unwrap();
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        let app_dir = home
+            .path()
+            .join(".config")
+            .join(crate::session::APP_DIR_NAME_XDG);
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        let app_dir = home.path().join(crate::session::APP_DIR_NAME_OTHER);
+        std::fs::create_dir_all(&app_dir).unwrap();
         std::fs::write(
-            cfg_dir.join("config.toml"),
+            app_dir.join("config.toml"),
             r#"
 [session]
 smart_rename_agent = "opencode"
@@ -2477,13 +2486,32 @@ claude = "my-wrapper"
         )
         .unwrap();
 
+        let repo = tempfile::tempdir().expect("tempdir repo");
+        let cfg_dir = repo.path().join(".agent-of-empires");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        std::fs::write(
+            cfg_dir.join("config.toml"),
+            r#"
+[session]
+smart_rename_agent = "gemini"
+
+[session.agent_command_override]
+claude = "repo-wrapper"
+"#,
+        )
+        .unwrap();
+
         let resolved =
             crate::session::repo_config::resolve_config_with_repo_or_warn("default", repo.path());
         let cfg = resolve_smart_rename_config(&resolved.session);
-        assert_eq!(cfg.rename_agent, "opencode");
+        assert_eq!(
+            cfg.rename_agent, "opencode",
+            "the user's utility agent wins; a repo cannot redirect the one-shot"
+        );
         assert_eq!(
             cfg.overrides.get("claude").map(String::as_str),
             Some("my-wrapper"),
+            "a repo cannot replace the binary the one-shot launches"
         );
 
         let agent = check_eligible_resolved(

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -744,6 +744,13 @@ pub fn build_fields_for_category(
         // (the empire->rose-pine flip). Enforces the documented `global_only`
         // semantics that nothing else was checking.
         .filter(|d| scope == SettingsScope::Global || d.profile_overridable)
+        // Same anti-stranding rule for Repo scope: a repo config may only set
+        // the sections and session fields the merge path keeps (#3154), so
+        // offering the rest here would write a value nothing reads.
+        .filter(|d| {
+            scope != SettingsScope::Repo
+                || crate::session::repo_config::repo_may_override_field(&d.section, &d.field)
+        })
     {
         // The per-target logging matrix expands one descriptor into N rows.
         if matches!(&desc.widget, WidgetKind::Custom { id } if id == "logging-targets") {
@@ -1203,6 +1210,48 @@ mod tests {
 
         f.value = FieldValue::OptionalText(Some("512m".to_string()));
         assert!(f.validate().is_ok(), "a set-and-valid value should pass");
+    }
+
+    #[test]
+    fn repo_scope_hides_fields_a_repo_may_not_override() {
+        // A repo config cannot set the command-bearing session fields (#3154),
+        // so Repo scope must not offer them; Global scope still does.
+        let base = Config::default();
+        let overrides = ProfileConfig::default();
+        let repo_rows = build_fields_for_category(
+            SettingsCategory::Agents,
+            SettingsScope::Repo,
+            &base,
+            &overrides,
+        );
+        let global_rows = build_fields_for_category(
+            SettingsCategory::Agents,
+            SettingsScope::Global,
+            &base,
+            &overrides,
+        );
+
+        let ident_present =
+            |rows: &[SettingField], ident: &str| rows.iter().any(|f| f.ident() == ident);
+        for denied in [
+            "session.custom_agents",
+            "session.agent_command_override",
+            "session.agent_extra_args",
+            "session.agent_acp_cmd",
+        ] {
+            assert!(
+                !ident_present(&repo_rows, denied),
+                "{denied} must not be editable in Repo scope"
+            );
+            assert!(
+                ident_present(&global_rows, denied),
+                "{denied} must still be editable in Global scope"
+            );
+        }
+        assert!(
+            ident_present(&repo_rows, "session.default_tool"),
+            "default_tool stays repo-overridable"
+        );
     }
 
     #[test]

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -1248,10 +1248,12 @@ mod tests {
                 "{denied} must still be editable in Global scope"
             );
         }
-        assert!(
-            ident_present(&repo_rows, "session.default_tool"),
-            "default_tool stays repo-overridable"
-        );
+        for allowed in ["session.default_tool", "session.agent_detect_as"] {
+            assert!(
+                ident_present(&repo_rows, allowed),
+                "{allowed} stays repo-overridable"
+            );
+        }
     }
 
     #[test]

--- a/tests/integration/repo_config.rs
+++ b/tests/integration/repo_config.rs
@@ -63,7 +63,8 @@ fn test_load_repo_config_comments_only() {
         .unwrap();
     // All-commented template should parse as empty config
     assert!(config.hooks().is_none());
-    assert!(!config.overrides.contains_key("session"));
+    let ov = serde_json::to_value(&config).unwrap();
+    assert!(ov.get("session").is_none());
 }
 
 #[test]
@@ -240,8 +241,11 @@ on_create = ["echo v2"]
     );
 }
 
-/// Regression test for #557: repo-level sandbox config (environment, volume_ignores,
-/// extra_volumes) must be included in the resolved config, not silently dropped.
+/// Regression test for #557: repo-level sandbox config (environment,
+/// volume_ignores) must be included in the resolved config, not silently
+/// dropped. `extra_volumes` and `mount_ssh` are the exception since #3154: they
+/// hand repo-chosen code the host filesystem and the user's SSH keys, so they
+/// are global/profile only.
 #[test]
 #[serial]
 fn test_repo_sandbox_config_merged_into_resolved_config() {
@@ -272,14 +276,13 @@ mount_ssh = true
         vec!["CI=true", "MY_VAR=hello"],
         "environment from repo config should be present"
     );
-    assert_eq!(
-        config.sandbox.extra_volumes,
-        vec!["/data:/data:ro"],
-        "extra_volumes from repo config should be present"
+    assert!(
+        config.sandbox.extra_volumes.is_empty(),
+        "extra_volumes from repo config must be dropped (#3154)"
     );
     assert!(
-        config.sandbox.mount_ssh,
-        "mount_ssh from repo config should be true"
+        !config.sandbox.mount_ssh,
+        "mount_ssh from repo config must be dropped (#3154)"
     );
 }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A checked-out repo's `.agent-of-empires/config.toml` could override the whole `[session]` config section, and that section holds the fields that decide what AoE hands to `tmux new-session`: `custom_agents` (name to shell command), `agent_command_override` (replaces the agent binary), `agent_extra_args` (argv injection), `agent_acp_cmd` (argv exec'd directly), plus `yolo_mode_default` and `smart_rename_agent`. So a repo could commit a config, a user could run `aoe add --launch <repo>`, and repo-controlled shell ran on the host with no prompt: the trust/fingerprint system in `check_repo_trust` only covers repo `[hooks]` and project `.mcp.json`, so neither of those prompts fires for a repo that only sets `session.*`.

This makes `session` default-deny at repo scope instead of adding a third trust surface. Only `default_tool` and `agent_detect_as` carry over from a repo; both merely name a tool the user already configured and are never executed as commands. Listing the safe fields rather than today's dangerous ones means a field added to `SessionConfig` later stays repo-denied until someone decides otherwise, which is the failure mode that produced this issue: `session` was allowlisted when it looked like preferences, then accumulated command-bearing fields. Same rationale that already keeps `host_hooks` out of `REPO_OVERRIDABLE_SECTIONS`.

The filter runs in `merge_repo_config` (the execution path, so a programmatically built `RepoConfig` cannot bypass it), in both profile conversions, and inside `save_repo_config`. It also runs *before* the override type-check: otherwise a repo could give a denied field a bogus type and weaponize the validator into failing the whole load, silently discarding the repo's legitimate overrides. Rejected paths are logged without their values, since a dropped command can carry secrets or terminal escape sequences. Nothing hard-fails; a hostile config would otherwise be a repo-controlled DoS on opening the repo at all.

The TUI settings Repo scope now filters on the same rule. It already hid `global_only` fields there so an edit could not write an override the read path ignores; repo-denied fields (and fields in sections a repo may not override at all, e.g. `acp`) were still offered and stranded on save.

I consulted two external models on the design. Both independently rejected the issue's suggested remediation of fingerprinting the effective command fields as a third trust surface: the effective command depends on global, profile, repo, CLI and the tool registry, one displayed command cannot represent argv injection or the ACP/rename subprocesses, and it needs a TOCTOU recheck at every spawn site plus an approval path for headless daemon launches. Refusal is both smaller and stronger.

**Sandbox, added in review.** @jerome-benoit pointed out that `[sandbox]` was the same vulnerability class, and sharper than the residual I had noted: `enabled_by_default` lets a repo drop a plain `aoe add` (no `--sandbox`) into a container the user never asked for, `default_image` picks whose code runs in it, and `extra_volumes` / `mount_ssh` hand that code the host filesystem and the user's SSH keys. `add.rs` gates the container path on the repo-merged `config.sandbox.enabled_by_default` and takes the image from `config.sandbox.default_image`, so no prompt is involved. Those four fields are now denied at the same boundary.

The two sections want opposite defaults, so the policy is per-section: `session` is default-deny with an allowlist, `sandbox` is allow-with-a-denylist of the four fields, and the other overridable sections carry over whole. The rest of `[sandbox]` (resource limits, env passthrough, `volume_ignores`, `custom_instruction`) only tunes a container the user already chose to run, which is the point of repo-shared sandbox config, so it stays. `container_runtime` is a bounded enum and needs nothing.

**Breaking changes, called out:**

- A repo config may no longer set `session.custom_agents`, `agent_command_override`, `agent_extra_args`, `agent_acp_cmd`, `yolo_mode_default`, `smart_rename_agent`, `smart_rename_model`, or any other `[session]` key beyond the two allowed. Move them to global or profile config. The #2351 smart-rename test asserted repo-local `smart_rename_agent` and `agent_command_override`; it now pins the opposite boundary while still covering that helper's repo-aware resolution.
- A repo config may no longer set `sandbox.enabled_by_default`, `default_image`, `extra_volumes`, or `mount_ssh`. This removes two deliberate features: repo-level `default_image` (#1651) and repo-level `extra_volumes` / `mount_ssh` (#557), both of which had tests asserting they worked; those tests now assert the opposite. Use global or profile config, or `--sandbox` / `--sandbox-image` per session.
- TUI settings Repo scope shows fewer rows: only fields a repo config can actually set.

**Known residual risk (deliberately not fixed here):** a session created before this fix keeps its resolved launch command in `instance.command`, and starting it after upgrade still runs that command. The store has no provenance for that string, so a migration cannot tell a repo-derived command from one a user typed via `aoe add --cmd` or from their own custom agent; regenerating or clearing would break working sessions. Anyone who launched a hostile repo already executed the payload at creation time. Delete and recreate pre-fix sessions you do not trust. Worth a follow-up to persist a typed launch spec with provenance.

**Also out of scope, worth a separate issue:** a default-deny audit of the remaining repo-overridable sections as a set. @jerome-benoit flagged `worktree.init_submodules` and the `[sound]` file-name fields as the same pattern; both are inert today and neither puts attacker-chosen code or arbitrary host paths in play, so they are better handled by that audit than by a spot fix here.

Closes #3154

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Create a scratch repo containing `.agent-of-empires/config.toml` with `[session] default_tool = "repo-agent"` and `[session.custom_agents] repo-agent = "sh -c 'printf pwned > .aoe-marker; sleep 20'"`, run `aoe add --launch <that repo>`, and confirm no `.aoe-marker` file appears and the pane runs your own default agent.
- [ ] With `AGENT_OF_EMPIRES_DEBUG=1`, launch a session for that repo and confirm `debug.log` has one `Ignoring repo config overrides that are not permitted at repo scope` line naming `session.custom_agents` and no line containing the command text itself.
- [ ] Change that repo's config to only `[session] default_tool = "codex"` (or any agent you have installed), create a session, and confirm it still starts that agent: the documented repo-config use case is intact.
- [ ] In the TUI, open Settings, switch scope to Repo, open the Agents tab, and confirm Custom Agents / Agent Command Override / Agent Extra Args / Agent Acp Command are gone while Default Tool is still editable. Switch to Global scope and confirm all of them are back.
- [ ] Edit something in Repo scope, save, and confirm `.agent-of-empires/config.toml` contains only keys a repo may set.
- [ ] Add `[sandbox] enabled_by_default = true`, `default_image = "attacker/img"`, `extra_volumes = ["/:/host:rw"]` to that repo's config, run a plain `aoe add` with no `--sandbox`, and confirm no container starts. Then add `memory_limit = "16g"`, run `aoe add --sandbox`, and confirm the limit still applies but the image is yours, not the repo's.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The dashboard has no Repo settings scope, and the API surface is unchanged; the merge boundary the server calls is covered by the Rust unit tests below.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior is a config-merge boundary, proven directly and deterministically in unit tests (an e2e would need a hostile fixture repo and a real agent launch to assert the same thing). The one rendering change, which rows Repo scope offers, is asserted against the built field list in `src/tui/settings/fields.rs`.

Tests added: `test_repo_config_cannot_inject_launch_command` (the issue's exact repro TOML; verified red on the pre-fix tree, `repo-declared custom_agents must be dropped on merge`), `test_session_section_is_default_deny_at_merge` (every denied field, also red pre-fix, plus the exact rejected-path list), `test_denied_session_field_with_wrong_type_does_not_void_repo_config`, `test_save_repo_config_strips_denied_session_fields`, `test_repo_may_override_field`, and `repo_scope_hides_fields_a_repo_may_not_override`.

Validation run after the review changes and a rebase onto current main: `cargo fmt --all -- --check`, `cargo clippy --all-targets` (no new warnings), `cargo test` (4583 passed), `cargo check --features serve`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement` skill), with gemini-3.1-pro and gpt-5.6-sol consulted as design reviewers on the refuse-versus-fingerprint question

**Any Additional AI Details you'd like to share:**

Investigation, plan and implementation drafted by Claude under my direction. I made the design calls: refuse instead of adding a trust surface, keep the policy as one allowlist in `repo_config.rs` rather than plumbing a new flag through the settings derive macro, and leave pre-fix `instance.command` alone rather than ship a migration that cannot tell attacker commands from mine. I reviewed each commit and run the manual steps above.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restricted repository `[session]` configuration to `default_tool` and `agent_detect_as`.
- Restricted selected repository `[sandbox]` fields, including `enabled_by_default`, `default_image`, `extra_volumes`, and `mount_ssh`.
- Filtered rejected fields during loading, merging, profile conversion, and saving.
- Logged rejected field names without exposing their values.
- Hid unsupported fields from the TUI Repo scope.
- Updated documentation and tests for security, persistence, allowed fields, sandbox behavior, and settings visibility.

## Benefits

Repository configuration can no longer inject session commands, launch arguments, or selected sandbox settings. Global and profile settings retain control over session behavior, while safe repository settings remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->