### PR TITLE
fix(config): write through symlinks in every atomic_write, not just the settings save

### DIFF
--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -691,7 +691,7 @@ pub fn install_hooks(
             std::fs::create_dir_all(parent)?;
         }
         let formatted = serde_json::to_string_pretty(&settings)?;
-        crate::session::atomic_write_following_symlinks(settings_path, formatted.as_bytes())?;
+        crate::session::atomic_write(settings_path, formatted.as_bytes())?;
 
         tracing::info!(target: "hooks.install", "Installed AoE hooks in {}", settings_path.display());
         Ok(())
@@ -844,7 +844,7 @@ fn with_config_lock<T>(
 }
 
 fn write_codex_config(config_path: &Path, config: &toml_edit::DocumentMut) -> Result<()> {
-    crate::session::atomic_write_following_symlinks(config_path, config.to_string().as_bytes())
+    crate::session::atomic_write(config_path, config.to_string().as_bytes())
 }
 
 fn read_codex_config(config_path: &Path) -> Result<toml_edit::DocumentMut> {
@@ -1154,7 +1154,7 @@ pub fn disable_gemini_folder_trust(settings_path: &Path) -> Result<()> {
             std::fs::create_dir_all(parent)?;
         }
         let formatted = serde_json::to_string_pretty(&settings)?;
-        crate::session::atomic_write_following_symlinks(settings_path, formatted.as_bytes())?;
+        crate::session::atomic_write(settings_path, formatted.as_bytes())?;
         tracing::info!(target: "hooks.install",
             "Disabled Gemini folder trust in {}", settings_path.display());
         Ok(())
@@ -1277,7 +1277,7 @@ pub fn uninstall_hooks(settings_path: &Path) -> Result<bool> {
         }
 
         let formatted = serde_json::to_string_pretty(&settings)?;
-        crate::session::atomic_write_following_symlinks(settings_path, formatted.as_bytes())?;
+        crate::session::atomic_write(settings_path, formatted.as_bytes())?;
 
         tracing::info!(target: "hooks.uninstall", "Removed AoE hooks from {}", settings_path.display());
         Ok(true)
@@ -1366,7 +1366,7 @@ pub fn install_settl_hooks_with_events(
             std::fs::create_dir_all(parent)?;
         }
         let formatted = toml::to_string_pretty(&config)?;
-        crate::session::atomic_write_following_symlinks(config_path, formatted.as_bytes())?;
+        crate::session::atomic_write(config_path, formatted.as_bytes())?;
 
         tracing::info!(target: "hooks.install", "Installed AoE hooks in {}", config_path.display());
         Ok(())
@@ -1404,7 +1404,7 @@ pub fn uninstall_settl_hooks(config_path: &Path) -> Result<bool> {
         }
 
         let formatted = toml::to_string_pretty(&config)?;
-        crate::session::atomic_write_following_symlinks(config_path, formatted.as_bytes())?;
+        crate::session::atomic_write(config_path, formatted.as_bytes())?;
         tracing::info!(target: "hooks.uninstall", "Removed AoE hooks from {}", config_path.display());
         Ok(true)
     })
@@ -1479,10 +1479,7 @@ pub fn install_kimi_hooks_with_events(
         if let Some(parent) = config_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        crate::session::atomic_write_following_symlinks(
-            config_path,
-            config.to_string().as_bytes(),
-        )?;
+        crate::session::atomic_write(config_path, config.to_string().as_bytes())?;
 
         tracing::info!(target: "hooks.install", "Installed AoE hooks in {}", config_path.display());
         Ok(())
@@ -1579,10 +1576,7 @@ pub fn uninstall_kimi_hooks(config_path: &Path) -> Result<bool> {
             config.as_table_mut().remove("hooks");
         }
 
-        crate::session::atomic_write_following_symlinks(
-            config_path,
-            config.to_string().as_bytes(),
-        )?;
+        crate::session::atomic_write(config_path, config.to_string().as_bytes())?;
         tracing::info!(target: "hooks.uninstall", "Removed AoE hooks from {}", config_path.display());
         Ok(true)
     })
@@ -1704,17 +1698,14 @@ pub fn install_hermes_hooks_with_events(
                 std::fs::create_dir_all(parent)?;
             }
             let formatted = serde_yaml::to_string(&config)?;
-            crate::session::atomic_write_following_symlinks(config_path, formatted.as_bytes())?;
+            crate::session::atomic_write(config_path, formatted.as_bytes())?;
         }
 
         if allowlist_changed {
             if let Some(parent) = allowlist_path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            crate::session::atomic_write_following_symlinks(
-                &allowlist_path,
-                allowlist_formatted.as_bytes(),
-            )?;
+            crate::session::atomic_write(&allowlist_path, allowlist_formatted.as_bytes())?;
         }
 
         tracing::info!(target: "hooks.install", "Installed AoE hooks in {}", config_path.display());
