### PR TITLE
feat(cityhall): export and apply a CityHall config bundle

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -83,6 +83,9 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe theme dir`↴](#aoe-theme-dir)
 * [`aoe settings`↴](#aoe-settings)
 * [`aoe settings explain`↴](#aoe-settings-explain)
+* [`aoe cityhall`↴](#aoe-cityhall)
+* [`aoe cityhall export`↴](#aoe-cityhall-export)
+* [`aoe cityhall apply`↴](#aoe-cityhall-apply)
 * [`aoe telemetry`↴](#aoe-telemetry)
 * [`aoe telemetry status`↴](#aoe-telemetry-status)
 * [`aoe telemetry enable`↴](#aoe-telemetry-enable)
@@ -143,6 +146,7 @@ Run without arguments to launch the TUI dashboard.
 * `sounds` — Manage sound effects for agent state transitions
 * `theme` — Manage color themes (list, export, customize)
 * `settings` — Inspect resolved settings and their provenance
+* `cityhall` — Export and apply the CityHall config bundle (settings + projects)
 * `telemetry` — Manage anonymous opt-in usage telemetry
 * `mcp` — Inspect the effective MCP server set (provenance, conflicts, drift)
 * `serve` — Start a web dashboard for remote session access
@@ -1261,6 +1265,43 @@ Explain where a setting's effective value comes from. KEY is a core `section.fie
 ###### **Arguments:**
 
 * `<KEY>` — The setting key to explain
+
+
+
+## `aoe cityhall`
+
+Export and apply the CityHall config bundle (settings + projects)
+
+**Usage:** `aoe cityhall <COMMAND>`
+
+###### **Subcommands:**
+
+* `export` — Write a bundle describing this install's settings and projects
+* `apply` — Apply a bundle to this install (merge settings, clone and register projects, install the git identity)
+
+
+
+## `aoe cityhall export`
+
+Write a bundle describing this install's settings and projects
+
+**Usage:** `aoe cityhall export [OPTIONS]`
+
+###### **Options:**
+
+* `-o`, `--out <OUT>` — Write to a file instead of stdout
+
+
+
+## `aoe cityhall apply`
+
+Apply a bundle to this install (merge settings, clone and register projects, install the git identity)
+
+**Usage:** `aoe cityhall apply <FILE>`
+
+###### **Arguments:**
+
+* `<FILE>` — Bundle to apply; `-` reads stdin
 
 
 

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -133,6 +133,43 @@ AOE_CITYHALL_MODE=1 aoe serve --host 0.0.0.0
 
 The flag and the env var are equivalent; the daemon replays `--cityhall` to its child and persists it in `serve.launch`, so the mode survives `aoe serve --restart` and the post-`aoe update` re-exec (it is not silently dropped when the restart shell lacks the env var).
 
+#### The CityHall config bundle
+
+A locked-down client cannot configure itself: `PATCH /api/settings`, the project CRUD routes, and `POST /api/git/clone` are all closed in CityHall mode, and the project registry starts empty, so a fresh workspace has no project to launch a session against. The config bundle fills that gap. It is one TOML document describing how a workspace should be set up:
+
+```toml
+schema_version = 1
+
+[meta]
+generated_by = "aoe 1.13.2"
+
+# Sparse settings overrides: only the fields that differ from the defaults.
+[settings.acp]
+default_agent = "claude-code"
+
+[[projects]]
+name = "cityhall"
+remote = "https://github.com/agent-of-empires/cityhall.git"
+default_base_branch = "main"
+```
+
+Projects are addressed by **git remote**, not by path: an admin's local checkout path means nothing inside a workspace, so `apply` clones each remote into `<app_dir>/repos/<name>` and registers that path. Settings are a sparse patch keyed by section then field, the same shape a `PATCH /api/settings` body takes, so they go through the same validation.
+
+Produce one from a configured install with `aoe cityhall export --out cityhall.toml`, or from the dashboard's **Settings → CityHall** tab. The export deliberately omits host-specific fields (the ones marked local-only in the settings schema, such as binary paths) and never contains a credential. Apply one by hand with `aoe cityhall apply cityhall.toml`.
+
+Applying is idempotent, because a workspace does it on every boot: an existing checkout is left untouched so uncommitted work survives a restart, and an already-registered project is not re-added. A repo that fails to clone is reported without taking the other projects down. A bundle sets values; it cannot unset them.
+
+To have a workspace fetch its bundle at startup, point it at the URL that serves one:
+
+| Variable | Meaning |
+| --- | --- |
+| `AOE_CITYHALL_BUNDLE_URL` | URL to fetch the bundle from at `aoe serve` startup. Unset disables the fetch entirely. |
+| `AOE_CITYHALL_BUNDLE_TOKEN` | Bearer token sent with that request. |
+
+The fetch happens before the server reads any config, and its failure handling is asymmetric on purpose. On a first boot there is no cached bundle, so a fetch failure fails the startup rather than leaving the user in a workspace with default settings and no projects. Once a bundle has been applied it is cached in the app dir, and a later fetch failure only logs a warning and serves the cached configuration, so a transient outage cannot brick a working workspace. A bundle that arrives but is malformed, or names a setting this aoe does not know, is fatal either way.
+
+The document the bundle carries is also where a git identity and credential arrive (`[git]`), which is what makes clone, pull, and push work inside a workspace. That section is never written by `export`; the host serving the bundle composes it per user.
+
 ### Behind a reverse proxy
 
 When TLS is terminated by an external proxy (Traefik, nginx, Caddy) forwarding to `aoe serve` on loopback (often through an SSH reverse tunnel), use `--behind-proxy` so cookies carry `; Secure` and the rate limiter keys by the real client IP:

