### PR TITLE
fix(acp): track the MultiSelectItems::String rename in schema 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e981a7d0207a0e9eb67d0faafc04e8c6601dea572d67a3163798897c0024521d"
+checksum = "882b815ffa67b023e1b40e7ea3bab3f05869654e8565d6811870c5545285e1d3"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac542aba230234b1591ace7286a47c0514fe3efc3037d43296bde31ba7ee5728"
+checksum = "06679e1542356341f4550ccfb16338b64f37f6af70de2105446ef6fbb078234c"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/src/acp/elicitations.rs
+++ b/src/acp/elicitations.rs
@@ -424,7 +424,7 @@ fn parse_field(
                         label: o.title.clone(),
                     })
                     .collect(),
-                MultiSelectItems::Untitled(u) => u
+                MultiSelectItems::String(u) => u
                     .values
                     .iter()
                     .map(|v| ElicitationOption {


### PR DESCRIPTION
## Description

`agent-client-protocol-schema` 1.4.0 renamed the elicitation multi-select variant `Untitled(UntitledMultiSelectItems)` to `String(StringMultiSelectItems)` and added an `Other` variant. `parse_field` in `src/acp/elicitations.rs` still matched on the old name, so building against the new schema failed:

```
error[E0599]: no variant, associated function, or constant named `Untitled`
              found for enum `MultiSelectItems`
  --> src/acp/elicitations.rs:427:35
```

The payload is unchanged (`StringMultiSelectItems` still exposes `values: Vec<String>`), so this is a one-word fix. The existing wildcard arm, already there because `MultiSelectItems` is `#[non_exhaustive]`, absorbs the new `Other` variant without further changes.

**Why the Cargo.lock bump rides along.** The rename only exists in schema 1.4.0, and the old name only exists in 1.1.0, so the source fix and the dependency bump cannot compile separately. They have to land in the same commit. The lock change is limited to the version and checksum lines of `agent-client-protocol` (1.0.0 to 1.2.0) and `agent-client-protocol-schema` (1.1.0 to 1.4.0); nothing else is re-resolved.

Worth flagging that upstream shipped a breaking type change in a minor release. They can do that because elicitation sits behind their `unstable_elicitation` feature flag, which we enable.

This unblocks #3199 (the `cargo-minor-patch` group), whose eight failing checks were all this single compile error. Once this lands, that PR can be recreated and should shrink by these two crates.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none needed)
- [ ] For UI changes: included screenshot or recording

Verified locally with `cargo build --locked --features serve`, `cargo fmt --check`, `cargo clippy --locked -- -D warnings`, and `cargo test --locked --features serve --no-fail-fast`. Every target passes. Two lib tests, `acp::supervisor::tests::shutdown_and_wait_degrades_when_load_errs_without_peer` and `process::worker_registry::tests::pid_source_for_falls_back_to_peer_pid_on_load_err`, fail only in my sandbox because it runs as uid 0: both fixtures force a read error with `chmod 0o000`, which root ignores. Re-running the same test binary as an unprivileged user passes both, and CI does not run as root.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR does not change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle

No new test. This is a rename of an enum variant in a match arm, with no behavior change: the same input produces the same `ElicitationOption` list as before. The existing elicitation parsing tests plus the `acp_*` integration tests (164 passed) already cover the path, and a test asserting the new variant name would only restate the declaration.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:** Found while triaging the open Dependabot PRs. Claude diagnosed the failure on #3199, identified the upstream rename by diffing the schema crate sources, and wrote the fix and this description.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated ACP elicitation parsing to use `MultiSelectItems::String` for `agent-client-protocol-schema` 1.4.0.
- Updated `Cargo.lock` to compatible ACP dependency versions.
- Existing wildcard handling continues to support the new `Other` variant.

## Benefits

- Keeps ACP parsing compatible with the current schema.
- Unblocks the related dependency update.
- No behavior changes or new tests were required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->