### PR TITLE
fix(session): never remove a default-branch worktree or delete the branch

### DIFF
--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -130,6 +130,16 @@ On the delete side, aoe runs `git submodule deinit -f --all` before `git worktre
 
 Moving a worktree session to the trash (rather than purging it) relocates its worktree out of the active worktree dir into a sibling `.aoe-trash/<session-id>` holding directory via `git worktree move`, so trashed sessions stop cluttering the active checkouts. The worktree stays a live checkout, so previewing a trashed session still works. Restoring the session moves the worktree back to its original path; if that path is now occupied, the restore is refused so nothing is overwritten. Purging a trashed session removes the worktree from the holding dir. Sessions trashed before this behavior existed are relocated the next time the daemon starts or the TUI loads.
 
+### The default branch's checkout is never removed
+
+A bare-repo layout (git dir at `<project>/.bare`, default branch checked out at `<project>/main`) keeps the default branch in a linked worktree that other tooling expects to stay put. AOE therefore refuses to remove that checkout, refuses to delete the branch, and leaves the checkout where it is when the session is trashed. The refusal is reported as a message and the session is still deleted; only the worktree and branch survive.
+
+Detection uses what git itself states: a bare repo's own `HEAD`, plus every remote's `refs/remotes/<remote>/HEAD`. When neither exists (a repo that never ran `git remote set-head`), local `main` and `master` are protected by convention. A repo that explicitly names some other default leaves a branch merely called `main` deletable.
+
+Force does not bypass this, including the forced trash auto-purge and `aoe session empty-trash`. `aoe worktree cleanup` lists such a checkout as skipped rather than removing it. To remove one anyway, do it with git (`git worktree remove`, `git branch -D`) and then delete the session.
+
+Note that an externally placed `git worktree lock` is not a deletion guard: AOE locks every worktree it creates and unlocks before every intentional remove or move, so it unlocks yours too.
+
 ### Template Variables
 
 | Variable | Description |

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -5,7 +5,7 @@ use clap::Subcommand;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use crate::git::GitWorktree;
+use crate::git::{GitWorktree, WorktreeEntry};
 use crate::session::Storage;
 
 #[derive(Subcommand)]
@@ -153,6 +153,33 @@ async fn show_info(profile: &str, identifier: &str) -> Result<()> {
     Ok(())
 }
 
+/// Split a repo's worktrees into the ones `cleanup` may remove and the ones it
+/// must leave alone, dropping the main worktree and anything a session still
+/// points at.
+///
+/// Having no session normally makes a worktree garbage, but not when it holds a
+/// branch git states is the repo's default: in a bare-repo layout that checkout
+/// is the default branch's only working tree, and cleanup removes with force, so
+/// reaping it would destroy infrastructure the moment its session went away
+/// (#3215).
+fn partition_orphaned_worktrees(
+    worktrees: Vec<WorktreeEntry>,
+    main_repo: &Path,
+    tracked_paths: &HashSet<String>,
+    protected_branches: &HashSet<String>,
+) -> (Vec<WorktreeEntry>, Vec<WorktreeEntry>) {
+    worktrees
+        .into_iter()
+        .filter(|wt| {
+            wt.path != main_repo && !tracked_paths.contains(&wt.path.to_string_lossy().to_string())
+        })
+        .partition(|wt| {
+            !wt.branch
+                .as_ref()
+                .is_some_and(|b| protected_branches.contains(b))
+        })
+}
+
 async fn cleanup_orphaned(profile: &str, force: bool) -> Result<()> {
     let storage = Storage::open_unwatched(profile)?;
     let (instances, _groups) = storage.load_with_groups()?;
@@ -177,27 +204,34 @@ async fn cleanup_orphaned(profile: &str, force: bool) -> Result<()> {
     }
 
     // Find worktrees not associated with any session
+    let mut protected_worktrees = Vec::new();
     let current_dir = std::env::current_dir()?;
     if GitWorktree::is_git_repo(&current_dir) {
         let main_repo = GitWorktree::find_main_repo(&current_dir)?;
         let git_wt = GitWorktree::new(main_repo)?;
         let worktrees = git_wt.list_worktrees()?;
+        let tracked: HashSet<String> = instances
+            .iter()
+            .map(|inst| inst.project_path.clone())
+            .collect();
 
-        for wt in worktrees {
-            let is_main = wt.path == git_wt.repo_path;
-            if is_main {
-                continue;
-            }
+        (orphaned_worktrees, protected_worktrees) = partition_orphaned_worktrees(
+            worktrees,
+            &git_wt.repo_path,
+            &tracked,
+            &git_wt.protected_default_branch_names()?,
+        );
+    }
 
-            let wt_path_str = wt.path.to_string_lossy().to_string();
-            let is_tracked = instances
-                .iter()
-                .any(|inst| inst.project_path == wt_path_str);
-
-            if !is_tracked {
-                orphaned_worktrees.push(wt);
-            }
+    if !protected_worktrees.is_empty() {
+        println!("Skipped (default-branch checkouts, never removed):\n");
+        for wt in &protected_worktrees {
+            let unknown = "(unknown)".to_string();
+            let branch = wt.branch.as_ref().unwrap_or(&unknown);
+            println!("  • {}", wt.path.display());
+            println!("    Branch: {}", branch);
         }
+        println!();
     }
 
     if orphaned_sessions.is_empty() && orphaned_worktrees.is_empty() {
@@ -304,4 +338,48 @@ fn shorten_path(path: &Path) -> String {
         }
     }
     path_str.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(path: &str, branch: Option<&str>) -> WorktreeEntry {
+        WorktreeEntry {
+            path: PathBuf::from(path),
+            branch: branch.map(str::to_string),
+            is_detached: branch.is_none(),
+        }
+    }
+
+    /// #3215: cleanup removes with force, so a default branch's checkout must
+    /// never reach its removal list, however orphaned it looks.
+    #[test]
+    fn partition_orphaned_worktrees_keeps_the_default_branch_out_of_the_removal_list() {
+        let worktrees = vec![
+            entry("/p/.bare", Some("main")),
+            entry("/p/main", Some("main")),
+            entry("/p/wt/tracked", Some("feature/tracked")),
+            entry("/p/wt/orphan", Some("feature/orphan")),
+            entry("/p/wt/detached", None),
+        ];
+        let tracked = HashSet::from(["/p/wt/tracked".to_string()]);
+        let protected = HashSet::from(["main".to_string()]);
+
+        let (removable, kept) =
+            partition_orphaned_worktrees(worktrees, Path::new("/p/.bare"), &tracked, &protected);
+
+        assert_eq!(
+            removable.iter().map(|w| w.path.clone()).collect::<Vec<_>>(),
+            vec![
+                PathBuf::from("/p/wt/orphan"),
+                PathBuf::from("/p/wt/detached"),
+            ],
+            "the main worktree and tracked worktrees drop out; real orphans stay"
+        );
+        assert_eq!(
+            kept.iter().map(|w| w.path.clone()).collect::<Vec<_>>(),
+            vec![PathBuf::from("/p/main")]
+        );
+    }
 }

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -399,6 +399,69 @@ impl GitWorktree {
         best.map(|(name, _)| name)
     }
 
+    /// Branches this repository must never have removed out from under it:
+    /// the ones git itself states are its default. Session teardown refuses to
+    /// remove the worktree holding one of these, and therefore refuses to
+    /// delete the branch (#3215).
+    ///
+    /// Sources, most authoritative first:
+    ///
+    /// 1. A bare repo's own `HEAD` symbolic target. This is the case that
+    ///    matters: a bare-repo layout checks its default branch out as a
+    ///    linked worktree, and `git worktree remove` + `git branch -d` on it
+    ///    leaves `HEAD` pointing at a ref that no longer exists.
+    /// 2. Every remote's `refs/remotes/<remote>/HEAD` symbolic target, which
+    ///    is git's own record of what that remote calls default.
+    /// 3. Local `main` / `master`, but only when 1 and 2 found nothing. A repo
+    ///    that never ran `git remote set-head` has no explicit statement, so
+    ///    fall back to convention rather than protecting nothing.
+    ///
+    /// A non-bare repo's `HEAD` is deliberately NOT a source: it names the
+    /// branch that checkout currently has, not the repo's default, so trusting
+    /// it would protect whichever feature branch the user happens to be on
+    /// while still missing `main`.
+    ///
+    /// This is deliberately not `detect_default_branch_info`. That one picks a
+    /// branch to *base new work on*, so it scores candidates by commit recency
+    /// and falls back to the first local branch when it finds none; as a
+    /// deletion guard those heuristics would refuse to delete ordinary session
+    /// branches.
+    pub fn protected_default_branch_names(&self) -> Result<HashSet<String>> {
+        let repo = open_repo_at(&self.repo_path)?;
+        let mut names = HashSet::new();
+
+        // Symbolic target of `reference`, with `prefix` stripped. `HEAD` points
+        // into `refs/heads/`, a remote's `HEAD` into `refs/remotes/<remote>/`.
+        let symbolic_branch = |reference: &str, prefix: &str| -> Option<String> {
+            let reference = repo.find_reference(reference).ok()?;
+            let target = reference.symbolic_target().ok().flatten()?;
+            target.strip_prefix(prefix).map(str::to_string)
+        };
+
+        if repo.is_bare() {
+            names.extend(symbolic_branch("HEAD", "refs/heads/"));
+        }
+
+        let remotes = repo.remotes()?;
+        for remote in remotes.iter().filter_map(|r| r.ok().flatten()) {
+            names.extend(symbolic_branch(
+                &format!("refs/remotes/{remote}/HEAD"),
+                &format!("refs/remotes/{remote}/"),
+            ));
+        }
+
+        if names.is_empty() {
+            names.extend(
+                ["main", "master"]
+                    .into_iter()
+                    .filter(|b| repo.find_branch(b, git2::BranchType::Local).is_ok())
+                    .map(str::to_string),
+            );
+        }
+
+        Ok(names)
+    }
+
     /// Detect the default branch name by short name only. Wraps
     /// `detect_default_branch_info`; callers that need the remote (for
     /// fetching / building a tracking-ref string) should use the info
@@ -2595,6 +2658,140 @@ mod tests {
             wt_path.join(".git").is_file(),
             "Worktree should have a .git pointer file"
         );
+    }
+
+    /// Build a repo with an exact metadata shape: bare or not, an optional
+    /// `HEAD` target, an optional symbolic `refs/remotes/<r>/HEAD` per remote,
+    /// and a set of local branches. The remote HEADs are written directly
+    /// because only their symbolic target is read; no fetch is needed.
+    fn repo_with_default_metadata(
+        bare: bool,
+        head: Option<&str>,
+        remote_heads: &[(&str, &str)],
+        branches: &[&str],
+    ) -> (TempDir, GitWorktree) {
+        let dir = TempDir::new().unwrap();
+        let repo = if bare {
+            git2::Repository::init_bare(dir.path()).unwrap()
+        } else {
+            git2::Repository::init(dir.path()).unwrap()
+        };
+
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = {
+            let blob = repo.blob(b"hello").unwrap();
+            let mut tb = repo.treebuilder(None).unwrap();
+            tb.insert("file.txt", blob, 0o100644).unwrap();
+            tb.write().unwrap()
+        };
+        let tree = repo.find_tree(tree_id).unwrap();
+        let (first, rest) = branches.split_first().expect("at least one branch");
+        let oid = repo
+            .commit(
+                Some(&format!("refs/heads/{first}")),
+                &sig,
+                &sig,
+                "init",
+                &tree,
+                &[],
+            )
+            .unwrap();
+        let commit = repo.find_commit(oid).unwrap();
+        for branch in rest {
+            repo.branch(branch, &commit, true).unwrap();
+        }
+
+        if let Some(head) = head {
+            repo.set_head(&format!("refs/heads/{head}")).unwrap();
+        }
+        for (remote, branch) in remote_heads {
+            repo.remote(remote, "https://example.invalid/r.git")
+                .unwrap();
+            repo.reference_symbolic(
+                &format!("refs/remotes/{remote}/HEAD"),
+                &format!("refs/remotes/{remote}/{branch}"),
+                true,
+                "test",
+            )
+            .unwrap();
+        }
+
+        let git_wt = GitWorktree::new(dir.path().to_path_buf()).unwrap();
+        (dir, git_wt)
+    }
+
+    /// Authority table for the #3215 deletion guard. Explicit git metadata
+    /// wins; `main` / `master` are convention and apply only when the repo
+    /// states nothing. A non-bare repo's `HEAD` is never a source, since it
+    /// names what that checkout has rather than the repo's default.
+    #[test]
+    fn test_protected_default_branch_names_authority() {
+        // (label, bare, HEAD target, remote HEADs, local branches, expected)
+        let cases: &[(&str, bool, Option<&str>, &[(&str, &str)], &[&str], &[&str])] = &[
+            // The reported layout: bare repo whose HEAD is checked out as a
+            // linked worktree.
+            ("bare HEAD", true, Some("main"), &[], &["main"], &["main"]),
+            // No bare HEAD to consult, so the remote's stated default carries.
+            // Named `develop` so a passing row cannot be the convention
+            // fallback in disguise; `main` exists and stays deletable.
+            (
+                "remote HEAD",
+                false,
+                None,
+                &[("origin", "develop")],
+                &["develop", "main"],
+                &["develop"],
+            ),
+            // `git remote set-head` never ran and the repo is not bare, so
+            // convention is all there is.
+            (
+                "no metadata falls back to convention",
+                false,
+                None,
+                &[],
+                &["main", "master"],
+                &["main", "master"],
+            ),
+            // Explicit `trunk` beats a stale branch that merely happens to be
+            // named `main`, which stays deletable.
+            (
+                "explicit default beats a stale main",
+                true,
+                Some("trunk"),
+                &[],
+                &["trunk", "main"],
+                &["trunk"],
+            ),
+            // Two authorities disagreeing means both are infrastructure.
+            (
+                "bare HEAD and remote HEAD disagree",
+                true,
+                Some("trunk"),
+                &[("origin", "develop")],
+                &["trunk", "develop", "main"],
+                &["trunk", "develop"],
+            ),
+            // Nothing stated and nothing conventional: protect nothing, so an
+            // ordinary session branch is still deletable.
+            (
+                "no metadata and no conventional branch",
+                false,
+                None,
+                &[],
+                &["feature/x"],
+                &[],
+            ),
+        ];
+
+        for (label, bare, head, remote_heads, branches, expected) in cases {
+            let (_dir, git_wt) = repo_with_default_metadata(*bare, *head, remote_heads, branches);
+            let expected: HashSet<String> = expected.iter().map(|s| s.to_string()).collect();
+            assert_eq!(
+                git_wt.protected_default_branch_names().unwrap(),
+                expected,
+                "{label}"
+            );
+        }
     }
 
     // --- detect_default_branch tests ---

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -2726,8 +2726,16 @@ mod tests {
     /// names what that checkout has rather than the repo's default.
     #[test]
     fn test_protected_default_branch_names_authority() {
-        // (label, bare, HEAD target, remote HEADs, local branches, expected)
-        let cases: &[(&str, bool, Option<&str>, &[(&str, &str)], &[&str], &[&str])] = &[
+        // label, bare, HEAD target, remote HEADs, local branches, expected
+        type Case<'a> = (
+            &'a str,
+            bool,
+            Option<&'a str>,
+            &'a [(&'a str, &'a str)],
+            &'a [&'a str],
+            &'a [&'a str],
+        );
+        let cases: &[Case] = &[
             // The reported layout: bare repo whose HEAD is checked out as a
             // linked worktree.
             ("bare HEAD", true, Some("main"), &[], &["main"], &["main"]),

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -62,6 +62,18 @@ fn workspace_dir_is_aoe_owned(ws_info: &crate::session::WorkspaceInfo) -> bool {
     })
 }
 
+/// Whether `branch` is one of the branches git states is `main_repo`'s default,
+/// so its worktree must be preserved (#3215).
+///
+/// A repo aoe cannot open is a repo git cannot remove a worktree from either,
+/// so a failure here is not treated as protection: the removal stage surfaces
+/// its own error exactly as it did before this guard existed.
+fn is_protected_default_branch(main_repo: &Path, branch: &str) -> bool {
+    GitWorktree::new(main_repo.to_path_buf())
+        .and_then(|git| git.protected_default_branch_names())
+        .is_ok_and(|names| names.contains(branch))
+}
+
 pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     perform_deletion_with(request, |session_id| {
         DockerContainer::from_session_id(session_id).teardown(session_id)
@@ -145,25 +157,80 @@ fn perform_deletion_with(
         &[]
     };
 
-    let mut skip_worktree_paths: std::collections::HashSet<PathBuf> =
+    let mut preserved_worktree_paths: std::collections::HashSet<PathBuf> =
         std::collections::HashSet::new();
+
+    // Default-branch guard, deliberately NOT behind the `!force_delete` gate
+    // below. A bare-repo layout checks the repo's default branch out as a
+    // linked worktree, and removing it lets the branch stage delete the branch
+    // and leave the repo's HEAD dangling. Trash auto-purge and `empty-trash`
+    // both pass `force_delete`, so they are the paths that destroy such a
+    // checkout unattended (#3215). Reported as a message rather than an error
+    // so the purge still clears the row; an error would make it retry the same
+    // refusal every hour, forever.
+    if request.delete_worktree {
+        if let Some(wt_info) = &request.instance.worktree_info {
+            if wt_info.managed_by_aoe
+                && is_protected_default_branch(Path::new(&wt_info.main_repo_path), &wt_info.branch)
+            {
+                let path = PathBuf::from(&request.instance.project_path);
+                tracing::warn!(target: "session.delete",
+                    session_id = %request.session_id,
+                    branch = %wt_info.branch,
+                    path = %path.display(),
+                    "perform_deletion: preserving the worktree of a default branch"
+                );
+                messages.push(format!(
+                    "Worktree preserved; '{}' is a default branch of its repository",
+                    wt_info.branch
+                ));
+                preserved_worktree_paths.insert(path);
+            }
+        }
+        for repo in repos.iter().filter(|r| r.managed_by_aoe) {
+            if is_protected_default_branch(Path::new(&repo.main_repo_path), &repo.branch) {
+                tracing::warn!(target: "session.delete",
+                    session_id = %request.session_id,
+                    repo = %repo.name,
+                    branch = %repo.branch,
+                    path = %repo.worktree_path,
+                    "perform_deletion: preserving the worktree of a default branch"
+                );
+                messages.push(format!(
+                    "Workspace ({}) worktree preserved; '{}' is a default branch of its repository",
+                    repo.name, repo.branch
+                ));
+                preserved_worktree_paths.insert(PathBuf::from(&repo.worktree_path));
+            }
+        }
+    }
+
     if request.delete_worktree && !request.force_delete {
         if let Some(wt_info) = &request.instance.worktree_info {
             if wt_info.managed_by_aoe {
                 let path = PathBuf::from(&request.instance.project_path);
-                if let Some(msg) = crate::git::cleanup::dirty_worktree_message(&path) {
-                    tracing::debug!(target: "session.delete",
-                        session_id = %request.session_id,
-                        path = %path.display(),
-                        "perform_deletion: dirty worktree, skipping preclean + host remove"
-                    );
-                    errors.push(format!("Worktree: {}", msg));
-                    skip_worktree_paths.insert(path);
+                // A path the guard above already preserved must not also
+                // report dirty: that error would fail the deletion and strand
+                // the row in the trash, which is what the guard exists to
+                // avoid.
+                if !preserved_worktree_paths.contains(&path) {
+                    if let Some(msg) = crate::git::cleanup::dirty_worktree_message(&path) {
+                        tracing::debug!(target: "session.delete",
+                            session_id = %request.session_id,
+                            path = %path.display(),
+                            "perform_deletion: dirty worktree, skipping preclean + host remove"
+                        );
+                        errors.push(format!("Worktree: {}", msg));
+                        preserved_worktree_paths.insert(path);
+                    }
                 }
             }
         }
         for repo in repos.iter().filter(|r| r.managed_by_aoe) {
             let path = PathBuf::from(&repo.worktree_path);
+            if preserved_worktree_paths.contains(&path) {
+                continue;
+            }
             if let Some(msg) = crate::git::cleanup::dirty_worktree_message(&path) {
                 tracing::debug!(target: "session.delete",
                     session_id = %request.session_id,
@@ -172,13 +239,16 @@ fn perform_deletion_with(
                     "perform_deletion: dirty session repo, skipping preclean + host remove"
                 );
                 errors.push(format!("Workspace ({}): {}", repo.name, msg));
-                skip_worktree_paths.insert(path);
+                preserved_worktree_paths.insert(path);
             }
         }
     }
-    let any_dirty = !skip_worktree_paths.is_empty();
+    // Any preserved worktree, dirty or default-branch, blocks the in-container
+    // preclean and the recursive workspace-dir removal alike: both would reach
+    // through and destroy the contents we just decided to keep.
+    let any_preserved = !preserved_worktree_paths.is_empty();
 
-    if request.delete_worktree && is_sandboxed && !any_dirty {
+    if request.delete_worktree && is_sandboxed && !any_preserved {
         tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "sandbox_worktree_preclean", "perform_deletion: stage");
         // Best-effort. The container's workdir is the session's main
         // worktree (or, for workspace sessions, the workspace root that
@@ -236,7 +306,7 @@ fn perform_deletion_with(
         if let Some(wt_info) = &request.instance.worktree_info {
             if wt_info.managed_by_aoe {
                 let worktree_path = PathBuf::from(&request.instance.project_path);
-                if !skip_worktree_paths.contains(&worktree_path) {
+                if !preserved_worktree_paths.contains(&worktree_path) {
                     let main_repo = PathBuf::from(&wt_info.main_repo_path);
 
                     match GitWorktree::new(main_repo.clone()) {
@@ -279,7 +349,7 @@ fn perform_deletion_with(
                 continue;
             }
             let worktree_path = PathBuf::from(&repo.worktree_path);
-            if skip_worktree_paths.contains(&worktree_path) {
+            if preserved_worktree_paths.contains(&worktree_path) {
                 continue;
             }
             let main_repo = PathBuf::from(&repo.main_repo_path);
@@ -312,15 +382,15 @@ fn perform_deletion_with(
         }
 
         if let Some(ws_info) = &request.instance.workspace_info {
-            // Remove workspace parent directory only when every repo
-            // under it cleared the dirty check; otherwise we'd nuke
-            // the user's uncommitted changes through the back door.
+            // Remove workspace parent directory only when no repo under it was
+            // preserved; otherwise we'd nuke the user's uncommitted changes,
+            // or a default-branch checkout, through the back door.
             //
             // The ownership guard is the second half of that: this is a
             // recursive delete of a path read straight off the session
             // record, so it must prove aoe created that directory rather
             // than trusting the record. See `workspace_dir_is_aoe_owned`.
-            if ws_info.cleanup_on_delete && !any_dirty {
+            if ws_info.cleanup_on_delete && !any_preserved {
                 let ws_path = PathBuf::from(&ws_info.workspace_dir);
                 if !workspace_dir_is_aoe_owned(ws_info) {
                     tracing::warn!(target: "session.delete",
@@ -1130,6 +1200,108 @@ mod tests {
                     .is_empty(),
                 "branch should be deleted: stdout={}",
                 String::from_utf8_lossy(&branches_out.stdout)
+            );
+        }
+
+        /// Regression for #3215, in the shape that loses the most: the
+        /// bare-repo layout, where the repo's default branch is checked out as
+        /// a linked worktree that sibling tooling expects to stay put. Deleting
+        /// the session used to remove that checkout and then delete the branch,
+        /// leaving the bare repo's HEAD pointing at a ref that no longer
+        /// existed. `force_delete` is set because that is what trash
+        /// auto-purge and `empty-trash` pass, and it used to bypass every
+        /// existing protection.
+        #[test]
+        fn default_branch_worktree_survives_a_forced_delete() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let bare = tmp.path().join("project/.bare");
+            let worktree_path = tmp.path().join("project/main");
+            std::fs::create_dir_all(&bare).unwrap();
+
+            let repo = git2::Repository::init_bare(&bare).unwrap();
+            let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+            let tree_id = {
+                let blob = repo.blob(b"hello").unwrap();
+                let mut tb = repo.treebuilder(None).unwrap();
+                tb.insert("file.txt", blob, 0o100644).unwrap();
+                tb.write().unwrap()
+            };
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("refs/heads/main"), &sig, &sig, "init", &tree, &[])
+                .unwrap();
+            repo.set_head("refs/heads/main").unwrap();
+
+            let out = std::process::Command::new("git")
+                .args(["worktree", "add", worktree_path.to_str().unwrap(), "main"])
+                .current_dir(&bare)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git worktree add failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            assert!(worktree_path.exists());
+
+            let mut instance = Instance::new("Infra", worktree_path.to_str().unwrap());
+            instance.worktree_info = Some(crate::session::WorktreeInfo {
+                branch: "main".to_string(),
+                main_repo_path: bare.to_string_lossy().to_string(),
+                managed_by_aoe: true,
+                created_at: chrono::Utc::now(),
+                base_branch: None,
+            });
+
+            let result = perform_deletion(&DeletionRequest {
+                session_id: instance.id.clone(),
+                instance,
+                delete_worktree: true,
+                delete_branch: true,
+                delete_sandbox: false,
+                force_delete: true,
+                detach_hooks: true,
+                keep_scratch: false,
+            });
+
+            // Success matters as much as the preservation: a failure would keep
+            // the row, and auto-purge would retry the same refusal every hour.
+            assert!(
+                result.success,
+                "deletion must still succeed: {:?}",
+                result.errors
+            );
+            assert!(
+                result
+                    .messages
+                    .iter()
+                    .any(|m| m.contains("default branch of its repository")),
+                "preservation must be reported: {:?}",
+                result.messages
+            );
+            assert!(
+                worktree_path.exists(),
+                "the default branch's checkout must survive"
+            );
+
+            let branches = std::process::Command::new("git")
+                .args(["branch", "--list", "main"])
+                .current_dir(&bare)
+                .output()
+                .unwrap();
+            assert!(
+                !String::from_utf8_lossy(&branches.stdout).trim().is_empty(),
+                "the default branch itself must survive"
+            );
+
+            let head = std::process::Command::new("git")
+                .args(["symbolic-ref", "HEAD"])
+                .current_dir(&bare)
+                .output()
+                .unwrap();
+            assert_eq!(
+                String::from_utf8_lossy(&head.stdout).trim(),
+                "refs/heads/main",
+                "the bare repo's HEAD must still resolve"
             );
         }
 

--- a/src/session/trash.rs
+++ b/src/session/trash.rs
@@ -87,6 +87,18 @@ fn is_managed_single_worktree(inst: &Instance) -> bool {
             .is_some_and(|w| w.managed_by_aoe)
 }
 
+/// Whether the session's branch is one git states is the repo's default, so its
+/// checkout must be left where it is (#3215). Only meaningful for a managed
+/// single-repo worktree, which every caller has already established.
+fn is_protected_default_branch(inst: &Instance) -> bool {
+    let Some(wt) = inst.worktree_info.as_ref() else {
+        return false;
+    };
+    GitWorktree::new(PathBuf::from(&wt.main_repo_path))
+        .and_then(|git| git.protected_default_branch_names())
+        .is_ok_and(|names| names.contains(&wt.branch))
+}
+
 fn is_sandboxed(inst: &Instance) -> bool {
     inst.sandbox_info.as_ref().is_some_and(|s| s.enabled)
 }
@@ -103,6 +115,21 @@ pub fn relocate_worktree_to_trash(inst: &mut Instance) -> RelocateOutcome {
         return RelocateOutcome::Skipped;
     }
     if inst.pre_trash_project_path.is_some() {
+        return RelocateOutcome::Skipped;
+    }
+    // A default branch's checkout is infrastructure: sibling tooling expects
+    // `<project>/main` to stay where it is, so moving it into the holding area
+    // breaks that layout even though the move is reversible. Leaving it in place
+    // also keeps the purge from stranding it in `.aoe-trash` forever, since the
+    // purge now refuses to remove it (#3215). Skipped, not Failed: this is the
+    // intended outcome, not a move that could not run.
+    if is_protected_default_branch(inst) {
+        tracing::info!(
+            target: "session.trash",
+            session = %inst.id,
+            path = %inst.project_path,
+            "leaving a default branch's checkout in place instead of relocating it"
+        );
         return RelocateOutcome::Skipped;
     }
 
@@ -458,6 +485,29 @@ pub fn reconcile_trashed_location(inst: &mut Instance) -> bool {
     if !inst.is_trashed() || !is_managed_single_worktree(inst) {
         return false;
     }
+
+    // Upgrade path for #3215: a default branch's checkout that an earlier
+    // version relocated is still sitting in the holding area, and the purge now
+    // refuses to remove it, so clearing the row would leave that checkout there
+    // with nothing pointing at it. Move it back instead. Strict like every
+    // restore: an occupied original leaves the row untouched.
+    if inst.pre_trash_project_path.is_some() && is_protected_default_branch(inst) {
+        return match restore_worktree_location(inst) {
+            RestoreOutcome::Restored { .. } => true,
+            // The marker was set but nothing had actually moved, so restore
+            // dropped it. That is still a mutation worth persisting.
+            RestoreOutcome::NoChange => inst.pre_trash_project_path.is_none(),
+            RestoreOutcome::Failed { reason } => {
+                tracing::warn!(
+                    target: "session.trash",
+                    session = %inst.id,
+                    "could not move a default branch's checkout back out of the holding area: {reason}"
+                );
+                false
+            }
+        };
+    }
+
     let current = PathBuf::from(&inst.project_path);
     // The pre-trash location: the recorded marker if we have one, else the
     // current path (an un-relocated legacy row points at its own original).
@@ -682,6 +732,123 @@ mod tests {
             base_branch: None,
         });
         (tmp, inst)
+    }
+
+    /// The layout #3215 reports: a bare repo whose default branch is checked out
+    /// as a linked worktree at `<project>/main`, which sibling tooling expects
+    /// to stay exactly there.
+    fn default_branch_worktree_instance() -> (tempfile::TempDir, Instance) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let bare = tmp.path().join("project").join(".bare");
+        let worktree_path = tmp.path().join("project").join("main");
+        std::fs::create_dir_all(&bare).unwrap();
+
+        let repo = git2::Repository::init_bare(&bare).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = {
+            let blob = repo.blob(b"hello").unwrap();
+            let mut tb = repo.treebuilder(None).unwrap();
+            tb.insert("file.txt", blob, 0o100644).unwrap();
+            tb.write().unwrap()
+        };
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("refs/heads/main"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+        repo.set_head("refs/heads/main").unwrap();
+
+        let out = std::process::Command::new("git")
+            .args(["worktree", "add", worktree_path.to_str().unwrap(), "main"])
+            .current_dir(&bare)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let mut inst = Instance::new("Infra", worktree_path.to_str().unwrap());
+        inst.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "main".to_string(),
+            main_repo_path: bare.to_string_lossy().to_string(),
+            managed_by_aoe: true,
+            created_at: Utc::now(),
+            base_branch: None,
+        });
+        (tmp, inst)
+    }
+
+    /// #3215: trashing must not move a default branch's checkout. Relocation is
+    /// reversible, but it still breaks a layout that expects `<project>/main` to
+    /// exist, and the purge now refuses to remove the checkout, so a relocated
+    /// one would sit in the holding area forever.
+    #[test]
+    fn relocate_leaves_a_default_branch_checkout_in_place() {
+        if !git_available() {
+            return;
+        }
+        let (_tmp, mut inst) = default_branch_worktree_instance();
+        let original = inst.project_path.clone();
+        inst.trash();
+
+        let out = relocate_worktree_to_trash(&mut inst);
+        assert!(
+            matches!(out, RelocateOutcome::Skipped),
+            "expected the relocation to be skipped, got {out:?}"
+        );
+        assert_eq!(inst.project_path, original);
+        assert!(inst.pre_trash_project_path.is_none());
+        assert!(PathBuf::from(&original).exists());
+    }
+
+    /// Upgrade path for #3215: a row relocated by an earlier version. The purge
+    /// now preserves the checkout, so leaving it in the holding area would
+    /// orphan it once the row is cleared. Reconciliation moves it back.
+    #[test]
+    fn reconcile_moves_a_relocated_default_branch_checkout_back() {
+        if !git_available() {
+            return;
+        }
+        let (_tmp, mut inst) = default_branch_worktree_instance();
+        let original = PathBuf::from(&inst.project_path);
+        inst.trash();
+
+        // Reproduce what the previous version left behind: the worktree moved
+        // into the holding area with the marker recorded.
+        let holding = trash_holding_path(&original, &inst.id).unwrap();
+        std::fs::create_dir_all(holding.parent().unwrap()).unwrap();
+        let bare = inst.worktree_info.as_ref().unwrap().main_repo_path.clone();
+        let out = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "move",
+                original.to_str().unwrap(),
+                holding.to_str().unwrap(),
+            ])
+            .current_dir(&bare)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git worktree move failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        inst.pre_trash_project_path = Some(original.to_string_lossy().into_owned());
+        inst.project_path = holding.to_string_lossy().into_owned();
+
+        assert!(
+            reconcile_trashed_location(&mut inst),
+            "reconcile must move the checkout back and report the mutation"
+        );
+        assert_eq!(PathBuf::from(&inst.project_path), original);
+        assert!(inst.pre_trash_project_path.is_none());
+        assert!(original.exists());
+        assert!(!holding.exists());
+
+        assert!(
+            !reconcile_trashed_location(&mut inst),
+            "reconcile must be idempotent once the checkout is back"
+        );
     }
 
     fn git_available() -> bool {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Every session-deletion path could remove the git worktree holding the repository's default branch and then delete that branch. In a bare-repo layout (git dir at `<project>/.bare`, default branch checked out at `<project>/main` as a linked worktree) that destroys permanent infrastructure and leaves the bare repo's `HEAD` pointing at a ref that no longer exists.

`perform_deletion` gated worktree removal on `managed_by_aoe` alone, and it is the chokepoint for all seven delete paths. The dirty-working-tree skip set was only built when `!force_delete`, so trash auto-purge and `aoe session empty-trash` bypassed the one protection that existed and took uncommitted work with them. The existing safety mechanisms did not help either: AOE unlocks every worktree before removing it, so an externally placed `git worktree lock` is not a guard.

The guard is metadata-only and deliberately conservative, because as a deletion policy a wrong guess is expensive in both directions. It protects a bare repo's own `HEAD`, plus every remote's `refs/remotes/<remote>/HEAD`, and falls back to local `main` / `master` only when neither exists. A non-bare repo's `HEAD` is excluded on purpose: it names whatever that checkout currently has, not the repo's default, so trusting it would protect the user's current feature branch while still missing `main`. The existing `detect_default_branch_info` is not reused, since it picks a branch to base new work on and so scores candidates by commit recency and falls back to the first local branch; used as a guard, those heuristics would refuse to delete ordinary session branches.

Four call sites, not one:

- **Deletion** preserves the worktree, and branch preservation follows from the existing gate that only deletes a branch whose worktree was actually removed (#2532). The refusal is a message, not an error, so the purge still clears the row; an error would make auto-purge retry the same refusal every hour forever and strand the session in the trash. Protected paths join the same set dirty worktrees use, which is what suppresses the in-container `find -delete` preclean and the recursive workspace-dir removal.
- **Trashing** leaves the checkout in place instead of relocating it into `.aoe-trash/<id>`, which broke a layout expecting `<project>/main` to exist and would now strand the checkout in the holding area forever.
- **Reconciliation** moves a checkout that an earlier version already relocated back out of the holding area, so the fix does not convert a recoverable trash row into an orphan on upgrade. It reuses the existing strict restore, so an occupied original leaves the row untouched.
- **`aoe worktree cleanup --force`** treated any worktree with no live session as garbage and removed it with force, so `<project>/main` qualified the moment its session went away. Protected checkouts are now listed as skipped rather than refused outright, since the command still has real orphans to reap.

Reachable without the bare-repo layout too: `aoe add --worktree main` creates a worktree on a pre-existing `main` with `managed_by_aoe: true`, and `WorktreeInfo` has no `branch_preexisting` field, so that branch was treated as AOE's to delete.

Left out on purpose, and worth separate issues: the override flag the issue proposes (with the narrow authority above, the only false-positive source left is the no-metadata `main`/`master` fallback, and the escape hatch is `git worktree remove` plus `git branch -D` then delete the session); `branch_preexisting` on primary `WorktreeInfo`, which needs a tri-state origin and a migration to be correct for existing rows; a per-session `protected` flag; and hardening the workspace-dir `remove_dir_all` against unmanaged descendants.

Closes #3215

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

Set up the reported layout once:

```bash
mkdir -p /tmp/proj && cd /tmp/proj
git init --bare .bare && git --git-dir=.bare symbolic-ref HEAD refs/heads/main
git --git-dir=.bare worktree add /tmp/proj/main main 2>/dev/null \
  || (cd .bare && git commit-tree $(git hash-object -w -t tree /dev/null) -m init | xargs -I{} git update-ref refs/heads/main {} && git worktree add /tmp/proj/main main)