@@ -1786,7 +1777,7 @@ pub fn uninstall_hermes_hooks(config_path: &Path) -> Result<bool> {
         }
 
         let formatted = serde_yaml::to_string(&config)?;
-        crate::session::atomic_write_following_symlinks(config_path, formatted.as_bytes())?;
+        crate::session::atomic_write(config_path, formatted.as_bytes())?;
         tracing::info!(target: "hooks.uninstall", "Removed AoE hooks from {}", config_path.display());
         Ok(true)
     })
@@ -1957,7 +1948,7 @@ pub fn install_kiro_hooks_with_events(
             std::fs::create_dir_all(parent)?;
         }
         let formatted = serde_json::to_string_pretty(&Value::Object(config))?;
-        crate::session::atomic_write_following_symlinks(agent_config_path, formatted.as_bytes())?;
+        crate::session::atomic_write(agent_config_path, formatted.as_bytes())?;
 
         tracing::info!(target: "hooks.install", "Installed AoE hooks in {}", agent_config_path.display());
         Ok(())
@@ -2114,10 +2105,7 @@ pub fn uninstall_kiro_hooks(agent_config_path: &Path) -> Result<bool> {
             std::fs::remove_file(agent_config_path)?;
         } else {
             let formatted = serde_json::to_string_pretty(&Value::Object(config))?;
-            crate::session::atomic_write_following_symlinks(
-                agent_config_path,
-                formatted.as_bytes(),
-            )?;
+            crate::session::atomic_write(agent_config_path, formatted.as_bytes())?;
         }
 
         tracing::info!(target: "hooks.uninstall", "Removed AoE hooks from {}", agent_config_path.display());

--- a/src/migrations/v015_rewrite_hook_strings.rs
+++ b/src/migrations/v015_rewrite_hook_strings.rs
@@ -69,9 +69,9 @@
 //! ### Power-loss durability across formats
 //!
 //! Every install/uninstall path in `hooks/mod.rs` routes through
-//! `crate::session::atomic_write_following_symlinks` (resolve symlink
-//! chain, then temp file + fsync + rename + dir fsync on the resolved
-//! target). A power loss mid-rewrite either keeps the prior bytes intact
+//! `crate::session::atomic_write` (resolve symlink chain, then temp file,
+//! fsync, rename, and dir fsync on the resolved target). A power loss
+//! mid-rewrite either keeps the prior bytes intact
 //! or surfaces the freshly written bytes; partial writes are not
 //! observable. Symlinks at the destination (a common dotfile-manager
 //! pattern: `~/.claude/settings.json -> ~/dotfiles/...`) are followed

--- a/src/migrations/v021_split_app_state_to_state_toml.rs
+++ b/src/migrations/v021_split_app_state_to_state_toml.rs
@@ -126,6 +126,47 @@ mod tests {
         assert_eq!(state["has_seen_welcome"].as_bool(), Some(false));
     }
 
+    /// A `config.toml` symlinked into a dotfiles repo must survive the
+    /// rewrite: the link stays a link and the stripped content lands on the
+    /// target, instead of `rename(2)` replacing the link with a regular file
+    /// (#3186). v021 stands in for every migration here; they all share the
+    /// same `atomic_write` primitive.
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_config_survives_migration() {
+        let dir = tempfile::tempdir().unwrap();
+        let dotfiles = dir.path().join("dotfiles");
+        fs::create_dir_all(&dotfiles).unwrap();
+
+        let target = dotfiles.join("aoe-config.toml");
+        fs::write(
+            &target,
+            "default_profile = \"work\"\n\n[app_state]\nhas_seen_welcome = true\n",
+        )
+        .unwrap();
+
+        let app_dir = dir.path().join("app");
+        fs::create_dir_all(&app_dir).unwrap();
+        let link = app_dir.join("config.toml");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        run_in(&app_dir).unwrap();
+
+        assert!(
+            fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the migration must not replace the symlink with a regular file"
+        );
+        let config: toml::Table = fs::read_to_string(&target).unwrap().parse().unwrap();
+        assert!(
+            !config.contains_key("app_state"),
+            "the rewrite must land on the symlink target, got: {config:?}"
+        );
+        assert_eq!(config["default_profile"].as_str(), Some("work"));
+    }
+
     #[test]
     fn noop_when_no_app_state_present() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/server/login.rs
