### PR TITLE
fix(acp): repair the terminal event an agent-initiated turn never gets

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -2513,8 +2513,10 @@ impl AcpClient {
                 default_mode,
                 mcp_servers,
                 // Direct stdio agents have no runner and thus no control
-                // channel; the task owns its own terminal guard and speaks
-                // the full protocol over stdio.
+                // channel; the task owns its own terminal claim and
+                // prompt-in-flight flag and speaks the full protocol over
+                // stdio.
+                None,
                 None,
                 None,
             )
@@ -2611,14 +2613,19 @@ impl AcpClient {
         // byte-relay handshake and, for a mid-flight resume, the resume-idle
         // watchdog (guard left None so it still fires).
         let guard = Arc::new(TerminalClaim::new());
+        // Shared with the connection task so the control reader can hand idle
+        // ownership back when it surfaces a waiterless completion (#3190).
+        let prompt_in_flight = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let control_client = connect_runner_control_v2(
             &socket_path,
             event_tx.clone(),
             session_label.clone(),
             guard.clone(),
+            prompt_in_flight.clone(),
         )
         .await;
         let external_terminal_guard = control_client.as_ref().map(|_| guard);
+        let external_prompt_in_flight = control_client.as_ref().map(|_| prompt_in_flight);
 
         let (ready_tx, ready_rx) = oneshot::channel::<Result<(), AcpError>>();
 
@@ -2646,6 +2653,7 @@ impl AcpClient {
                 default_mode,
                 mcp_servers,
                 external_terminal_guard,
+                external_prompt_in_flight,
                 control_client,
             )
             .instrument(conn_span),
@@ -3941,6 +3949,7 @@ async fn connect_runner_control_v2(
     event_tx: mpsc::Sender<Event>,
     session_label: String,
     terminal_claim: Arc<TerminalClaim>,
+    prompt_in_flight: Arc<std::sync::atomic::AtomicBool>,
 ) -> Option<Arc<DaemonControlClient>> {
     let control_path = crate::process::worker::control_socket_sibling(main_socket);
     // A single deadline covers connect plus the Hello read. The runner
@@ -3988,6 +3997,7 @@ async fn connect_runner_control_v2(
         "runner control channel v2 attached; runner owns handshake + turn"
     );
 
+    let reader_prompt_in_flight = prompt_in_flight.clone();
     let (hs_tx, hs_rx) = mpsc::channel::<ControlBody>(8);
     let completion: Arc<
         std::sync::Mutex<Option<oneshot::Sender<control_protocol::PromptOutcome>>>,
@@ -4018,23 +4028,44 @@ async fn connect_runner_control_v2(
                         // never issued the prompt, so surface the completion
                         // as Stopped and stand the watchdogs down.
                         //
-                        // This is also the one path that can emit a turn's
-                        // terminal WITHOUT the prompt loop ever leaving its
-                        // prompt arm, so if it fires when no turn was adopted
-                        // the loop is stranded: `prompt_in_flight` stays set,
-                        // the between-prompt watchdog never arms, and the next
-                        // agent-initiated turn gets no terminal at all. Loud
-                        // on purpose, it used to be silent. See #3190.
+                        // The waiter being absent means no `prompt_fut` on
+                        // this connection can ever resolve for this turn, so a
+                        // `prompt_in_flight` still set here is stale by
+                        // definition. Left set, it silently disables the whole
+                        // between-prompt lane (every bit of that bookkeeping is
+                        // gated on `!prompt_active`), so the next
+                        // agent-initiated turn gets no terminal either and the
+                        // session renders Running until the reconciler's repair
+                        // pass. Clearing it hands idle ownership back the way
+                        // the prompt drain would have.
+                        //
+                        // Partial cure by construction: it re-arms the lane but
+                        // cannot unpark a prompt loop still awaiting that dead
+                        // future, which keeps rejecting new prompts as
+                        // `agent_busy`. See #3190 and PR #3192 review.
                         let claimed = terminal_claim.claim();
-                        warn!(
-                            target: "acp.protocol",
-                            session = %reader_session,
-                            claimed_terminal_guard = claimed,
-                            "runner reported PromptCompleted with no waiter installed"
-                        );
+                        let was_in_flight =
+                            reader_prompt_in_flight.swap(false, AtomicOrdering::Relaxed);
                         if claimed {
+                            // The expected shape: a turn adopted at reattach,
+                            // whose completion this connection has to surface.
+                            debug!(
+                                target: "acp.protocol",
+                                session = %reader_session,
+                                stranded_prompt = was_in_flight,
+                                "runner reported PromptCompleted with no waiter; surfacing as Stopped"
+                            );
                             let reason = control_outcome_reason(&outcome);
                             let _ = event_tx.send(Event::Stopped { reason }).await;
+                        } else {
+                            // Something already published this turn's terminal,
+                            // so this completion is a duplicate. Not expected.
+                            warn!(
+                                target: "acp.protocol",
+                                session = %reader_session,
+                                stranded_prompt = was_in_flight,
+                                "runner reported PromptCompleted with no waiter and the turn's terminal was already claimed"
+                            );
                         }
                     }
                 }
@@ -6109,6 +6140,7 @@ async fn run_connection_task<W, R>(
     // see it already fired and stand down. `None` on paths with no
     // control channel (direct stdio), where the task owns its own guard.
     external_terminal_guard: Option<Arc<TerminalClaim>>,
+    external_prompt_in_flight: Option<Arc<std::sync::atomic::AtomicBool>>,
     // #2976 Phase B: control client for a v2 runner. When Some, the task
     // drives `initialize` / `session/*` / `session/prompt` / cancel over it
     // instead of the crate connection (relay), which stays attached only
@@ -6272,7 +6304,8 @@ async fn run_connection_task<W, R>(
     let between_prompt_bg_agents = Arc::new(std::sync::Mutex::new(std::collections::HashSet::<
         String,
     >::new()));
-    let prompt_in_flight = Arc::new(AtomicBool::new(false));
+    let prompt_in_flight =
+        external_prompt_in_flight.unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
     let last_event_at_for_notif = last_event_at.clone();
     let first_event_after_attach_for_notif = first_event_after_attach.clone();
     let last_lifecycle_at_for_notif = last_lifecycle_at.clone();
@@ -14422,9 +14455,18 @@ done
 
         let (event_tx, mut event_rx) = mpsc::channel::<Event>(8);
         let guard = Arc::new(TerminalClaim::new());
-        let client = connect_runner_control_v2(&main_socket, event_tx, "s".into(), guard.clone())
-            .await
-            .expect("v2 control client");
+        // Set, as a stranded prompt loop would leave it: the reader must hand
+        // idle ownership back when it surfaces the waiterless completion.
+        let prompt_in_flight = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let client = connect_runner_control_v2(
+            &main_socket,
+            event_tx,
+            "s".into(),
+            guard.clone(),
+            prompt_in_flight.clone(),
+        )
+        .await
+        .expect("v2 control client");
 
         let ev = tokio::time::timeout(std::time::Duration::from_secs(5), event_rx.recv())
             .await
@@ -14432,6 +14474,10 @@ done
             .expect("event channel closed");
         assert!(matches!(ev, Event::Stopped { reason } if reason == "prompt_complete"));
         assert!(guard.claimed(), "the turn's terminal must be claimed");
+        assert!(
+            !prompt_in_flight.load(std::sync::atomic::Ordering::Relaxed),
+            "a waiterless completion must hand idle ownership back so the lane can arm"
+        );
         drop(client);
         let _ = fake.await;
     }
@@ -14464,8 +14510,14 @@ done
 
         let (event_tx, mut event_rx) = mpsc::channel::<Event>(8);
         let guard = Arc::new(TerminalClaim::new());
-        let client =
-            connect_runner_control_v2(&main_socket, event_tx, "s".into(), guard.clone()).await;
+        let client = connect_runner_control_v2(
+            &main_socket,
+            event_tx,
+            "s".into(),
+            guard.clone(),
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        )
+        .await;
 
         assert!(
             client.is_none(),
@@ -14527,8 +14579,14 @@ done
 
         let (event_tx, mut event_rx) = mpsc::channel::<Event>(8);
         let guard = Arc::new(TerminalClaim::new());
-        let client =
-            connect_runner_control_v2(&main_socket, event_tx, "s".into(), guard.clone()).await;
+        let client = connect_runner_control_v2(
+            &main_socket,
+            event_tx,
+            "s".into(),
+            guard.clone(),
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        )
+        .await;
 
         assert!(
             client.is_none(),

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -14,6 +14,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -1509,6 +1510,75 @@ fn between_prompt_stop_reason(adopted: bool, cost_seen: bool) -> &'static str {
     }
 }
 
+/// Per-turn claim on "who publishes this turn's terminal `Stopped`", shared by
+/// every path that can end one: the runner control reader's waiterless
+/// completion, the resume-idle watchdog, the between-prompt watchdog, and the
+/// cancel / force-stop desync recovery.
+///
+/// It replaces a single one-shot `AtomicBool`. That bool was claimed at most
+/// once per CONNECTION, so once any path had used it, a later turn on the same
+/// connection could not claim it: the between-prompt watchdog would reset its
+/// state, compute `claimed == false`, and skip the emit, leaving the session
+/// rendering Running with no terminal event. Reachable today by reattaching to
+/// an in-flight turn (the reader claims the guard for the adopted turn) and
+/// then letting the agent resume itself once more.
+///
+/// Keyed by turn instead: `begin_turn` marks the start of a turn, and a claim
+/// succeeds once per turn. An epoch rather than a reset so a claim can never
+/// clear the state of a NEWER turn, which is the race a plain "release the
+/// guard when done" would reintroduce. See #3190 and PR #3192 review.
+pub(crate) struct TerminalClaim {
+    /// Incremented for each turn that begins on this connection.
+    epoch: AtomicU64,
+    /// Epoch whose terminal has already been published. `0` means none, and
+    /// `epoch` starts at 1, so the first turn is claimable.
+    claimed_for: AtomicU64,
+}
+
+impl TerminalClaim {
+    pub(crate) fn new() -> Self {
+        Self {
+            epoch: AtomicU64::new(1),
+            claimed_for: AtomicU64::new(0),
+        }
+    }
+
+    /// A turn is starting; its terminal is unclaimed.
+    fn begin_turn(&self) {
+        self.epoch.fetch_add(1, AtomicOrdering::AcqRel);
+    }
+
+    /// Take ownership of the current turn's terminal event. `false` when some
+    /// other path already published it for this same turn, in which case the
+    /// caller must not emit.
+    fn claim(&self) -> bool {
+        let epoch = self.epoch.load(AtomicOrdering::Acquire);
+        loop {
+            let claimed = self.claimed_for.load(AtomicOrdering::Acquire);
+            if claimed == epoch {
+                return false;
+            }
+            if self
+                .claimed_for
+                .compare_exchange(
+                    claimed,
+                    epoch,
+                    AtomicOrdering::AcqRel,
+                    AtomicOrdering::Acquire,
+                )
+                .is_ok()
+            {
+                return true;
+            }
+        }
+    }
+
+    /// Whether the current turn's terminal has already been published.
+    fn claimed(&self) -> bool {
+        self.claimed_for.load(AtomicOrdering::Acquire) == self.epoch.load(AtomicOrdering::Acquire)
+    }
+}
+
 /// Tagged lifecycle signal carried over the watchdog mpsc. The
 /// `epoch` field is captured at signal-construction time from the
 /// shared `current_prompt_epoch` atomic; the prompt loop discards
@@ -2540,7 +2610,7 @@ impl AcpClient {
         // older (v1) runner returns None: the task falls back to the
         // byte-relay handshake and, for a mid-flight resume, the resume-idle
         // watchdog (guard left None so it still fires).
-        let guard = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let guard = Arc::new(TerminalClaim::new());
         let control_client = connect_runner_control_v2(
             &socket_path,
             event_tx.clone(),
@@ -3870,10 +3940,8 @@ async fn connect_runner_control_v2(
     main_socket: &std::path::Path,
     event_tx: mpsc::Sender<Event>,
     session_label: String,
-    terminal_guard: Arc<std::sync::atomic::AtomicBool>,
+    terminal_claim: Arc<TerminalClaim>,
 ) -> Option<Arc<DaemonControlClient>> {
-    use std::sync::atomic::Ordering;
-
     let control_path = crate::process::worker::control_socket_sibling(main_socket);
     // A single deadline covers connect plus the Hello read. The runner
     // binds the control socket before the main relay socket the caller
@@ -3957,9 +4025,7 @@ async fn connect_runner_control_v2(
                         // the between-prompt watchdog never arms, and the next
                         // agent-initiated turn gets no terminal at all. Loud
                         // on purpose, it used to be silent. See #3190.
-                        let claimed = terminal_guard
-                            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-                            .is_ok();
+                        let claimed = terminal_claim.claim();
                         warn!(
                             target: "acp.protocol",
                             session = %reader_session,
@@ -6042,7 +6108,7 @@ async fn run_connection_task<W, R>(
     // `Stopped`, so the resume-idle and between-prompt watchdogs below
     // see it already fired and stand down. `None` on paths with no
     // control channel (direct stdio), where the task owns its own guard.
-    external_terminal_guard: Option<Arc<std::sync::atomic::AtomicBool>>,
+    external_terminal_guard: Option<Arc<TerminalClaim>>,
     // #2976 Phase B: control client for a v2 runner. When Some, the task
     // drives `initialize` / `session/*` / `session/prompt` / cancel over it
     // instead of the crate connection (relay), which stays attached only
@@ -6140,22 +6206,22 @@ async fn run_connection_task<W, R>(
     //   - `prompt_sent_since_attach`: set when the user issues a prompt
     //     after attach; the user's real PromptRequest will own the next
     //     Stopped, so the watchdog must stand down.
-    //   - `watchdog_fired`: ensures we synthesize Stopped at most once.
+    //   - `terminal_claim`: ensures exactly one path publishes a given
+    //     turn's terminal Stopped (see `TerminalClaim`).
     let now_ms = chrono::Utc::now().timestamp_millis();
     let last_event_at = Arc::new(AtomicI64::new(now_ms));
     let first_event_after_attach = Arc::new(AtomicBool::new(false));
     let prompt_sent_since_attach = Arc::new(AtomicBool::new(false));
-    // Shared with the runner control reader (#1054 Phase A) when present,
-    // so a native `prompt_complete` from the runner and the resume-idle /
-    // between-prompt watchdogs all claim the same one-shot terminal guard.
-    let watchdog_fired =
-        external_terminal_guard.unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
+    // Shared with the runner control reader (#1054 Phase A) when present, so
+    // a native `prompt_complete` from the runner and the resume-idle /
+    // between-prompt watchdogs all claim the same per-turn terminal.
+    let terminal_claim = external_terminal_guard.unwrap_or_else(|| Arc::new(TerminalClaim::new()));
     // True for a turn adopted mid-flight via `Resume { in_flight_turn: true }`:
     // a prior connection issued the `session/prompt`, so this connection has no
     // owning `prompt_fut` and no real `ClientCmd::Prompt` will emit the turn's
     // terminal Stopped. Set true once the handshake resolves the mode (below).
     // Cleared when a real prompt starts or when a terminal path claims the
-    // `watchdog_fired` guard. Drives the cost-marker completion the between-
+    // turn's terminal. Drives the cost-marker completion the between-
     // prompt watchdog emits for the adopted turn. See #2899.
     let adopted_turn_active = Arc::new(AtomicBool::new(false));
     // Between-prompt idle watchdog state (#2325). Tracks an agent-initiated
@@ -6211,6 +6277,7 @@ async fn run_connection_task<W, R>(
     let first_event_after_attach_for_notif = first_event_after_attach.clone();
     let last_lifecycle_at_for_notif = last_lifecycle_at.clone();
     let between_prompt_active_for_notif = between_prompt_active.clone();
+    let terminal_claim_for_notif = terminal_claim.clone();
     let between_prompt_cost_seen_for_notif = between_prompt_cost_seen.clone();
     let between_prompt_wake_at_for_notif = between_prompt_wake_at.clone();
     let last_rate_limit_rejections_for_notif = last_rate_limit_rejections.clone();
@@ -6250,6 +6317,7 @@ async fn run_connection_task<W, R>(
                 let agent_msg_dedup = agent_msg_dedup_for_notif.clone();
                 let last_lifecycle_at = last_lifecycle_at_for_notif.clone();
                 let between_prompt_active = between_prompt_active_for_notif.clone();
+                let terminal_claim = terminal_claim_for_notif.clone();
                 let between_prompt_cost_seen =
                     between_prompt_cost_seen_for_notif.clone();
                 let between_prompt_wake_at =
@@ -6332,7 +6400,21 @@ async fn run_connection_task<W, R>(
                             now,
                             between_prompt_wake_at.load(Ordering::Relaxed),
                         ) {
-                            between_prompt_active.store(true, Ordering::Relaxed);
+                            // False -> true is an agent-initiated turn
+                            // starting, so it gets its own terminal to claim.
+                            // Logged because the arming decision was
+                            // previously invisible: the watchdog only ever
+                            // logged when it fired, which is exactly the
+                            // information a stuck-Running investigation
+                            // needs. See #3190.
+                            if !between_prompt_active.swap(true, Ordering::Relaxed) {
+                                terminal_claim.begin_turn();
+                                debug!(
+                                    target: "acp.protocol",
+                                    session = %session_label,
+                                    "between-prompt watchdog armed for an agent-initiated turn"
+                                );
+                            }
                             between_prompt_cost_seen.store(u.cost_seen, Ordering::Relaxed);
                             // Refresh from `now` on every tracked signal,
                             // including TerminalUsage, so the fast grace
@@ -7319,14 +7401,14 @@ async fn run_connection_task<W, R>(
                 let last_event_at = last_event_at.clone();
                 let first_event_after_attach = first_event_after_attach.clone();
                 let prompt_sent_since_attach = prompt_sent_since_attach.clone();
-                let watchdog_fired = watchdog_fired.clone();
+                let terminal_claim = terminal_claim.clone();
                 let session_label_for_watchdog = session_label.clone();
                 let grace = resume_idle_grace();
                 tokio::spawn(async move {
                     let grace_ms = grace.as_millis() as i64;
                     loop {
                         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                        if watchdog_fired.load(Ordering::Relaxed) {
+                        if terminal_claim.claimed() {
                             return;
                         }
                         if prompt_sent_since_attach.load(Ordering::Relaxed) {
@@ -7362,15 +7444,7 @@ async fn run_connection_task<W, R>(
                             // prompt watchdog can't also emit for this adopted
                             // turn in the narrow window where the first event
                             // and this grace expiry interleave. See #2899.
-                            if watchdog_fired
-                                .compare_exchange(
-                                    false,
-                                    true,
-                                    Ordering::AcqRel,
-                                    Ordering::Acquire,
-                                )
-                                .is_err()
-                            {
+                            if !terminal_claim.claim() {
                                 return;
                             }
                             info!(
@@ -7432,7 +7506,7 @@ async fn run_connection_task<W, R>(
                         ) {
                             // An adopted turn (#2899) has no owning prompt_fut, so
                             // this watchdog owns its terminal Stopped. Claim the
-                            // shared `watchdog_fired` guard so the detached
+                            // turn's shared terminal so the detached
                             // resume-idle task can't also fire in the narrow window
                             // where the first observable event and its grace expiry
                             // interleave; if that task already claimed, still reset
@@ -7440,15 +7514,7 @@ async fn run_connection_task<W, R>(
                             // agent-initiated turn is serialized on this loop and
                             // needs no guard.
                             let adopted = adopted_turn_active.load(Ordering::Relaxed);
-                            let claimed = !adopted
-                                || watchdog_fired
-                                    .compare_exchange(
-                                        false,
-                                        true,
-                                        Ordering::AcqRel,
-                                        Ordering::Acquire,
-                                    )
-                                    .is_ok();
+                            let claimed = !adopted || terminal_claim.claim();
                             if adopted {
                                 adopted_turn_active.store(false, Ordering::Relaxed);
                             }
@@ -7520,6 +7586,10 @@ async fn run_connection_task<W, R>(
                         // The per-prompt watchdog owns idle detection until the
                         // Stopped emit below clears `prompt_in_flight`. See #2325.
                         prompt_in_flight.store(true, Ordering::Relaxed);
+                        // This prompt is a new turn: its terminal is nobody's
+                        // yet, whatever an earlier turn on this connection
+                        // claimed.
+                        terminal_claim.begin_turn();
                         between_prompt_active.store(false, Ordering::Relaxed);
                         // A real prompt supersedes any agent-initiated turn the
                         // between-prompt watchdog was tracking; reset its state
@@ -8218,7 +8288,7 @@ async fn run_connection_task<W, R>(
                         // the detached resume-idle task can't fire, and clear the
                         // adopted / between-prompt tracking so a later tick can't
                         // add a duplicate. See #2899.
-                        watchdog_fired.store(true, Ordering::Relaxed);
+                        terminal_claim.claim();
                         adopted_turn_active.store(false, Ordering::Relaxed);
                         between_prompt_active.store(false, Ordering::Relaxed);
                         let _ = event_tx_for_block
@@ -8235,7 +8305,7 @@ async fn run_connection_task<W, R>(
                         info!(target: "acp.protocol", "force-stop requested with no prompt in flight; best-effort cancel only");
                         // The supervisor owns the terminal here, so stand down the
                         // local idle-completion paths to avoid a duplicate. See #2899.
-                        watchdog_fired.store(true, Ordering::Relaxed);
+                        terminal_claim.claim();
                         adopted_turn_active.store(false, Ordering::Relaxed);
                         between_prompt_active.store(false, Ordering::Relaxed);
                         let _ = send_session_cancel!();
@@ -14314,7 +14384,6 @@ done
     #[tokio::test]
     async fn runner_control_native_completion_fires_stopped() {
         use crate::acp::control_protocol::{self, ControlBody, PromptOutcome};
-        use std::sync::atomic::{AtomicBool, Ordering};
         use tokio::net::UnixListener;
 
         let tmp = tempfile::tempdir().unwrap();
@@ -14352,7 +14421,7 @@ done
         });
 
         let (event_tx, mut event_rx) = mpsc::channel::<Event>(8);
-        let guard = Arc::new(AtomicBool::new(false));
+        let guard = Arc::new(TerminalClaim::new());
         let client = connect_runner_control_v2(&main_socket, event_tx, "s".into(), guard.clone())
             .await
             .expect("v2 control client");
@@ -14362,10 +14431,7 @@ done
             .expect("timed out waiting for Stopped")
             .expect("event channel closed");
         assert!(matches!(ev, Event::Stopped { reason } if reason == "prompt_complete"));
-        assert!(
-            guard.load(Ordering::Relaxed),
-            "terminal guard must be claimed"
-        );
+        assert!(guard.claimed(), "the turn's terminal must be claimed");
         drop(client);
         let _ = fake.await;
     }
@@ -14376,7 +14442,6 @@ done
     #[tokio::test]
     async fn runner_control_version_mismatch_leaves_guard_unclaimed() {
         use crate::acp::control_protocol::{self, ControlBody};
-        use std::sync::atomic::{AtomicBool, Ordering};
         use tokio::net::UnixListener;
 
         let tmp = tempfile::tempdir().unwrap();
@@ -14398,7 +14463,7 @@ done
         });
 
         let (event_tx, mut event_rx) = mpsc::channel::<Event>(8);
-        let guard = Arc::new(AtomicBool::new(false));
+        let guard = Arc::new(TerminalClaim::new());
         let client =
             connect_runner_control_v2(&main_socket, event_tx, "s".into(), guard.clone()).await;
 
@@ -14407,8 +14472,8 @@ done
             "unknown control version must not yield a v2 client"
         );
         assert!(
-            !guard.load(Ordering::Relaxed),
-            "unknown control version must not claim the guard"
+            !guard.claimed(),
+            "unknown control version must not claim the terminal"
         );
         assert!(
             event_rx.try_recv().is_err(),
@@ -14417,19 +14482,51 @@ done
         let _ = fake.await;
     }
 
+    /// The one-shot guard this replaced could be claimed once per CONNECTION,
+    /// so a second turn on the same connection found it taken and its
+    /// watchdog skipped the emit, leaving the session rendering Running with
+    /// no terminal event. Reachable by reattaching to an in-flight turn (the
+    /// control reader claims for the adopted turn) and then letting the agent
+    /// resume itself again. Each turn must own its own claim. See #3190 and
+    /// PR #3192 review.
+    #[test]
+    fn terminal_claim_is_per_turn_not_per_connection() {
+        let claim = TerminalClaim::new();
+
+        // First turn: claimable exactly once.
+        assert!(!claim.claimed());
+        assert!(claim.claim(), "first turn's terminal is unclaimed");
+        assert!(claim.claimed());
+        assert!(
+            !claim.claim(),
+            "a second path must not double-publish the same turn's terminal"
+        );
+
+        // Second turn on the same connection: its own terminal.
+        claim.begin_turn();
+        assert!(
+            !claim.claimed(),
+            "a new turn must not inherit the previous turn's claim"
+        );
+        assert!(claim.claim(), "second turn's terminal is claimable");
+        assert!(!claim.claim());
+
+        // And it keeps working, so a long-lived connection cannot run out.
+        claim.begin_turn();
+        assert!(claim.claim());
+    }
+
     /// The load-bearing backward-compat path: an old runner that never binds
     /// the control socket leaves the guard unclaimed, so the resume-idle
     /// watchdog remains the terminal authority.
     #[tokio::test]
     async fn runner_control_absent_socket_leaves_guard_unclaimed() {
-        use std::sync::atomic::{AtomicBool, Ordering};
-
         let tmp = tempfile::tempdir().unwrap();
         // No control listener is bound at the sibling path.
         let main_socket = tmp.path().join("s.sock");
 
         let (event_tx, mut event_rx) = mpsc::channel::<Event>(8);
-        let guard = Arc::new(AtomicBool::new(false));
+        let guard = Arc::new(TerminalClaim::new());
         let client =
             connect_runner_control_v2(&main_socket, event_tx, "s".into(), guard.clone()).await;
 
@@ -14438,7 +14535,7 @@ done
             "absent control socket must fall back to the watchdog"
         );
         assert!(
-            !guard.load(Ordering::Relaxed),
+            !guard.claimed(),
             "absent control socket must fall back to the watchdog"
         );
         assert!(event_rx.try_recv().is_err());

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3826,7 +3826,25 @@ impl DaemonControlClient {
         request: serde_json::Value,
     ) -> oneshot::Receiver<control_protocol::PromptOutcome> {
         let (tx, rx) = oneshot::channel();
-        *self.completion.lock().expect("completion mutex poisoned") = Some(tx);
+        let displaced = self
+            .completion
+            .lock()
+            .expect("completion mutex poisoned")
+            .replace(tx);
+        // Installing over an unresolved waiter drops the previous prompt's
+        // receiver, so that turn's loop sees `Err -> Aborted` instead of its
+        // real outcome. It should be impossible (one prompt is in flight at a
+        // time) which is exactly why it is worth a line when it happens: a
+        // stranded prompt future is the leading suspect for a session that
+        // keeps rendering Running with no terminal event. See #3190.
+        if displaced.is_some() {
+            warn!(
+                target: "acp.protocol",
+                "installing a prompt completion waiter over an unresolved one"
+            );
+        } else {
+            debug!(target: "acp.protocol", "prompt completion waiter installed");
+        }
         if self.send(ControlBody::Prompt { request }).await.is_err() {
             // Write failed: drop the parked sender so `rx` resolves to Err ->
             // Aborted immediately instead of hanging until the cancel /
@@ -3927,15 +3945,31 @@ async fn connect_runner_control_v2(
                         .take();
                     if let Some(tx) = waiter {
                         let _ = tx.send(outcome);
-                    } else if terminal_guard
-                        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-                        .is_ok()
-                    {
+                    } else {
                         // Adopted turn on a mid-flight resume: this daemon
                         // never issued the prompt, so surface the completion
                         // as Stopped and stand the watchdogs down.
-                        let reason = control_outcome_reason(&outcome);
-                        let _ = event_tx.send(Event::Stopped { reason }).await;
+                        //
+                        // This is also the one path that can emit a turn's
+                        // terminal WITHOUT the prompt loop ever leaving its
+                        // prompt arm, so if it fires when no turn was adopted
+                        // the loop is stranded: `prompt_in_flight` stays set,
+                        // the between-prompt watchdog never arms, and the next
+                        // agent-initiated turn gets no terminal at all. Loud
+                        // on purpose, it used to be silent. See #3190.
+                        let claimed = terminal_guard
+                            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                            .is_ok();
+                        warn!(
+                            target: "acp.protocol",
+                            session = %reader_session,
+                            claimed_terminal_guard = claimed,
+                            "runner reported PromptCompleted with no waiter installed"
+                        );
+                        if claimed {
+                            let reason = control_outcome_reason(&outcome);
+                            let _ = event_tx.send(Event::Stopped { reason }).await;
+                        }
                     }
                 }
                 Ok(Some(_)) => {}
@@ -8134,7 +8168,21 @@ async fn run_connection_task<W, R>(
                         // The prompt drain is done; hand idle ownership back to
                         // the between-prompt watchdog for any agent-initiated
                         // turn that fires after this point. See #2325.
+                        //
+                        // Logged because the absence of this line after a
+                        // `Stopped` is the signature of a stranded prompt
+                        // future: the terminal was emitted by some other path
+                        // while this loop stayed parked in its prompt arm, so
+                        // the between-prompt watchdog is still disarmed and
+                        // the next agent-initiated turn will get no terminal.
+                        // See #3190.
                         prompt_in_flight.store(false, Ordering::Relaxed);
+                        debug!(
+                            target: "acp.protocol",
+                            session = %session_label,
+                            reason,
+                            "prompt drain complete; between-prompt idle ownership restored"
+                        );
                         if shutdown {
                             break;
                         }

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -1467,6 +1467,117 @@ impl EventStore {
         bg_in_flight > 0
     }
 
+    /// Latest substantive event for `session_id` as `(seq, event,
+    /// created_at_ms)`, or `None` when the session has only
+    /// non-substantive rows.
+    ///
+    /// Shares `NON_SUBSTANTIVE_EVENT_DISCRIMINANTS` with
+    /// [`Self::last_event_at_for_sessions`], so the terminal-repair pass in
+    /// `acp_reconciler` can pre-filter candidates on that batched age query
+    /// and then ask this for the single row that decides the repair. Both
+    /// predicates must see the same "latest" row or the pass would probe a
+    /// row it never aged. Returns the event decoded rather than a
+    /// discriminant string so the caller reuses the same
+    /// cost-bearing-`UsageUpdated` semantic that `acp_client`'s
+    /// `LifecycleSignal::TerminalUsage` classifier applies, instead of
+    /// re-deriving it in SQL where the two could drift. See #3190.
+    pub fn latest_substantive_event(&self, session_id: &str) -> Option<(u64, Event, i64)> {
+        let conn = match self.conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let clauses = NON_SUBSTANTIVE_EVENT_DISCRIMINANTS
+            .iter()
+            .map(|_| "AND event_json NOT LIKE ?")
+            .collect::<Vec<_>>()
+            .join("\n                   ");
+        let sql = format!(
+            "SELECT seq, event_json, created_at FROM acp_events
+                 WHERE session_id = ?
+                   {clauses}
+                 ORDER BY seq DESC
+                 LIMIT 1"
+        );
+        let mut bind: Vec<String> = vec![session_id.to_string()];
+        bind.extend(
+            NON_SUBSTANTIVE_EVENT_DISCRIMINANTS
+                .iter()
+                .map(|name| format!("{{\"{name}\":%")),
+        );
+        let row = conn
+            .query_row(&sql, rusqlite::params_from_iter(bind), |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            })
+            .optional()
+            .unwrap_or_else(|e| {
+                warn!(target: "acp.event_store", "latest_substantive_event for {session_id}: {e}");
+                None
+            })?;
+        let event: Event = serde_json::from_str(&row.1).ok()?;
+        Some((row.0 as u64, event, row.2))
+    }
+
+    /// True when the session's CURRENT turn epoch has a `ToolCallStarted`
+    /// with no matching `ToolCallCompleted`, i.e. a tool the agent is still
+    /// running.
+    ///
+    /// Scoped to events after the latest terminator (`Stopped` /
+    /// `AgentStartupError`) on purpose: a tool call stranded by an earlier
+    /// crashed turn is history, and counting it would suppress the
+    /// terminal-repair pass for the rest of the session's life. Failures
+    /// arrive as `ToolCallCompleted { is_error: true }`, so completion needs
+    /// only that one variant. See #3190.
+    pub fn has_open_tool_call_in_epoch(&self, session_id: &str) -> bool {
+        let conn = match self.conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let epoch_start: i64 = conn
+            .query_row(
+                "SELECT MAX(seq) FROM acp_events
+                 WHERE session_id = ?1
+                   AND (json_extract(event_json, '$.Stopped') IS NOT NULL
+                     OR json_extract(event_json, '$.AgentStartupError') IS NOT NULL)",
+                params![session_id],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .optional()
+            .unwrap_or_else(|e| {
+                warn!(target: "acp.event_store", "has_open_tool_call_in_epoch epoch query for {session_id}: {e}");
+                None
+            })
+            .flatten()
+            .unwrap_or(0);
+        let open: Option<i64> = conn
+            .query_row(
+                "SELECT 1 FROM acp_events
+                 WHERE session_id = ?1
+                   AND seq > ?2
+                   AND json_extract(event_json, '$.ToolCallStarted') IS NOT NULL
+                   AND json_extract(event_json, '$.ToolCallStarted.tool_call.id') NOT IN (
+                       SELECT json_extract(event_json, '$.ToolCallCompleted.tool_call_id')
+                         FROM acp_events
+                        WHERE session_id = ?1
+                          AND seq > ?2
+                          AND json_extract(event_json, '$.ToolCallCompleted') IS NOT NULL
+                   )
+                 LIMIT 1",
+                params![session_id, epoch_start],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .unwrap_or_else(|e| {
+                warn!(target: "acp.event_store", "has_open_tool_call_in_epoch for {session_id}: {e}");
+                // Fail closed: an unreadable log must not license a repair.
+                Some(1)
+            });
+        open.is_some()
+    }
+
     /// Latest `created_at` (ms since epoch) per session for the given
     /// ids, in a single grouped query. Sessions with no events are
     /// absent from the returned map. Backed by the

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -1542,7 +1542,7 @@ impl EventStore {
             })
             .optional()
             .unwrap_or_else(|e| {
-                warn!(target: "acp.event_store", "latest_substantive_event for {session_id}: {e}");
+                warn!(target: "acp.event_store", "terminal_repair_probe substantive event for {session_id}: {e}");
                 None
             })?;
         let substantive: Event = serde_json::from_str(&row.0).ok()?;

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -1564,6 +1564,12 @@ impl EventStore {
                         WHERE session_id = ?1
                           AND seq > ?2
                           AND json_extract(event_json, '$.ToolCallCompleted') IS NOT NULL
+                          -- `x NOT IN (a, NULL)` is NULL in SQLite, not true,
+                          -- which would drop every open call from the result
+                          -- and silently cost the repair pass its veto. The
+                          -- id is non-optional on the event today, so this
+                          -- keeps the fail-closed bias if that ever changes.
+                          AND json_extract(event_json, '$.ToolCallCompleted.tool_call_id') IS NOT NULL
                    )
                  LIMIT 1",
                 params![session_id, epoch_start],

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -82,6 +82,25 @@ const NON_SUBSTANTIVE_EVENT_DISCRIMINANTS: &[&str] = &[
     "PromptCapabilities",
 ];
 
+/// What the terminal-repair pass needs to decide, and to publish safely.
+///
+/// `substantive` decides: it is the newest event that is not ambient
+/// bookkeeping, and its `substantive_at_ms` is what the grace is measured
+/// against. `latest_seq` is the newest seq in the log of ANY kind, which is
+/// what the compare-and-publish must expect: `Supervisor::next_seqs` counts
+/// every allocation, ambient events included, so expecting the substantive
+/// seq would make the repair refuse forever on any session where a resume
+/// replay appended an `AcpSessionAssigned` after the end-of-turn marker.
+/// See #3190 and PR #3192 review.
+pub struct TerminalRepairProbe {
+    /// Newest seq of any kind, for the seq-conditional publish.
+    pub latest_seq: u64,
+    /// Newest substantive event, which decides whether to repair.
+    pub substantive: Event,
+    /// `created_at` of `substantive`, in ms since epoch.
+    pub substantive_at_ms: i64,
+}
+
 /// One page of replayed events plus the cursor metadata a paginating
 /// client needs to fetch the next page.
 pub struct ReplayPage {
@@ -1467,9 +1486,9 @@ impl EventStore {
         bg_in_flight > 0
     }
 
-    /// Latest substantive event for `session_id` as `(seq, event,
-    /// created_at_ms)`, or `None` when the session has only
-    /// non-substantive rows.
+    /// Read the inputs the terminal-repair pass decides on. `None` when the
+    /// session has no substantive event at all, or its newest one fails to
+    /// decode.
     ///
     /// Shares `NON_SUBSTANTIVE_EVENT_DISCRIMINANTS` with
     /// [`Self::last_event_at_for_sessions`], so the terminal-repair pass in
@@ -1481,18 +1500,31 @@ impl EventStore {
     /// cost-bearing-`UsageUpdated` semantic that `acp_client`'s
     /// `LifecycleSignal::TerminalUsage` classifier applies, instead of
     /// re-deriving it in SQL where the two could drift. See #3190.
-    pub fn latest_substantive_event(&self, session_id: &str) -> Option<(u64, Event, i64)> {
+    pub fn terminal_repair_probe(&self, session_id: &str) -> Option<TerminalRepairProbe> {
         let conn = match self.conn.lock() {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
+        let latest_seq: Option<i64> = conn
+            .query_row(
+                "SELECT MAX(seq) FROM acp_events WHERE session_id = ?1",
+                params![session_id],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .optional()
+            .unwrap_or_else(|e| {
+                warn!(target: "acp.event_store", "terminal_repair_probe latest seq for {session_id}: {e}");
+                None
+            })
+            .flatten();
+        let latest_seq = latest_seq?;
         let clauses = NON_SUBSTANTIVE_EVENT_DISCRIMINANTS
             .iter()
             .map(|_| "AND event_json NOT LIKE ?")
             .collect::<Vec<_>>()
             .join("\n                   ");
         let sql = format!(
-            "SELECT seq, event_json, created_at FROM acp_events
+            "SELECT event_json, created_at FROM acp_events
                  WHERE session_id = ?
                    {clauses}
                  ORDER BY seq DESC
@@ -1506,19 +1538,19 @@ impl EventStore {
         );
         let row = conn
             .query_row(&sql, rusqlite::params_from_iter(bind), |row| {
-                Ok((
-                    row.get::<_, i64>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, i64>(2)?,
-                ))
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
             })
             .optional()
             .unwrap_or_else(|e| {
                 warn!(target: "acp.event_store", "latest_substantive_event for {session_id}: {e}");
                 None
             })?;
-        let event: Event = serde_json::from_str(&row.1).ok()?;
-        Some((row.0 as u64, event, row.2))
+        let substantive: Event = serde_json::from_str(&row.0).ok()?;
+        Some(TerminalRepairProbe {
+            latest_seq: latest_seq as u64,
+            substantive,
+            substantive_at_ms: row.1,
+        })
     }
 
     /// True when the session's CURRENT turn epoch has a `ToolCallStarted`

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -908,6 +908,49 @@ impl<S: BroadcastSink> Supervisor<S> {
         self.publish_next(session_id, &Event::AgentStartupError { message });
     }
 
+    /// Publish `Stopped { reason }` only if `expected_seq` is still the
+    /// session's most recently allocated seq. Returns whether it published.
+    ///
+    /// The compare and the allocation happen under one `next_seqs` guard,
+    /// which is what makes this safe: `next_seqs` is the single ordering
+    /// authority for every publisher of a session (the drain task allocates
+    /// the same way), while the SQLite log trails it by however long an
+    /// append takes. A caller that decided from the log alone and then
+    /// published unconditionally could append a turn terminator AFTER a
+    /// prompt that was allocated in the gap, terminating a brand new turn in
+    /// canonical history. Comparing against the counter instead of the log
+    /// closes that window: anything allocated since the caller's observation
+    /// moves the counter and this returns false, so the caller retries on its
+    /// next pass. The guard is released before `sink.publish`, matching every
+    /// other publisher, so a SQLite write never runs under it.
+    ///
+    /// Used by the reconciler's terminal-repair pass (#3190).
+    pub fn publish_stopped_if_seq(
+        &self,
+        session_id: &str,
+        reason: &str,
+        expected_seq: u64,
+    ) -> bool {
+        let seq = {
+            let mut guard = lock_recover(&self.next_seqs);
+            let current = guard.get(session_id).copied().unwrap_or(0);
+            if current != expected_seq {
+                return false;
+            }
+            let seq = current.saturating_add(1);
+            guard.insert(session_id.to_string(), seq);
+            seq
+        };
+        self.sink.publish(
+            session_id,
+            seq,
+            &Event::Stopped {
+                reason: reason.to_string(),
+            },
+        );
+        true
+    }
+
     /// Mirror an `AcpError::IncompatibleAgent` onto the broadcast sink
     /// and tear down the detached runner. Called from every spawn-
     /// failure site so the structured detail reaches the reducer (the

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -4865,6 +4865,40 @@ mod tests {
         assert_eq!(next_seq(&sup.next_seqs, "s-1"), 3);
     }
 
+    /// #3190. The terminal-repair pass decides from the event log, which
+    /// trails `next_seqs`, so it must not publish once anything else has
+    /// been allocated since the seq it observed. That is the whole race:
+    /// otherwise a prompt allocated in the gap gets terminated by a repair
+    /// that was decided before it existed.
+    #[tokio::test]
+    async fn publish_stopped_if_seq_refuses_when_the_counter_moved() {
+        let sink = VecSink::new();
+        let sup = Supervisor::new(sink.clone());
+        sup.hydrate_seqs([("s-1".to_string(), 7)]);
+
+        // A stale expectation (something was allocated after the observation).
+        assert!(!sup.publish_stopped_if_seq("s-1", "inferred_prompt_complete", 6));
+        assert!(
+            sink.frames.lock().unwrap().is_empty(),
+            "a refused repair must not reach the sink"
+        );
+
+        // Current expectation: publishes as the next seq.
+        assert!(sup.publish_stopped_if_seq("s-1", "inferred_prompt_complete", 7));
+        let frames = sink.frames.lock().unwrap().clone();
+        assert_eq!(frames.len(), 1);
+        assert_eq!(
+            frames[0].1, 8,
+            "must land immediately after the observed seq"
+        );
+        assert!(
+            matches!(&frames[0].2, Event::Stopped { reason } if reason == "inferred_prompt_complete")
+        );
+        // And the counter moved, so a duplicate attempt with the same
+        // expectation is now refused.
+        assert!(!sup.publish_stopped_if_seq("s-1", "inferred_prompt_complete", 7));
+    }
+
     /// `publish_user_prompt` writes a `UserPromptSent { text }` event
     /// through the sink with a fresh seq. The handler invokes this
     /// before forwarding to the agent so the on-disk store has the

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -185,12 +185,21 @@ type RawTargetTuple = (
     String,
 );
 
+/// When each cadence-gated pass last ran. Grouped rather than passed as
+/// three more `&mut Option<Instant>` parameters: the passes are gated on the
+/// same 2s tick and the count was already at clippy's argument limit, so the
+/// next one to be added would have to either bundle or silence the lint.
+#[derive(Default)]
+pub struct ReapCadence {
+    pub idle: Option<Instant>,
+    pub rate_limit: Option<Instant>,
+    pub terminal_repair: Option<Instant>,
+}
+
 pub async fn reconcile_acp_workers(
     state: &Arc<AppState>,
     attempted: &mut HashSet<String>,
-    last_idle_reap: &mut Option<std::time::Instant>,
-    last_rate_limit_reap: &mut Option<std::time::Instant>,
-    last_terminal_repair: &mut Option<std::time::Instant>,
+    cadence: &mut ReapCadence,
     respawn_history: &mut HashMap<String, Vec<Instant>>,
     parked: &mut HashSet<String>,
     capacity_deferred: &mut HashSet<String>,
@@ -238,18 +247,24 @@ pub async fn reconcile_acp_workers(
     // filter. The idle threshold is resolved per session profile inside
     // `reap_idle_workers`; `auto_stop_idle_secs == 0` (the default)
     // disables the feature for sessions on that profile.
-    if last_idle_reap.is_none_or(|t| t.elapsed() >= IDLE_REAP_INTERVAL) {
+    if cadence
+        .idle
+        .is_none_or(|t| t.elapsed() >= IDLE_REAP_INTERVAL)
+    {
         reap_idle_workers(state).await;
-        *last_idle_reap = Some(std::time::Instant::now());
+        cadence.idle = Some(Instant::now());
     }
 
     // Terminal-event repair (#3190). Cadence-gated like the reaps above.
     // Runs AFTER the idle reap so a session the reap just marked dormant and
     // shut down carries the reap's own `idle_auto_stop` terminal instead of
     // collecting a second, redundant one from this pass on the same tick.
-    if last_terminal_repair.is_none_or(|t| t.elapsed() >= TERMINAL_REPAIR_INTERVAL) {
+    if cadence
+        .terminal_repair
+        .is_none_or(|t| t.elapsed() >= TERMINAL_REPAIR_INTERVAL)
+    {
         repair_missing_terminal(state).await;
-        *last_terminal_repair = Some(std::time::Instant::now());
+        cadence.terminal_repair = Some(Instant::now());
     }
 
     // Rate-limit auto-resume (#1722). Cadence-gated like the idle reaper:
@@ -259,9 +274,12 @@ pub async fn reconcile_acp_workers(
     // for this same tick's spawn pass to bring its worker back. The pass is
     // a no-op for the default-off case: profiles that did not opt in are
     // dropped before any event-store probe.
-    if last_rate_limit_reap.is_none_or(|t| t.elapsed() >= RATE_LIMIT_RESUME_INTERVAL) {
+    if cadence
+        .rate_limit
+        .is_none_or(|t| t.elapsed() >= RATE_LIMIT_RESUME_INTERVAL)
+    {
         reap_rate_limit_resumes(state, attempted).await;
-        *last_rate_limit_reap = Some(std::time::Instant::now());
+        cadence.rate_limit = Some(Instant::now());
     }
 
     // Snapshot per-target resume inputs under the instances read lock.
@@ -2402,15 +2420,17 @@ mod tests {
         parked: &mut HashSet<String>,
         capacity_deferred: &mut HashSet<String>,
     ) {
-        let mut last_idle_reap = Some(Instant::now());
-        let mut last_rate_limit_reap = Some(Instant::now());
-        let mut last_terminal_repair = Some(Instant::now());
+        // Pre-stamped so the cadence-gated passes sit out these ticks; the
+        // capacity tests below exercise the spawn path only.
+        let mut cadence = super::ReapCadence {
+            idle: Some(Instant::now()),
+            rate_limit: Some(Instant::now()),
+            terminal_repair: Some(Instant::now()),
+        };
         super::reconcile_acp_workers(
             state,
             attempted,
-            &mut last_idle_reap,
-            &mut last_rate_limit_reap,
-            &mut last_terminal_repair,
+            &mut cadence,
             respawn_history,
             parked,
             capacity_deferred,

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -613,6 +613,15 @@ const TERMINAL_REPAIR_GRACE_SECS: u32 = 60;
 ///
 /// `terminal_usage` is the load-bearing one: the repair infers completion from
 /// the adapter's own end-of-turn marker being latest, NOT from silence.
+///
+/// It rests on that marker meaning end-of-turn, which is the same thing
+/// `acp_client`'s watchdog trusts on a 3s grace. The residual risk, accepted:
+/// an adapter that emits a cost-bearing frame MID-turn and then spends over
+/// the grace inside a silent model call with no open tool gets a terminal it
+/// did not send. The status self-heals on the turn's next event, but unlike
+/// the in-memory status the fabricated `Stopped` stays in the log, so the
+/// timeline keeps a turn boundary that never happened. That is why the reason
+/// string is distinct rather than `prompt_complete`. See PR #3192 review.
 /// Silence alone is not evidence a turn finished (an agent can sit in a model
 /// call), and a turn that died mid-stream without ever emitting the marker is
 /// a worker-liveness problem with a different fix, so it is left to the idle

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -190,6 +190,7 @@ pub async fn reconcile_acp_workers(
     attempted: &mut HashSet<String>,
     last_idle_reap: &mut Option<std::time::Instant>,
     last_rate_limit_reap: &mut Option<std::time::Instant>,
+    last_terminal_repair: &mut Option<std::time::Instant>,
     respawn_history: &mut HashMap<String, Vec<Instant>>,
     parked: &mut HashSet<String>,
     capacity_deferred: &mut HashSet<String>,
@@ -240,6 +241,15 @@ pub async fn reconcile_acp_workers(
     if last_idle_reap.is_none_or(|t| t.elapsed() >= IDLE_REAP_INTERVAL) {
         reap_idle_workers(state).await;
         *last_idle_reap = Some(std::time::Instant::now());
+    }
+
+    // Terminal-event repair (#3190). Cadence-gated like the reaps above.
+    // Runs AFTER the idle reap so a session the reap just marked dormant and
+    // shut down carries the reap's own `idle_auto_stop` terminal instead of
+    // collecting a second, redundant one from this pass on the same tick.
+    if last_terminal_repair.is_none_or(|t| t.elapsed() >= TERMINAL_REPAIR_INTERVAL) {
+        repair_missing_terminal(state).await;
+        *last_terminal_repair = Some(std::time::Instant::now());
     }
 
     // Rate-limit auto-resume (#1722). Cadence-gated like the idle reaper:
@@ -561,6 +571,164 @@ pub async fn reconcile_acp_workers(
 /// every tick would hammer SQLite for no benefit; this gates the batched
 /// activity query to a coarse cadence. See #1689.
 const IDLE_REAP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How often the terminal-repair pass runs. Coarser than the 2s tick so the
+/// per-candidate event-log probes stay cheap, fine enough that the wrong badge
+/// clears within about half a minute of the grace expiring. See #3190.
+const TERMINAL_REPAIR_INTERVAL: Duration = Duration::from_secs(30);
+
+/// How long a cost-bearing `UsageUpdated` must stand as the session's latest
+/// event before the repair pass treats the turn as finished.
+///
+/// The adapter emits that frame as its "wrap up accounting" end-of-turn
+/// marker, which is why `acp_client`'s own between-prompt watchdog trusts it
+/// on a 3s grace. This backstop is deliberately an order of magnitude more
+/// patient: it must not race a turn that emits the marker and then spends time
+/// inside a model call before its next frame, and unlike the in-connection
+/// watchdogs it writes to the canonical log, so a false positive costs more
+/// than a late one. 60s still bounds the wrong status to about a minute,
+/// against the hour the idle reap used to take. See #3190.
+const TERMINAL_REPAIR_GRACE_SECS: u32 = 60;
+
+/// Pure terminal-repair decision. Every input must line up before the daemon
+/// writes a terminal event the agent never sent.
+///
+/// `terminal_usage` is the load-bearing one: the repair infers completion from
+/// the adapter's own end-of-turn marker being latest, NOT from silence.
+/// Silence alone is not evidence a turn finished (an agent can sit in a model
+/// call), and a turn that died mid-stream without ever emitting the marker is
+/// a worker-liveness problem with a different fix, so it is left to the idle
+/// reap rather than guessed at here.
+///
+/// The rest are refusals: a user prompt still lacking its terminator
+/// (`in_flight_turn`, which also covers a live async sub-agent), a tool the
+/// agent is still running in this epoch (`open_tool_call`), or a pending
+/// approval / elicitation (`awaiting_user`, which can outlive the `Waiting`
+/// status because a later activity event overwrites it). See #3190.
+#[allow(clippy::too_many_arguments)]
+fn should_repair_terminal(
+    now_ms: i64,
+    last_event_ms: i64,
+    terminal_usage: bool,
+    grace_secs: u32,
+    in_flight_turn: bool,
+    open_tool_call: bool,
+    awaiting_user: bool,
+) -> bool {
+    if !terminal_usage || in_flight_turn || open_tool_call || awaiting_user {
+        return false;
+    }
+    now_ms.saturating_sub(last_event_ms) >= i64::from(grace_secs) * 1000
+}
+
+/// Terminal-repair pass (#3190). Publishes the `Stopped` an agent-initiated
+/// turn never got, so a session whose agent is demonstrably done stops
+/// rendering as Running.
+///
+/// Why this lives outside the connection task: the three watchdogs that are
+/// supposed to emit that terminal all live inside one `run_connection_task`
+/// state machine, sharing a one-shot guard and a set of atomics, and a
+/// command loop that can block while also owning its own watchdog timer
+/// cannot reliably watchdog itself. Two confirmed sessions ran a full
+/// agent-initiated turn (a Monitor and a backgrounded Bash resuming the
+/// agent after its prompt had already completed), ended on the adapter's
+/// cost-bearing end-of-turn marker, and never got a terminal at all; the only
+/// thing that recovered them was the 1-hour idle reap, which kills the worker
+/// to get there.
+///
+/// Deliberately narrow: it only appends the missing event. It never stops,
+/// restarts, or marks a worker dormant, so a live agent that is merely quiet
+/// loses nothing but its green dot, and any further activity re-arms Running
+/// through `derive_acp_status` as usual.
+async fn repair_missing_terminal(state: &Arc<AppState>) {
+    // Only rows the daemon currently projects as Running. `Waiting` is
+    // excluded: a session parked on an approval is legitimately silent for
+    // as long as the user takes.
+    let candidates: Vec<String> = {
+        let instances = state.instances.read().await;
+        instances
+            .iter()
+            .filter(|i| i.is_structured() && i.status == crate::session::Status::Running)
+            .map(|i| i.id.clone())
+            .collect()
+    };
+    if candidates.is_empty() {
+        return;
+    }
+    // Batched age pre-filter, so the per-candidate probes below only run for
+    // sessions that could possibly qualify. Mirrors the idle reap's shape.
+    let store = Arc::clone(&state.acp_event_store);
+    let ids = candidates.clone();
+    let latest_at = match tokio::task::spawn_blocking(move || {
+        store.last_event_at_for_sessions(&ids)
+    })
+    .await
+    {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(target: "acp.supervisor", error = %e, "terminal-repair activity query failed");
+            return;
+        }
+    };
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let grace_ms = i64::from(TERMINAL_REPAIR_GRACE_SECS) * 1000;
+    for id in candidates {
+        let Some(last_ms) = latest_at.get(&id).copied() else {
+            continue;
+        };
+        if now_ms.saturating_sub(last_ms) < grace_ms {
+            continue;
+        }
+        let store = Arc::clone(&state.acp_event_store);
+        let probe_id = id.clone();
+        let probe = tokio::task::spawn_blocking(move || {
+            let latest = store.latest_substantive_event(&probe_id);
+            (
+                latest,
+                store.has_in_flight_turn(&probe_id),
+                store.has_open_tool_call_in_epoch(&probe_id),
+                !store.unresolved_approval_nonces(&probe_id).is_empty()
+                    || !store.unresolved_elicitation_nonces(&probe_id).is_empty(),
+            )
+        })
+        .await;
+        let Ok((Some((seq, event, at_ms)), in_flight, open_tool, awaiting_user)) = probe else {
+            continue;
+        };
+        // The same condition `acp_client`'s `LifecycleSignal::TerminalUsage`
+        // classifier applies, evaluated on the decoded event so the two
+        // cannot drift apart in SQL.
+        let terminal_usage =
+            matches!(&event, crate::acp::Event::UsageUpdated { usage } if usage.cost.is_some());
+        if !should_repair_terminal(
+            now_ms,
+            at_ms,
+            terminal_usage,
+            TERMINAL_REPAIR_GRACE_SECS,
+            in_flight,
+            open_tool,
+            awaiting_user,
+        ) {
+            continue;
+        }
+        // Conditional on `seq` still being the newest allocation: anything
+        // published between the probe and here (a fresh prompt above all)
+        // must not be terminated by this repair. A refusal just waits for
+        // the next pass.
+        if state
+            .acp_supervisor
+            .publish_stopped_if_seq(&id, "inferred_prompt_complete", seq)
+        {
+            tracing::info!(
+                target: "acp.supervisor",
+                session = %id,
+                after_seq = seq,
+                quiet_ms = now_ms.saturating_sub(at_ms),
+                "terminal-repair: agent-initiated turn ended with no Stopped; published inferred_prompt_complete"
+            );
+        }
+    }
+}
 
 /// Pure idle-reap decision. A structured view worker is auto-stopped only when the
 /// feature is enabled (`threshold_secs > 0`), it is not mid-turn, and its

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -2239,18 +2239,21 @@ mod tests {
                 },
             }
         }
+        fn tool_call(id: &str) -> ToolCall {
+            ToolCall {
+                id: id.to_string(),
+                name: "Terminal".to_string(),
+                kind: "execute".to_string(),
+                args_preview: "{}".to_string(),
+                started_at: Utc::now(),
+                parent_tool_call_id: None,
+                memory_recall: None,
+                diffs: Vec::new(),
+            }
+        }
         fn tool_started(id: &str) -> Event {
             Event::ToolCallStarted {
-                tool_call: ToolCall {
-                    id: id.to_string(),
-                    name: "Terminal".to_string(),
-                    kind: "execute".to_string(),
-                    args_preview: "{}".to_string(),
-                    started_at: Utc::now(),
-                    parent_tool_call_id: None,
-                    memory_recall: None,
-                    diffs: Vec::new(),
-                },
+                tool_call: tool_call(id),
             }
         }
         fn tool_done(id: &str) -> Event {
@@ -2354,6 +2357,28 @@ mod tests {
             Case {
                 name: "tool still open in this epoch",
                 events: finished_agent_turn(vec![tool_started("t2")]),
+                status: crate::session::Status::Running,
+                age_secs: 120,
+                expect_repair: false,
+            },
+            Case {
+                // The veto that keeps the daemon from terminating a session
+                // genuinely blocked on the user. It has to be reachable with
+                // status Running, because an approval can outlive the Waiting
+                // status: a later activity event overwrites it. The row below
+                // seeds the approval BEFORE the marker so the marker is still
+                // latest, which is what isolates this veto from the
+                // not-the-marker one. See PR #3192 review.
+                name: "unresolved approval, marker still latest",
+                events: finished_agent_turn(vec![Event::ApprovalRequested {
+                    approval: crate::acp::approvals::Approval {
+                        nonce: crate::acp::approvals::Nonce("n-1".to_string()),
+                        tool_call: tool_call("t-approval"),
+                        destructive: false,
+                        requested_at: Utc::now(),
+                        resolved: None,
+                    },
+                }]),
                 status: crate::session::Status::Running,
                 age_secs: 120,
                 expect_repair: false,

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -2168,6 +2168,195 @@ mod tests {
     use std::sync::Arc;
     use std::time::Instant;
 
+    /// #3190. An agent that parks on off-protocol work resumes itself after
+    /// its prompt already completed, and that resumed turn used to end with no
+    /// terminal event at all, pinning the session at Running until the 1-hour
+    /// reap killed the worker. Case 0 is the real occurrence, replayed from the
+    /// affected session's log: prompt, its own `Stopped`, then agent-initiated
+    /// work ending on the adapter's cost-bearing end-of-turn marker.
+    ///
+    /// The rest are the refusals, each one thing that must veto writing a
+    /// terminal the agent never sent. Table rather than a test per case
+    /// because they share the whole fixture; only the seeded log and the row's
+    /// status differ.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn terminal_repair_publishes_only_for_a_finished_agent_turn() {
+        use crate::acp::state::{SessionUsage, ToolCall, UsageCost};
+        use crate::acp::Event;
+        use crate::server::test_support::build_test_app_state;
+
+        fn usage(cost: bool) -> Event {
+            Event::UsageUpdated {
+                usage: SessionUsage {
+                    used: 400_000,
+                    size: 1_000_000,
+                    cost: cost.then(|| UsageCost {
+                        amount: 21.4,
+                        currency: "USD".to_string(),
+                    }),
+                },
+            }
+        }
+        fn tool_started(id: &str) -> Event {
+            Event::ToolCallStarted {
+                tool_call: ToolCall {
+                    id: id.to_string(),
+                    name: "Terminal".to_string(),
+                    kind: "execute".to_string(),
+                    args_preview: "{}".to_string(),
+                    started_at: Utc::now(),
+                    parent_tool_call_id: None,
+                    memory_recall: None,
+                    diffs: Vec::new(),
+                },
+            }
+        }
+        fn tool_done(id: &str) -> Event {
+            Event::ToolCallCompleted {
+                tool_call_id: id.to_string(),
+                is_error: false,
+                content: String::new(),
+                output: Vec::new(),
+                completed_at: Utc::now(),
+                async_subagent: false,
+            }
+        }
+        let stopped = |reason: &str| Event::Stopped {
+            reason: reason.to_string(),
+        };
+        // The agent-initiated turn, shared by every case: no UserPromptSent
+        // behind it, ending on the cost-bearing marker.
+        let finished_agent_turn = |extra: Vec<Event>| {
+            let mut evs = vec![
+                Event::UserPromptSent {
+                    text: "continue".to_string(),
+                    attachments: Vec::new(),
+                },
+                stopped("prompt_complete"),
+                tool_started("t1"),
+                tool_done("t1"),
+                Event::AgentMessageChunk {
+                    text: "Done.".to_string(),
+                },
+            ];
+            evs.extend(extra);
+            evs.push(usage(true));
+            evs
+        };
+
+        struct Case {
+            name: &'static str,
+            events: Vec<Event>,
+            status: crate::session::Status,
+            /// Age of every seeded event, so a case can sit inside the grace.
+            age_secs: i64,
+            expect_repair: bool,
+        }
+        let cases = vec![
+            Case {
+                name: "finished agent-initiated turn",
+                events: finished_agent_turn(Vec::new()),
+                status: crate::session::Status::Running,
+                age_secs: 120,
+                expect_repair: true,
+            },
+            Case {
+                name: "still inside the grace window",
+                events: finished_agent_turn(Vec::new()),
+                status: crate::session::Status::Running,
+                age_secs: 5,
+                expect_repair: false,
+            },
+            Case {
+                name: "latest event is not the end-of-turn marker",
+                // A cost-free usage frame is ordinary mid-turn accounting.
+                events: {
+                    let mut evs = finished_agent_turn(Vec::new());
+                    evs.push(usage(false));
+                    evs
+                },
+                status: crate::session::Status::Running,
+                age_secs: 120,
+                expect_repair: false,
+            },
+            Case {
+                name: "user prompt still lacks its terminator",
+                events: vec![
+                    Event::UserPromptSent {
+                        text: "go".to_string(),
+                        attachments: Vec::new(),
+                    },
+                    usage(true),
+                ],
+                status: crate::session::Status::Running,
+                age_secs: 120,
+                expect_repair: false,
+            },
+            Case {
+                name: "tool still open in this epoch",
+                events: finished_agent_turn(vec![tool_started("t2")]),
+                status: crate::session::Status::Running,
+                age_secs: 120,
+                expect_repair: false,
+            },
+            Case {
+                name: "waiting on the user",
+                events: finished_agent_turn(Vec::new()),
+                status: crate::session::Status::Waiting,
+                age_secs: 120,
+                expect_repair: false,
+            },
+        ];
+
+        for case in cases {
+            let id = "acp-terminal-repair";
+            let project = tempfile::TempDir::new().unwrap();
+            let mut inst = structured_instance(id, &project.path().to_string_lossy());
+            inst.status = case.status;
+            let state = build_test_app_state(vec![inst]);
+            let at_ms = Utc::now().timestamp_millis() - case.age_secs * 1000;
+            let last_seq = case.events.len() as u64;
+            for (idx, event) in case.events.iter().enumerate() {
+                state
+                    .acp_event_store
+                    .record_at(id, idx as u64 + 1, event, at_ms)
+                    .unwrap();
+            }
+            // Mirror daemon startup: the seq counter is seeded from the log,
+            // so the repair's compare-and-publish has something to compare.
+            state
+                .acp_supervisor
+                .hydrate_seqs([(id.to_string(), last_seq)]);
+
+            super::repair_missing_terminal(&state).await;
+
+            let repaired: Vec<u64> = state
+                .acp_event_store
+                .replay_from(id, 0)
+                .into_iter()
+                .filter(|(_, e)| {
+                    matches!(e, Event::Stopped { reason } if reason == "inferred_prompt_complete")
+                })
+                .map(|(seq, _)| seq)
+                .collect();
+            if case.expect_repair {
+                assert_eq!(
+                    repaired,
+                    vec![last_seq + 1],
+                    "{}: expected exactly one inferred terminal, appended after the marker",
+                    case.name
+                );
+            } else {
+                assert!(
+                    repaired.is_empty(),
+                    "{}: must not write a terminal the agent never sent",
+                    case.name
+                );
+            }
+        }
+    }
+
     fn structured_instance(id: &str, project_path: &str) -> crate::session::Instance {
         use crate::session::{Instance, View};
         let mut inst = Instance::new(id, project_path);
@@ -2215,11 +2404,13 @@ mod tests {
     ) {
         let mut last_idle_reap = Some(Instant::now());
         let mut last_rate_limit_reap = Some(Instant::now());
+        let mut last_terminal_repair = Some(Instant::now());
         super::reconcile_acp_workers(
             state,
             attempted,
             &mut last_idle_reap,
             &mut last_rate_limit_reap,
+            &mut last_terminal_repair,
             respawn_history,
             parked,
             capacity_deferred,

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -700,7 +700,7 @@ async fn repair_missing_terminal(state: &Arc<AppState>) {
         let store = Arc::clone(&state.acp_event_store);
         let probe_id = id.clone();
         let probe = tokio::task::spawn_blocking(move || {
-            let latest = store.latest_substantive_event(&probe_id);
+            let latest = store.terminal_repair_probe(&probe_id);
             (
                 latest,
                 store.has_in_flight_turn(&probe_id),
@@ -710,17 +710,35 @@ async fn repair_missing_terminal(state: &Arc<AppState>) {
             )
         })
         .await;
-        let Ok((Some((seq, event, at_ms)), in_flight, open_tool, awaiting_user)) = probe else {
+        // A panicking probe is worth a line: this pass exists to explain
+        // missing terminal events, so swallowing a panic inside it defeats
+        // the point. The no-substantive-event case below is ordinary and
+        // stays quiet.
+        let (latest, in_flight, open_tool, awaiting_user) = match probe {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    target: "acp.supervisor",
+                    session = %id,
+                    error = %e,
+                    "terminal-repair probe task failed; skipping this session"
+                );
+                continue;
+            }
+        };
+        let Some(latest) = latest else {
             continue;
         };
         // The same condition `acp_client`'s `LifecycleSignal::TerminalUsage`
         // classifier applies, evaluated on the decoded event so the two
         // cannot drift apart in SQL.
-        let terminal_usage =
-            matches!(&event, crate::acp::Event::UsageUpdated { usage } if usage.cost.is_some());
+        let terminal_usage = matches!(
+            &latest.substantive,
+            crate::acp::Event::UsageUpdated { usage } if usage.cost.is_some()
+        );
         if !should_repair_terminal(
             now_ms,
-            at_ms,
+            latest.substantive_at_ms,
             terminal_usage,
             TERMINAL_REPAIR_GRACE_SECS,
             in_flight,
@@ -729,19 +747,24 @@ async fn repair_missing_terminal(state: &Arc<AppState>) {
         ) {
             continue;
         }
-        // Conditional on `seq` still being the newest allocation: anything
-        // published between the probe and here (a fresh prompt above all)
-        // must not be terminated by this repair. A refusal just waits for
-        // the next pass.
-        if state
-            .acp_supervisor
-            .publish_stopped_if_seq(&id, "inferred_prompt_complete", seq)
-        {
+        // Conditional on the log's newest seq still being the newest
+        // allocation: anything published between the probe and here (a fresh
+        // prompt above all) must not be terminated by this repair. A refusal
+        // just waits for the next pass. Expects `latest_seq` rather than the
+        // substantive event's own seq, because the seq counter also advances
+        // for ambient events (an `AcpSessionAssigned` from a resume replay),
+        // and expecting the substantive one would make every later pass
+        // refuse forever. See PR #3192 review.
+        if state.acp_supervisor.publish_stopped_if_seq(
+            &id,
+            "inferred_prompt_complete",
+            latest.latest_seq,
+        ) {
             tracing::info!(
                 target: "acp.supervisor",
                 session = %id,
-                after_seq = seq,
-                quiet_ms = now_ms.saturating_sub(at_ms),
+                after_seq = latest.latest_seq,
+                quiet_ms = now_ms.saturating_sub(latest.substantive_at_ms),
                 "terminal-repair: agent-initiated turn ended with no Stopped; published inferred_prompt_complete"
             );
         }
@@ -2275,6 +2298,23 @@ mod tests {
             Case {
                 name: "finished agent-initiated turn",
                 events: finished_agent_turn(Vec::new()),
+                status: crate::session::Status::Running,
+                age_secs: 120,
+                expect_repair: true,
+            },
+            Case {
+                // The seq counter advances for ambient events too, so a
+                // repair that expected the substantive event's own seq
+                // refused forever on any session a resume had replayed
+                // into. See PR #3192 review.
+                name: "ambient event trails the marker",
+                events: {
+                    let mut evs = finished_agent_turn(Vec::new());
+                    evs.push(Event::AcpSessionAssigned {
+                        acp_session_id: "acp-1".to_string(),
+                    });
+                    evs
+                },
                 status: crate::session::Status::Running,
                 age_secs: 120,
                 expect_repair: true,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4205,6 +4205,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
     let mut last_sleep_inhibit_reconcile: Option<std::time::Instant> = None;
     #[cfg(feature = "serve")]
     let mut last_rate_limit_reap: Option<std::time::Instant> = None;
+    let mut last_terminal_repair: Option<std::time::Instant> = None;
     // Per-session reconciler respawn budget + crash-loop park set (#1945).
     // Owned by the loop so they persist across ticks, swept against live
     // sessions inside the reconciler.
@@ -4365,6 +4366,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
                 &mut attempted_acp_spawns,
                 &mut last_idle_reap,
                 &mut last_rate_limit_reap,
+                &mut last_terminal_repair,
                 &mut acp_respawn_history,
                 &mut acp_parked,
                 &mut acp_capacity_deferred,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4203,7 +4203,6 @@ async fn status_poll_loop(state: Arc<AppState>) {
     let mut sleep_inhibitor: Option<Box<dyn crate::process::SleepInhibit>> = None;
     #[cfg(feature = "serve")]
     let mut last_sleep_inhibit_reconcile: Option<std::time::Instant> = None;
-    #[cfg(feature = "serve")]
     // Per-session reconciler respawn budget + crash-loop park set (#1945).
     // Owned by the loop so they persist across ticks, swept against live
     // sessions inside the reconciler.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4192,7 +4192,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
     let mut attempted_acp_spawns: std::collections::HashSet<String> =
         std::collections::HashSet::new();
     #[cfg(feature = "serve")]
-    let mut last_idle_reap: Option<std::time::Instant> = None;
+    let mut acp_reap_cadence = acp_reconciler::ReapCadence::default();
     #[cfg(feature = "serve")]
     let mut last_session_idle_reap: Option<std::time::Instant> = None;
     // Loop-local, single-owner sleep-inhibit assertion (single global toggle,
@@ -4204,8 +4204,6 @@ async fn status_poll_loop(state: Arc<AppState>) {
     #[cfg(feature = "serve")]
     let mut last_sleep_inhibit_reconcile: Option<std::time::Instant> = None;
     #[cfg(feature = "serve")]
-    let mut last_rate_limit_reap: Option<std::time::Instant> = None;
-    let mut last_terminal_repair: Option<std::time::Instant> = None;
     // Per-session reconciler respawn budget + crash-loop park set (#1945).
     // Owned by the loop so they persist across ticks, swept against live
     // sessions inside the reconciler.
@@ -4364,9 +4362,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
             acp_reconciler::reconcile_acp_workers(
                 &state,
                 &mut attempted_acp_spawns,
-                &mut last_idle_reap,
-                &mut last_rate_limit_reap,
-                &mut last_terminal_repair,
+                &mut acp_reap_cadence,
                 &mut acp_respawn_history,
                 &mut acp_parked,
                 &mut acp_capacity_deferred,


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A structured session pins to `Running` for an hour after its agent is demonstrably finished. Two sessions confirmed it, three hours apart, with the same shape: mid-prompt the agent launches off-protocol work (a claude-code `Monitor` in one, `run_in_background` Bash in the other), ends its turn to wait for it, and then resumes ITSELF minutes later when that work completes. No new user prompt, so it is an agent-initiated turn. That turn runs 7 to 13 tool calls, ends on the adapter's cost-bearing `UsageUpdated` end-of-turn marker, and never gets a terminal `Stopped`. `derive_acp_status` maps activity events to `Running` and only a `Stopped` clears it, so the badge stays green until the 1-hour idle reap kills the worker to get there. I polled the second session every 45s from 22:32 to 23:20 UTC: `status=Running` on all 60 samples, 50 minutes past its last event.

The three watchdogs that should synthesize that terminal all live inside one `run_connection_task` state machine, sharing a one-shot guard and a set of atomics, and the between-prompt one (`acp_client.rs:1421`, built for exactly this scenario) never fired. I refuted every one of its suppression inputs against both sessions: no dangling tool calls (7/7 and 13/13 completed), no tracked async sub-agents, no scheduled wake, and the 30-minute off-protocol floor refuted empirically twice. It logs only when it fires, so which gate held is still unproven. This bug family has now recurred through seven closed issues (#2325, #2371, #2573, #2645, #2888, #2899, #3007), each fixed by adding another precedence branch inside that same state machine.

So this PR puts the invariant OUTSIDE it. A command loop that can block while also owning its own watchdog timer cannot reliably watchdog itself, and the event log already knows the turn is over. A new cadence-gated reconciler pass fires when the adapter's own end-of-turn marker has stood as the session's latest event for 60s and the log shows no in-flight prompt, no open tool call in this epoch, and nothing awaiting the user; it appends the `Stopped { reason: "inferred_prompt_complete" }` the agent never sent. It never stops, restarts, or marks a worker dormant, so a live agent that is merely quiet loses nothing but its green dot and re-arms `Running` on its next event.

Two design points worth calling out, both from pressure-testing the plan before writing it. First, the repair keys on the terminal marker rather than on silence: silence alone is not evidence a turn finished (an agent can sit inside a model call), and a turn that died mid-stream without ever emitting the marker is a worker-liveness problem with a different fix, left to the reap. Second, the publish is conditional on the sequence number. `next_seqs` in the supervisor is the single ordering authority for every publisher, while the SQLite log trails it by however long an append takes, so a pass that decided from the log and then published unconditionally could append a turn terminator AFTER a prompt allocated in that gap, terminating a brand new turn in canonical history. `publish_stopped_if_seq` compares against the counter under its own guard, so anything allocated since the observation makes the repair stand down and retry on the next pass.

The root cause of the missing terminal is still a hypothesis (a stranded prompt future leaving `prompt_in_flight` set, which silently disables the whole between-prompt lane), so this PR also makes that path observable instead of guessing at it: the no-waiter `PromptCompleted` branch was completely silent while being the one path that can emit a turn's terminal without the prompt loop leaving its prompt arm. It now warns, as does installing a completion waiter over an unresolved one, and the prompt drain logs when it hands idle ownership back so the absence of that line after a `Stopped` is itself the signature.

Refs #3190, deliberately not `Closes`. The root cause of the missing terminal is observed and half treated, not cured: the no-waiter branch now clears the stale `prompt_in_flight` so the between-prompt lane re-arms, but it cannot unpark a prompt loop still awaiting the dead future, which keeps rejecting new prompts as `agent_busy`. The remaining half, and the question of how the completion waiter goes missing at all, is tracked in #3203 and gated on the logs this PR adds. Leaving #3190 open until the cure lands, per review.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured session and ask the agent to start a backgrounded command that takes a couple of minutes, report that it is waiting, and end its turn; then let it summarize when the command finishes. When that self-resumed turn stops, the sidebar badge leaves `Running` within about 90s instead of staying green.
- [ ] Immediately after that, send a normal prompt to the same session. It answers straight away with no reconnect banner and no respawn wait, confirming the repair did not touch the worker.
- [ ] Check the repair is honest in the log: `sqlite3 ~/.agent-of-empires/acp_events.db "SELECT seq, event_json FROM acp_events WHERE session_id='<id>' ORDER BY seq DESC LIMIT 1;"` shows `{"Stopped":{"reason":"inferred_prompt_complete"}}`.
- [ ] Send an ordinary prompt and let it finish normally. The badge goes `Running` then `Idle` on the real `prompt_complete`, and no `inferred_prompt_complete` appears in the log for that turn.
- [ ] Have the agent run a single tool call that takes well over a minute (a long build, a slow test run) so the turn is genuinely live but quiet. The badge stays `Running` for the whole call, because an open tool call in the current epoch vetoes the repair.
- [ ] Leave a session parked on a pending approval for a few minutes without answering. It stays `Waiting`, never flips to `Idle`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

No `web/` file changes. The sidebar already renders the server's `status` field and that contract is unchanged; this PR only fixes what the daemon puts in it.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Daemon-internal self-healing, no TUI or CLI surface. The TUI inherits the fix for free since it sources structured-session status from the daemon (#3170).

Covered instead by two Rust tests:

- `terminal_repair_publishes_only_for_a_finished_agent_turn` replays the affected session's real log shape through the actual pass, a real temp SQLite event store and a broadcast-sink supervisor, and asserts exactly one inferred terminal lands after the marker. Neutering `repair_missing_terminal` makes it fail on that case, so the assertion is not vacuous. Its table rows are the vetoes: inside the grace, latest frame is not the marker, prompt still unterminated, tool still open, status `Waiting`.
- `publish_stopped_if_seq_refuses_when_the_counter_moved` pins the append race directly: a stale expected seq publishes nothing, a current one lands at seq + 1, and the same expectation is refused afterwards.

No docs change: this is daemon-internal self-healing with no operator-facing knob and no new setting (the grace is a constant, deliberately, so it carries no settings-parity burden).

Local validation: `cargo fmt --all -- --check`, `cargo clippy --features serve --all-targets` (clean for every file this PR touches), and `cargo test --features serve` (23 suites, 0 failures). The e2e suite was not run locally since no TUI, CLI, or session-lifecycle surface changed; CI covers it.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-investigate` and `/aoe-implement` skills, with a two-round `/debate` between Gemini 3.1 Pro and GPT-5.6 on the design)

**Any Additional AI Details you'd like to share:**

Investigation, prose, and implementation drafted by Claude under my direction. I made the design calls and reviewed each commit. The debate round earned its keep: both models independently produced the same concrete interleaving that broke my first race mitigation, which is why the publish is sequence-conditional against the supervisor's counter rather than re-checked against the log.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added recovery for ACP sessions that remain `Running` after agent-initiated turns complete.
- Added a 60-second reconciler that publishes `Stopped { reason: "inferred_prompt_complete" }` when completion is safe to infer.
- Added per-turn terminal claims and sequence checks to prevent duplicate stops and stale updates.
- Restored prompt-idle state after waiterless completion.
- Added event checks, diagnostics, approval veto handling, and regression tests.
- Grouped reconciler timing through `ReapCadence`.

## Benefits

- Prevents completed sessions from waiting for idle reap.
- Recovers status without stopping or restarting workers.
- Preserves normal worker behavior and the one-hour idle reap.
- Improves visibility into stalled prompt state and repair decisions.

## Potential enhancement

- Continue monitoring recovery behavior. The remaining prompt-loop unparking issue is tracked separately in `#3203`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