--- a/src/cli/cityhall.rs
+++ b/src/cli/cityhall.rs
@@ -1,0 +1,78 @@
+//! `aoe cityhall` subcommands: produce and consume the CityHall config bundle.
+//!
+//! `export` runs on an admin's own machine; `apply` runs inside a CityHall
+//! workspace (normally driven automatically at `aoe serve` boot, see
+//! `crate::cli::serve`). See `crate::session::cityhall_bundle`.
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand, ValueHint};
+use std::path::PathBuf;
+
+use crate::session::cityhall_bundle::{self, CityHallBundle};
+
+#[derive(Subcommand)]
+pub enum CityHallCommands {
+    /// Write a bundle describing this install's settings and projects
+    Export(ExportArgs),
+
+    /// Apply a bundle to this install (merge settings, clone and register
+    /// projects, install the git identity)
+    Apply(ApplyArgs),
+}
+
+#[derive(Args)]
+pub struct ExportArgs {
+    /// Write to a file instead of stdout
+    #[arg(long, short, value_hint = ValueHint::FilePath)]
+    out: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub struct ApplyArgs {
+    /// Bundle to apply; `-` reads stdin
+    #[arg(value_hint = ValueHint::FilePath)]
+    file: String,
+}
+
+pub fn run(command: CityHallCommands) -> Result<()> {
+    match command {
+        CityHallCommands::Export(args) => run_export(args),
+        CityHallCommands::Apply(args) => run_apply(args),
+    }
+}
+
+fn run_export(args: ExportArgs) -> Result<()> {
+    let toml = cityhall_bundle::export()?.to_toml()?;
+    match args.out {
+        Some(path) => {
+            std::fs::write(&path, &toml).with_context(|| format!("writing {}", path.display()))?;
+            println!("Wrote {}", path.display());
+        }
+        None => print!("{toml}"),
+    }
+    Ok(())
+}
+
+fn run_apply(args: ApplyArgs) -> Result<()> {
+    let raw = if args.file == "-" {
+        std::io::read_to_string(std::io::stdin()).context("reading the bundle from stdin")?
+    } else {
+        std::fs::read_to_string(&args.file).with_context(|| format!("reading {}", args.file))?
+    };
+
+    let report = cityhall_bundle::apply(&CityHallBundle::from_toml(&raw)?)?;
+
+    println!("Applied {} settings.", report.settings_applied);
+    if !report.cloned.is_empty() {
+        println!("Cloned: {}", report.cloned.join(", "));
+    }
+    if !report.registered.is_empty() {
+        println!("Registered: {}", report.registered.join(", "));
+    }
+    // Project failures are collected rather than fatal, so surface them here
+    // instead of letting a partial apply look like a clean one.
+    for failure in &report.failures {
+        eprintln!("Warning: {failure}");
+    }
+    Ok(())
+}

--- a/src/cli/cityhall.rs
+++ b/src/cli/cityhall.rs
@@ -4,7 +4,7 @@
 //! workspace (normally driven automatically at `aoe serve` boot, see
 //! `crate::cli::serve`). See `crate::session::cityhall_bundle`.
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::{Args, Subcommand, ValueHint};
 use std::path::PathBuf;
 
@@ -73,6 +73,12 @@ fn run_apply(args: ApplyArgs) -> Result<()> {
     // instead of letting a partial apply look like a clean one.
     for failure in &report.failures {
         eprintln!("Warning: {failure}");
+    }
+    // A partial apply stays a success: the other projects landed, and the boot
+    // path depends on that. But when nothing landed at all, a script has no way
+    // to tell this from a clean run, so fail.
+    if !report.failures.is_empty() && report.cloned.is_empty() && report.registered.is_empty() {
+        bail!("no project could be applied");
     }
     Ok(())
 }

--- a/src/cli/cityhall.rs
+++ b/src/cli/cityhall.rs
@@ -69,16 +69,71 @@ fn run_apply(args: ApplyArgs) -> Result<()> {
     if !report.registered.is_empty() {
         println!("Registered: {}", report.registered.join(", "));
     }
+    if !report.preserved.is_empty() {
+        println!("Already in place: {}", report.preserved.join(", "));
+    }
     // Project failures are collected rather than fatal, so surface them here
     // instead of letting a partial apply look like a clean one.
     for failure in &report.failures {
         eprintln!("Warning: {failure}");
     }
-    // A partial apply stays a success: the other projects landed, and the boot
-    // path depends on that. But when nothing landed at all, a script has no way
-    // to tell this from a clean run, so fail.
-    if !report.failures.is_empty() && report.cloned.is_empty() && report.registered.is_empty() {
+    if nothing_applied(&report) {
         bail!("no project could be applied");
     }
     Ok(())
+}
+
+/// Whether an apply that reported failures managed to land nothing at all.
+///
+/// A partial apply stays a success: the other projects are in place, and the
+/// boot path depends on that. Only a run where every project failed is worth a
+/// non-zero exit, because a script cannot otherwise tell it from a clean one. A
+/// project that was already cloned and already registered counts as landed;
+/// without that, re-applying an unchanged bundle alongside one bad remote would
+/// look like a total failure.
+fn nothing_applied(report: &cityhall_bundle::ApplyReport) -> bool {
+    !report.failures.is_empty()
+        && report.cloned.is_empty()
+        && report.registered.is_empty()
+        && report.preserved.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cityhall_bundle::ApplyReport;
+
+    fn report(
+        cloned: &[&str],
+        registered: &[&str],
+        preserved: &[&str],
+        failures: &[&str],
+    ) -> ApplyReport {
+        let own = |v: &[&str]| v.iter().map(|s| s.to_string()).collect();
+        ApplyReport {
+            settings_applied: 0,
+            cloned: own(cloned),
+            registered: own(registered),
+            preserved: own(preserved),
+            failures: own(failures),
+        }
+    }
+
+    #[test]
+    fn only_a_totally_failed_apply_is_an_error() {
+        let cases = [
+            (report(&[], &[], &[], &["a: clone failed"]), true),
+            // The regression this guards: one repo already in place next to one
+            // bad remote is a partial apply, not a total failure.
+            (report(&[], &[], &["kept"], &["a: clone failed"]), false),
+            (report(&["new"], &[], &[], &["a: clone failed"]), false),
+            (report(&[], &["reg"], &[], &["a: clone failed"]), false),
+            // No failures at all is never an error, including a pure no-op.
+            (report(&[], &[], &[], &[]), false),
+            (report(&[], &[], &["kept"], &[]), false),
+        ];
+        for (report, expected) in cases {
+            assert_eq!(nothing_applied(&report), expected, "{report:?}");
+        }
+    }
 }

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -9,6 +9,7 @@ use clap_complete::Shell;
 #[cfg(feature = "serve")]
 use super::acp::AcpCommands;
 use super::add::AddArgs;
+use super::cityhall::CityHallCommands;
 use super::extract_session_id::ExtractSessionIdArgs;
 use super::group::GroupCommands;
 use super::init::InitArgs;
@@ -181,6 +182,12 @@ pub enum Commands {
         command: SettingsCommands,
     },
 
+    /// Export and apply the CityHall config bundle (settings + projects)
+    Cityhall {
+        #[command(subcommand)]
+        command: CityHallCommands,
+    },
+
     /// Manage anonymous opt-in usage telemetry
     Telemetry {
         #[command(subcommand)]
@@ -266,6 +273,7 @@ pub const CLI_COMMAND_NAMES: &[&str] = &[
     "sounds",
     "theme",
     "settings",
+    "cityhall",
     "telemetry",
     "mcp",
     "serve",
@@ -312,6 +320,7 @@ pub fn command_name(command: &Commands) -> Option<&'static str> {
         Commands::Sounds { .. } => "sounds",
         Commands::Theme { .. } => "theme",
         Commands::Settings { .. } => "settings",
+        Commands::Cityhall { .. } => "cityhall",
         Commands::Telemetry { .. } => "telemetry",
         Commands::Mcp { .. } => "mcp",
         #[cfg(feature = "serve")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@
 pub mod acp;
 pub mod add;
 pub mod agents;
+pub mod cityhall;
 pub mod definition;
 pub mod extract_session_id;
 pub mod graft;

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -892,6 +892,11 @@ pub async fn run(profile: &str, mut args: ServeArgs) -> Result<()> {
         return start_daemon(profile, &args);
     }
 
+    // Past the daemon fork, so exactly the process that serves applies the
+    // bundle, and before the server resolves any config, because the bundle can
+    // change every setting it is about to read.
+    apply_cityhall_bundle().await?;
+
     tracing::info!(
         target: "serve.daemon",
         profile = %profile,
@@ -963,6 +968,98 @@ pub fn stdio_redirect_path() -> Result<PathBuf> {
         .map(|c| c.logging)
         .unwrap_or_default();
     Ok(crate::logging::resolve_log_path(&log_cfg, &dir))
+}
+
+/// URL a CityHall-hosted workspace fetches its config bundle from. Unset means
+/// this install is not CityHall-managed and the fetch is skipped entirely.
+const BUNDLE_URL_ENV: &str = "AOE_CITYHALL_BUNDLE_URL";
+/// Bearer token for [`BUNDLE_URL_ENV`]. CityHall issues one per workspace.
+const BUNDLE_TOKEN_ENV: &str = "AOE_CITYHALL_BUNDLE_TOKEN";
+/// The bundle is small and the workspace cannot serve until it lands, so a short
+/// ceiling is better than a slow start behind an unresponsive CityHall.
+const BUNDLE_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// Fetch and apply the CityHall config bundle when this install is pointed at
+/// one. See `crate::session::cityhall_bundle`.
+///
+/// Failure is deliberately asymmetric:
+///
+/// - **No cached bundle** means this is a first boot. Continuing would leave the
+///   user in a workspace with default settings and no projects, which is the
+///   exact confusion the bundle exists to remove, so the boot fails loudly and
+///   CityHall surfaces it as a workspace that would not start.
+/// - **A cached bundle exists**, so the workspace is already configured. A
+///   transient CityHall outage must not brick it, so this warns and serves with
+///   what is on disk.
+///
+/// A bundle that arrives but is malformed or carries an unknown settings key is
+/// fatal either way: that is an admin error, and swallowing it would leave the
+/// admin believing a broken document had been applied.
+async fn apply_cityhall_bundle() -> Result<()> {
+    use crate::session::cityhall_bundle::{self, CityHallBundle};
+
+    let Some(url) = std::env::var(BUNDLE_URL_ENV)
+        .ok()
+        .map(|u| u.trim().to_string())
+        .filter(|u| !u.is_empty())
+    else {
+        return Ok(());
+    };
+    let token = std::env::var(BUNDLE_TOKEN_ENV).unwrap_or_default();
+    let cache = cityhall_bundle::cache_path()?;
+
+    let raw = match fetch_cityhall_bundle(&url, &token).await {
+        Ok(raw) => raw,
+        Err(e) if cache.exists() => {
+            tracing::warn!(
+                target: "serve.cityhall",
+                error = %e,
+                "could not refresh the CityHall config bundle; serving the cached configuration"
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            return Err(e.context(format!(
+                "fetching the CityHall config bundle from {url}. \
+                 The workspace has no cached configuration, so it cannot start."
+            )))
+        }
+    };
+
+    let report = cityhall_bundle::apply(&CityHallBundle::from_toml(&raw)?)?;
+    tracing::info!(
+        target: "serve.cityhall",
+        settings = report.settings_applied,
+        cloned = ?report.cloned,
+        registered = ?report.registered,
+        "applied the CityHall config bundle"
+    );
+    for failure in &report.failures {
+        tracing::warn!(target: "serve.cityhall", "{failure}");
+    }
+
+    // Cache last: a document that failed to apply must not be remembered as the
+    // configuration this workspace is running.
+    if let Err(e) = std::fs::write(&cache, &raw) {
+        tracing::warn!(target: "serve.cityhall", error = %e, "could not cache the bundle");
+    }
+    Ok(())
+}
+
+async fn fetch_cityhall_bundle(url: &str, token: &str) -> Result<String> {
+    let mut request = reqwest::Client::builder()
+        .timeout(BUNDLE_FETCH_TIMEOUT)
+        .build()?
+        .get(url);
+    if !token.is_empty() {
+        request = request.bearer_auth(token);
+    }
+    let response = request.send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        bail!("CityHall returned HTTP {status}");
+    }
+    Ok(response.text().await?)
 }
 
 fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -1032,6 +1032,7 @@ async fn apply_cityhall_bundle() -> Result<()> {
         settings = report.settings_applied,
         cloned = ?report.cloned,
         registered = ?report.registered,
+        preserved = ?report.preserved,
         "applied the CityHall config bundle"
     );
     for failure in &report.failures {

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -1057,7 +1057,18 @@ async fn fetch_cityhall_bundle(url: &str, token: &str) -> Result<String> {
     let response = request.send().await?;
     let status = response.status();
     if !status.is_success() {
-        bail!("CityHall returned HTTP {status}");
+        // On a first boot this error is fatal and is the only thing the operator
+        // sees, so carry CityHall's own explanation (bad token, wrong path, a
+        // validation message) instead of just the status.
+        let body = response.text().await.unwrap_or_default();
+        let body = body.trim();
+        if body.is_empty() {
+            bail!("CityHall returned HTTP {status}");
+        }
+        bail!(
+            "CityHall returned HTTP {status}: {}",
+            body.chars().take(300).collect::<String>()
+        );
     }
     Ok(response.text().await?)
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -23,7 +23,7 @@ mod remote;
 pub mod template;
 mod worktree;
 
-pub use remote::{clone_bare_repo, clone_repo, get_remote_owner, get_remote_slug};
+pub use remote::{clone_bare_repo, clone_repo, get_remote_owner, get_remote_slug, get_remote_url};
 pub use worktree::{GitWorktree, WorktreeEntry};
 
 /// Open a git repository at the given path without searching parent directories.

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -353,6 +353,17 @@ pub(crate) fn parse_slug_from_remote_url(url: &str) -> Option<String> {
     Some(format!("{}/{}", owner, repo))
 }
 
+/// Read a git repository's `origin` remote URL verbatim. Returns `None` if the
+/// path is not a git repo or has no origin remote.
+///
+/// Unlike [`get_remote_owner`] / [`get_remote_slug`] this does no parsing: the
+/// CityHall bundle needs the URL itself, so a workspace can clone it.
+pub fn get_remote_url(path: &Path) -> Option<String> {
+    let repo = open_repo_at(path).ok()?;
+    let remote = repo.find_remote("origin").ok()?;
+    remote.url().ok().map(str::to_string)
+}
+
 /// Look up the `owner/repo` slug of a git repository by reading the `origin`
 /// remote URL. Returns `None` if the path is not a git repo, has no origin
 /// remote, or the URL cannot be parsed into an owner/repo pair.

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,6 +400,7 @@ async fn run(
             };
         }
         Some(Commands::Settings { command }) => return cli::settings::run(command),
+        Some(Commands::Cityhall { command }) => return cli::cityhall::run(command),
         Some(Commands::Telemetry { command }) => return cli::telemetry::run(command),
         Some(Commands::Mcp { command }) => {
             let profile = cli.profile.clone().unwrap_or_default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,7 +400,6 @@ async fn run(
             };
         }
         Some(Commands::Settings { command }) => return cli::settings::run(command),
-        Some(Commands::Cityhall { command }) => return cli::cityhall::run(command),
         Some(Commands::Telemetry { command }) => return cli::telemetry::run(command),
         Some(Commands::Mcp { command }) => {
             let profile = cli.profile.clone().unwrap_or_default();
@@ -438,6 +437,9 @@ async fn run(
             cli::project::run(&profile, profile_explicit, command).await
         }
         Some(Commands::Worktree { command }) => cli::worktree::run(&profile, command).await,
+        // `apply` merges settings and writes the project registry, so it has to
+        // run after migrations have brought that data to the current shape.
+        Some(Commands::Cityhall { command }) => cli::cityhall::run(command),
         #[cfg(feature = "serve")]
         Some(Commands::Serve(args)) => cli::serve::run(&profile, args).await,
         #[cfg(feature = "serve")]

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -71,12 +71,12 @@ pub(crate) use sessions::purge_expired_trash;
 pub(crate) use sessions::reconcile_trashed_worktrees;
 pub use system::{
     browse_filesystem, create_profile, default_profile, delete_profile, dismiss_update,
-    docker_status, filesystem_home, get_about, get_current_theme, get_profile_settings,
-    get_resolved_theme, get_settings, get_settings_resolved, get_settings_schema, get_tips,
-    get_update_status, get_web_ui_state, list_agents, list_groups, list_profiles, list_sounds,
-    list_themes, mark_tip_seen, mark_volume_ignores_globs_acknowledged, mark_web_tour_seen,
-    patch_web_ui_state, rename_profile, serve_sound_file, set_show_tips, update_profile_settings,
-    update_settings, update_theme,
+    docker_status, filesystem_home, get_about, get_cityhall_bundle, get_current_theme,
+    get_profile_settings, get_resolved_theme, get_settings, get_settings_resolved,
+    get_settings_schema, get_tips, get_update_status, get_web_ui_state, list_agents, list_groups,
+    list_profiles, list_sounds, list_themes, mark_tip_seen, mark_volume_ignores_globs_acknowledged,
+    mark_web_tour_seen, patch_web_ui_state, rename_profile, serve_sound_file, set_show_tips,
+    update_profile_settings, update_settings, update_theme,
 };
 pub use telemetry::{
     get_telemetry_status, post_telemetry_seen, post_telemetry_structured_interaction,

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -332,6 +332,49 @@ pub async fn update_settings(
     }
 }
 
+/// `GET /api/cityhall/bundle` returns this install's CityHall config bundle as
+/// TOML, for an admin to paste into CityHall. See
+/// `crate::session::cityhall_bundle`.
+///
+/// Refused in CityHall client mode: this is the surface an admin uses to
+/// configure workspaces, and an end user inside one has no business reading it.
+/// `cityhall_gate` only guards mutations, so a read needs its own block.
+pub async fn get_cityhall_bundle(
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+) -> axum::response::Response {
+    if let Some(resp) = super::cityhall_block(&state) {
+        return resp;
+    }
+    let built = tokio::task::spawn_blocking(|| {
+        crate::session::cityhall_bundle::export().and_then(|b| b.to_toml())
+    })
+    .await;
+    match built {
+        Ok(Ok(toml)) => (
+            StatusCode::OK,
+            [(axum::http::header::CONTENT_TYPE, "application/toml")],
+            toml,
+        )
+            .into_response(),
+        Ok(Err(e)) => {
+            tracing::error!(target: "http.api.system", "CityHall bundle export failed: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "export_failed", "message": e.to_string()})),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!(target: "http.api.system", "CityHall bundle export panicked: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "internal", "message": "Internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
 /// `GET /api/settings/schema` returns the flat list of settings field
 /// descriptors (the single source of truth, see #1692). The web dashboard
 /// renders a generic field component from this list instead of hand-written

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1782,6 +1782,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/settings/schema", get(api::get_settings_schema))
         .route("/api/settings/resolved", get(api::get_settings_resolved))
+        // The CityHall config bundle an admin hands to CityHall. Blocked inside
+        // a CityHall workspace by the handler itself (reads bypass
+        // `cityhall_gate`).
+        .route("/api/cityhall/bundle", get(api::get_cityhall_bundle))
         .route("/api/tips", get(api::get_tips))
         .route("/api/tips/show", post(api::set_show_tips))
         .route("/api/app-state/tip-seen", post(api::mark_tip_seen))

--- a/src/session/cityhall_bundle.rs
+++ b/src/session/cityhall_bundle.rs
@@ -1,0 +1,553 @@
+//! The CityHall config bundle: one document describing how a CityHall-hosted
+//! aoe workspace should be set up (#8).
+//!
+//! CityHall runs one locked-down `aoe serve --cityhall` per user, and in that
+//! mode the routes that would configure it are closed: `PATCH /api/settings`,
+//! `POST /api/projects` and `POST /api/git/clone` all sit in
+//! `CITYHALL_MUTATION_DENY`. So configuration cannot arrive over the workspace's
+//! own API; it arrives as this document, applied at boot below the HTTP layer.
+//!
+//! The round trip is:
+//!
+//! 1. An admin configures a normal aoe install, then [`export`]s a bundle
+//!    (`aoe cityhall export`, or the Settings page's CityHall tab).
+//! 2. CityHall stores that file and serves it, per user, to each workspace it
+//!    spawns, splicing in the `[git]` section (see below).
+//! 3. The workspace fetches it at boot and [`apply`]s it.
+//!
+//! Two deliberate shapes:
+//!
+//! - `settings` is a **sparse** patch keyed by section then field, the same
+//!   shape a `PATCH /api/settings` body has, so it validates through
+//!   [`validate_patch`] and merges through [`merge_json`] with no second code
+//!   path. Only leaves that differ from [`Config::default`] are exported.
+//! - `projects` carries **remotes, not paths**. A [`Project`] is a path to an
+//!   already-cloned repo, and the admin's `/Users/me/src/foo` means nothing
+//!   inside a container, so [`apply`] clones each remote into the workspace and
+//!   registers the resulting path.
+//!
+//! `[git]` is never exported and never stored by CityHall: it holds a
+//! credential, and CityHall composes it per user when it serves the document.
+//!
+//! Known limit: a bundle sets values, it cannot unset them. A field whose value
+//! is `null` (a cleared `Option`) is dropped on export, because TOML has no way
+//! to spell it. Setting a field to some other value works normally.
+
+use anyhow::{anyhow, bail, Context, Result};
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use super::config::{update_config, Config};
+use super::get_app_dir;
+use super::projects::{self, Project, ProjectScope};
+use super::settings_schema::{
+    apply_changed_leaves, merge_json, schema, strip_local_only, validate_patch, Scope,
+};
+
+/// Format version. [`apply`] refuses anything else rather than guessing at a
+/// document a future aoe wrote.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Subdirectory of the app dir bundle repos are cloned into.
+///
+/// Under the app dir on purpose: a workspace container mounts its per-user
+/// volume at the app dir and nothing else, so a clone anywhere else is lost the
+/// next time the container is recreated.
+const REPOS_DIR: &str = "repos";
+
+/// Credential store the `[git]` section writes, read by
+/// `credential.helper store --file=...`.
+const CREDENTIALS_FILE: &str = "git-credentials";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct CityHallBundle {
+    pub schema_version: u32,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
+
+    /// Sparse aoe settings overrides: section -> field -> value.
+    #[serde(default = "empty_object", skip_serializing_if = "is_empty_object")]
+    pub settings: Value,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub projects: Vec<BundleProject>,
+
+    /// Git identity and credential. Spliced in by CityHall per user; never
+    /// written by [`export`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git: Option<GitIdentity>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct Meta {
+    /// Which aoe wrote the document. Informational.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generated_by: Option<String>,
+}
+
+/// A repo a workspace should have, addressed by remote so it is reproducible on
+/// a machine that has never seen the admin's filesystem.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct BundleProject {
+    /// Registry name, and the directory name under `<app_dir>/repos`.
+    pub name: String,
+    pub remote: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_base_branch: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct GitIdentity {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_email: Option<String>,
+    /// Origin the credential is for, e.g. `https://github.com`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_host: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_username: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_token: Option<String>,
+}
+
+fn empty_object() -> Value {
+    Value::Object(serde_json::Map::new())
+}
+
+fn is_empty_object(v: &Value) -> bool {
+    v.as_object().is_some_and(|o| o.is_empty())
+}
+
+/// What [`apply`] did, so the CLI can print it and the serve path can log it.
+///
+/// Project failures are collected rather than fatal: one unreachable remote
+/// must not cost the user every other repo.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ApplyReport {
+    /// Settings leaves merged into `config.toml`.
+    pub settings_applied: usize,
+    /// Projects cloned by this run (an existing checkout is left alone).
+    pub cloned: Vec<String>,
+    /// Projects added to the registry by this run.
+    pub registered: Vec<String>,
+    /// Per-project failures, pre-formatted for display.
+    pub failures: Vec<String>,
+}
+
+impl CityHallBundle {
+    pub fn to_toml(&self) -> Result<String> {
+        toml::to_string_pretty(self).context("serializing the CityHall bundle")
+    }
+
+    pub fn from_toml(raw: &str) -> Result<Self> {
+        let bundle: Self = toml::from_str(raw).context("parsing the CityHall bundle")?;
+        if bundle.schema_version != SCHEMA_VERSION {
+            bail!(
+                "unsupported CityHall bundle schema_version {} (this aoe understands {SCHEMA_VERSION})",
+                bundle.schema_version
+            );
+        }
+        Ok(bundle)
+    }
+}
+
+/// Build a bundle from this install's global config and project registry.
+///
+/// The project registry read is the **global** scope only: a workspace runs the
+/// default profile, so a profile-scoped entry would not be visible there anyway.
+pub fn export() -> Result<CityHallBundle> {
+    let baseline = serde_json::to_value(Config::default())?;
+    let current = serde_json::to_value(Config::load()?)?;
+
+    let mut settings = empty_object();
+    apply_changed_leaves(&mut settings, &baseline, &current);
+    // `Config` has sections with no settings descriptors (`hooks`, `agents`,
+    // `plugins`, ...). `validate_patch` rejects those outright, so drop them
+    // here rather than shipping a document that cannot be applied.
+    retain_schema_fields(&mut settings);
+    // Host-specific paths (node binaries, socket paths) are meaningless in a
+    // container, which is exactly what `local_only` marks.
+    strip_local_only(&mut settings);
+    strip_nulls(&mut settings);
+
+    let mut projects_out = Vec::new();
+    for project in projects::load_global()? {
+        match crate::git::get_remote_url(Path::new(&project.path)) {
+            Some(remote) => projects_out.push(BundleProject {
+                name: project.name,
+                remote,
+                default_base_branch: project.default_base_branch,
+            }),
+            // Without a remote there is nothing a workspace could clone.
+            None => tracing::warn!(
+                project = %project.name,
+                path = %project.path,
+                "skipping project with no origin remote"
+            ),
+        }
+    }
+
+    Ok(CityHallBundle {
+        schema_version: SCHEMA_VERSION,
+        meta: Some(Meta {
+            generated_by: Some(format!("aoe {}", env!("CARGO_PKG_VERSION"))),
+        }),
+        settings,
+        projects: projects_out,
+        git: None,
+    })
+}
+
+/// Apply a bundle to this install: merge its settings, install its git identity,
+/// then clone and register its projects.
+///
+/// Idempotent, because it runs on every workspace boot. An existing checkout is
+/// left completely alone (a user's uncommitted work must survive a restart) and
+/// an already-registered project is not re-added.
+pub fn apply(bundle: &CityHallBundle) -> Result<ApplyReport> {
+    if bundle.schema_version != SCHEMA_VERSION {
+        bail!(
+            "unsupported CityHall bundle schema_version {} (this aoe understands {SCHEMA_VERSION})",
+            bundle.schema_version
+        );
+    }
+
+    let mut report = ApplyReport::default();
+    let app_dir = get_app_dir()?;
+
+    report.settings_applied = apply_settings(&bundle.settings)?;
+
+    if let Some(git) = &bundle.git {
+        apply_git_identity(git, &app_dir)?;
+    }
+
+    apply_projects(&bundle.projects, &app_dir, &mut report);
+
+    Ok(report)
+}
+
+/// Merge the sparse settings patch into the global `config.toml`, going through
+/// the same validate-then-merge pair the settings PATCH handler uses.
+fn apply_settings(settings: &Value) -> Result<usize> {
+    let count = leaf_count(settings);
+    if count == 0 {
+        return Ok(0);
+    }
+
+    // Elevated: the bundle is admin-authored, so an elevation-gated field is
+    // legitimately settable. `local_only` fields are still refused by the
+    // validator itself.
+    validate_patch(settings, Scope::Global, true)
+        .map_err(|e| anyhow!("bundle settings rejected: {}", e.message()))?;
+
+    update_config(|config| -> Result<()> {
+        let mut merged = serde_json::to_value(&*config)?;
+        merge_json(&mut merged, settings);
+        // Build the new value before assigning: `update_config` writes whatever
+        // it finds in `config` even when the closure returns an error, so a
+        // failed deserialize must not leave a half-applied struct behind.
+        let next: Config = serde_json::from_value(merged)?;
+        *config = next;
+        Ok(())
+    })??;
+
+    Ok(count)
+}
+
+/// Install `user.name` / `user.email` and, when a credential is present, a
+/// `store` helper pointed at an owner-only file.
+///
+/// Shells out to `git config --global` rather than editing `~/.gitconfig`
+/// directly: idempotent, and no config parsing to get wrong.
+fn apply_git_identity(git: &GitIdentity, app_dir: &Path) -> Result<()> {
+    if let Some(name) = git.user_name.as_deref().filter(|s| !s.is_empty()) {
+        git_config_global("user.name", name)?;
+    }
+    if let Some(email) = git.user_email.as_deref().filter(|s| !s.is_empty()) {
+        git_config_global("user.email", email)?;
+    }
+
+    let (Some(host), Some(username), Some(token)) = (
+        git.credential_host.as_deref().filter(|s| !s.is_empty()),
+        git.credential_username.as_deref().filter(|s| !s.is_empty()),
+        git.credential_token.as_deref().filter(|s| !s.is_empty()),
+    ) else {
+        return Ok(());
+    };
+
+    let path = app_dir.join(CREDENTIALS_FILE);
+    std::fs::write(&path, credential_line(host, username, token))
+        .with_context(|| format!("writing {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+
+    git_config_global(
+        "credential.helper",
+        &format!("store --file={}", path.display()),
+    )
+}
+
+/// One `.git-credentials` line: `https://user:token@host`.
+///
+/// Both userinfo halves are percent-encoded, so a token containing `@` or `/`
+/// cannot corrupt the line (or silently authenticate against the wrong host).
+fn credential_line(host: &str, username: &str, token: &str) -> String {
+    let (scheme, authority) = host
+        .split_once("://")
+        .unwrap_or(("https", host.trim_end_matches('/')));
+    let user = utf8_percent_encode(username, NON_ALPHANUMERIC);
+    let pass = utf8_percent_encode(token, NON_ALPHANUMERIC);
+    format!(
+        "{scheme}://{user}:{pass}@{}\n",
+        authority.trim_end_matches('/')
+    )
+}
+
+fn git_config_global(key: &str, value: &str) -> Result<()> {
+    let output = std::process::Command::new("git")
+        .args(["config", "--global", key, value])
+        .output()
+        .with_context(|| format!("running git config --global {key}"))?;
+    if !output.status.success() {
+        bail!(
+            "git config --global {key} failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// Clone each project that is missing, then register each one that is not in the
+/// global registry yet.
+fn apply_projects(wanted: &[BundleProject], app_dir: &Path, report: &mut ApplyReport) {
+    if wanted.is_empty() {
+        return;
+    }
+
+    let existing = projects::load_global().unwrap_or_default();
+    let repos_dir = app_dir.join(REPOS_DIR);
+    let profile = Config::load()
+        .map(|c| c.default_profile)
+        .unwrap_or_else(|_| "default".to_string());
+
+    for project in wanted {
+        if let Err(e) = check_project_name(&project.name) {
+            report.failures.push(format!("{}: {e}", project.name));
+            continue;
+        }
+        let dest = repos_dir.join(&project.name);
+
+        if !dest.exists() {
+            if let Err(e) = std::fs::create_dir_all(&repos_dir) {
+                report.failures.push(format!(
+                    "{}: creating {}: {e}",
+                    project.name,
+                    repos_dir.display()
+                ));
+                continue;
+            }
+            match crate::git::clone_repo(&project.remote, &dest, false) {
+                Ok(()) => report.cloned.push(project.name.clone()),
+                Err(e) => {
+                    report
+                        .failures
+                        .push(format!("{}: clone failed: {e}", project.name));
+                    continue;
+                }
+            }
+        }
+
+        let dest_str = dest.to_string_lossy().to_string();
+        if existing
+            .iter()
+            .any(|p| p.name.eq_ignore_ascii_case(&project.name) || p.path == dest_str)
+        {
+            continue;
+        }
+
+        let mut entry = Project::new(&project.name, &dest_str, ProjectScope::Global);
+        entry.default_base_branch = project.default_base_branch.clone();
+        match projects::add(&profile, ProjectScope::Global, entry, false) {
+            Ok(_) => report.registered.push(project.name.clone()),
+            Err(e) => report
+                .failures
+                .push(format!("{}: could not register: {e}", project.name)),
+        }
+    }
+}
+
+/// A bundle arrives over the network, and its project name becomes a directory
+/// name, so it has to be a plain single path segment.
+fn check_project_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        bail!("project name is empty");
+    }
+    if name == "." || name == ".." || name.contains('/') || name.contains('\\') {
+        bail!("project name '{name}' is not a single path segment");
+    }
+    Ok(())
+}
+
+/// Drop every `section.field` that has no settings descriptor.
+fn retain_schema_fields(patch: &mut Value) {
+    let known: HashSet<(String, String)> =
+        schema().into_iter().map(|d| (d.section, d.field)).collect();
+    let Some(root) = patch.as_object_mut() else {
+        return;
+    };
+    root.retain(|section, value| {
+        let Some(fields) = value.as_object_mut() else {
+            return false;
+        };
+        fields.retain(|field, _| known.contains(&(section.clone(), field.clone())));
+        !fields.is_empty()
+    });
+}
+
+/// Drop `null` leaves: TOML cannot represent them, and a bundle sets values
+/// rather than unsetting them.
+fn strip_nulls(patch: &mut Value) {
+    let Some(root) = patch.as_object_mut() else {
+        return;
+    };
+    root.retain(|_, value| {
+        let Some(fields) = value.as_object_mut() else {
+            return false;
+        };
+        fields.retain(|_, v| !v.is_null());
+        !fields.is_empty()
+    });
+}
+
+fn leaf_count(patch: &Value) -> usize {
+    patch
+        .as_object()
+        .map(|root| {
+            root.values()
+                .filter_map(|v| v.as_object())
+                .map(|fields| fields.len())
+                .sum()
+        })
+        .unwrap_or(0)
+}
+
+/// Where a fetched bundle is cached, so a later boot can tell "CityHall is
+/// unreachable and we have never been configured" from "unreachable but we
+/// already are".
+pub fn cache_path() -> Result<PathBuf> {
+    Ok(get_app_dir()?.join("cityhall-bundle.toml"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn round_trips_through_toml() {
+        let bundle = CityHallBundle {
+            schema_version: SCHEMA_VERSION,
+            meta: Some(Meta {
+                generated_by: Some("aoe 1.2.3".into()),
+            }),
+            settings: json!({"acp": {"default_agent": "claude-code"}}),
+            projects: vec![BundleProject {
+                name: "cityhall".into(),
+                remote: "https://github.com/agent-of-empires/cityhall.git".into(),
+                default_base_branch: Some("main".into()),
+            }],
+            git: None,
+        };
+        let raw = bundle.to_toml().unwrap();
+        assert_eq!(CityHallBundle::from_toml(&raw).unwrap(), bundle);
+    }
+
+    #[test]
+    fn a_future_schema_version_is_refused() {
+        let raw = format!("schema_version = {}\n", SCHEMA_VERSION + 1);
+        let err = CityHallBundle::from_toml(&raw).unwrap_err().to_string();
+        assert!(err.contains("schema_version"), "{err}");
+    }
+
+    /// A section with no descriptors (`hooks`, `agents`, ...) would make
+    /// `validate_patch` reject the whole document, so export must not emit one.
+    #[test]
+    fn unknown_sections_are_dropped() {
+        let mut patch = json!({
+            "acp": {"default_agent": "claude-code"},
+            "hooks": {"pre_create": "echo hi"},
+            "theme": {"not_a_field": 1},
+        });
+        retain_schema_fields(&mut patch);
+        assert_eq!(patch, json!({"acp": {"default_agent": "claude-code"}}));
+    }
+
+    #[test]
+    fn null_leaves_are_dropped() {
+        let mut patch = json!({"session": {"cpu_limit": null, "confirm_delete": true}});
+        strip_nulls(&mut patch);
+        assert_eq!(patch, json!({"session": {"confirm_delete": true}}));
+    }
+
+    /// Whatever export produces has to survive the validator, or a bundle from
+    /// a stock install is dead on arrival.
+    #[test]
+    fn an_exported_settings_patch_validates() {
+        let baseline = serde_json::to_value(Config::default()).unwrap();
+        let mut current = baseline.clone();
+        current["acp"]["max_concurrent_workers"] = json!(7);
+
+        let mut settings = empty_object();
+        apply_changed_leaves(&mut settings, &baseline, &current);
+        retain_schema_fields(&mut settings);
+        strip_local_only(&mut settings);
+        strip_nulls(&mut settings);
+
+        assert_eq!(leaf_count(&settings), 1, "only the moved leaf: {settings}");
+        validate_patch(&settings, Scope::Global, true).expect("export must validate");
+    }
+
+    #[test]
+    fn a_bad_settings_key_is_rejected_by_name() {
+        let err = apply_settings(&json!({"acp": {"nope": 1}}))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("acp.nope"),
+            "must name the offending key: {err}"
+        );
+    }
+
+    #[test]
+    fn credential_line_encodes_the_token() {
+        assert_eq!(
+            credential_line("https://github.com", "someone", "gh/p@ss"),
+            "https://someone:gh%2Fp%40ss@github.com\n"
+        );
+    }
+
+    /// A bare host with no scheme still has to produce a usable line.
+    #[test]
+    fn credential_line_defaults_to_https() {
+        assert_eq!(
+            credential_line("github.com/", "u", "t"),
+            "https://u:t@github.com\n"
+        );
+    }
+
+    #[test]
+    fn project_names_must_be_one_path_segment() {
+        assert!(check_project_name("cityhall").is_ok());
+        for bad in ["", "..", "a/b", "a\\b"] {
+            assert!(check_project_name(bad).is_err(), "{bad} must be refused");
+        }
+    }
+}

--- a/src/session/cityhall_bundle.rs
+++ b/src/session/cityhall_bundle.rs
@@ -180,7 +180,7 @@ pub fn export() -> Result<CityHallBundle> {
         match crate::git::get_remote_url(Path::new(&project.path)) {
             Some(remote) => projects_out.push(BundleProject {
                 name: project.name,
-                remote,
+                remote: strip_userinfo(&remote),
                 default_base_branch: project.default_base_branch,
             }),
             // Without a remote there is nothing a workspace could clone.
@@ -281,13 +281,8 @@ fn apply_git_identity(git: &GitIdentity, app_dir: &Path) -> Result<()> {
     };
 
     let path = app_dir.join(CREDENTIALS_FILE);
-    std::fs::write(&path, credential_line(host, username, token))
+    write_owner_only(&path, &credential_line(host, username, token))
         .with_context(|| format!("writing {}", path.display()))?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
-    }
 
     git_config_global(
         "credential.helper",
@@ -311,9 +306,63 @@ fn credential_line(host: &str, username: &str, token: &str) -> String {
     )
 }
 
+/// Write a secret so it is owner-only from the moment it exists.
+///
+/// A plain `fs::write` creates the file with the umask (usually 0644) and leaves
+/// the token world-readable until a follow-up chmod lands. This file is a
+/// persisted credential store, so like `login_sessions.toml` it deliberately
+/// survives shutdown rather than being swept with the `serve.*` files.
+fn write_owner_only(path: &Path, contents: &str) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut file = opts.open(path)?;
+    // `mode` only applies when the file is created, and boot reruns this over an
+    // existing file, so narrow the one already on disk as well.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+    file.write_all(contents.as_bytes())
+}
+
+/// Drop any `user[:password]@` from a remote URL.
+///
+/// A checkout's origin can embed a token (`https://u:tok@host/org/repo.git`),
+/// and the exported bundle is written to a file, served over HTTP, and stored by
+/// CityHall. Auth arrives separately in `[git]`, so the userinfo is not needed to
+/// clone. SSH shorthand (`git@host:org/repo`) is left alone: there the `git@` is
+/// the transport user, not a secret.
+fn strip_userinfo(remote: &str) -> String {
+    let Some((scheme, rest)) = remote.split_once("://") else {
+        return remote.to_string();
+    };
+    // Only the authority may hold userinfo; a path is allowed to contain `@`.
+    let (authority, path) = match rest.split_once('/') {
+        Some((authority, path)) => (authority, Some(path)),
+        None => (rest, None),
+    };
+    let authority = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    match path {
+        Some(path) => format!("{scheme}://{authority}/{path}"),
+        None => format!("{scheme}://{authority}"),
+    }
+}
+
 fn git_config_global(key: &str, value: &str) -> Result<()> {
     let output = std::process::Command::new("git")
-        .args(["config", "--global", key, value])
+        // --replace-all: without it git refuses a key that already holds several
+        // values, and a bundle apply would fail on a config it could have fixed.
+        .args(["config", "--global", "--replace-all", key, value])
         .output()
         .with_context(|| format!("running git config --global {key}"))?;
     if !output.status.success() {
@@ -527,20 +576,63 @@ mod tests {
     }
 
     #[test]
-    fn credential_line_encodes_the_token() {
-        assert_eq!(
-            credential_line("https://github.com", "someone", "gh/p@ss"),
-            "https://someone:gh%2Fp%40ss@github.com\n"
-        );
+    fn credential_line_cases() {
+        let cases = [
+            // A token with `@` or `/` must not be able to corrupt the line.
+            (
+                ("https://github.com", "someone", "gh/p@ss"),
+                "https://someone:gh%2Fp%40ss@github.com\n",
+            ),
+            // A bare host with no scheme still has to produce a usable line.
+            (("github.com/", "u", "t"), "https://u:t@github.com\n"),
+        ];
+        for ((host, username, token), expected) in cases {
+            assert_eq!(credential_line(host, username, token), expected, "{host}");
+        }
     }
 
-    /// A bare host with no scheme still has to produce a usable line.
+    /// An origin can embed a token, and the bundle is stored and served, so the
+    /// userinfo must not travel with it.
     #[test]
-    fn credential_line_defaults_to_https() {
-        assert_eq!(
-            credential_line("github.com/", "u", "t"),
-            "https://u:t@github.com\n"
-        );
+    fn exported_remotes_carry_no_userinfo() {
+        let cases = [
+            (
+                "https://u:ghp_secret@github.com/org/repo.git",
+                "https://github.com/org/repo.git",
+            ),
+            (
+                "https://github.com/org/repo.git",
+                "https://github.com/org/repo.git",
+            ),
+            // A path is allowed to contain `@`; only the authority is stripped.
+            (
+                "https://github.com/org/re@po.git",
+                "https://github.com/org/re@po.git",
+            ),
+            // SSH shorthand has no scheme, and its `git@` is the transport user.
+            ("git@github.com:org/repo.git", "git@github.com:org/repo.git"),
+            ("https://u:p@github.com", "https://github.com"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(strip_userinfo(input), expected, "{input}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_credential_file_is_owner_only_even_if_it_already_exists() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("git-credentials");
+        std::fs::write(&path, "stale").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_owner_only(&path, "fresh").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "fresh");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "mode was {:o}", mode & 0o777);
     }
 
     #[test]

--- a/src/session/cityhall_bundle.rs
+++ b/src/session/cityhall_bundle.rs
@@ -135,6 +135,10 @@ pub struct ApplyReport {
     pub cloned: Vec<String>,
     /// Projects added to the registry by this run.
     pub registered: Vec<String>,
+    /// Projects already checked out and already registered, so this run had
+    /// nothing to do. Tracked because a re-apply of an unchanged bundle
+    /// legitimately does no work, and that is not the same as doing none.
+    pub preserved: Vec<String>,
     /// Per-project failures, pre-formatted for display.
     pub failures: Vec<String>,
 }
@@ -393,8 +397,9 @@ fn apply_projects(wanted: &[BundleProject], app_dir: &Path, report: &mut ApplyRe
             continue;
         }
         let dest = repos_dir.join(&project.name);
+        let checkout_existed = dest.exists();
 
-        if !dest.exists() {
+        if !checkout_existed {
             if let Err(e) = std::fs::create_dir_all(&repos_dir) {
                 report.failures.push(format!(
                     "{}: creating {}: {e}",
@@ -419,6 +424,12 @@ fn apply_projects(wanted: &[BundleProject], app_dir: &Path, report: &mut ApplyRe
             .iter()
             .any(|p| p.name.eq_ignore_ascii_case(&project.name) || p.path == dest_str)
         {
+            // Already in place. Recorded rather than silently skipped, so a
+            // re-apply that legitimately has nothing to do is distinguishable
+            // from one where every project failed.
+            if checkout_existed {
+                report.preserved.push(project.name.clone());
+            }
             continue;
         }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -4,6 +4,7 @@ pub mod artifacts;
 pub mod attach_project;
 pub mod builder;
 pub(crate) mod capture;
+pub mod cityhall_bundle;
 pub mod civilizations;
 pub(crate) mod claim;
 // Discovery of on-disk Claude Code sessions. Lives here (not under the

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -576,6 +576,7 @@ export function SettingsView({
       activeTab !== "mcp" &&
       activeTab !== "plugins" &&
       activeTab !== "telemetry" &&
+      activeTab !== "cityhall" &&
       activeTab !== "panels"
     ) {
       return <div className="text-sm text-text-dim">Loading settings...</div>;

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -22,6 +22,7 @@ import { SelectField } from "./settings/FormFields";
 import { DiffSettings } from "./settings/DiffSettings";
 import { PanelsSettings } from "./settings/PanelsSettings";
 import { TelemetrySettings } from "./settings/TelemetrySettings";
+import { CityHallSettings } from "./settings/CityHallSettings";
 import { PluginsSettings } from "./settings/PluginsSettings";
 import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 import { PluginSettingsSections } from "./settings/PluginSettingsSections";
@@ -48,7 +49,8 @@ export type TabId =
   | "structured-view"
   | "mcp"
   | "logging"
-  | "plugins";
+  | "plugins"
+  | "cityhall";
 
 // A plugin-contributed settings page (#2985): one nav entry per declared
 // `settings-page` UI contribution. The tab id is a parametric string outside the
@@ -175,6 +177,7 @@ export function buildSidebar(pluginPages: PluginPageNav[] = []): SidebarItem[] {
     { kind: "tab", id: "telemetry", label: "Telemetry" },
     { kind: "tab", id: "logging", label: "Logging" },
     { kind: "tab", id: "plugins", label: "Plugins" },
+    { kind: "tab", id: "cityhall", label: "CityHall" },
   ];
   if (pluginPages.length > 0) {
     items.push({ kind: "divider", label: "Plugin pages" });
@@ -260,6 +263,7 @@ const ALL_TAB_IDS = new Set<TabId>([
   "mcp",
   "logging",
   "plugins",
+  "cityhall",
 ]);
 
 function isTabId(value: unknown): value is TabId {
@@ -738,6 +742,8 @@ export function SettingsView({
         );
       case "telemetry":
         return <TelemetrySettings />;
+      case "cityhall":
+        return <CityHallSettings />;
       case "logging":
         return (
           <SchemaSection

--- a/web/src/components/__tests__/SettingsView.test.tsx
+++ b/web/src/components/__tests__/SettingsView.test.tsx
@@ -49,6 +49,7 @@ describe("buildSidebar", () => {
       { kind: "tab", id: "telemetry", label: "Telemetry" },
       { kind: "tab", id: "logging", label: "Logging" },
       { kind: "tab", id: "plugins", label: "Plugins" },
+      { kind: "tab", id: "cityhall", label: "CityHall" },
     ]);
   });
 

--- a/web/src/components/settings/CityHallSettings.tsx
+++ b/web/src/components/settings/CityHallSettings.tsx
@@ -70,7 +70,7 @@ export function CityHallSettings() {
       <div className="flex flex-wrap items-center gap-2">
         <button
           type="button"
-          className="rounded bg-brand-600 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-brand-500 disabled:opacity-50 cursor-pointer"
+          className="h-8 cursor-pointer rounded-md bg-brand-600 px-3 text-xs font-medium text-white transition-colors duration-150 hover:bg-brand-500 disabled:opacity-50"
           disabled={busy}
           onClick={() => void generate()}
           data-testid="cityhall-export"
@@ -81,14 +81,14 @@ export function CityHallSettings() {
           <>
             <button
               type="button"
-              className="rounded border border-surface-600 px-2 py-0.5 text-[11px] text-text-secondary hover:text-text-primary cursor-pointer"
+              className="h-8 cursor-pointer rounded-md px-3 text-xs text-text-secondary transition-colors duration-150 hover:bg-surface-800 hover:text-text-primary"
               onClick={download}
             >
               Download cityhall.toml
             </button>
             <button
               type="button"
-              className="rounded border border-surface-600 px-2 py-0.5 text-[11px] text-text-secondary hover:text-text-primary cursor-pointer"
+              className="h-8 cursor-pointer rounded-md px-3 text-xs text-text-secondary transition-colors duration-150 hover:bg-surface-800 hover:text-text-primary"
               onClick={() => void copy()}
             >
               {copied ? "Copied" : "Copy"}

--- a/web/src/components/settings/CityHallSettings.tsx
+++ b/web/src/components/settings/CityHallSettings.tsx
@@ -70,7 +70,7 @@ export function CityHallSettings() {
       <div className="flex flex-wrap items-center gap-2">
         <button
           type="button"
-          className="rounded bg-brand-600 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-brand-500 disabled:opacity-50"
+          className="rounded bg-brand-600 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-brand-500 disabled:opacity-50 cursor-pointer"
           disabled={busy}
           onClick={() => void generate()}
           data-testid="cityhall-export"
@@ -81,14 +81,14 @@ export function CityHallSettings() {
           <>
             <button
               type="button"
-              className="rounded border border-surface-600 px-2 py-0.5 text-[11px] text-text-secondary hover:text-text-primary"
+              className="rounded border border-surface-600 px-2 py-0.5 text-[11px] text-text-secondary hover:text-text-primary cursor-pointer"
               onClick={download}
             >
               Download cityhall.toml
             </button>
             <button
               type="button"
-              className="rounded border border-surface-600 px-2 py-0.5 text-[11px] text-text-secondary hover:text-text-primary"
+              className="rounded border border-surface-600 px-2 py-0.5 text-[11px] text-text-secondary hover:text-text-primary cursor-pointer"
               onClick={() => void copy()}
             >
               {copied ? "Copied" : "Copy"}

--- a/web/src/components/settings/CityHallSettings.tsx
+++ b/web/src/components/settings/CityHallSettings.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+
+import { fetchCityHallBundle } from "../../lib/api";
+
+/// Export this install's CityHall config bundle: the settings and projects a
+/// CityHall deployment should give every workspace it spawns (#8).
+///
+/// One-way on purpose. An admin configures a normal aoe install, exports the
+/// bundle here, and pastes it into CityHall; CityHall then serves it to each
+/// workspace, which applies it at boot. There is no import button because a
+/// workspace never authors its own config: the routes that would write it are
+/// closed in CityHall client mode, and applying a bundle by hand is
+/// `aoe cityhall apply`.
+///
+/// This tab is absent from the curated CityHall sidebar, and the endpoint
+/// refuses CityHall mode outright, so an end user inside a workspace can reach
+/// it by neither route.
+export function CityHallSettings() {
+  const [bundle, setBundle] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  async function generate() {
+    setBusy(true);
+    setError(null);
+    setCopied(false);
+    try {
+      setBundle(await fetchCityHallBundle());
+    } catch (e) {
+      setBundle(null);
+      setError(e instanceof Error ? e.message : "Export failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function download() {
+    if (!bundle) return;
+    const url = URL.createObjectURL(new Blob([bundle], { type: "application/toml" }));
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "cityhall.toml";
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  async function copy() {
+    if (!bundle) return;
+    try {
+      await navigator.clipboard.writeText(bundle);
+      setCopied(true);
+    } catch {
+      // Clipboard access needs a secure context and can be denied outright;
+      // Download is always available, so this needs no error of its own.
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <div className="text-[13px] text-text-secondary">CityHall config bundle</div>
+        <p className="mt-1 text-[11px] text-text-muted">
+          One file describing how CityHall should set up every workspace: the settings on this install that differ from
+          the defaults, plus your saved projects, addressed by git remote so a workspace can clone them. Host-specific
+          paths are left out, and no credentials are included. Paste it into CityHall's workspace configuration.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          className="rounded bg-brand-600 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-brand-500 disabled:opacity-50"
+          disabled={busy}
+          onClick={() => void generate()}
+          data-testid="cityhall-export"
+        >
+          {busy ? "Generating…" : bundle ? "Regenerate" : "Generate bundle"}
+        </button>
+        {bundle && (
+          <>
+            <button
+              type="button"
+              className="rounded border border-surface-600 px-2 py-0.5 text-[11px] text-text-secondary hover:text-text-primary"
+              onClick={download}
+            >
+              Download cityhall.toml
+            </button>
+            <button
+              type="button"
+              className="rounded border border-surface-600 px-2 py-0.5 text-[11px] text-text-secondary hover:text-text-primary"
+              onClick={() => void copy()}
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </>
+        )}
+        <span className="text-[11px] text-text-dim">
+          or in a terminal: <code>aoe cityhall export --out cityhall.toml</code>
+        </span>
+      </div>
+
+      {error && <p className="text-[11px] text-status-error">{error}</p>}
+
+      {bundle && (
+        <pre className="max-h-96 overflow-auto rounded border border-surface-700 bg-surface-900 p-3 text-[11px] leading-relaxed text-text-secondary">
+          {bundle}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/settings/__tests__/CityHallSettings.test.tsx
+++ b/web/src/components/settings/__tests__/CityHallSettings.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+//
+// Contract test for the CityHall export panel. The panel is the only settings
+// surface that hands an admin a file to carry to another system, so what matters
+// is that nothing is offered before a bundle exists, that a failed export
+// surfaces the server's reason rather than a blank pane, and that the download
+// really carries the fetched bytes.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+
+const fetchCityHallBundle = vi.fn<[], Promise<string>>();
+
+vi.mock("../../../lib/api", () => ({
+  fetchCityHallBundle: () => fetchCityHallBundle(),
+}));
+
+// Imported after the mock is registered.
+import { CityHallSettings } from "../CityHallSettings";
+
+const BUNDLE = 'schema_version = 1\n\n[[projects]]\nname = "demo"\nremote = "https://example.com/demo.git"\n';
+
+beforeEach(() => {
+  fetchCityHallBundle.mockReset();
+});
+
+describe("CityHallSettings contract", () => {
+  /// Download and Copy would produce an empty file before a bundle is fetched.
+  it("offers nothing to take away until a bundle has been generated", () => {
+    const { queryByText, getByTestId } = render(<CityHallSettings />);
+    expect(getByTestId("cityhall-export").textContent).toBe("Generate bundle");
+    expect(queryByText(/Download/)).toBeNull();
+    expect(queryByText("Copy")).toBeNull();
+  });
+
+  it("renders the fetched bundle and offers it for download", async () => {
+    fetchCityHallBundle.mockResolvedValue(BUNDLE);
+    const { getByTestId, findByText, container } = render(<CityHallSettings />);
+
+    fireEvent.click(getByTestId("cityhall-export"));
+    await findByText(/Download cityhall.toml/);
+    // The document itself is shown, so an admin can see what they are about to
+    // hand over.
+    expect(container.querySelector("pre")?.textContent).toContain('name = "demo"');
+    // A second run replaces rather than appends.
+    expect(getByTestId("cityhall-export").textContent).toBe("Regenerate");
+  });
+
+  it("downloads exactly the fetched bytes", async () => {
+    fetchCityHallBundle.mockResolvedValue(BUNDLE);
+    const blobs: Blob[] = [];
+    // jsdom implements neither createObjectURL nor an anchor click that
+    // navigates, so record what would have been handed to the browser.
+    const createObjectURL = vi.fn((blob: Blob) => {
+      blobs.push(blob);
+      return "blob:stub";
+    });
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL: vi.fn(),
+    });
+
+    const { getByTestId, findByText } = render(<CityHallSettings />);
+    fireEvent.click(getByTestId("cityhall-export"));
+    const download = await findByText(/Download cityhall.toml/);
+    fireEvent.click(download);
+
+    expect(blobs).toHaveLength(1);
+    expect(await blobs[0].text()).toBe(BUNDLE);
+    expect(blobs[0].type).toBe("application/toml");
+    vi.unstubAllGlobals();
+  });
+
+  /// The endpoint refuses CityHall client mode with a 403 whose message says so.
+  /// Swallowing it would leave an admin staring at an empty panel.
+  it("surfaces the server's reason when the export fails", async () => {
+    fetchCityHallBundle.mockRejectedValue(new Error("This action is disabled in CityHall client mode"));
+    const { getByTestId, findByText, queryByText } = render(<CityHallSettings />);
+
+    fireEvent.click(getByTestId("cityhall-export"));
+    await findByText(/disabled in CityHall client mode/);
+    expect(queryByText(/Download/)).toBeNull();
+  });
+
+  /// A failed retry must not leave the previous bundle on screen looking current.
+  it("clears a stale bundle when a later export fails", async () => {
+    fetchCityHallBundle.mockResolvedValueOnce(BUNDLE);
+    const { getByTestId, findByText, container } = render(<CityHallSettings />);
+    fireEvent.click(getByTestId("cityhall-export"));
+    await findByText(/Download cityhall.toml/);
+
+    fetchCityHallBundle.mockRejectedValueOnce(new Error("Export failed"));
+    fireEvent.click(getByTestId("cityhall-export"));
+    await findByText("Export failed");
+    await waitFor(() => {
+      expect(container.querySelector("pre")).toBeNull();
+    });
+  });
+});

--- a/web/src/components/settings/__tests__/CityHallSettings.test.tsx
+++ b/web/src/components/settings/__tests__/CityHallSettings.test.tsx
@@ -6,7 +6,7 @@
 // surfaces the server's reason rather than a blank pane, and that the download
 // really carries the fetched bytes.
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 
 const fetchCityHallBundle = vi.fn<[], Promise<string>>();
@@ -22,6 +22,13 @@ const BUNDLE = 'schema_version = 1\n\n[[projects]]\nname = "demo"\nremote = "htt
 
 beforeEach(() => {
   fetchCityHallBundle.mockReset();
+});
+
+// In cleanup rather than at the end of each test body: a failing assertion
+// before the restore would otherwise leak a replaced URL/navigator into
+// unrelated tests.
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe("CityHallSettings contract", () => {
@@ -69,7 +76,41 @@ describe("CityHallSettings contract", () => {
     expect(blobs).toHaveLength(1);
     expect(await blobs[0].text()).toBe(BUNDLE);
     expect(blobs[0].type).toBe("application/toml");
-    vi.unstubAllGlobals();
+  });
+
+  it("copies exactly the fetched bundle to the clipboard", async () => {
+    fetchCityHallBundle.mockResolvedValue(BUNDLE);
+    const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+
+    const { getByTestId, findByText } = render(<CityHallSettings />);
+    fireEvent.click(getByTestId("cityhall-export"));
+    fireEvent.click(await findByText("Copy"));
+
+    await findByText("Copied");
+    expect(writeText).toHaveBeenCalledWith(BUNDLE);
+  });
+
+  /// The clipboard needs a secure context and can be denied outright. Download
+  /// still works, so the denial is swallowed on purpose; what must not happen is
+  /// an unhandled rejection or a "Copied" label that lies.
+  it("stays usable when the clipboard is denied", async () => {
+    fetchCityHallBundle.mockResolvedValue(BUNDLE);
+    vi.stubGlobal("navigator", {
+      ...navigator,
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+
+    const { getByTestId, findByText, queryByText } = render(<CityHallSettings />);
+    fireEvent.click(getByTestId("cityhall-export"));
+    const copyButton = await findByText("Copy");
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(queryByText("Copied")).toBeNull();
+    });
+    // Download is the fallback, so it has to survive the failed copy.
+    expect(await findByText(/Download cityhall.toml/)).toBeTruthy();
   });
 
   /// The endpoint refuses CityHall client mode with a 403 whose message says so.

--- a/web/src/components/settings/__tests__/CityHallSettings.test.tsx
+++ b/web/src/components/settings/__tests__/CityHallSettings.test.tsx
@@ -96,19 +96,20 @@ describe("CityHallSettings contract", () => {
   /// an unhandled rejection or a "Copied" label that lies.
   it("stays usable when the clipboard is denied", async () => {
     fetchCityHallBundle.mockResolvedValue(BUNDLE);
-    vi.stubGlobal("navigator", {
-      ...navigator,
-      clipboard: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
-    });
+    const writeText = vi.fn<(text: string) => Promise<void>>().mockRejectedValue(new Error("denied"));
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
 
     const { getByTestId, findByText, queryByText } = render(<CityHallSettings />);
     fireEvent.click(getByTestId("cityhall-export"));
-    const copyButton = await findByText("Copy");
-    fireEvent.click(copyButton);
+    fireEvent.click(await findByText("Copy"));
 
+    // Wait on the rejected call, not on the absence of "Copied": that label is
+    // absent before the click too, so waiting for it would pass even if the
+    // handler never ran.
     await waitFor(() => {
-      expect(queryByText("Copied")).toBeNull();
+      expect(writeText).toHaveBeenCalledWith(BUNDLE);
     });
+    expect(queryByText("Copied")).toBeNull();
     // Download is the fallback, so it has to survive the failed copy.
     expect(await findByText(/Download cityhall.toml/)).toBeTruthy();
   });

--- a/web/src/lib/__tests__/cityhallBundleApi.test.ts
+++ b/web/src/lib/__tests__/cityhallBundleApi.test.ts
@@ -1,0 +1,44 @@
+// Vitest coverage for the CityHall bundle export client. Unlike most of api.ts
+// this one throws rather than returning null, because the Settings panel has to
+// show the admin *why* an export failed: the endpoint is refused outright in
+// CityHall client mode, and "nothing happened" would be indistinguishable from
+// a network blip.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchCityHallBundle } from "../api";
+
+const fetchSpy = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+describe("fetchCityHallBundle", () => {
+  it("returns the TOML body on success", async () => {
+    const body = 'schema_version = 1\n\n[settings.acp]\ndefault_agent = "claude-code"\n';
+    fetchSpy.mockResolvedValue(new Response(body, { status: 200 }));
+
+    await expect(fetchCityHallBundle()).resolves.toBe(body);
+    expect(fetchSpy).toHaveBeenCalledWith("/api/cityhall/bundle");
+  });
+
+  it("throws the server's message when the endpoint refuses", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ error: "cityhall_mode", message: "This action is disabled in CityHall client mode" }), {
+        status: 403,
+      }),
+    );
+
+    await expect(fetchCityHallBundle()).rejects.toThrow(/disabled in CityHall client mode/);
+  });
+
+  // A proxy or a crash can return a non-JSON error body; falling back to the
+  // status keeps the panel from rendering "undefined".
+  it("falls back to the status code when the error body is not JSON", async () => {
+    fetchSpy.mockResolvedValue(new Response("<html>502</html>", { status: 502 }));
+
+    await expect(fetchCityHallBundle()).rejects.toThrow("Export failed (HTTP 502)");
+  });
+});

--- a/web/src/lib/__tests__/cityhallBundleApi.test.ts
+++ b/web/src/lib/__tests__/cityhallBundleApi.test.ts
@@ -26,9 +26,12 @@ describe("fetchCityHallBundle", () => {
 
   it("throws the server's message when the endpoint refuses", async () => {
     fetchSpy.mockResolvedValue(
-      new Response(JSON.stringify({ error: "cityhall_mode", message: "This action is disabled in CityHall client mode" }), {
-        status: 403,
-      }),
+      new Response(
+        JSON.stringify({ error: "cityhall_mode", message: "This action is disabled in CityHall client mode" }),
+        {
+          status: 403,
+        },
+      ),
     );
 
     await expect(fetchCityHallBundle()).rejects.toThrow(/disabled in CityHall client mode/);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -244,6 +244,20 @@ export function fetchSettings(profile?: string): Promise<SettingsResponse | null
   return fetchJson<SettingsResponse>(`/api/settings${params}`);
 }
 
+/** Fetch this install's CityHall config bundle as TOML text (settings +
+ *  projects), for an admin to hand to CityHall. Throws with the server's
+ *  message so the Settings page can show why an export failed. */
+export async function fetchCityHallBundle(): Promise<string> {
+  const res = await fetch("/api/cityhall/bundle");
+  if (!res.ok) {
+    // The failure body is JSON (`{error, message}`); fall back to the status
+    // when it is not, e.g. the 403 CityHall client mode returns.
+    const detail = await res.json().catch(() => null);
+    throw new Error(detail?.message ?? `Export failed (HTTP ${res.status})`);
+  }
+  return res.text();
+}
+
 // The schema is static for the server's run, and the profile-settings write
 // guard (`updateProfileSettings`) derives its section allowlist from it, so we
 // cache the first successful fetch and reuse it instead of refetching on every

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -388,12 +388,8 @@
       "id": "settings.cityhall-export",
       "kind": "vitest",
       "risk": "medium",
-      "specs": [
-        "src/components/settings/__tests__/CityHallSettings.test.tsx"
-      ],
-      "components": [
-        "web/src/components/settings/CityHallSettings.tsx"
-      ]
+      "specs": ["src/components/settings/__tests__/CityHallSettings.test.tsx"],
+      "components": ["web/src/components/settings/CityHallSettings.tsx"]
     },
     {
       "id": "telemetry.acp-seen",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -385,6 +385,17 @@
       ]
     },
     {
+      "id": "settings.cityhall-export",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/settings/__tests__/CityHallSettings.test.tsx"
+      ],
+      "components": [
+        "web/src/components/settings/CityHallSettings.tsx"
+      ]
+    },
+    {
       "id": "telemetry.acp-seen",
       "kind": "mocked-playwright",
       "risk": "medium",


### PR DESCRIPTION
> Written with Claude Code.

A CityHall-hosted workspace cannot configure itself. In CityHall client mode (#2853) `PATCH /api/settings`, the project CRUD routes, and `POST /api/git/clone` are all in `CITYHALL_MUTATION_DENY`, and the project registry starts empty. The result, found while validating that mode end to end: the composer renders, and the user cannot create a session because there is no project to launch against.

This adds one document that carries configuration in below the HTTP layer.

## The bundle

`cityhall.toml`, produced by a configured aoe install and applied by a workspace:

```toml
schema_version = 1

[meta]
generated_by = "aoe 1.13.2"

[settings.acp]
default_agent = "claude-code"

[[projects]]
name = "cityhall"
remote = "https://github.com/agent-of-empires/cityhall.git"
default_base_branch = "main"
```

- **`settings` is a sparse patch** keyed by section then field, the same shape a `PATCH /api/settings` body takes. It goes through the existing `validate_patch` and `merge_json`, so there is no second validation or merge path to keep in step. Export diffs the config against `Config::default()` via `apply_changed_leaves`, drops sections with no settings descriptors (`validate_patch` would reject the document otherwise), and runs `strip_local_only` so host-specific paths never ship to a container.
- **`projects` carries remotes, not paths.** `Project` has no remote field anywhere, and an admin's `/Users/me/src/foo` means nothing inside a container, so `apply` clones each remote into `<app_dir>/repos/<name>` and registers that path. Under the app dir specifically: a workspace volume mounts nothing else, so a clone anywhere else is lost on the next container recreate.
- **`[git]`** is never written by `export` and holds a credential. The host serving the bundle composes it per user.

Applying is idempotent, because a workspace does it on every boot: an existing checkout is left completely untouched so a user's uncommitted work survives a restart, an already-registered project is not re-added, and a repo that fails to clone is reported without taking the other projects down.

## Surfaces

- `aoe cityhall export [--out FILE]` and `aoe cityhall apply <FILE|->`.
- A **Settings → CityHall** tab with generate / download / copy and a preview, backed by `GET /api/cityhall/bundle`.
- `AOE_CITYHALL_BUNDLE_URL` and `AOE_CITYHALL_BUNDLE_TOKEN` make `aoe serve` fetch and apply a bundle at startup, past the daemon fork so exactly the serving process does it, and before the server resolves any config.

Both new surfaces are closed inside a workspace. The curated CityHall sidebar is a separate list that simply omits the tab, and the handler carries its own `cityhall_block` because `cityhall_gate` only guards mutations.

## Boot-fetch failure policy

Deliberately asymmetric:

- **No cached bundle** means a first boot. Continuing would leave the user in exactly the default-settings, no-projects workspace this feature exists to prevent, so the boot fails and CityHall surfaces it as a workspace that would not start.
- **A cached bundle exists**, so the workspace is already configured and a transient CityHall outage must not brick it. Warn, serve what is on disk.
- A bundle that arrives but is **malformed, or names a setting this aoe does not know, is fatal either way**: that is an admin error, and swallowing it would leave them believing a broken document had been applied.

## Known limit

A bundle sets values; it cannot unset them. A `null` leaf (a cleared `Option`) is dropped on export because TOML cannot spell it. Documented in the module docs and the guide.

## Testing

- [x] `cargo test --features serve --lib` — 5837 passed, 0 failed
- [x] `cargo clippy --features serve --all-targets` — clean
- [x] `cargo fmt`
- [x] `cargo xtask gen-docs` (the CLI reference diff is committed, so the CI freshness check passes)
- [x] `npx tsc --noEmit`, `npx eslint`, and the web unit suite (1049 passed)
- [x] New unit tests: TOML round trip, future `schema_version` refused, unknown sections dropped, null leaves dropped, an exported patch validates, a bad settings key is rejected **by name**, credential-line percent-encoding, and project-name path-segment validation

Not covered by a unit test: the clone-and-register loop in `apply_projects`, because `projects::add` writes to the real app dir and isolating it would mean mutating `HOME` process-wide. It is exercised end to end by the CityHall side of this work.

Refs agent-of-empires/cityhall#8, agent-of-empires/cityhall#9, agent-of-empires/cityhall#43, agent-of-empires/cityhall#44

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added portable CityHall bundles for settings, Git projects, and optional credentials.
- Added `aoe cityhall export` and `aoe cityhall apply` commands.
- Added CityHall export support to the Settings page and `/api/cityhall/bundle`.
- Added startup bundle fetching with token support and cached fallback behavior.
- Added validation, path safety checks, idempotent project handling, and clear failure reporting.
- Added documentation and tests for CLI, startup, bundle handling, and web workflows.

## Benefits

- Teams can transfer settings and projects with one file.
- Repeated applies preserve existing projects and registrations.
- Cached bundles support startup during temporary network failures.
- CLI and web workflows provide clear export and apply options.

## Further enhancement

- Add broader integration coverage for startup recovery.
- Expand guidance for credential handling and bundle security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->