+++ b/src/server/login.rs
@@ -215,23 +215,11 @@ impl LoginManager {
         // Rewrite the store once at startup so the passphrase hash is
         // refreshed (rotates the salt) and any dropped/expired entries
         // are pruned on disk. Synchronous: a one-time tiny write, and no
-        // tokio lock is held yet. Skip the rewrite when the path is
-        // insecure (symlink, loose perms, untrusted parent dir): writing
-        // there would be the same fail-open the load-side rejection
-        // guards against. See #1235.
-        match check_path_security(&sessions_path) {
-            Ok(()) => {
-                let snapshot = build_persisted(&passphrase_hash, &sessions);
-                write_sessions(&sessions_path, &snapshot);
-            }
-            Err(e) => {
-                tracing::warn!(
-                    target: "auth.passphrase",
-                    error = %e,
-                    "refusing to write persisted login sessions to an insecure path"
-                );
-            }
-        }
+        // tokio lock is held yet. An insecure path (symlink, loose perms,
+        // untrusted parent dir) is refused inside `write_sessions`, which
+        // guards every writer rather than this one call site. See #1235.
+        let snapshot = build_persisted(&passphrase_hash, &sessions);
+        write_sessions(&sessions_path, &snapshot);
 
         Self {
             passphrase_hash,
@@ -714,6 +702,18 @@ fn build_persisted(
 /// failed persist must not break a login, but the boolean lets callers
 /// avoid advancing the on-disk-expiry watermark on a failed write.
 fn write_sessions(path: &Path, file: &PersistedFile) -> bool {
+    // The no-symlink, owner-only invariant belongs on the write path too,
+    // not just at load. `atomic_write` resolves symlinks and writes through
+    // to the target, so an unguarded persist would hand the session secret
+    // to whatever a planted link points at. See #1235, #3186.
+    if let Err(e) = check_path_security(path) {
+        tracing::warn!(
+            target: "auth.passphrase",
+            error = %e,
+            "refusing to write persisted login sessions to an insecure path"
+        );
+        return false;
+    }
     let toml = match toml::to_string(file) {
         Ok(s) => s,
         Err(e) => {
@@ -1930,6 +1930,34 @@ mod tests {
         assert!(
             !dir.path().join(SESSIONS_FILE).exists(),
             "no persistence path means no file"
+        );
+    }
+
+    /// The write path enforces the same no-symlink invariant the load path
+    /// does. `atomic_write` follows symlinks (#3186), so an unguarded
+    /// persist would write the session secret through a planted link.
+    #[cfg(unix)]
+    #[test]
+    fn write_sessions_refuses_symlinked_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("planted.toml");
+        std::fs::write(&target, "untouched").unwrap();
+        let link = dir.path().join(SESSIONS_FILE);
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let file = PersistedFile {
+            schema_version: SESSIONS_SCHEMA_VERSION,
+            passphrase_hash: Some(hash_passphrase("pass")),
+            sessions: vec![],
+        };
+        assert!(
+            !write_sessions(&link, &file),
+            "a symlinked sessions path must be refused, not followed"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "untouched",
+            "the symlink target must never receive the session store"
         );
     }
 

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -2529,7 +2529,7 @@ pub fn update_config<R>(f: impl FnOnce(&mut Config) -> R) -> Result<R> {
     let mut table = toml::Table::try_from(&config)?;
     table.remove("app_state");
     let content = toml::to_string_pretty(&table)?;
-    super::atomic_write_following_symlinks(&config_path()?, content.as_bytes())?;
+    super::atomic_write(&config_path()?, content.as_bytes())?;
 
     Ok(result)
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -128,7 +128,7 @@ pub use repo_config::{
     resolve_config_with_repo_or_warn, save_repo_config, trust_repo, HookTimeout, HooksConfig,
     RepoConfig, RepoTrust, TrustSurface,
 };
-pub(crate) use storage::{atomic_write, atomic_write_following_symlinks, resolve_symlink_chain};
+pub(crate) use storage::{atomic_write, resolve_symlink_chain};
 pub use storage::{
     load_recent_projects, load_workspace_ordering, recent_project_entry_for, record_recent_project,
     update_workspace_ordering, RecentProjectEntry, Storage, WorkspaceOrdering,

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -97,7 +97,15 @@ const FLOCK_WAIT_WARN_AFTER: Duration = Duration::from_secs(1);
 
 /// Write `content` to `path` atomically (temp file + fsync + rename + dir fsync).
 /// Existing perms are preserved; on a fresh file the result is tempfile's 0o600 default.
+///
+/// A symlink at `path` is resolved first and the write lands on the target, so
+/// a user who symlinks `config.toml` (or any other file we own) into a dotfiles
+/// repo keeps the link: `rename(2)` would otherwise replace it with a regular
+/// file and silently desync the dotfile tree (#2784, #3186). Nothing in AoE
+/// wants to clobber such a link, so this is the single write behavior rather
+/// than an opt-in helper the next caller can forget to reach for.
 pub(crate) fn atomic_write(path: &Path, content: &[u8]) -> Result<()> {
+    let path = &resolve_symlink_chain(path)?;
     let dir = path.parent().ok_or_else(|| {
         anyhow!(
             "atomic_write needs a path with a parent: {}",
@@ -928,6 +936,43 @@ mod tests {
             (THREADS * INCREMENTS).to_string(),
             "every increment must land; the sidecar flock serializes read-modify-write"
         );
+    }
+
+    /// Every write goes through the symlink to the target. Users symlink
+    /// `config.toml` and friends into a dotfiles repo, and a `rename(2)` over
+    /// the link would swap it for a regular file, silently desyncing the
+    /// dotfile tree (#2784, #3186).
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_follows_symlinks() {
+        let tmp = tempdir().unwrap();
+        let target = tmp.path().join("real-config.toml");
+        std::fs::write(&target, "old").unwrap();
+        let link = tmp.path().join("config.toml");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        atomic_write(&link, b"new").unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the symlink must survive; a rename over it would desync dotfile setups"
+        );
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "new");
+
+        // A dangling link materialises the target, not a regular file at the
+        // link path: a fresh install can symlink config.toml before it exists.
+        let missing = tmp.path().join("not-yet.toml");
+        let dangling = tmp.path().join("dangling.toml");
+        std::os::unix::fs::symlink(&missing, &dangling).unwrap();
+        atomic_write(&dangling, b"seeded").unwrap();
+        assert_eq!(std::fs::read_to_string(&missing).unwrap(), "seeded");
+        assert!(std::fs::symlink_metadata(&dangling)
+            .unwrap()
+            .file_type()
+            .is_symlink());
     }
 
     #[cfg(unix)]

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -169,15 +169,6 @@ pub(crate) fn resolve_symlink_chain(path: &Path) -> Result<PathBuf> {
     }
 }
 
-/// Like [`atomic_write`], but resolves any symlink at `path` first and writes
-/// through to the underlying file. Use for user-facing agent config files
-/// where users may symlink the path into a dotfiles repo (chezmoi, stow,
-/// dotbot). Plain [`atomic_write`] would replace the symlink with a regular
-/// file via `rename(2)`, silently desyncing the dotfile tree.
-pub(crate) fn atomic_write_following_symlinks(path: &Path, content: &[u8]) -> Result<()> {
-    atomic_write(&resolve_symlink_chain(path)?, content)
-}
-
 /// Serialized read-modify-write of a small standalone data file.
 ///
 /// Acquires an exclusive cross-process `flock` on a sidecar


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A symlinked `~/.agent-of-empires/config.toml` survived a settings save after #2785, but not an update. Every migration that rewrites the file went through the plain `atomic_write`, whose temp-file plus `rename(2)` dance replaces the symlink with a regular file. So on the first launch after an update carrying a config-touching migration, a dotfiles user's symlink silently became a detached regular file and their repo copy stopped receiving changes.

`v021_split_app_state_to_state_toml` (2026-07-15, fires whenever `[app_state]` is present in `config.toml`, so effectively anyone who used the TUI) and `v022_prune_tuning_settings` (2026-07-17) both landed after the #2785 fix merged on 2026-07-14, which is why this came back as a fresh regression rather than old history.

The direct cause is 16 migration call sites, but the reason it will keep happening is that #2785 fixed one call site instead of the invariant, and two runtime writers were still wrong for the same reason (`save_profile_config`, `save_repo_config`). Rather than swap 20 more call sites and add a guard to police the next one, this PR resolves the symlink chain inside `atomic_write` itself and deletes the opt-in `atomic_write_following_symlinks`.

That is the shape `locked_update` already had: it resolves the chain unconditionally for `sessions.json`, `groups.json`, `state.toml`, and `mcp_state.json`, and its docstring already carried the dotfiles rationale. The codebase was giving two answers to one question, and the wrong answer had the shorter, more discoverable name. Nothing in AoE wants to replace a user's symlink with a regular file, so one behavior for every writer removes the footgun instead of policing it. `src/plugin/host_api.rs` is untouched; it refuses symlinks via its own `symlink_metadata` checks as a separate security boundary.

Non-symlinked installs are byte-identical: `resolve_symlink_chain` returns the path unchanged when the path is not a symlink. Perms do not regress either, because `fs::metadata` already followed symlinks, so `atomic_write` was already reading the target's perms; now the write lands there too.

Closes #3186

### Follow-on from review: the login-session write path

Making `atomic_write` follow symlinks reversed an explicit invariant on one file, caught by @jerome-benoit in review. `check_path_security` refuses a symlinked `login_sessions.toml` and ran at load (`login.rs:795`) and at the startup rewrite, but `persist()` to `write_sessions` to `atomic_write` skipped it. That was only incidentally safe while `rename(2)` destroyed the planted link.

The check now lives inside `write_sessions`, so every writer inherits it instead of one call site remembering to ask, and the outer guard at the startup rewrite is gone (it became a redundant second stat and a second warn path). Not privilege escalation: app-dir perms gate it and the store is re-asserted 0600. The reason to fix it is that `login_sessions.toml` is the one file with an explicit no-symlink invariant, so it should not depend on a write primitive's incidental behavior.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Move `~/.agent-of-empires/config.toml` into a separate dir and symlink it back: `mkdir -p ~/dotfiles && mv ~/.agent-of-empires/config.toml ~/dotfiles/aoe-config.toml && ln -s ~/dotfiles/aoe-config.toml ~/.agent-of-empires/config.toml`.
- [ ] Force a migration to run: `echo 20 > ~/.agent-of-empires/.schema_version` (this replays v021 onward on next launch). Back up `config.toml` first if you care about the contents.
- [ ] Launch `aoe`, quit, then confirm `ls -l ~/.agent-of-empires/config.toml` still shows a symlink, not a regular file.
- [ ] Confirm the migrated content landed in `~/dotfiles/aoe-config.toml` (its `[app_state]` table should be gone, and `~/.agent-of-empires/state.toml` should exist).
- [ ] Symlink a profile config the same way (`~/.agent-of-empires/profiles/<name>/config.toml`), change a profile-scoped setting in the settings TUI, and confirm the link survives with the new value at the target.
- [ ] On a non-symlinked install, change a setting and confirm nothing about saving behaves differently.
- [ ] Symlink `~/.agent-of-empires/login_sessions.toml` at something harmless, run `aoe serve`, log in, and confirm the target is never written and the log carries `refusing to write persisted login sessions to an insecure path`.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior is a filesystem write primitive, so a unit test can fail on it deterministically while an e2e test would only exercise it incidentally. Three unit tests cover it instead, each verified red on the pre-fix tree:

- `session::storage::tests::atomic_write_follows_symlinks`: the link survives, the target receives the bytes, and a dangling link materialises its target rather than a regular file at the link path. Fails pre-fix with "the symlink must survive".
- `migrations::v021_split_app_state_to_state_toml::tests::symlinked_config_survives_migration`: end-to-end on the migration that most likely clobbered the reporter's config. Fails pre-fix with "the migration must not replace the symlink with a regular file". This is the one that proves the reported bug dead.
- `server::login::tests::write_sessions_refuses_symlinked_path`: the persist path refuses a symlinked store and never writes the target. Verified red by disabling the new guard, where the write returns `true` and the target receives the session store.

The red direction for the first two was proven in a detached worktree at the pre-fix commit, so the fix line is reverted but the committed test text is unchanged.

One thing the issue asked for that deliberately did not become its own test fn, per the repo's test-cost policy: a source-scanning guard test so a future migration cannot reintroduce the bug. Not needed under this shape, because the unsafe variant no longer exists, so there is no wrong helper left to reach for. A profile-config-level test is likewise skipped: `save_profile_config` writes through `atomic_write` with no logic of its own, so it would assert the primitive a second time; the manual step above covers it.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-investigate` and `/aoe-implement` skills)

**Any Additional AI Details you'd like to share:**
Claude did the investigation and drafted the implementation and prose. I made the design call: collapse the primitive rather than swap 20 call sites and add a guard test, on the grounds that `locked_update` already established that behavior. I reviewed each commit and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated `atomic_write` to follow symlink chains and write to their targets.
- Removed `atomic_write_following_symlinks`.
- Applied the safer write behavior to configuration, migration, and hook files.
- Added regression tests for symlinked configuration and storage paths.
- Moved session-store security checks into `write_sessions` so all writes reject symlinks.
- Updated the live-frame-compression test to poll for compressed frames, reducing CI timing flakes.

## Benefits

These changes preserve symlinked configuration files and protect the session store from unintended writes. They also improve test reliability.

## Validation

- 6,193 tests passed.
- Formatting and Clippy checks passed.

## Potential follow-up

Additional coverage could verify symlink behavior across all supported configuration formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->