### PR TITLE
fix(tui): make Ctrl+P open the worktree branch picker

### DIFF
--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -1442,6 +1442,7 @@ impl NewSessionDialog {
             if self.focused_field == worktree_field {
                 self.worktree_config_mode = true;
                 self.worktree_config_focused_field = 0;
+                self.error_message = None;
                 return DialogResult::Continue;
             }
             if self.focused_field == sandbox_field && self.sandbox_enabled {
@@ -1731,6 +1732,32 @@ impl NewSessionDialog {
         }
     }
 
+    /// Build and activate the branch picker (Ctrl+P on the worktree name and
+    /// base-branch fields). The path field holds whatever the user typed, so
+    /// it needs the same tilde expansion the submit and dir-picker paths do;
+    /// without it `~/repo` never opens and the picker silently did nothing.
+    /// Failures surface inline instead of being swallowed. See #3166.
+    fn open_branch_picker(&mut self) {
+        let path_str = self.path.value().trim().to_string();
+        if path_str.is_empty() {
+            self.error_message = Some("Set the project path before picking a branch.".into());
+            return;
+        }
+        let resolved = path_input::expand_tilde(&path_str);
+        match crate::git::diff::list_branches(std::path::Path::new(&resolved)) {
+            Ok(branches) if !branches.is_empty() => {
+                self.error_message = None;
+                self.branch_picker.activate(branches);
+            }
+            Ok(_) => {
+                self.error_message = Some(format!("No branches found in {}.", path_str));
+            }
+            Err(e) => {
+                self.error_message = Some(format!("Cannot list branches in {}: {}", path_str, e));
+            }
+        }
+    }
+
     /// Build and activate the registered-projects picker (Ctrl+R on the
     /// extra-repos field). Filters out the primary repo and any paths already
     /// in the workspace_repos list to avoid the builder's duplicate-name guard.
@@ -1790,39 +1817,22 @@ impl NewSessionDialog {
         match key.code {
             KeyCode::Esc => {
                 self.worktree_config_mode = false;
+                self.error_message = None;
                 DialogResult::Continue
             }
             KeyCode::Char('?') => {
                 self.show_help = true;
                 DialogResult::Continue
             }
-            // Ctrl+P on name field opens branch picker
-            KeyCode::Char('p')
-                if key.modifiers.contains(KeyModifiers::CONTROL)
-                    && self.worktree_config_focused_field == WT_NAME =>
-            {
-                let path = std::path::Path::new(self.path.value().trim());
-                if let Ok(branches) = crate::git::diff::list_branches(path) {
-                    if !branches.is_empty() {
-                        self.branch_picker.activate(branches);
-                    }
-                }
-                DialogResult::Continue
-            }
-            // Ctrl+P on base-branch field opens the branch picker too.
-            // Selection routes through `branch_picker` like WT_NAME, so we
+            // Ctrl+P opens the branch picker for the name and base-branch
+            // fields. Selection routes through `branch_picker` for both, so we
             // disambiguate after selection by checking the focused field.
             // See `branch_picker` handling at the top of this function.
             KeyCode::Char('p')
                 if key.modifiers.contains(KeyModifiers::CONTROL)
-                    && self.worktree_config_focused_field == WT_BASE_BRANCH =>
+                    && matches!(self.worktree_config_focused_field, WT_NAME | WT_BASE_BRANCH) =>
             {
-                let path = std::path::Path::new(self.path.value().trim());
-                if let Ok(branches) = crate::git::diff::list_branches(path) {
-                    if !branches.is_empty() {
-                        self.branch_picker.activate(branches);
-                    }
-                }
+                self.open_branch_picker();
                 DialogResult::Continue
             }
             // Ctrl+R on extra_repos field opens the registered-projects picker.
@@ -1841,6 +1851,7 @@ impl NewSessionDialog {
             }
             KeyCode::Enter => {
                 self.worktree_config_mode = false;
+                self.error_message = None;
                 DialogResult::Continue
             }
             KeyCode::Tab | KeyCode::Down => {

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -32,6 +32,11 @@ pub(super) struct FieldHelp {
 
 pub(super) const HELP_DIALOG_WIDTH: u16 = 85;
 
+/// Index of the Base field in the worktree config overlay. Both the key and
+/// mouse handlers need it to route a branch selection, so it lives here rather
+/// than inside one handler.
+pub(super) const WT_BASE_BRANCH_FIELD: usize = 2;
+
 pub(super) const FIELD_HELP: &[FieldHelp] = &[
     FieldHelp {
         name: "Scratch",
@@ -1056,7 +1061,7 @@ impl NewSessionDialog {
                     return Some(DialogResult::Continue);
                 }
                 ListPickerResult::Selected(value) => {
-                    self.worktree_branch = Input::new(value);
+                    self.apply_branch_selection(value);
                     return Some(DialogResult::Continue);
                 }
             }
@@ -1321,7 +1326,7 @@ impl NewSessionDialog {
 
         if self.branch_picker.is_active() {
             if let ListPickerResult::Selected(value) = self.branch_picker.handle_key(key) {
-                self.worktree_branch = Input::new(value);
+                self.apply_branch_selection(value);
             }
             return DialogResult::Continue;
         }
@@ -1737,6 +1742,18 @@ impl NewSessionDialog {
     /// it needs the same tilde expansion the submit and dir-picker paths do;
     /// without it `~/repo` never opens and the picker silently did nothing.
     /// Failures surface inline instead of being swallowed. See #3166.
+    /// Store a branch the user picked. The picker serves both the Name and
+    /// Base fields, so the focused field decides where the value lands; every
+    /// entry point (keyboard and mouse) has to route through here or a
+    /// selection made from Base overwrites Name instead.
+    fn apply_branch_selection(&mut self, value: String) {
+        if self.worktree_config_focused_field == WT_BASE_BRANCH_FIELD {
+            self.base_branch = Input::new(value);
+        } else {
+            self.worktree_branch = Input::new(value);
+        }
+    }
+
     fn open_branch_picker(&mut self) {
         let path_str = self.path.value().trim().to_string();
         if path_str.is_empty() {
@@ -1787,17 +1804,13 @@ impl NewSessionDialog {
         // Worktree config fields: 0=name, 1=new_branch checkbox, 2=extra_repos list
         const WT_NAME: usize = 0;
         const WT_NEW_BRANCH: usize = 1;
-        const WT_BASE_BRANCH: usize = 2;
+        const WT_BASE_BRANCH: usize = WT_BASE_BRANCH_FIELD;
         const WT_EXTRA_REPOS: usize = 3;
         const WT_MAX: usize = 4;
 
         if self.branch_picker.is_active() {
             if let ListPickerResult::Selected(value) = self.branch_picker.handle_key(key) {
-                if self.worktree_config_focused_field == WT_BASE_BRANCH {
-                    self.base_branch = Input::new(value);
-                } else {
-                    self.worktree_branch = Input::new(value);
-                }
+                self.apply_branch_selection(value);
             }
             return DialogResult::Continue;
         }

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -35,7 +35,7 @@ pub(super) const HELP_DIALOG_WIDTH: u16 = 85;
 /// Index of the Base field in the worktree config overlay. Both the key and
 /// mouse handlers need it to route a branch selection, so it lives here rather
 /// than inside one handler.
-pub(super) const WT_BASE_BRANCH_FIELD: usize = 2;
+const WT_BASE_BRANCH_FIELD: usize = 2;
 
 pub(super) const FIELD_HELP: &[FieldHelp] = &[
     FieldHelp {
@@ -1737,23 +1737,26 @@ impl NewSessionDialog {
         }
     }
 
-    /// Build and activate the branch picker (Ctrl+P on the worktree name and
-    /// base-branch fields). The path field holds whatever the user typed, so
-    /// it needs the same tilde expansion the submit and dir-picker paths do;
-    /// without it `~/repo` never opens and the picker silently did nothing.
-    /// Failures surface inline instead of being swallowed. See #3166.
     /// Store a branch the user picked. The picker serves both the Name and
     /// Base fields, so the focused field decides where the value lands; every
     /// entry point (keyboard and mouse) has to route through here or a
-    /// selection made from Base overwrites Name instead.
+    /// selection made from Base overwrites Name instead. The focused field only
+    /// means "Base" while the overlay is open, so a picker opened from anywhere
+    /// else still lands in Name.
     fn apply_branch_selection(&mut self, value: String) {
-        if self.worktree_config_focused_field == WT_BASE_BRANCH_FIELD {
+        if self.worktree_config_mode && self.worktree_config_focused_field == WT_BASE_BRANCH_FIELD {
             self.base_branch = Input::new(value);
         } else {
             self.worktree_branch = Input::new(value);
         }
     }
 
+    /// Build and activate the branch picker (Ctrl+P anywhere in the worktree
+    /// overlay bar the extra-repos list). The path field holds what the user
+    /// typed, so
+    /// it needs the same tilde expansion the submit and create-dir paths do;
+    /// without it `~/repo` never opens and the picker silently did nothing.
+    /// Failures surface inline instead of being swallowed. See #3166.
     fn open_branch_picker(&mut self) {
         let path_str = self.path.value().trim().to_string();
         if path_str.is_empty() {
@@ -1801,10 +1804,10 @@ impl NewSessionDialog {
 
     /// Handle key events when in worktree configuration mode.
     fn handle_worktree_config_key(&mut self, key: KeyEvent) -> DialogResult<NewSessionData> {
-        // Worktree config fields: 0=name, 1=new_branch checkbox, 2=extra_repos list
+        // Worktree config fields: 0=name, 1=new_branch checkbox,
+        // 2=base_branch, 3=extra_repos list
         const WT_NAME: usize = 0;
         const WT_NEW_BRANCH: usize = 1;
-        const WT_BASE_BRANCH: usize = WT_BASE_BRANCH_FIELD;
         const WT_EXTRA_REPOS: usize = 3;
         const WT_MAX: usize = 4;
 
@@ -1837,13 +1840,18 @@ impl NewSessionDialog {
                 self.show_help = true;
                 DialogResult::Continue
             }
-            // Ctrl+P opens the branch picker for the name and base-branch
-            // fields. Selection routes through `branch_picker` for both, so we
-            // disambiguate after selection by checking the focused field.
+            // Ctrl+P opens the branch picker. The hint row advertises it for
+            // every field that is not the extra-repos list, so the guard has to
+            // cover the New Branch checkbox too or the key is a silent no-op
+            // there. Selection routes through `branch_picker` for all of them,
+            // so we disambiguate after selection by checking the focused field.
             // See `branch_picker` handling at the top of this function.
             KeyCode::Char('p')
                 if key.modifiers.contains(KeyModifiers::CONTROL)
-                    && matches!(self.worktree_config_focused_field, WT_NAME | WT_BASE_BRANCH) =>
+                    && matches!(
+                        self.worktree_config_focused_field,
+                        WT_NAME | WT_NEW_BRANCH | WT_BASE_BRANCH_FIELD
+                    ) =>
             {
                 self.open_branch_picker();
                 DialogResult::Continue
@@ -1891,7 +1899,7 @@ impl NewSessionDialog {
                     .handle_event(&crossterm::event::Event::Key(key));
                 DialogResult::Continue
             }
-            _ if self.worktree_config_focused_field == WT_BASE_BRANCH => {
+            _ if self.worktree_config_focused_field == WT_BASE_BRANCH_FIELD => {
                 self.base_branch
                     .handle_event(&crossterm::event::Event::Key(key));
                 DialogResult::Continue

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -928,32 +928,40 @@ impl NewSessionDialog {
         );
         self.worktree_config_rects.push((3, chunks[3]));
 
-        // Hints
-        let mut hint_spans = vec![
-            Span::styled("Tab", Style::default().fg(theme.hint)),
-            Span::raw(" next  "),
-            Span::styled("Space", Style::default().fg(theme.hint)),
-            Span::raw(" toggle  "),
-            Span::styled("Ctrl+P", Style::default().fg(theme.hint)),
-            Span::raw(" branches  "),
-            Span::styled("Enter", Style::default().fg(theme.hint)),
-            Span::raw(" done  "),
-            Span::styled("Esc", Style::default().fg(theme.hint)),
-            Span::raw(" back"),
-        ];
-        if self.worktree_config_focused_field == 3 && !self.workspace_repos_expanded {
-            hint_spans = vec![
+        // Hints, or the pending error (branch listing failures land here so
+        // Ctrl+P always produces visible feedback). See #3166.
+        if let Some(error) = &self.error_message {
+            let error_paragraph = Paragraph::new(format!("✗ Error: {}", error))
+                .style(Style::default().fg(theme.error))
+                .wrap(Wrap { trim: true });
+            frame.render_widget(error_paragraph, chunks[4]);
+        } else {
+            let mut hint_spans = vec![
                 Span::styled("Tab", Style::default().fg(theme.hint)),
                 Span::raw(" next  "),
+                Span::styled("Space", Style::default().fg(theme.hint)),
+                Span::raw(" toggle  "),
+                Span::styled("Ctrl+P", Style::default().fg(theme.hint)),
+                Span::raw(" branches  "),
                 Span::styled("Enter", Style::default().fg(theme.hint)),
-                Span::raw(" edit repos  "),
-                Span::styled("Ctrl+R", Style::default().fg(theme.hint)),
-                Span::raw(" pick project  "),
+                Span::raw(" done  "),
                 Span::styled("Esc", Style::default().fg(theme.hint)),
                 Span::raw(" back"),
             ];
+            if self.worktree_config_focused_field == 3 && !self.workspace_repos_expanded {
+                hint_spans = vec![
+                    Span::styled("Tab", Style::default().fg(theme.hint)),
+                    Span::raw(" next  "),
+                    Span::styled("Enter", Style::default().fg(theme.hint)),
+                    Span::raw(" edit repos  "),
+                    Span::styled("Ctrl+R", Style::default().fg(theme.hint)),
+                    Span::raw(" pick project  "),
+                    Span::styled("Esc", Style::default().fg(theme.hint)),
+                    Span::raw(" back"),
+                ];
+            }
+            frame.render_widget(Paragraph::new(Line::from(hint_spans)), chunks[4]);
         }
-        frame.render_widget(Paragraph::new(Line::from(hint_spans)), chunks[4]);
 
         if self.show_help {
             self.render_help_overlay(frame, area, theme);

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -813,12 +813,22 @@ impl NewSessionDialog {
             2
         };
 
+        // Errors share the hint row, so size it to the wrapped text the way the
+        // main dialog does; a long git error would otherwise clip to one line.
+        let hint_height: u16 = if let Some(error) = &self.error_message {
+            let inner_width = dialog_width - 4;
+            let error_text = format!("✗ Error: {}", error);
+            (error_text.len() as u16).div_ceil(inner_width).clamp(1, 6)
+        } else {
+            1
+        };
+
         let constraints = vec![
             Constraint::Length(2),            // Name
             Constraint::Length(2),            // New Branch checkbox
             Constraint::Length(2),            // Base Branch
             Constraint::Length(repos_height), // Extra Repos
-            Constraint::Min(1),               // Hints
+            Constraint::Min(hint_height),     // Hints or error
         ];
 
         let fields_height: u16 = constraints

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -1770,3 +1770,54 @@ fn branch_picker_surfaces_failures_and_clears_them() {
         assert!(dialog.error_message.is_none());
     }
 }
+
+/// A branch picked with the mouse has to land in the same field a keyboard
+/// pick would, so opening the picker from Base and clicking a row must not
+/// overwrite Name. Needs a real render pass because the picker learns its
+/// clickable area while drawing.
+#[test]
+#[serial_test::serial]
+fn branch_picker_mouse_selection_routes_to_the_focused_field() {
+    use ratatui::{backend::TestBackend, Terminal};
+
+    let temp_home = tempfile::tempdir().expect("temp home");
+    let _home = crate::session::test_support::isolate_home(temp_home.path());
+    let repo = branch_picker_repo_in(temp_home.path());
+
+    let mut dialog = worktree_config_dialog(repo.to_string_lossy().to_string());
+    dialog.worktree_config_focused_field = 2; // base branch
+    dialog.handle_key(ctrl_key(KeyCode::Char('p')));
+    assert!(dialog.branch_picker.is_active());
+
+    let mut terminal = Terminal::new(TestBackend::new(100, 40)).expect("terminal");
+    let theme = crate::tui::styles::Theme::default();
+    terminal
+        .draw(|frame| dialog.render(frame, frame.area(), &theme))
+        .expect("render");
+
+    // Walk the rendered rows for the branch the repo actually has, then click it.
+    let branch = dialog
+        .branch_picker
+        .filtered_items()
+        .first()
+        .map(|s| (*s).clone())
+        .expect("repo should expose a branch");
+    let buffer = terminal.backend().buffer().clone();
+    let (col, row) = (0..buffer.area.height)
+        .find_map(|row| {
+            let line: String = (0..buffer.area.width)
+                .map(|col| buffer[(col, row)].symbol())
+                .collect();
+            line.find(&branch).map(|idx| (idx as u16, row))
+        })
+        .expect("branch row should be rendered");
+
+    dialog.handle_click(col, row);
+
+    assert_eq!(dialog.base_branch.value(), branch);
+    assert!(
+        dialog.worktree_branch.value().is_empty(),
+        "Name must stay untouched, got {:?}",
+        dialog.worktree_branch.value()
+    );
+}

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -1676,3 +1676,97 @@ fn structured_submits_false_when_toggled_then_capability_lost() {
         _ => panic!("expected submit"),
     }
 }
+
+/// Init a repo with one commit so it has a branch to list.
+fn branch_picker_repo_in(parent: &std::path::Path) -> std::path::PathBuf {
+    let dir = parent.join("repo");
+    fs::create_dir_all(&dir).expect("create repo dir");
+    let repo = git2::Repository::init(&dir).expect("git init");
+    let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+    fs::write(dir.join("README.md"), "hi\n").unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(std::path::Path::new("README.md")).unwrap();
+    index.write().unwrap();
+    let tree_id = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+        .unwrap();
+    drop(tree);
+    dir
+}
+
+fn worktree_config_dialog(path: String) -> NewSessionDialog {
+    let mut dialog = NewSessionDialog::new_with_tools(vec!["claude"], path);
+    dialog.worktree_enabled = true;
+    dialog.focused_field = 3; // worktree field
+    dialog.handle_key(ctrl_key(KeyCode::Char('p')));
+    assert!(dialog.worktree_config_mode);
+    dialog
+}
+
+/// Ctrl+P must reach the picker from both branch fields, and for a path
+/// spelled with a leading `~` (the submit path expands it, so the picker
+/// has to as well). See #3166.
+#[test]
+#[serial_test::serial]
+fn branch_picker_opens_for_reachable_repo_paths() {
+    // `isolate_home` holds the shared env lock and restores HOME/XDG on Drop,
+    // so the `~` case resolves against a temp home no sibling test can pull
+    // out from under it.
+    let temp_home = tempfile::tempdir().expect("temp home");
+    let _home = crate::session::test_support::isolate_home(temp_home.path());
+    let repo = branch_picker_repo_in(temp_home.path());
+    let absolute = repo.to_string_lossy().to_string();
+
+    let cases = [
+        (absolute.clone(), 0),     // name field
+        (absolute, 2),             // base-branch field
+        ("~/repo".to_string(), 0), // tilde path, name field
+    ];
+
+    for (path, field) in cases {
+        let mut dialog = worktree_config_dialog(path.clone());
+        dialog.worktree_config_focused_field = field;
+
+        dialog.handle_key(ctrl_key(KeyCode::Char('p')));
+
+        assert!(
+            dialog.branch_picker.is_active(),
+            "{path} field {field} should open the picker, got {:?}",
+            dialog.error_message
+        );
+        assert!(dialog.error_message.is_none());
+    }
+}
+
+/// A path the picker cannot use has to say so; silently doing nothing is
+/// what #3166 reported.
+#[test]
+fn branch_picker_surfaces_failures_and_clears_them() {
+    let not_a_repo = tempfile::tempdir().expect("failed to create temp dir");
+    let cases = [
+        (
+            not_a_repo.path().to_string_lossy().to_string(),
+            "Cannot list branches",
+        ),
+        (String::new(), "Set the project path"),
+    ];
+
+    for (path, expected) in cases {
+        let mut dialog = worktree_config_dialog(path.clone());
+
+        dialog.handle_key(ctrl_key(KeyCode::Char('p')));
+
+        assert!(!dialog.branch_picker.is_active(), "path {path:?}");
+        let error = dialog
+            .error_message
+            .clone()
+            .unwrap_or_else(|| panic!("expected an inline error for {path:?}"));
+        assert!(error.contains(expected), "unexpected error: {error}");
+
+        // Leaving the overlay must not strand the error in the main dialog.
+        dialog.handle_key(key(KeyCode::Esc));
+        assert!(!dialog.worktree_config_mode);
+        assert!(dialog.error_message.is_none());
+    }
+}

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -1704,9 +1704,9 @@ fn worktree_config_dialog(path: String) -> NewSessionDialog {
     dialog
 }
 
-/// Ctrl+P must reach the picker from both branch fields, and for a path
-/// spelled with a leading `~` (the submit path expands it, so the picker
-/// has to as well). See #3166.
+/// Ctrl+P must reach the picker from every field whose hint row advertises it,
+/// and for a path spelled with a leading `~` (the submit path expands it, so
+/// the picker has to as well). See #3166.
 #[test]
 #[serial_test::serial]
 fn branch_picker_opens_for_reachable_repo_paths() {
@@ -1719,9 +1719,10 @@ fn branch_picker_opens_for_reachable_repo_paths() {
     let absolute = repo.to_string_lossy().to_string();
 
     let cases = [
-        (absolute.clone(), 0),     // name field
-        (absolute, 2),             // base-branch field
-        ("~/repo".to_string(), 0), // tilde path, name field
+        (absolute.clone(), 0),            // name field
+        (absolute.clone(), 1),            // new-branch checkbox row
+        (absolute, WT_BASE_BRANCH_FIELD), // base-branch field
+        ("~/repo".to_string(), 0),        // tilde path, name field
     ];
 
     for (path, field) in cases {
@@ -1739,10 +1740,29 @@ fn branch_picker_opens_for_reachable_repo_paths() {
     }
 }
 
+/// Rows joined into one whitespace-normalized string, so an assertion does not
+/// have to know where `Wrap` broke the line.
+fn screen_text(buffer: &ratatui::buffer::Buffer) -> String {
+    let rows: Vec<String> = (0..buffer.area.height)
+        .map(|row| {
+            (0..buffer.area.width)
+                .map(|col| buffer[(col, row)].symbol())
+                .collect()
+        })
+        .collect();
+    rows.join(" ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 /// A path the picker cannot use has to say so; silently doing nothing is
-/// what #3166 reported.
+/// what #3166 reported. The error also has to be drawn: the overlay used to
+/// render hints unconditionally, so a set `error_message` stayed invisible.
 #[test]
 fn branch_picker_surfaces_failures_and_clears_them() {
+    use ratatui::{backend::TestBackend, Terminal};
+
     let not_a_repo = tempfile::tempdir().expect("failed to create temp dir");
     let cases = [
         (
@@ -1763,6 +1783,21 @@ fn branch_picker_surfaces_failures_and_clears_them() {
             .clone()
             .unwrap_or_else(|| panic!("expected an inline error for {path:?}"));
         assert!(error.contains(expected), "unexpected error: {error}");
+
+        let mut terminal = Terminal::new(TestBackend::new(100, 40)).expect("terminal");
+        let theme = crate::tui::styles::Theme::default();
+        terminal
+            .draw(|frame| dialog.render(frame, frame.area(), &theme))
+            .expect("render");
+        let screen = screen_text(terminal.backend().buffer());
+        assert!(
+            screen.contains(&format!("✗ Error: {expected}")),
+            "error not rendered for {path:?}: {screen}"
+        );
+        assert!(
+            !screen.contains("Ctrl+P branches"),
+            "the error must replace the hints, not hide behind them: {screen}"
+        );
 
         // Leaving the overlay must not strand the error in the main dialog.
         dialog.handle_key(key(KeyCode::Esc));
@@ -1785,7 +1820,7 @@ fn branch_picker_mouse_selection_routes_to_the_focused_field() {
     let repo = branch_picker_repo_in(temp_home.path());
 
     let mut dialog = worktree_config_dialog(repo.to_string_lossy().to_string());
-    dialog.worktree_config_focused_field = 2; // base branch
+    dialog.worktree_config_focused_field = WT_BASE_BRANCH_FIELD;
     dialog.handle_key(ctrl_key(KeyCode::Char('p')));
     assert!(dialog.branch_picker.is_active());
 


### PR DESCRIPTION
## Description

Fixes #3166. The worktree configuration overlay advertises `Ctrl+P  branches`, but pressing it produced no UI change at all. Three separate things combined to swallow the keypress:

1. **The path was never expanded.** The handler passed the raw path field straight to `list_branches`, so a path the user spelled as `~/code/project` failed to open the repo. Every other consumer of that same field expands it first (`expand_tilde` on submit, on create-dir, and on each extra-repo entry) - the branch picker was the one that didn't.
2. **Failures were silent.** `if let Ok(branches) = ...` with an inner `if !branches.is_empty()` returned `Continue` in every failure path, so a non-repo path, a git error, and a branchless repo all looked identical to a keypress that did nothing.
3. **The overlay never rendered `error_message`.** Even where an error was set, the worktree overlay only ever drew its hint row, so nothing could have surfaced.

The reporter's flow (type a path, then open worktree config) hits all three at once.

## Changes

- Route both branch-taking fields (Name and Base) through one `open_branch_picker` that expands the path before listing, matching the rest of the dialog.
- Report failures inline instead of returning silently: a git/listing error, a repo with no branches, and an empty path each get their own message.
- Render a pending `error_message` in the overlay's hint row, and clear it when the overlay is left so nothing leaks into the main dialog.

The two Ctrl+P arms were byte-identical apart from which `Input` they wrote on selection (that dispatch already lives in the `branch_picker` block at the top of the handler), so they collapse into one arm.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no user-facing docs describe this overlay; the in-app hint was already correct, the behavior was not)
- [ ] For UI changes: included screenshot or recording

<!-- The change is an inline error line in an existing overlay row; the unit tests assert the same state the renderer reads. Happy to add a recording if you'd like one. -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: driving this needs a real git repo plus a tilde-addressable `$HOME` inside the tmux harness, and the behavior is fully determined by dialog state (`branch_picker.is_active()` / `error_message`) that unit tests can assert directly. Two table-driven unit tests in `src/tui/dialogs/new_session/tests.rs` cover it at ~15ms instead of ~2s, per the tiering guidance in AGENTS.md.

Added:
- `branch_picker_opens_for_reachable_repo_paths` - name field, base-branch field, and a `~/...` path. Uses `isolate_home` + `#[serial_test::serial]` so the tilde case resolves against a temp home rather than the developer's real one.
- `branch_picker_surfaces_failures_and_clears_them` - non-repo path and empty path each produce an inline error rather than nothing, and leaving the overlay clears it.

Verification, including a negative control: reverting just the `expand_tilde` call turns the tilde case red with `Cannot list branches in ~/repo: ... No such file or directory`, which is the reported symptom.

- `cargo test -p agent-of-empires --lib new_session` - 121 passed
- `cargo clippy --all-targets` - no new warnings
- `cargo fmt --all -- --check` - clean

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Fable 5

**Any Additional AI Details you'd like to share:**

I had the AI trace the keypress rather than guess at it, which is how the tilde gap turned up: the fix started as "the handler is fine, maybe the picker renders wrong", and comparing the branch picker against the dialog's other path consumers is what showed it was the only one skipping expansion. The first version of the tilde test silently skipped on macOS (temp dirs live outside `$HOME`), and the second flaked under the parallel suite against a sibling test that swaps `HOME`; the `isolate_home` + `serial` pattern already in this file is what fixed it. I'll answer review questions myself.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed `Ctrl+P` branch selection in worktree configuration.
- Enabled branch selection from the Name, New Branch, and Base fields.
- Routed keyboard and mouse selections to the focused field.
- Expanded `~` in repository paths before listing branches.
- Added inline errors for missing paths, empty repositories, and listing failures.
- Rendered wrapped errors and cleared them when the overlay closes.
- Added tests for path handling, error states, error clearing, rendering, and mouse selection.

## Benefits

Users can select a worktree branch reliably. The overlay now provides clear feedback when branch loading fails and keeps selections in the correct field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->