### PR TITLE
feat(acp): steer mid-turn prompts into the running turn instead of rejecting them

### DIFF
--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -213,12 +213,20 @@ render as a labelled chip rather than an inline player or preview.
 The web composer keeps your messages around even when the session can't
 accept them yet. Three cases:
 
-1. **Mid-turn follow-up.** While the agent is producing the current
-   response, the Send button becomes a paper-plane with a pending-count
-   badge. Click (or press Enter) and your text lands in the **Queued
-   (N)** strip above the composer. Once the agent reports `Stopped`, the
-   queue drains: every parked entry is joined into one combined prompt
-   (clear commands like `/clear` fire alone so they keep their meaning).
+1. **Mid-turn follow-up.** What happens depends on whether the agent
+   supports steering. Claude Code does, from `claude-agent-acp` 0.64.0;
+   no other agent does yet.
+
+   With steering, your message goes into the turn already running, the
+   same as typing ahead in the `claude` CLI. The agent picks it up
+   mid-work and course-corrects rather than finishing first and reading
+   it after. Nothing is queued, and this applies to every client, so
+   `aoe acp prompt` works mid-turn too.
+
+   Without it, your text lands in the **Queued (N)** strip above the
+   composer. Once the agent reports `Stopped`, the queue drains: every
+   parked entry is joined into one combined prompt (clear commands like
+   `/clear` fire alone so they keep their meaning).
 2. **Inactive session.** If the WebSocket is mid-reconnect or the worker
    is stopped or restarting, the composer still accepts submissions. The
    tooltip swaps to `Queue message until session resumes` and the parked
@@ -247,8 +255,10 @@ unmistakable; `Esc` abandons the edit and restores your draft. Editing a
 recalled prompt and pressing `Enter` updates that entry in place rather
 than queueing a duplicate.
 
-**TUI structured view.** The TUI has the same client-side queue.
-Pressing `Enter` while a turn is active (or while the WebSocket is down)
+**TUI structured view.** The TUI has the same client-side queue, and the
+same steering behavior: against a steerable agent `Enter` mid-turn sends
+straight into the running turn. Otherwise, pressing `Enter` while a turn
+is active (or while the WebSocket is down)
 parks the prompt in a **Queued (N)** strip instead of sending; the queue
 drains on the next `Stopped` as one combined prompt, the same batching
 as the web composer. `Ctrl+X` clears the queue, and pressing `Enter` on an empty

--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -55,7 +55,7 @@ such as a pending approval, receive a full-width border.
 
 | Focus       | Key             | Action                                                |
 | ----------- | --------------- | ----------------------------------------------------- |