aoe add /tmp/proj/main --cmd claude
```

Then, with `worktree.delete_branch_on_cleanup = true` in your config:

- [ ] Delete that session from the TUI with `d`, cleanup checked. `/tmp/proj/main` still exists, `git --git-dir=/tmp/proj/.bare branch --list main` still prints `main`, and `git --git-dir=/tmp/proj/.bare symbolic-ref HEAD` still resolves. The delete reports "Worktree preserved; 'main' is a default branch of its repository" and the session is gone.
- [ ] Repeat via the web dashboard's `DELETE /api/sessions/{id}` and confirm the same.
- [ ] `aoe rm <session>` (trash, not purge). `/tmp/proj/main` stays exactly where it is; nothing appears under `/tmp/proj/.aoe-trash/`.
- [ ] With the session trashed, run `aoe session empty-trash`. The row leaves the trash, and the checkout plus branch survive.
- [ ] Simulate the upgrade path: `git --git-dir=/tmp/proj/.bare worktree move /tmp/proj/main /tmp/proj/.aoe-trash/<session-id>` on a trashed session, then start the daemon or open the TUI. The checkout moves back to `/tmp/proj/main`.
- [ ] Delete the session, then run `aoe worktree cleanup --force` from `/tmp/proj/main`. It lists `/tmp/proj/main` under "Skipped (default-branch checkouts, never removed)" and does not remove it.
- [ ] Create an ordinary session on a feature branch and delete it with cleanup and branch deletion. The worktree and branch are removed exactly as before, so the guard has not made normal cleanup sticky.
- [ ] In a repo whose `origin/HEAD` names something other than `main` (`git remote set-head origin develop`), a session on a stale `main` is still fully deletable.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the guard lives at the shared chokepoints, and each is covered by a test at the cheapest tier that can actually fail if it breaks. `session::deletion` builds a real bare repo plus linked `main` worktree and asserts a forced delete preserves both and still succeeds; `session::trash` covers relocation and the already-relocated upgrade path; `cli::worktree` covers the orphan split. All four are verified red on the pre-fix tree. An e2e would drive the same functions through tmux for ~2s of permanent serial CI time without being able to fail where these cannot.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. The plan went through a two-model debate, which is what killed the original authority rule (a non-bare repo's `HEAD` is not a statement about the default branch) and surfaced the `aoe worktree cleanup` hole. I made the design calls, including dropping the override flag and keeping the refusal a message rather than an error, reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Protects default-branch worktrees from deletion, trashing, reconciliation, and forced cleanup.
- Detects protected branches from repository metadata, remote `HEAD` references, or `main`/`master` fallback.
- Preserves protected worktrees while still removing related sessions and trash records.
- Restores default-branch worktrees moved by older versions when possible.
- Adds documentation and tests for bare repositories, deletion flows, cleanup, reconciliation, and feature-branch removal.

## Benefits

This prevents AoE from deleting critical default branches or worktrees. It also keeps cleanup safe while preserving normal feature-branch cleanup behavior.

## Potential Enhancement

Future changes could add more coverage for unusual Git reference layouts and restoration failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->