-| Composer    | `Enter`         | Send the buffered text, or queue it if a turn is active |
+| Composer    | `Enter`         | Send the buffered text, or queue it if it cannot be sent yet |
 | Composer    | `Shift+Enter`   | Insert a newline (multi-line prompts)                 |
 | Composer    | `@`             | Open the file-mention picker; keep typing to filter   |
 | Composer    | `Enter` (empty) | Retry draining the queue when idle (e.g. after a failed send) |

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -6660,14 +6660,28 @@ async fn run_connection_task<W, R>(
             // both Fresh and Resume connects, so this re-emits on every
             // reconnect and replay always carries a current copy. See
             // #1000 / #965.
+            // Derived here rather than cached across connections: a
+            // respawn can land on a different adapter build, and this
+            // runs on every connect. Emitted even when false so replay
+            // cannot leave a client holding a stale `true` after a
+            // downgrade. See #2805.
+            let steering_capable = agent_compat::supports_steering(expected_agent, &init);
             let prompt_caps = &init.agent_capabilities.prompt_capabilities;
             let _ = event_tx_for_block
                 .send(Event::PromptCapabilities {
                     image: prompt_caps.image,
                     audio: prompt_caps.audio,
                     embedded_context: prompt_caps.embedded_context,
+                    steering: steering_capable,
                 })
                 .await;
+            if steering_capable {
+                info!(
+                    target: "acp.protocol",
+                    session = %session_label,
+                    "agent supports _session/steering; mid-turn prompts will be injected into the running turn"
+                );
+            }
             // Snapshot the watchdog-arming flag before `mode` is moved
             // into the match below.
             let arm_resume_watchdog = matches!(

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -482,6 +482,86 @@ pub struct SpawnConfig {
     pub artifact_dir: Option<PathBuf>,
 }
 
+/// Params for the `_session/steering` extension request: apply a
+/// follow-up message to the turn that is already running, rather than
+/// queuing it as a separate `session/prompt`. See #2805.
+///
+/// `_meta.steering.idleBehavior = "promptRequired"` is the opt-in added
+/// in claude-agent-acp 0.64.0 (upstream #903 / #919). Without it a steer
+/// that arrives after the turn settled starts a detached turn whose
+/// `PromptResponse` no request owns; with it the adapter leaves the
+/// content untouched and says so, and AoE resends it as a normal prompt.
+/// `agent_compat::supports_steering` is what guarantees the adapter
+/// honors the opt-in, so this always requests it.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[request(method = "_session/steering", response = serde_json::Value)]
+#[serde(rename_all = "camelCase")]
+struct SteerRequest {
+    session_id: SessionId,
+    prompt: Vec<ContentBlock>,
+    #[serde(rename = "_meta")]
+    meta: serde_json::Value,
+}
+
+impl SteerRequest {
+    fn new(session_id: SessionId, prompt: Vec<ContentBlock>) -> Self {
+        Self {
+            session_id,
+            prompt,
+            meta: serde_json::json!({ "steering": { "idleBehavior": "promptRequired" } }),
+        }
+    }
+}
+
+/// Text of the first text block, for the retry pill on a refused prompt.
+/// Attachments are not carried back into the pill; text is the retry hook
+/// and this is a rare edge.
+fn first_text_block(blocks: &[ContentBlock]) -> String {
+    blocks
+        .iter()
+        .find_map(|b| match b {
+            ContentBlock::Text(t) => Some(t.text.clone()),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+/// What the agent did with a steered message. Both success outcomes are
+/// normal: the adapter, not AoE, adjudicates whether a turn was still
+/// running when the steer landed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SteerOutcome {
+    /// Delivered into the running turn. The message's own output streams
+    /// as ordinary `session/update` notifications and the turn's existing
+    /// `PromptResponse` still owns the terminal `Stopped`.
+    Injected,
+    /// The turn settled before the steer was handled. The adapter
+    /// guarantees the content was neither queued nor consumed, so it is
+    /// safe (and required) to resend it as a normal `session/prompt`.
+    PromptRequired,
+    /// The adapter ignored the `promptRequired` opt-in and started a
+    /// detached turn with the content anyway. Only reachable from an
+    /// adapter that clears `supports_steering` but does not honor the
+    /// contract, so it is a protocol violation rather than an expected
+    /// state. The content IS consumed, so it must not be resent.
+    StartedNewTurn,
+    /// An outcome string this build does not know. Treated like
+    /// `StartedNewTurn`: delivery is unproven either way, and resending
+    /// risks duplicating the user's message.
+    Unknown,
+}
+
+impl SteerOutcome {
+    fn from_response(value: &serde_json::Value) -> Self {
+        match value.get("outcome").and_then(serde_json::Value::as_str) {
+            Some("injected") => Self::Injected,
+            Some("promptRequired") => Self::PromptRequired,
+            Some("startedNewTurn") => Self::StartedNewTurn,
+            _ => Self::Unknown,
+        }
+    }
+}
+
 /// Commands sent from `AcpClient` methods to the background connection task.
 enum ClientCmd {
     /// The fully-built prompt content blocks (text first, then any
@@ -7381,8 +7461,22 @@ async fn run_connection_task<W, R>(
                 tokio::time::interval(BETWEEN_PROMPT_IDLE_CHECK_INTERVAL);
             between_prompt_idle_tick
                 .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            // Mid-turn prompts a steer handed back unconsumed (#2805).
+            // The adapter answers `promptRequired` when the turn it was
+            // meant to steer had already settled, so the message runs as
+            // an ordinary next turn instead. Kept here rather than
+            // self-sent through `cmd_tx`: this task holds only the
+            // receiver, and sending into the bounded channel it is the
+            // sole consumer of deadlocks once that channel fills.
+            let mut pending_prompts: VecDeque<Vec<ContentBlock>> = VecDeque::new();
             loop {
-                let cmd = tokio::select! {
+                // Drain the fallback queue ahead of the channel so a
+                // message the user sent first cannot be overtaken by one
+                // they sent after it.
+                let cmd = if let Some(blocks) = pending_prompts.pop_front() {
+                    Some(ClientCmd::Prompt(blocks))
+                } else {
+                    tokio::select! {
                     cmd = cmd_rx.recv() => cmd,
                     _ = between_prompt_idle_tick.tick() => {
                         let now = chrono::Utc::now().timestamp_millis();
@@ -7463,6 +7557,7 @@ async fn run_connection_task<W, R>(
                             }
                         }
                         continue;
+                    }
                     }
                 };
                 match cmd {
@@ -7688,6 +7783,59 @@ async fn run_connection_task<W, R>(
                         let cancel_grace = tokio::time::sleep(CANCEL_ESCALATION_GRACE);
                         tokio::pin!(cancel_grace);
 
+                        // Mid-turn steering (#2805). At most one
+                        // `_session/steering` request is outstanding at a
+                        // time, with any further mid-turn prompts waiting
+                        // in `steer_backlog`. Running them concurrently
+                        // would let two steers that both race the turn's
+                        // end come back out of order, and the
+                        // `promptRequired` fallback would then replay the
+                        // user's messages in the wrong order. The future
+                        // is polled as a select arm rather than awaited
+                        // inline so Cancel and ForceStop stay responsive
+                        // for the whole round trip.
+                        #[allow(clippy::type_complexity)]
+                        let mut steer_fut: Option<
+                            std::pin::Pin<
+                                Box<
+                                    dyn std::future::Future<
+                                            Output = (
+                                                Vec<ContentBlock>,
+                                                Result<
+                                                    serde_json::Value,
+                                                    agent_client_protocol::Error,
+                                                >,
+                                            ),
+                                        > + Send,
+                                >,
+                            >,
+                        > = None;
+                        let mut steer_backlog: VecDeque<Vec<ContentBlock>> = VecDeque::new();
+                        // Issue a steer for `blocks`, or park it behind the
+                        // one already in flight.
+                        macro_rules! steer_or_backlog {
+                            ($blocks:expr) => {{
+                                let blocks: Vec<ContentBlock> = $blocks;
+                                if steer_fut.is_some() {
+                                    steer_backlog.push_back(blocks);
+                                } else {
+                                    info!(
+                                        target: "acp.protocol",
+                                        session = %session_label,
+                                        "sending _session/steering during in-flight prompt ({} content blocks)",
+                                        blocks.len()
+                                    );
+                                    let sent = connection.send_request(SteerRequest::new(
+                                        acp_session_id.clone(),
+                                        blocks.clone(),
+                                    ));
+                                    steer_fut = Some(Box::pin(async move {
+                                        (blocks, sent.block_task().await)
+                                    }));
+                                }
+                            }};
+                        }
+
                         loop {
                             tokio::select! {
                                 res = &mut prompt_fut, if !simulate_orphan => {
@@ -7870,6 +8018,115 @@ async fn run_connection_task<W, R>(
                                     shutdown = true;
                                     break;
                                 }
+                                (blocks, res) = async {
+                                    steer_fut.as_mut().expect("guarded by the arm condition").await
+                                }, if steer_fut.is_some() => {
+                                    steer_fut = None;
+                                    match res {
+                                        Ok(value) => match SteerOutcome::from_response(&value) {
+                                            SteerOutcome::Injected => {
+                                                info!(
+                                                    target: "acp.protocol",
+                                                    session = %session_label,
+                                                    "_session/steering injected into the running turn"
+                                                );
+                                                // No event: the prompt handler
+                                                // already published this text as
+                                                // `UserPromptSent` before it
+                                                // reached the daemon, and the
+                                                // running turn's own
+                                                // `PromptResponse` still owns the
+                                                // terminal Stopped.
+                                                //
+                                                // An accepted steer proves the
+                                                // agent is alive and took new
+                                                // work, so it counts as progress.
+                                                // Injection pre-empts the current
+                                                // generation, which can swallow an
+                                                // update the silent-orphan
+                                                // watchdog was waiting on; without
+                                                // this the watchdog could kill a
+                                                // healthy agent right after a
+                                                // successful course correction.
+                                                watchdog.apply_signal(
+                                                    LifecycleSignal::Progress,
+                                                    tokio::time::Instant::now(),
+                                                    chrono::Utc::now(),
+                                                    watchdog_cfg,
+                                                );
+                                            }
+                                            SteerOutcome::PromptRequired => {
+                                                // The turn settled in the race
+                                                // window. The adapter kept its
+                                                // hands off the content, so run it
+                                                // as an ordinary next turn. The
+                                                // in-flight turn is over in all but
+                                                // bookkeeping, so the outer loop
+                                                // picks this up as soon as
+                                                // `prompt_fut` resolves.
+                                                info!(
+                                                    target: "acp.protocol",
+                                                    session = %session_label,
+                                                    "_session/steering raced the turn's end; re-dispatching as a normal prompt"
+                                                );
+                                                pending_prompts.push_back(blocks);
+                                                // Anything still parked raced the
+                                                // same boundary, so it follows the
+                                                // same path, in order.
+                                                pending_prompts.extend(steer_backlog.drain(..));
+                                            }
+                                            outcome @ (SteerOutcome::StartedNewTurn
+                                            | SteerOutcome::Unknown) => {
+                                                // The adapter cleared the version
+                                                // gate yet ignored the
+                                                // `promptRequired` opt-in, so it
+                                                // consumed the content into a turn
+                                                // no request owns. Resending would
+                                                // duplicate the user's message, and
+                                                // `PromptRejected` would offer a
+                                                // Retry that does the same. Leave
+                                                // the already-published
+                                                // `UserPromptSent` standing and let
+                                                // the between-prompt idle watchdog
+                                                // synthesize the detached turn's
+                                                // terminal Stopped once this turn's
+                                                // own Stopped clears
+                                                // `prompt_in_flight`.
+                                                warn!(
+                                                    target: "acp.protocol",
+                                                    session = %session_label,
+                                                    ?outcome,
+                                                    "_session/steering returned an outcome that consumed the message without an owning request; the between-prompt watchdog will close the detached turn"
+                                                );
+                                            }
+                                        },
+                                        Err(e) => {
+                                            // Transport or agent error. Nothing
+                                            // proves the message landed, but
+                                            // nothing proves it did not either, so
+                                            // surface it as the same retryable
+                                            // rejection a non-steering agent gives
+                                            // and let the user decide.
+                                            warn!(
+                                                target: "acp.protocol",
+                                                session = %session_label,
+                                                error = %e,
+                                                "_session/steering failed; falling back to agent_busy rejection"
+                                            );
+                                            let _ = event_tx_for_block
+                                                .send(Event::PromptRejected {
+                                                    reason: "agent_busy".into(),
+                                                    text: first_text_block(&blocks),
+                                                })
+                                                .await;
+                                        }
+                                    }
+                                    // Start the next parked steer, if the
+                                    // outcome above left any parked.
+                                    if let Some(next) = steer_backlog.pop_front() {
+                                        steer_or_backlog!(next);
+                                    }
+                                }
                                 cmd = cmd_rx.recv() => {
                                     match cmd {
                                         Some(ClientCmd::Cancel) => {
@@ -7952,40 +8209,7 @@ async fn run_connection_task<W, R>(
                                                 respond_to,
                                             );
                                         }
-                                        Some(ClientCmd::Prompt(rejected_blocks)) => {
-                                            // Surface the dropped prompt
-                                            // to the UI so the user can
-                                            // retry from a Rejected pill
-                                            // instead of having their
-                                            // message vanish silently.
-                                            // Client-side composer queueing
-                                            // is tracked separately in
-                                            // #1031; this event covers the
-                                            // server-side gap when a prompt
-                                            // does make it to the daemon
-                                            // while another is in flight.
-                                            // Recover the text from the
-                                            // first text block; attachments
-                                            // aren't carried back into the
-                                            // retry pill (rare agent-busy
-                                            // edge, text is the retry hook).
-                                            let rejected_text = rejected_blocks
-                                                .iter()
-                                                .find_map(|b| match b {
-                                                    ContentBlock::Text(t) => Some(t.text.clone()),
-                                                    _ => None,
-                                                })
-                                                .unwrap_or_default();
-                                            warn!(
-                                                target: "acp.protocol",
-                                                "received Prompt while one is in flight; rejecting"
-                                            );
-                                            let _ = event_tx_for_block
-                                                .send(Event::PromptRejected {
-                                                    reason: "agent_busy".into(),
-                                                    text: rejected_text,
-                                                })
-                                                .await;
+                                        Some(ClientCmd::Prompt(followup_blocks)) => {
                                             // A follow-up arriving while
                                             // a cancel is in flight means
                                             // the user has clicked Force
@@ -7997,15 +8221,59 @@ async fn run_connection_task<W, R>(
                                             // wedged; escalate immediately
                                             // without waiting for the 10s
                                             // grace.
+                                            //
+                                            // Checked ahead of steering
+                                            // (#2805): this turn is on its way
+                                            // to forced termination, so
+                                            // injecting into it would strand
+                                            // the message in a turn nobody
+                                            // finishes. Reject first so it is
+                                            // never lost, then escalate.
                                             if cancelling {
                                                 warn!(
                                                     target: "acp.protocol",
                                                     session = %session_label,
                                                     "follow-up prompt arrived while cancel pending; escalating to runner restart"
                                                 );
+                                                let _ = event_tx_for_block
+                                                    .send(Event::PromptRejected {
+                                                        reason: "agent_busy".into(),
+                                                        text: first_text_block(&followup_blocks),
+                                                    })
+                                                    .await;
                                                 agent_unresponsive = true;
                                                 shutdown = true;
                                                 break;
+                                            }
+                                            if steering_capable {
+                                                // Hand it to the running turn
+                                                // instead of refusing it. The
+                                                // adapter decides whether a turn
+                                                // is still running; the outcome
+                                                // arm above applies its answer.
+                                                steer_or_backlog!(followup_blocks);
+                                            } else {
+                                                // Surface the dropped prompt
+                                                // to the UI so the user can
+                                                // retry from a Rejected pill
+                                                // instead of having their
+                                                // message vanish silently.
+                                                // Client-side composer queueing
+                                                // is tracked separately in
+                                                // #1031; this event covers the
+                                                // server-side gap when a prompt
+                                                // does make it to the daemon
+                                                // while another is in flight.
+                                                warn!(
+                                                    target: "acp.protocol",
+                                                    "received Prompt while one is in flight and the agent cannot be steered; rejecting"
+                                                );
+                                                let _ = event_tx_for_block
+                                                    .send(Event::PromptRejected {
+                                                        reason: "agent_busy".into(),
+                                                        text: first_text_block(&followup_blocks),
+                                                    })
+                                                    .await;
                                             }
                                         }
                                         Some(ClientCmd::ResetSession {
@@ -9275,6 +9543,56 @@ async fn handle_elicitation_request(
 mod tests {
     use super::*;
     use rusqlite::Connection;
+
+    /// The steer wire contract (#2805). `sessionId` must be camelCase and
+    /// the `_meta` opt-in must be spelled exactly as the adapter reads it:
+    /// a typo in either silently degrades a racing steer back to
+    /// `startedNewTurn`, the detached-turn bug the version floor exists to
+    /// avoid, with no error to notice.
+    #[test]
+    fn steer_request_carries_the_prompt_required_opt_in() {
+        let req = SteerRequest::new(
+            SessionId::new("sess-1"),
+            vec![ContentBlock::Text(TextContent::new("also check the tests"))],
+        );
+        let wire = serde_json::to_value(&req).unwrap();
+        assert_eq!(wire["sessionId"], "sess-1");
+        assert_eq!(wire["_meta"]["steering"]["idleBehavior"], "promptRequired");
+        assert_eq!(wire["prompt"][0]["text"], "also check the tests");
+    }
+
+    /// An unrecognized outcome must land on `Unknown`, not on a success
+    /// arm: `Unknown` is treated as "consumed, do not resend", which is
+    /// the only safe reading when a future adapter adds an outcome this
+    /// build has never seen.
+    #[test]
+    fn steer_outcome_maps_every_wire_form() {
+        let cases = [
+            (
+                serde_json::json!({"outcome": "injected"}),
+                SteerOutcome::Injected,
+            ),
+            (
+                serde_json::json!({"outcome": "promptRequired", "reason": "noRunningTurn"}),
+                SteerOutcome::PromptRequired,
+            ),
+            (
+                serde_json::json!({"outcome": "startedNewTurn"}),
+                SteerOutcome::StartedNewTurn,
+            ),
+            // Forward-compat and malformed shapes both fall to Unknown.
+            (
+                serde_json::json!({"outcome": "teleported"}),
+                SteerOutcome::Unknown,
+            ),
+            (serde_json::json!({"outcome": 7}), SteerOutcome::Unknown),
+            (serde_json::json!({}), SteerOutcome::Unknown),
+            (serde_json::json!(null), SteerOutcome::Unknown),
+        ];
+        for (value, expected) in cases {
+            assert_eq!(SteerOutcome::from_response(&value), expected, "{value}");
+        }
+    }
 
     #[test]
     fn reset_request_deadline_precedes_the_outer_guard() {

--- a/src/acp/agent_compat.rs
+++ b/src/acp/agent_compat.rs
@@ -51,6 +51,31 @@ fn claude_agent_acp_min_version() -> semver::Version {
         .expect("CLAUDE_AGENT_ACP_MIN_VERSION must be valid semver")
 }
 
+/// Version at which `claude-agent-acp`'s `_session/steering` extension
+/// became safe for AoE to use, i.e. the release that added the
+/// request-level `_meta.steering.idleBehavior: "promptRequired"` opt-in
+/// (upstream #903, PR #919).
+///
+/// This is a *feature* floor, deliberately separate from
+/// [`CLAUDE_AGENT_ACP_MIN_VERSION`]: that one is a hard startup reject,
+/// so folding steering into it would force every user to upgrade for an
+/// optional capability. Below this floor the adapter still advertises
+/// `steering.supported` (steering itself landed in 0.61.0) but answers a
+/// racing steer with `startedNewTurn`, spawning a detached turn whose
+/// `PromptResponse` nobody owns. AoE scopes streaming, cancellation, and
+/// UI state to a pending prompt request, so it cannot consume that turn;
+/// gating on the opt-in is what keeps the race safe.
+///
+/// `steering_min_floor_at_or_above_hard_floor` below pins the invariant
+/// that a feature floor never sits under the startup floor.
+pub const CLAUDE_AGENT_ACP_STEERING_MIN_VERSION: &str = "0.64.0";
+
+/// Parsed form of [`CLAUDE_AGENT_ACP_STEERING_MIN_VERSION`].
+fn claude_agent_acp_steering_min_version() -> semver::Version {
+    semver::Version::parse(CLAUDE_AGENT_ACP_STEERING_MIN_VERSION)
+        .expect("CLAUDE_AGENT_ACP_STEERING_MIN_VERSION must be valid semver")
+}
+
 /// Single source of truth for the `opencode` minimum-version floor.
 ///
 /// 1.16.0 is the first release that ships upstream #30567: pre-1.16
@@ -433,6 +458,44 @@ pub fn validate(expected: ExpectedAgent, init: &InitializeResponse) -> Result<()
     Ok(())
 }
 
+/// Whether AoE may steer this agent's running turn via the
+/// `_session/steering` extension request (#2805).
+///
+/// Two conditions, both required. The adapter must advertise
+/// `_meta.steering.supported` on its `initialize` response, and, for
+/// `claude-agent-acp`, report a version at or above
+/// [`CLAUDE_AGENT_ACP_STEERING_MIN_VERSION`]. The advertised bit alone is
+/// not enough: 0.61.0 through 0.63.x advertise steering but predate the
+/// `promptRequired` idle opt-in, so a steer that races the turn's end
+/// spawns a detached turn AoE cannot own.
+///
+/// Other adapters get the advertised bit alone. None ships steering
+/// today, so the version arm would have nothing to gate on; when one
+/// does, its floor belongs here next to claude's.
+///
+/// Callers must re-derive this on every `initialize`, including
+/// reconnect and resume, rather than caching it across connections: a
+/// worker respawn can land on a different adapter build.
+pub fn supports_steering(expected: ExpectedAgent, init: &InitializeResponse) -> bool {
+    let advertised = init
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.get("steering"))
+        .and_then(|steering| steering.get("supported"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if !advertised {
+        return false;
+    }
+    if expected != ExpectedAgent::ClaudeAgentAcp {
+        return true;
+    }
+    init.agent_info
+        .as_ref()
+        .and_then(|info| semver::Version::parse(info.version.trim()).ok())
+        .is_some_and(|version| version >= claude_agent_acp_steering_min_version())
+}
+
 /// The ACP binary name aoe expects for this agent, or `None` for agents
 /// with no fixed binary (`AoeAgent`, `Other`).
 fn binary_for(expected: ExpectedAgent) -> Option<&'static str> {
@@ -602,6 +665,68 @@ mod tests {
             pins,
             vec![CLAUDE_AGENT_ACP_MIN_VERSION.to_string()],
             "docker/Dockerfile claude-agent-acp pin must match CLAUDE_AGENT_ACP_MIN_VERSION",
+        );
+    }
+
+    /// Steering needs the advertised bit AND, for claude, the
+    /// `promptRequired` floor. The table is the whole contract: an
+    /// advertised-but-old adapter is the case that matters, since 0.61
+    /// through 0.63 answer a racing steer with a detached turn.
+    #[test]
+    fn steering_gate_requires_advert_and_floor() {
+        let below = "0.63.9";
+        let cases: [(ExpectedAgent, Option<bool>, &str, bool); 8] = [
+            // (agent, advertised bit, version, expected)
+            (
+                ExpectedAgent::ClaudeAgentAcp,
+                Some(true),
+                CLAUDE_AGENT_ACP_STEERING_MIN_VERSION,
+                true,
+            ),
+            (ExpectedAgent::ClaudeAgentAcp, Some(true), "999.0.0", true),
+            // Advertised but pre-opt-in: the case the floor exists for.
+            (ExpectedAgent::ClaudeAgentAcp, Some(true), below, false),
+            // A prerelease of the floor sorts strictly below it.
+            (
+                ExpectedAgent::ClaudeAgentAcp,
+                Some(true),
+                "0.64.0-alpha.1",
+                false,
+            ),
+            // Floor met but the adapter never advertised.
+            (ExpectedAgent::ClaudeAgentAcp, Some(false), "999.0.0", false),
+            (ExpectedAgent::ClaudeAgentAcp, None, "999.0.0", false),
+            // Unparseable version cannot clear the floor.
+            (ExpectedAgent::ClaudeAgentAcp, Some(true), "nightly", false),
+            // Non-claude adapters have no floor to clear, only the bit.
+            (ExpectedAgent::CodexAcp, Some(true), "0.0.1", true),
+        ];
+        for (agent, advertised, version, expected) in cases {
+            let mut init = make_init("@agentclientprotocol/claude-agent-acp", version);
+            if let Some(supported) = advertised {
+                init = init.meta(
+                    serde_json::json!({ "steering": { "supported": supported } })
+                        .as_object()
+                        .unwrap()
+                        .clone(),
+                );
+            }
+            assert_eq!(
+                supports_steering(agent, &init),
+                expected,
+                "{agent:?} advertised={advertised:?} version={version}"
+            );
+        }
+    }
+
+    /// A feature floor that sat below the startup floor would be dead
+    /// weight: every session that got past `validate` would already
+    /// clear it. Fails if a future hard-floor bump overtakes steering.
+    #[test]
+    fn steering_floor_at_or_above_hard_floor() {
+        assert!(
+            claude_agent_acp_steering_min_version() >= claude_agent_acp_min_version(),
+            "steering floor {CLAUDE_AGENT_ACP_STEERING_MIN_VERSION} must not sit below the startup floor {CLAUDE_AGENT_ACP_MIN_VERSION}",
         );
     }
 

--- a/src/acp/agent_compat.rs
+++ b/src/acp/agent_compat.rs
@@ -66,7 +66,7 @@ fn claude_agent_acp_min_version() -> semver::Version {
 /// UI state to a pending prompt request, so it cannot consume that turn;
 /// gating on the opt-in is what keeps the race safe.
 ///
-/// `steering_min_floor_at_or_above_hard_floor` below pins the invariant
+/// `steering_floor_at_or_above_hard_floor` below pins the invariant
 /// that a feature floor never sits under the startup floor.
 pub const CLAUDE_AGENT_ACP_STEERING_MIN_VERSION: &str = "0.64.0";
 

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -1569,10 +1569,14 @@ impl EventStore {
         let (_, json) =
             events::latest_by_discriminant(&conn, &self.schema, session_id, "PromptCapabilities")?;
         match serde_json::from_str::<Event>(&json).ok()? {
+            // `steering` is deliberately not returned: this getter feeds
+            // the attachment gate, and the steering decision lives in the
+            // connection task, which holds the capability directly.
             Event::PromptCapabilities {
                 image,
                 audio,
                 embedded_context,
+                ..
             } => Some((image, audio, embedded_context)),
             _ => None,
         }
@@ -2120,6 +2124,7 @@ mod tests {
                     image: true,
                     audio: false,
                     embedded_context: true,
+                    steering: false,
                 },
             )
             .unwrap();
@@ -2136,6 +2141,7 @@ mod tests {
                     image: false,
                     audio: false,
                     embedded_context: false,
+                    steering: false,
                 },
             )
             .unwrap();
@@ -3942,6 +3948,7 @@ mod tests {
                     image: true,
                     audio: false,
                     embedded_context: true,
+                    steering: false,
                 },
             )
             .unwrap();

--- a/src/acp/state.rs
+++ b/src/acp/state.rs
@@ -955,6 +955,17 @@ pub enum Event {
         image: bool,
         audio: bool,
         embedded_context: bool,
+        /// Whether the agent accepts `_session/steering`, so a prompt
+        /// sent mid-turn is injected into the running turn instead of
+        /// being parked in the composer's client-side queue. Gated on
+        /// both the advertised capability and a version floor; see
+        /// `agent_compat::supports_steering`. `#[serde(default)]` keeps
+        /// pre-steering events on disk deserialising as `false`, so no
+        /// migration is needed. Re-emitted on every connect, including
+        /// as `false`, so replay cannot retain a stale `true` after a
+        /// respawn onto an older adapter. See #2805.
+        #[serde(default)]
+        steering: bool,
     },
     /// Echo of a "Send diff comments" submission, published by the
     /// `POST /acp/prompt/diff-comments` handler before

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -802,9 +802,10 @@ async fn handle_terminal_event(
                 }
                 return Ok(false);
             }
-            if state.is_busy() {
-                // A turn is running (or the socket is down): park the
-                // prompt so it drains when the agent next goes idle.
+            if state.should_queue_prompt() {
+                // A turn is running on an agent that cannot be steered
+                // (or the socket is down): park the prompt so it drains
+                // when the agent next goes idle.
                 state.queue.push(text);
                 set_toast(
                     state,

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -346,10 +346,19 @@ impl AcpTranscript {
                     .push(ActivityRow::UserPrompt(assembled_markdown.clone()));
                 self.context_primer_pending = false;
                 self.turn_active = true;
+                // The other fresh-turn branch, so it clears a stale
+                // pending cancel like `UserPromptSent` does. Web routes
+                // both through the same `applyNewTurnResets`.
+                self.cancelling = false;
             }
             Event::ThinkingStarted => {
                 self.flush_pending_chunk();
                 self.status_text = Some("thinking…".to_string());
+                // Deliberately does NOT clear `cancelling`, even though it
+                // sets `turn_active`. This fires repeatedly *within* a
+                // running turn, so clearing here would drop the pending
+                // cancel the moment the agent emits its next thought,
+                // which is exactly when a user is waiting on a stop.
                 self.turn_active = true;
             }
             Event::ThinkingEnded => {
@@ -782,8 +791,21 @@ mod tests {
             "a rejected prompt must not clear a pending cancel"
         );
 
-        // Every terminal turn event does clear it.
-        let terminals = [
+        // `ThinkingStarted` also sets `turn_active`, but it fires within
+        // a running turn, so it must NOT count as a fresh turn: clearing
+        // there would drop the cancel the moment the agent thinks again.
+        let mut t = AcpTranscript::new("s-1");
+        t.apply(&frame(1, cancel()));
+        t.apply(&frame(2, Event::ThinkingStarted));
+        assert!(
+            t.cancelling,
+            "mid-turn thinking must not clear a pending cancel"
+        );
+
+        // Terminal turn events clear it, and so does either fresh-turn
+        // branch: web routes both prompt kinds through the same
+        // `applyNewTurnResets`.
+        let clearing = [
             Event::Stopped {
                 reason: "cancelled".into(),
             },
@@ -793,18 +815,23 @@ mod tests {
             Event::PromptRuntimeError {
                 message: "boom".into(),
             },
-            // A fresh turn supersedes one that leaked across a boundary,
-            // matching the web reducer.
             Event::UserPromptSent {
                 text: "next turn".into(),
                 attachments: Vec::new(),
             },
+            Event::UserDiffCommentsPrompt {
+                intro: "look".into(),
+                outro: "thanks".into(),
+                is_multi_repo: false,
+                comments: Vec::new(),
+                assembled_markdown: "next turn".into(),
+            },
         ];
-        for terminal in terminals {
-            let label = format!("{terminal:?}");
+        for event in clearing {
+            let label = format!("{event:?}");
             let mut t = AcpTranscript::new("s-1");
             t.apply(&frame(1, cancel()));
-            t.apply(&frame(2, terminal));
+            t.apply(&frame(2, event));
             assert!(!t.cancelling, "{label} must clear the pending cancel");
         }
     }

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -211,6 +211,19 @@ pub enum NoteKind {
 }
 
 impl AcpTranscript {
+    /// Whether an arriving user prompt is a message steered into the turn
+    /// already running rather than the start of a new one (#2805).
+    ///
+    /// The daemon injects a mid-turn prompt via `_session/steering`
+    /// instead of starting a turn for it, so the same condition the
+    /// composer used to send it identifies it on the way back. Such a
+    /// prompt must not run the fresh-turn bookkeeping: no new turn began,
+    /// and the running turn's `Stopped` still owns the state it built up.
+    /// Call before mutating `turn_active`.
+    fn is_steered_continuation(&self) -> bool {
+        self.turn_active && self.steering
+    }
+
     pub fn new(session_id: impl Into<String>) -> Self {
         Self {
             session_id: session_id.into(),
@@ -327,13 +340,16 @@ impl AcpTranscript {
                 self.rows.push(ActivityRow::UserPrompt(row));
                 // Sending a prompt dismisses any context-primer hint.
                 self.context_primer_pending = false;
+                let steered = self.is_steered_continuation();
                 self.turn_active = true;
                 // A fresh turn supersedes any stale pending cancel from a
                 // prior one, matching the web reducer. Belt and braces
                 // next to the terminal clears: a `cancelling` that leaked
                 // across a turn boundary would park every mid-turn send
                 // for the whole next turn. See #1727 / #2805.
-                self.cancelling = false;
+                if !steered {
+                    self.cancelling = false;
+                }
             }
             Event::UserDiffCommentsPrompt {
                 assembled_markdown, ..
@@ -345,11 +361,14 @@ impl AcpTranscript {
                 self.rows
                     .push(ActivityRow::UserPrompt(assembled_markdown.clone()));
                 self.context_primer_pending = false;
+                let steered = self.is_steered_continuation();
                 self.turn_active = true;
                 // The other fresh-turn branch, so it clears a stale
                 // pending cancel like `UserPromptSent` does. Web routes
                 // both through the same `applyNewTurnResets`.
-                self.cancelling = false;
+                if !steered {
+                    self.cancelling = false;
+                }
             }
             Event::ThinkingStarted => {
                 self.flush_pending_chunk();

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -328,6 +328,12 @@ impl AcpTranscript {
                 // Sending a prompt dismisses any context-primer hint.
                 self.context_primer_pending = false;
                 self.turn_active = true;
+                // A fresh turn supersedes any stale pending cancel from a
+                // prior one, matching the web reducer. Belt and braces
+                // next to the terminal clears: a `cancelling` that leaked
+                // across a turn boundary would park every mid-turn send
+                // for the whole next turn. See #1727 / #2805.
+                self.cancelling = false;
             }
             Event::UserDiffCommentsPrompt {
                 assembled_markdown, ..
@@ -647,8 +653,14 @@ impl AcpTranscript {
                 // turn started, so clear the busy flag the optimistic
                 // submit path may have set. The richer rejected-prompt
                 // renderer is followup work (see the no-op group below).
+                //
+                // `cancelling` deliberately survives this: a rejection is
+                // not a turn boundary. The turn that the cancel targets
+                // is still running (the daemon rejects a mid-cancel
+                // prompt and then escalates, so its real `Stopped` is
+                // still to come), and clearing here would let the next
+                // send take the steering path into that escalation.
                 self.turn_active = false;
-                self.cancelling = false;
             }
             Event::RateLimitAutoResumed { resets_at } => {
                 // Timeline breadcrumb: the reconciler auto-resumed the
@@ -740,31 +752,61 @@ mod tests {
     }
 
     /// The composer parks a mid-turn send while a cancel is pending even
-    /// on a steerable agent (#2805). Clearing on the turn's terminal
-    /// event is the load-bearing half: a `cancelling` left set would park
-    /// every later mid-turn send on a session that had ever been
-    /// stopped once.
+    /// on a steerable agent (#2805). Both directions matter: a
+    /// `cancelling` left set would park every later mid-turn send on a
+    /// session that had been stopped once, while one cleared too early
+    /// lets the next send take the steering path into the daemon's
+    /// wedged-agent escalation.
     #[test]
-    fn cancel_requested_sets_and_stopped_clears_cancelling() {
+    fn cancelling_tracks_the_turn_not_the_rejection() {
+        let cancel = || Event::CancelRequested {
+            escalates_at: Utc::now(),
+        };
+
+        // A rejection is not a turn boundary. The daemon rejects a
+        // mid-cancel prompt and then escalates, so the cancel is still
+        // pending and its real `Stopped` is still to come.
         let mut t = AcpTranscript::new("s-1");
         assert!(!t.cancelling);
-        t.apply(&frame(
-            1,
-            Event::CancelRequested {
-                escalates_at: Utc::now(),
-            },
-        ));
+        t.apply(&frame(1, cancel()));
         assert!(t.cancelling);
         t.apply(&frame(
             2,
-            Event::Stopped {
-                reason: "cancelled".into(),
+            Event::PromptRejected {
+                reason: "agent_busy".into(),
+                text: "hi".into(),
             },
         ));
         assert!(
-            !t.cancelling,
-            "a settled turn must not leave a pending cancel behind"
+            t.cancelling,
+            "a rejected prompt must not clear a pending cancel"
         );
+
+        // Every terminal turn event does clear it.
+        let terminals = [
+            Event::Stopped {
+                reason: "cancelled".into(),
+            },
+            Event::AgentStartupError {
+                message: "boom".into(),
+            },
+            Event::PromptRuntimeError {
+                message: "boom".into(),
+            },
+            // A fresh turn supersedes one that leaked across a boundary,
+            // matching the web reducer.
+            Event::UserPromptSent {
+                text: "next turn".into(),
+                attachments: Vec::new(),
+            },
+        ];
+        for terminal in terminals {
+            let label = format!("{terminal:?}");
+            let mut t = AcpTranscript::new("s-1");
+            t.apply(&frame(1, cancel()));
+            t.apply(&frame(2, terminal));
+            assert!(!t.cancelling, "{label} must clear the pending cancel");
+        }
     }
 
     #[test]

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -88,6 +88,13 @@ pub struct AcpTranscript {
     /// by `/replay` after a `reset()`. The composer reads it to decide
     /// whether Enter sends now or parks the prompt in the local queue.
     pub turn_active: bool,
+    /// Whether the agent accepts `_session/steering`, from the latest
+    /// `PromptCapabilities`. When true the composer sends a mid-turn
+    /// prompt straight through instead of parking it: the daemon injects
+    /// it into the running turn. Rebuilt by `/replay` like `turn_active`,
+    /// and re-emitted as `false` on a respawn onto an adapter that lacks
+    /// the capability, so it cannot go stale. See #2805.
+    pub steering: bool,
     /// Latest context-window usage / cost snapshot the agent reported.
     /// Rendered as a token meter in the status line, mirroring the web
     /// composer's usage chip.
@@ -210,6 +217,7 @@ impl AcpTranscript {
             available_modes: Vec::new(),
             available_commands: Vec::new(),
             context_primer_pending: false,
+            steering: false,
             turn_active: false,
             usage: None,
             current_plan: Vec::new(),
@@ -668,11 +676,13 @@ impl AcpTranscript {
             | Event::WakeupScheduled { .. }
             | Event::MonitorArmed { .. }
             | Event::CancelRequested { .. }
-            | Event::PromptCapabilities { .. }
             | Event::ConfigOptionsUpdated { .. }
             | Event::ConfigOptionSwitchFailed { .. } => {
                 // Surface as info notes for now; richer renderers are
                 // followup work tracked in the plan's "out of scope".
+            }
+            Event::PromptCapabilities { steering, .. } => {
+                self.steering = *steering;
             }
             Event::AgentSwitched { to, .. } => {
                 self.agent_name = Some(to.clone());

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -95,6 +95,13 @@ pub struct AcpTranscript {
     /// and re-emitted as `false` on a respawn onto an adapter that lacks
     /// the capability, so it cannot go stale. See #2805.
     pub steering: bool,
+    /// Whether a `session/cancel` is in flight, from `CancelRequested`
+    /// until the turn's `Stopped`. Only consulted by the composer's park
+    /// decision: the daemon reads a prompt arriving mid-cancel as a
+    /// wedged agent and escalates to a runner restart, so a steerable
+    /// agent must still park here rather than route Stop-then-type into
+    /// that path. See #2805 / #1727.
+    pub cancelling: bool,
     /// Latest context-window usage / cost snapshot the agent reported.
     /// Rendered as a token meter in the status line, mirroring the web
     /// composer's usage chip.
@@ -218,6 +225,7 @@ impl AcpTranscript {
             available_commands: Vec::new(),
             context_primer_pending: false,
             steering: false,
+            cancelling: false,
             turn_active: false,
             usage: None,
             current_plan: Vec::new(),
@@ -532,6 +540,7 @@ impl AcpTranscript {
                     text: format!("agent stopped: {reason}"),
                 });
                 self.turn_active = false;
+                self.cancelling = false;
             }
             Event::AgentStartupError { message } => {
                 self.flush_pending_chunk();
@@ -541,6 +550,7 @@ impl AcpTranscript {
                     text: format!("agent startup failed: {message}"),
                 });
                 self.turn_active = false;
+                self.cancelling = false;
             }
             Event::PromptRuntimeError { message } => {
                 self.flush_pending_chunk();
@@ -550,6 +560,7 @@ impl AcpTranscript {
                     text: format!("prompt failed: {message}"),
                 });
                 self.turn_active = false;
+                self.cancelling = false;
             }
             Event::IncompatibleAgent { .. } => {
                 // Structured detail for the web structured view's StartupErrorScreen.
@@ -637,6 +648,7 @@ impl AcpTranscript {
                 // submit path may have set. The richer rejected-prompt
                 // renderer is followup work (see the no-op group below).
                 self.turn_active = false;
+                self.cancelling = false;
             }
             Event::RateLimitAutoResumed { resets_at } => {
                 // Timeline breadcrumb: the reconciler auto-resumed the
@@ -675,7 +687,6 @@ impl AcpTranscript {
             | Event::BackgroundAgentCompleted { .. }
             | Event::WakeupScheduled { .. }
             | Event::MonitorArmed { .. }
-            | Event::CancelRequested { .. }
             | Event::ConfigOptionsUpdated { .. }
             | Event::ConfigOptionSwitchFailed { .. } => {
                 // Surface as info notes for now; richer renderers are
@@ -683,6 +694,9 @@ impl AcpTranscript {
             }
             Event::PromptCapabilities { steering, .. } => {
                 self.steering = *steering;
+            }
+            Event::CancelRequested { .. } => {
+                self.cancelling = true;
             }
             Event::AgentSwitched { to, .. } => {
                 self.agent_name = Some(to.clone());
@@ -723,6 +737,34 @@ mod tests {
             memory_recall: None,
             diffs: Vec::new(),
         }
+    }
+
+    /// The composer parks a mid-turn send while a cancel is pending even
+    /// on a steerable agent (#2805). Clearing on the turn's terminal
+    /// event is the load-bearing half: a `cancelling` left set would park
+    /// every later mid-turn send on a session that had ever been
+    /// stopped once.
+    #[test]
+    fn cancel_requested_sets_and_stopped_clears_cancelling() {
+        let mut t = AcpTranscript::new("s-1");
+        assert!(!t.cancelling);
+        t.apply(&frame(
+            1,
+            Event::CancelRequested {
+                escalates_at: Utc::now(),
+            },
+        ));
+        assert!(t.cancelling);
+        t.apply(&frame(
+            2,
+            Event::Stopped {
+                reason: "cancelled".into(),
+            },
+        ));
+        assert!(
+            !t.cancelling,
+            "a settled turn must not leave a pending cancel behind"
+        );
     }
 
     #[test]

--- a/src/tui/structured_view/state.rs
+++ b/src/tui/structured_view/state.rs
@@ -348,12 +348,17 @@ impl StructuredViewState {
     /// round-trip, where a second Enter would double-fire, and a dead
     /// socket means an immediate send fires into a daemon whose turn
     /// boundaries we can no longer observe.
+    ///
+    /// A pending cancel parks even on a steerable agent: the daemon reads
+    /// a prompt arriving mid-cancel as a wedged agent and escalates to a
+    /// runner restart, so sending there would respawn the worker on a
+    /// Stop-then-type that used to just queue.
     pub fn should_queue_prompt(&self) -> bool {
         should_queue_prompt_for(
             self.in_flight,
             self.ws.is_some(),
             self.transcript.turn_active,
-            self.transcript.steering,
+            self.transcript.steering && !self.transcript.cancelling,
         )
     }
 
@@ -603,13 +608,16 @@ impl StructuredViewState {
 /// Pure form of [`StructuredViewState::should_queue_prompt`]. Split out
 /// because a `WsHandle` cannot be built in a unit test, so the decision
 /// table would otherwise only be reachable with the socket down.
+///
+/// `steerable` is the capability AND the absence of a pending cancel;
+/// the caller folds those together.
 fn should_queue_prompt_for(
     in_flight: bool,
     socket_up: bool,
     turn_active: bool,
-    steering: bool,
+    steerable: bool,
 ) -> bool {
-    in_flight || !socket_up || (turn_active && !steering)
+    in_flight || !socket_up || (turn_active && !steerable)
 }
 
 #[cfg(test)]

--- a/src/tui/structured_view/state.rs
+++ b/src/tui/structured_view/state.rs
@@ -330,13 +330,31 @@ impl StructuredViewState {
         self.plugin_notify.pending.pop_front()
     }
 
-    /// Whether a fresh Enter should park in the queue rather than send
-    /// now. Busy when the agent is mid-turn, a POST is in flight, or the
-    /// WebSocket is down (no handle): in every case an immediate send
-    /// would either collide with the running turn or fire into a daemon
-    /// whose turn boundaries we can no longer observe.
+    /// Whether the agent is working, for display and for Esc-to-cancel.
+    /// Busy when the agent is mid-turn, a POST is in flight, or the
+    /// WebSocket is down (no handle).
     pub fn is_busy(&self) -> bool {
         self.transcript.turn_active || self.in_flight || self.ws.is_none()
+    }
+
+    /// Whether a fresh Enter should park in the queue rather than send
+    /// now.
+    ///
+    /// Same as [`Self::is_busy`] except for a steerable agent, where a
+    /// mid-turn send is the point: the daemon injects it into the running
+    /// turn rather than refusing it, so parking it locally would
+    /// reintroduce the queue-after behavior steering replaces (#2805).
+    /// The other two terms still park. `in_flight` covers the POST
+    /// round-trip, where a second Enter would double-fire, and a dead
+    /// socket means an immediate send fires into a daemon whose turn
+    /// boundaries we can no longer observe.
+    pub fn should_queue_prompt(&self) -> bool {
+        should_queue_prompt_for(
+            self.in_flight,
+            self.ws.is_some(),
+            self.transcript.turn_active,
+            self.transcript.steering,
+        )
     }
 
     /// Drain the composer's current text and clear it so the user can
@@ -582,6 +600,18 @@ impl StructuredViewState {
     }
 }
 
+/// Pure form of [`StructuredViewState::should_queue_prompt`]. Split out
+/// because a `WsHandle` cannot be built in a unit test, so the decision
+/// table would otherwise only be reachable with the socket down.
+fn should_queue_prompt_for(
+    in_flight: bool,
+    socket_up: bool,
+    turn_active: bool,
+    steering: bool,
+) -> bool {
+    in_flight || !socket_up || (turn_active && !steering)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -620,6 +650,34 @@ mod tests {
         // boundaries can't be observed to drive an immediate send.
         let state = test_state(None);
         assert!(state.is_busy());
+    }
+
+    /// Steering removes the mid-turn park and nothing else (#2805). The
+    /// in-flight POST and dead-socket terms must keep parking even for a
+    /// steerable agent: the first would double-fire, the second fires at
+    /// a daemon whose turn boundaries we can no longer observe.
+    #[test]
+    fn steering_only_unblocks_the_mid_turn_park() {
+        // (in_flight, socket_up, turn_active, steering, expect_queue)
+        let cases = [
+            (false, true, false, false, false),
+            (false, true, false, true, false),
+            // The behavior change: mid-turn sends through when steerable.
+            (false, true, true, false, true),
+            (false, true, true, true, false),
+            // Steering does not override the other two gates.
+            (true, true, false, true, true),
+            (false, false, false, true, true),
+            (true, true, true, true, true),
+            (false, false, true, true, true),
+        ];
+        for (in_flight, socket_up, turn_active, steering, expected) in cases {
+            assert_eq!(
+                should_queue_prompt_for(in_flight, socket_up, turn_active, steering),
+                expected,
+                "in_flight={in_flight} socket_up={socket_up} turn_active={turn_active} steering={steering}"
+            );
+        }
     }
 
     fn composer_text(state: &StructuredViewState) -> String {

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -1178,7 +1178,12 @@ export function Composer({
                 {turnActive ? (
                   <>
                     <StopButton />
-                    <QueueSendButton connected={connected} queuedCount={queuedCount} onSend={submitComposer} />
+                    <QueueSendButton
+                      connected={connected}
+                      steering={!!promptCapabilities?.steering}
+                      queuedCount={queuedCount}
+                      onSend={submitComposer}
+                    />
                   </>
                 ) : (
                   <SendButton connected={connected} onSend={submitComposer} />
@@ -1658,24 +1663,32 @@ function StopButton() {
  *  POSTing. See #1359. */
 function QueueSendButton({
   connected,
+  steering,
   queuedCount,
   onSend,
 }: {
   connected: boolean;
+  steering: boolean;
   queuedCount: number;
   onSend: () => void;
 }) {
+  // A steerable agent takes the message into the turn already running,
+  // so the queue-after copy would be wrong. Disconnected still wins:
+  // steering does nothing for a prompt that cannot reach the daemon,
+  // and those really do park. See #2805.
   const title = !connected
     ? queuedCount > 0
       ? `Queue follow-up (${queuedCount} pending), will send on resume, Enter`
       : "Queue follow-up, will send on resume, Enter"
-    : queuedCount > 0
-      ? `Queue follow-up (${queuedCount} pending), Enter`
-      : "Queue follow-up (sent when current turn ends), Enter";
+    : steering
+      ? "Send into the current turn, Enter"
+      : queuedCount > 0
+        ? `Queue follow-up (${queuedCount} pending), Enter`
+        : "Queue follow-up (sent when current turn ends), Enter";
   return (
     <button
       type="button"
-      aria-label="Queue follow-up message"
+      aria-label={connected && steering ? "Send message into the current turn" : "Queue follow-up message"}
       {...tourAnchor(TOUR_ANCHORS.queueSend)}
       title={title}
       onClick={onSend}

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -920,7 +920,12 @@ export function Composer({
               cancelOnEscape={false}
               placeholder={
                 turnActive
-                  ? "Queue a follow-up… (sent when current turn ends)"
+                  ? // Same condition as QueueSendButton, so the
+                    // placeholder and the button next to it never give
+                    // opposite instructions. See #2805.
+                    connected && promptCapabilities?.steering
+                    ? "Add to the current turn… (the agent picks it up mid-work)"
+                    : "Queue a follow-up… (sent when current turn ends)"
                   : "Send a message…  Type @ for files, / for commands"
               }
               onInput={onInput}

--- a/web/src/hooks/useAcpSession.history.test.ts
+++ b/web/src/hooks/useAcpSession.history.test.ts
@@ -67,14 +67,14 @@ describe("useAcpSession recent-first paging", () => {
     // (older) handshake snapshot.
     const withCaps = {
       ...emptyAcpState(),
-      promptCapabilities: { image: false, audio: false, embeddedContext: false },
+      promptCapabilities: { image: false, audio: false, embeddedContext: false, steering: false },
     };
     const kept = reducer(withCaps, { kind: "handshake", frames: [caps] });
-    expect(kept.promptCapabilities).toEqual({ image: false, audio: false, embeddedContext: false });
+    expect(kept.promptCapabilities).toEqual({ image: false, audio: false, embeddedContext: false, steering: false });
 
     // When the field is still empty, the handshake fills it.
     const filled = reducer(emptyAcpState(), { kind: "handshake", frames: [caps] });
-    expect(filled.promptCapabilities).toEqual({ image: true, audio: false, embeddedContext: true });
+    expect(filled.promptCapabilities).toEqual({ image: true, audio: false, embeddedContext: true, steering: false });
     // The handshake projects state only; it adds no transcript rows.
     expect(filled.activity).toHaveLength(0);
   });

--- a/web/src/hooks/useAcpSession.queue.test.ts
+++ b/web/src/hooks/useAcpSession.queue.test.ts
@@ -472,13 +472,19 @@ describe("useAcpSession drain race (#1144)", () => {
   // #2805: mid-turn is the one gate steering removes. On a steerable
   // agent the prompt POSTs straight through and the daemon injects it
   // into the running turn; on every other agent it still parks.
+  //
+  // A pending cancel parks even on a steerable agent. The daemon reads a
+  // prompt arriving mid-cancel as "user hit Stop and re-typed, agent is
+  // wedged" and escalates to a runner restart, so POSTing there would
+  // respawn the worker on a Stop-then-type that used to just queue.
   it.each([
-    { steering: true, expectedPosts: 2, expectedQueued: 0 },
-    { steering: false, expectedPosts: 1, expectedQueued: 1 },
+    { steering: true, cancelling: false, expectedPosts: 2, expectedQueued: 0 },
+    { steering: false, cancelling: false, expectedPosts: 1, expectedQueued: 1 },
+    { steering: true, cancelling: true, expectedPosts: 1, expectedQueued: 1 },
   ])(
-    "mid-turn prompt posts through when steering=$steering (#2805)",
-    async ({ steering, expectedPosts, expectedQueued }) => {
-      const sessionId = `sess-steer-${String(steering)}`;
+    "mid-turn prompt with steering=$steering cancelling=$cancelling (#2805)",
+    async ({ steering, cancelling, expectedPosts, expectedQueued }) => {
+      const sessionId = `sess-steer-${String(steering)}-${String(cancelling)}`;
       const { result } = renderHook(() => useAcpSession(sessionId));
       await flushAsync();
       const ws = sockets[0]!;
@@ -522,6 +528,22 @@ describe("useAcpSession drain race (#1144)", () => {
       });
       await flushAsync();
       expect(result.current.state.turnActive).toBe(true);
+
+      if (cancelling) {
+        act(() => {
+          ws.onmessage?.({
+            data: JSON.stringify({
+              session_id: sessionId,
+              seq: 3,
+              event: { CancelRequested: { escalates_at: "2026-01-01T00:00:10Z" } },
+            }),
+          } as MessageEvent);
+        });
+        await flushAsync();
+        expect(result.current.state.cancelling).toBe(true);
+        // The turn is still running; only the cancel is pending.
+        expect(result.current.state.turnActive).toBe(true);
+      }
 
       act(() => {
         void result.current.sendPrompt("also check the tests");

--- a/web/src/hooks/useAcpSession.queue.test.ts
+++ b/web/src/hooks/useAcpSession.queue.test.ts
@@ -469,6 +469,70 @@ describe("useAcpSession drain race (#1144)", () => {
     expect(reportAcpInteraction).toHaveBeenCalledWith("prompt_queued");
   });
 
+  // #2805: mid-turn is the one gate steering removes. On a steerable
+  // agent the prompt POSTs straight through and the daemon injects it
+  // into the running turn; on every other agent it still parks.
+  it.each([
+    { steering: true, expectedPosts: 2, expectedQueued: 0 },
+    { steering: false, expectedPosts: 1, expectedQueued: 1 },
+  ])(
+    "mid-turn prompt posts through when steering=$steering (#2805)",
+    async ({ steering, expectedPosts, expectedQueued }) => {
+      const sessionId = `sess-steer-${String(steering)}`;
+      const { result } = renderHook(() => useAcpSession(sessionId));
+      await flushAsync();
+      const ws = sockets[0]!;
+      act(() => {
+        ws.readyState = FakeWebSocket.OPEN;
+        ws.onopen?.({} as Event);
+      });
+      await flushAsync();
+
+      act(() => {
+        ws.onmessage?.({
+          data: JSON.stringify({
+            session_id: sessionId,
+            seq: 1,
+            event: {
+              PromptCapabilities: {
+                image: false,
+                audio: false,
+                embedded_context: false,
+                steering,
+              },
+            },
+          }),
+        } as MessageEvent);
+      });
+      await flushAsync();
+
+      // First prompt starts the turn.
+      act(() => {
+        void result.current.sendPrompt("start the turn");
+      });
+      await flushAsync();
+      act(() => {
+        ws.onmessage?.({
+          data: JSON.stringify({
+            session_id: sessionId,
+            seq: 2,
+            event: { UserPromptSent: { text: "start the turn" } },
+          }),
+        } as MessageEvent);
+      });
+      await flushAsync();
+      expect(result.current.state.turnActive).toBe(true);
+
+      act(() => {
+        void result.current.sendPrompt("also check the tests");
+      });
+      await flushAsync();
+
+      expect(promptPostCount).toBe(expectedPosts);
+      expect(result.current.state.queuedPrompts).toHaveLength(expectedQueued);
+    },
+  );
+
   it("drains the queue once the WS opens after an inactive-state enqueue (#1359)", async () => {
     const { result } = renderHook(() => useAcpSession("sess-drain-resume"));
     await flushAsync();

--- a/web/src/hooks/useAcpSession.recentFirst.test.ts
+++ b/web/src/hooks/useAcpSession.recentFirst.test.ts
@@ -143,7 +143,7 @@ describe("useAcpSession recent-first cold open + loadOlder (#2236)", () => {
       "user-seq-10",
     ]);
     expect(result.current.hasMoreOlder).toBe(true);
-    expect(result.current.state.promptCapabilities).toEqual({ image: true, audio: false, embeddedContext: true });
+    expect(result.current.state.promptCapabilities).toEqual({ image: true, audio: false, embeddedContext: true, steering: false });
     expect(result.current.state.oldestSeq).toBe(6);
 
     // Scroll-up fetch: the older page prepends ahead of the tail and

--- a/web/src/hooks/useAcpSession.recentFirst.test.ts
+++ b/web/src/hooks/useAcpSession.recentFirst.test.ts
@@ -143,7 +143,12 @@ describe("useAcpSession recent-first cold open + loadOlder (#2236)", () => {
       "user-seq-10",
     ]);
     expect(result.current.hasMoreOlder).toBe(true);
-    expect(result.current.state.promptCapabilities).toEqual({ image: true, audio: false, embeddedContext: true, steering: false });
+    expect(result.current.state.promptCapabilities).toEqual({
+      image: true,
+      audio: false,
+      embeddedContext: true,
+      steering: false,
+    });
     expect(result.current.state.oldestSeq).toBe(6);
 
     // Scroll-up fetch: the older page prepends ahead of the tail and

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -1709,7 +1709,15 @@ export function useAcpSession(
       // behavior steering replaces. Only the turn-active term is dropped;
       // the socket and worker gates below still park, because steering
       // does nothing for a prompt that cannot reach the daemon. See #2805.
-      const turnBlocks = state.turnActive && !state.promptCapabilities?.steering;
+      //
+      // A pending cancel is the exception: the daemon refuses a prompt
+      // that arrives while it is cancelling AND escalates to a runner
+      // restart, reading it as "the user hit Stop and re-typed, so the
+      // agent is wedged". Steering must not route the composer into that
+      // path, or Stop-then-type would respawn the worker where it used
+      // to just queue. That turn is ending either way, so park and let
+      // the drain fire it as the next turn.
+      const turnBlocks = state.turnActive && !(state.promptCapabilities?.steering && !state.cancelling);
       const blockedAsideFromWorker = wsClosed || turnBlocks || state.workerStopped || state.workerRestarting;
       const shouldEnqueue = state.workerIdleStopped
         ? blockedAsideFromWorker
@@ -1746,6 +1754,7 @@ export function useAcpSession(
       sessionId,
       state.turnActive,
       state.promptCapabilities?.steering,
+      state.cancelling,
       state.workerStopped,
       state.workerRestarting,
       state.workerIdleStopped,

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -1703,7 +1703,14 @@ export function useAcpSession(
       // "absent" until the respawn lands); parking would leave it in the
       // local queue forever and the worker would never come back. Only a
       // non-dormant cold worker (genuine mid-resume) still parks. See #1689.
-      const blockedAsideFromWorker = wsClosed || state.turnActive || state.workerStopped || state.workerRestarting;
+      // A steerable agent takes a mid-turn prompt directly: the daemon
+      // injects it into the running turn via `_session/steering` rather
+      // than refusing it, so parking here would put back the queue-after
+      // behavior steering replaces. Only the turn-active term is dropped;
+      // the socket and worker gates below still park, because steering
+      // does nothing for a prompt that cannot reach the daemon. See #2805.
+      const turnBlocks = state.turnActive && !state.promptCapabilities?.steering;
+      const blockedAsideFromWorker = wsClosed || turnBlocks || state.workerStopped || state.workerRestarting;
       const shouldEnqueue = state.workerIdleStopped
         ? blockedAsideFromWorker
         : blockedAsideFromWorker || workerNotRunning;
@@ -1738,6 +1745,7 @@ export function useAcpSession(
     [
       sessionId,
       state.turnActive,
+      state.promptCapabilities?.steering,
       state.workerStopped,
       state.workerRestarting,
       state.workerIdleStopped,

--- a/web/src/lib/acpAttachments.test.ts
+++ b/web/src/lib/acpAttachments.test.ts
@@ -29,6 +29,7 @@ describe("structured view attachments reducer", () => {
       image: true,
       audio: false,
       embeddedContext: true,
+      steering: false,
     });
   });
 
@@ -59,6 +60,7 @@ describe("structured view attachments reducer", () => {
       image: false,
       audio: false,
       embeddedContext: false,
+      steering: false,
     });
   });
 

--- a/web/src/lib/acpTypes.reducer.test.ts
+++ b/web/src/lib/acpTypes.reducer.test.ts
@@ -343,7 +343,28 @@ describe("applyEvent / PromptCapabilities", () => {
       image: true,
       audio: false,
       embeddedContext: true,
+      // Absent on the wire: events persisted before #2805 have no
+      // `steering` key and must not read as capable.
+      steering: false,
     });
+  });
+
+  it("carries the steering flag through, both ways (#2805)", () => {
+    for (const steering of [true, false]) {
+      const next = applyEvent(emptyAcpState(), {
+        session_id: "s-1",
+        seq: 1,
+        event: {
+          PromptCapabilities: {
+            image: false,
+            audio: false,
+            embedded_context: false,
+            steering,
+          },
+        },
+      });
+      expect(next.promptCapabilities?.steering).toBe(steering);
+    }
   });
 });
 

--- a/web/src/lib/acpTypes.test.ts
+++ b/web/src/lib/acpTypes.test.ts
@@ -917,6 +917,74 @@ describe("applyEvent / Stopped empty-output fallback", () => {
     expect(state.turnActive).toBe(false);
   });
 
+  // #2805 field report: a steered mid-turn prompt is not a new turn, so
+  // it must not reset the output flag the running turn already earned.
+  // Replays the reported trace: prompt, agent output, steered prompt,
+  // one Stopped. Before the fix the steered prompt cleared
+  // `turnHasOutput` and the single Stopped rendered a bogus notice.
+  it("does not append the notice when a steered prompt lands mid-turn (#2805)", () => {
+    let state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        PromptCapabilities: {
+          image: false,
+          audio: false,
+          embedded_context: false,
+          steering: true,
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { UserPromptSent: { text: "read every file in src/acp" } },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: { AgentMessageChunk: { text: "I'll dispatch parallel readers." } },
+    });
+    expect(state.turnHasOutput).toBe(true);
+
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 4,
+      event: { UserPromptSent: { text: "actually, just do acp_client.rs" } },
+    });
+    // The steered message is a continuation: the turn keeps the output it
+    // has already produced, and no second turn was opened.
+    expect(state.turnHasOutput).toBe(true);
+
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 5,
+      event: { Stopped: { reason: "prompt_complete" } },
+    });
+    expect(state.activity.some((r) => r.kind === "empty_output")).toBe(false);
+  });
+
+  // The same shape without steering must keep today's behavior: that
+  // prompt really did open a turn, so the reset is correct.
+  it("still resets the output flag for a mid-turn prompt on a non-steerable agent", () => {
+    let state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { UserPromptSent: { text: "first" } },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { AgentMessageChunk: { text: "output" } },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: { UserPromptSent: { text: "second" } },
+    });
+    expect(state.turnHasOutput).toBe(false);
+  });
+
   it("does not append the notice when the agent emitted a message", () => {
     let state = applyEvent(emptyAcpState(), {
       session_id: "s-1",

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -1075,6 +1075,23 @@ export function emptyAcpState(): AcpState {
  *  event (a plain `UserPromptSent` and a `UserDiffCommentsPrompt`).
  *  Mutates `next` in place; the caller has already appended the
  *  activity row and bumped `pendingUserPromptSeq`. */
+/** Whether a `UserPromptSent` is a message steered into the turn already
+ *  running rather than the start of a new one (#2805).
+ *
+ *  The daemon injects a mid-turn prompt via `_session/steering` instead of
+ *  starting a turn for it, so the same condition the composer used to send
+ *  it identifies it on the way back. Such a prompt must NOT run
+ *  {@link applyNewTurnResets}: there is no new turn, and the running
+ *  turn's single `Stopped` still has to see the output flag and the
+ *  pending-cancel state the turn actually accumulated.
+ *
+ *  Takes the pre-event state, since the arms bump `pendingUserPromptSeq`
+ *  (which feeds `isTurnActive`) before they reach the reset.
+ */
+function isSteeredContinuation(state: AcpState): boolean {
+  return state.turnActive && !!state.promptCapabilities?.steering;
+}
+
 function applyNewTurnResets(next: AcpState): void {
   next.assistantMessage = "";
   next.startupError = null;
@@ -1842,7 +1859,9 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
       });
       next.pendingUserPromptSeq = next.pendingUserPromptSeq + 1;
     }
-    applyNewTurnResets(next);
+    if (!isSteeredContinuation(state)) {
+      applyNewTurnResets(next);
+    }
     return next;
   }
   if ("UserDiffCommentsPrompt" in event) {
@@ -1865,7 +1884,9 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
       at: new Date().toISOString(),
     });
     next.pendingUserPromptSeq = next.pendingUserPromptSeq + 1;
-    applyNewTurnResets(next);
+    if (!isSteeredContinuation(state)) {
+      applyNewTurnResets(next);
+    }
     return next;
   }
   if ("AcpSessionAssigned" in event) {

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -540,6 +540,9 @@ export type AcpEvent =
         image: boolean;
         audio: boolean;
         embedded_context: boolean;
+        /** Absent on events persisted before #2805; the Rust side
+         *  defaults it to false, so treat a missing value the same. */
+        steering?: boolean;
       };
     }
   | { AcpSessionAssigned: { acp_session_id: string } }
@@ -569,6 +572,12 @@ export interface PromptCapabilities {
   image: boolean;
   audio: boolean;
   embeddedContext: boolean;
+  /** Whether the agent accepts `_session/steering`, so a prompt sent
+   *  mid-turn is injected into the running turn instead of parked in
+   *  the composer queue. Re-emitted on every connect, including as
+   *  false, so it cannot go stale after a respawn onto an adapter
+   *  without the capability. See #2805. */
+  steering: boolean;
 }
 
 /** One attachment as the composer hands it to `sendPrompt`: the raw
@@ -1764,6 +1773,7 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
       image: c.image,
       audio: c.audio,
       embeddedContext: c.embedded_context,
+      steering: c.steering ?? false,
     };
     return next;
   }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2952,9 +2952,13 @@
     },
     {
       "id": "acp.mid-turn-steering",
-      "kind": "vitest",
+      "kind": "live-playwright",
       "risk": "high",
-      "specs": ["src/hooks/useAcpSession.queue.test.ts", "src/lib/acpTypes.reducer.test.ts"],
+      "specs": [
+        "tests/live/acp-mid-turn-steering.spec.ts",
+        "src/hooks/useAcpSession.queue.test.ts",
+        "src/lib/acpTypes.reducer.test.ts"
+      ],
       "components": ["web/src/hooks/useAcpSession.ts", "web/src/lib/acpTypes.ts", "web/src/components/acp/Composer.tsx"]
     },
     {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2951,6 +2951,17 @@
       "components": ["web/src/components/acp/Composer.tsx", "web/src/components/acp/ToolCards.tsx"]
     },
     {
+      "id": "acp.mid-turn-steering",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/hooks/useAcpSession.queue.test.ts", "src/lib/acpTypes.reducer.test.ts"],
+      "components": [
+        "web/src/hooks/useAcpSession.ts",
+        "web/src/lib/acpTypes.ts",
+        "web/src/components/acp/Composer.tsx"
+      ]
+    },
+    {
       "id": "story.wizard-open-close",
       "kind": "mocked-playwright",
       "risk": "low",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2955,11 +2955,7 @@
       "kind": "vitest",
       "risk": "high",
       "specs": ["src/hooks/useAcpSession.queue.test.ts", "src/lib/acpTypes.reducer.test.ts"],
-      "components": [
-        "web/src/hooks/useAcpSession.ts",
-        "web/src/lib/acpTypes.ts",
-        "web/src/components/acp/Composer.tsx"
-      ]
+      "components": ["web/src/hooks/useAcpSession.ts", "web/src/lib/acpTypes.ts", "web/src/components/acp/Composer.tsx"]
     },
     {
       "id": "story.wizard-open-close",

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -486,6 +486,20 @@ const INITIALIZE_RESULT = {
 // src/acp/agent_compat.rs); otherwise the gate rejects the handshake and
 // the opencode live specs (acp-mode-picker) fail. The shim sets
 // FAKE_ACP_IMPERSONATE; default stays claude.
+// Mid-turn steering (#2805). Off by default so the existing specs keep
+// exercising the queue-after path. When on, the fake advertises the
+// `_session/steering` extension and reports a version at the separate
+// steering floor (CLAUDE_AGENT_ACP_STEERING_MIN_VERSION in
+// src/acp/agent_compat.rs), which the gate requires on top of the
+// advertised bit.
+const STEERING_ENABLED = process.env.FAKE_ACP_STEERING === "1";
+const STEERING_MIN_VERSION = "0.64.0";
+
+// Sessions with a `session/prompt` still running. `steer()` reads this
+// the way the real adapter reads its unsettled `turnQueue`: it decides
+// `injected` vs `promptRequired`, and the daemon applies that answer.
+const activeTurns = new Set();
+
 function resolveAgentInfo() {
   if (process.env.FAKE_ACP_IMPERSONATE === "opencode") {
     // Keep at (or above) the agent_compat opencode floor (>=1.16.0).
@@ -493,6 +507,9 @@ function resolveAgentInfo() {
   }
   if (process.env.FAKE_ACP_IMPERSONATE === "codex") {
     return { name: "@agentclientprotocol/codex-acp", version: "1.1.4" };
+  }
+  if (STEERING_ENABLED) {
+    return { ...INITIALIZE_RESULT.agentInfo, version: STEERING_MIN_VERSION };
   }
   return INITIALIZE_RESULT.agentInfo;
 }
@@ -549,7 +566,48 @@ async function handleRequest(msg) {
             },
           }
         : { ...INITIALIZE_RESULT, agentInfo: resolveAgentInfo() };
+      // Top-level `_meta`, sibling of agentCapabilities, matching where
+      // the real adapter advertises the steering extension.
+      if (STEERING_ENABLED) {
+        result._meta = { steering: { supported: true } };
+      }
       sendResult(id, result);
+      return;
+    }
+
+    // Mid-turn steering (#2805). Mirrors the real adapter: a message
+    // handed to a running turn is `injected` and streams its own
+    // updates; one that arrives after the turn settled is
+    // `promptRequired`, meaning the content was NOT consumed and the
+    // host must resend it as a normal session/prompt.
+    case "_session/steering": {
+      const sessionId = params?.sessionId;
+      if (!STEERING_ENABLED) {
+        sendError(id, -32601, "method not found");
+        return;
+      }
+      if (!activeTurns.has(sessionId)) {
+        sendResult(id, { outcome: "promptRequired", reason: "noRunningTurn" });
+        return;
+      }
+      const text = (params?.prompt ?? [])
+        .filter((b) => b?.type === "text")
+        .map((b) => b.text)
+        .join("");
+      // Echo the steered message into the running turn so a spec can
+      // assert it landed there rather than in a turn of its own.
+      send({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: `steered: ${text}` },
+          },
+        },
+      });
+      sendResult(id, { outcome: "injected" });
       return;
     }
 
@@ -760,7 +818,15 @@ async function handleRequest(msg) {
       // Reset any prior cancel flag so this turn starts clean.
       if (sessionId) cancelFlags.set(sessionId, false);
       if (sessionId) {
-        await emitSessionUpdates(sessionId, turn.updates);
+        // Marked for the whole emission window so a `_session/steering`
+        // arriving during a `wait_ms` sees a running turn, and one
+        // arriving after it does not.
+        activeTurns.add(sessionId);
+        try {
+          await emitSessionUpdates(sessionId, turn.updates);
+        } finally {
+          activeTurns.delete(sessionId);
+        }
       }
       const wasCancelled = sessionId ? cancelFlags.get(sessionId) : false;
       if (sessionId) cancelFlags.set(sessionId, false);

--- a/web/tests/live/acp-mid-turn-steering.spec.ts
+++ b/web/tests/live/acp-mid-turn-steering.spec.ts
@@ -1,0 +1,123 @@
+// Mid-turn steering (#2805).
+//
+// A prompt that reaches the daemon while a turn is running used to be
+// refused with `PromptRejected { reason: "agent_busy" }`. Against an
+// agent that advertises `_session/steering` (and clears the separate
+// steering version floor) the daemon now hands it to the running turn
+// instead, which is what the claude CLI does with typed-ahead input.
+//
+// Both specs drive the REST prompt endpoint rather than the composer:
+// the daemon-side gate is what changed, and going through REST is also
+// the `aoe acp prompt` path, which had no client-side queue to fall back
+// on and so just failed before this.
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions, seedSessionViaAoeAdd } from "../helpers/aoeServe";
+import { enableStructuredViewAndWait, waitForReplayContains } from "../helpers/acp";
+
+// One turn that stays open long enough for a second prompt to land
+// inside it. `wait_ms` is the fake agent's hold primitive; it sleeps in
+// slices so a cancel is still observed promptly.
+const HELD_TURN_SCRIPT = {
+  turns: [
+    {
+      updates: [
+        { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "working" } },
+        { sessionUpdate: "wait_ms", ms: 4000 },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+async function postPrompt(baseUrl: string, sessionId: string, text: string) {
+  return fetch(`${baseUrl}/api/sessions/${sessionId}/acp/prompt`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+}
+
+async function replayJson(baseUrl: string, sessionId: string): Promise<string> {
+  const replay = await fetch(`${baseUrl}/api/sessions/${sessionId}/acp/replay?since=0`).then((r) => r.json());
+  const frames: unknown[] = Array.isArray(replay) ? replay : (replay?.frames ?? []);
+  return JSON.stringify(frames);
+}
+
+test("a mid-turn prompt is steered into the running turn instead of rejected", async ({}, testInfo) => {
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-steer-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(HELD_TURN_SCRIPT));
+
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    acp: true,
+    fakeAcpScript: scriptPath,
+    extraEnv: { FAKE_ACP_STEERING: "1" },
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "acp-steering" }),
+  });
+
+  try {
+    const sessionId = (await listSessions(serve.baseUrl))[0]!.id;
+    await enableStructuredViewAndWait(serve.baseUrl, sessionId);
+
+    // The capability has to reach the event stream, otherwise the daemon
+    // would take the reject path and this spec would pass for the wrong
+    // reason.
+    await waitForReplayContains(serve.baseUrl, sessionId, '"steering":true');
+
+    await postPrompt(serve.baseUrl, sessionId, "start the turn");
+    await waitForReplayContains(serve.baseUrl, sessionId, "working");
+
+    // Lands while the turn is held open by `wait_ms`.
+    const second = await postPrompt(serve.baseUrl, sessionId, "also check the tests");
+    expect(second.ok).toBe(true);
+
+    // The fake echoes an injected steer back into the running turn, so
+    // this text only appears if the daemon really sent
+    // `_session/steering` and the agent accepted it.
+    await waitForReplayContains(serve.baseUrl, sessionId, "steered: also check the tests");
+
+    const json = await replayJson(serve.baseUrl, sessionId);
+    expect(json).not.toContain("agent_busy");
+  } finally {
+    await serve.stop();
+  }
+});
+
+test("a mid-turn prompt is still rejected when the agent cannot be steered", async ({}, testInfo) => {
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-nosteer-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(HELD_TURN_SCRIPT));
+
+  // Same fixture with steering off, so the only difference between the
+  // two specs is the capability. Guards the fallback: agents without
+  // steering must keep today's behavior, since their users rely on the
+  // composer's client-side queue-after.
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    acp: true,
+    fakeAcpScript: scriptPath,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "acp-no-steering" }),
+  });
+
+  try {
+    const sessionId = (await listSessions(serve.baseUrl))[0]!.id;
+    await enableStructuredViewAndWait(serve.baseUrl, sessionId);
+
+    await postPrompt(serve.baseUrl, sessionId, "start the turn");
+    await waitForReplayContains(serve.baseUrl, sessionId, "working");
+
+    await postPrompt(serve.baseUrl, sessionId, "also check the tests");
+    await waitForReplayContains(serve.baseUrl, sessionId, "agent_busy");
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Sending a message while the agent is working now reaches the turn already running, the way typed-ahead input and `/btw` behave in the `claude` CLI. Previously the daemon refused it outright: the in-flight `ClientCmd::Prompt` arm emitted `PromptRejected { reason: "agent_busy" }` and dropped the content. The web and TUI composers papered over that with a client-side FIFO that drained after `Stopped`, which is queue-after, not course-correction. `aoe acp prompt` and scripted clients had no fallback at all and simply failed.

`claude-agent-acp` shipped the piece that was missing. `_session/steering` injects a message into the running turn at `priority: "now"`, and 0.64.0 added the `_meta.steering.idleBehavior: "promptRequired"` opt-in that makes a steer racing the turn's end safe: the adapter leaves the content untouched and says so, instead of starting a detached turn nobody owns (upstream #903). Because the gate lives in the daemon, every client gets this at once, so the `aoe acp prompt` gap closes with it.

The version floor for steering is a separate constant from `CLAUDE_AGENT_ACP_MIN_VERSION`. That one is a hard startup reject, and raising it to 0.64.0 would force every user to upgrade for an optional capability. Agents that do not advertise steering, including claude below the floor, keep today's rejection and the composer's client-side queue-after, unchanged.

Three implementation details worth calling out for review:

- **The steer goes over the byte relay, not the v2 runner control channel.** No `ControlBody` variant and no control-protocol version bump. Request ids cannot collide (the daemon's crate connection issues UUID strings; the runner issues integers), the relay is the documented path for every RPC outside the runner-owned set, and the adapter, not AoE, adjudicates whether a turn was still running. A v3 bump would have stranded every already-detached v2 runner.
- **One steer outstanding at a time**, with the rest in a backlog, and polled as a `select!` arm rather than awaited inline. Inline would block `Cancel` and `ForceStop` for the whole round trip. Concurrent steers would let two that both race the turn's end resolve out of order and replay the user's messages in the wrong order.
- **No new transcript event.** The prompt handler already publishes `UserPromptSent` before forwarding (`session_service.rs`), so the user's row exists before the connection task sees the command. A steered message needs no event of its own.

A cancel already in flight still wins over steering: that turn is headed for forced termination, so injecting into it would strand the message.

Closes #2805

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

Needs `claude-agent-acp` >= 0.64.0 (`npm i -g @agentclientprotocol/claude-agent-acp@latest`). Steering is off below that, which is itself worth checking.

- [x] Open a structured-view session on Claude, send a prompt that takes a while ("read every file in src/acp and summarise it"), and while it is still working type "actually, just do acp_client.rs" and hit Enter. It sends immediately, no **Queued (1)** strip, and the agent changes course mid-work rather than after finishing.
- [x] During that same turn, hover the send button. The tooltip reads "Send into the current turn", not "sent when current turn ends".
- [x] With a turn running, from another terminal: `aoe acp prompt <session> "also check the tests"`. It is accepted rather than failing, and the text lands in the running turn. This is the case that had no fallback before.
- [x] Repeat the first step in the native TUI structured view. Same behavior, no **Queued (N)** strip.
- [x] Downgrade (`npm i -g @agentclientprotocol/claude-agent-acp@0.63.0`) and repeat the first step. The message parks in the **Queued (1)** strip and drains when the turn ends, exactly as before this PR.
- [x] On a non-Claude agent (codex, gemini, opencode), send mid-turn. Still parks and drains, unchanged.
- [x] Start a turn, hit Stop, then immediately send a follow-up while it is still stopping. The follow-up is rejected with a Retry pill and the worker restarts, unchanged from today.
- [x] Send mid-turn, then reload the page. The transcript shows one user row per message you sent, with no duplicates and no orphaned spinner.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added `web/tests/live/acp-mid-turn-steering.spec.ts`: two live specs differing only in the fake agent's steering switch, so the capability is the single variable. One asserts a mid-turn prompt reaches the running turn and produces no `agent_busy`; the other asserts a non-steerable agent still rejects it. The fake ACP agent gained a `FAKE_ACP_STEERING` mode that advertises the extension, reports a version at the steering floor, and answers `_session/steering` with `injected` or `promptRequired` the way the real adapter does. Matrix entry `acp.mid-turn-steering`.

Also Vitest: the hook's enqueue gate under both capability values, and the reducer carrying the flag (including a wire payload with the key absent, which must not read as capable).

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the CLI path is covered where the behavior actually lives. `aoe acp prompt` is a thin client over `POST /acp/prompt`, which both live specs drive directly, so a live-daemon e2e would spend 10-28s on the serial critical path re-testing the CLI's HTTP client rather than the steering decision. The TUI's park decision is covered by a table test over the pure `should_queue_prompt_for`, extracted for that purpose since a `WsHandle` cannot be constructed in a unit test.

Rust unit tests cover the two things a typo would silently break: the steer wire contract (a wrong `_meta` spelling degrades a racing steer back to `startedNewTurn` with no error to notice) and the outcome mapping, where an unrecognized outcome must fall to "consumed, do not resend".

Validation run locally: `cargo fmt --check`, `cargo clippy --features serve --all-targets`, `cargo test --features serve` (6194 passed), `cargo test --features serve,e2e-tests --test e2e` (171 passed), Vitest (3628 passed), and the full acp live Playwright suite (78 passed).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-investigate` + `/aoe-implement` skills)

**Any Additional AI Details you'd like to share:**

Investigation, plan, and implementation drafted by Claude under my direction. The design was pressure-tested through a `/debate` round with two external models, which changed three things: no self-send on the bounded command channel, one steer in flight instead of concurrent futures, and dropping the `promptQueueing` half of the original scope as redundant once steering lands. I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added mid-turn steering for compatible Claude ACP agents through `_session/steering`.
- Added capability detection and backward-compatible capability reporting.
- Updated web and TUI composers to send prompts during active turns when steering is available.
- Preserved queueing or rejection for unsupported, disconnected, or cancelling sessions.
- Added ordered steering requests and cancellation safeguards.
- Added unit, reducer, wire-contract, and Playwright coverage.

## Benefits

Users can guide an active turn without waiting for it to finish. The daemon, web UI, TUI, CLI, and scripted clients now follow consistent behavior. Unsupported agents retain safe fallback behavior.

## Follow-up considerations

Steering requires Claude ACP version `0.64.0` or newer. Future work could extend steering to more adapters and support broader prompt queueing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->