### PR TITLE
fix(tui): let a real repo named "scratch" be pinned in project view

### DIFF
--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -723,7 +723,10 @@ pub static BINDINGS: &[Binding] = &[
     // Pin toggle shares `p` (Shift+P in strict) with Projects, but only fires
     // when a project header is selected, so it must precede the Projects
     // binding. On a project header `p` pins/unpins; everywhere else `p` still
-    // opens the projects dialog.
+    // opens the projects dialog. The help desc names that gate ("group header
+    // only", the same idiom the Attention section uses) because the `?` overlay
+    // has no notion of context and lists both `p` rows unconditionally, which
+    // is what made the shared key look ambiguous in #3133.
     Binding {
         id: ActionId::ToggleProjectPin,
         non_strict: &[k('p')],
@@ -731,7 +734,7 @@ pub static BINDINGS: &[Binding] = &[
         context: Context::ProjectGroupSelected,
         help: Some(HelpMeta {
             section: HelpSection::Actions,
-            desc: "Pin/unpin project (keep without sessions)",
+            desc: "Pin/unpin project (group header only)",
         }),
         palette: None,
     },
@@ -1368,5 +1371,37 @@ mod tests {
         assert_eq!(label(ActionId::Restart, false), "e");
         // NextWaiting has no strict binding.
         assert_eq!(label(ActionId::NextWaiting, true), "");
+    }
+
+    /// The `?` overlay renders one row per help-listed binding and never
+    /// consults `Context`, so two bindings sharing a chord show the same key
+    /// twice (#3133: `p` for the pin toggle and `p` for the projects dialog).
+    /// The convention that keeps that readable is that the guarded one states
+    /// when it applies. Enforced here rather than by asserting a desc string,
+    /// so it also catches a future guarded binding added onto a shared chord.
+    #[test]
+    fn shared_help_chords_document_their_guard() {
+        // A qualifier the desc can use to say when the guarded action fires.
+        let qualifies = |d: &str| ["only", "when ", "selected"].iter().any(|q| d.contains(q));
+        for strict in [false, true] {
+            let rows: Vec<(String, Context, &str)> = BINDINGS
+                .iter()
+                .filter_map(|b| {
+                    let help = b.help.as_ref()?;
+                    let l = label(b.id, strict);
+                    (!l.is_empty()).then_some((l, b.context, help.desc))
+                })
+                .collect();
+            for (l, context, desc) in &rows {
+                let shared = rows.iter().filter(|(other, ..)| other == l).count() > 1;
+                if shared && *context != Context::Always {
+                    assert!(
+                        qualifies(desc),
+                        "strict={strict}: {l:?} is shared, so the {context:?} row \
+                         must say when it applies, got {desc:?}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -6841,16 +6841,20 @@ impl HomeView {
     /// bucket, so there is no repo behind it to register or pin. Judged by
     /// backing identity rather than by the label: scratch sessions and a user's
     /// own repo named `scratch` derive the same header label, and that header is
-    /// a real project (#3133). A registry entry carrying the label also counts as
-    /// backing, so an empty pinned `scratch` project stays unpinnable-by-mistake
-    /// but reachable to unpin.
+    /// a real project (#3133). A PINNED registry entry carrying the label also
+    /// counts as backing, so an empty pinned `scratch` project stays reachable to
+    /// unpin. The pin flag is required because it is what `unpopulated_projects`
+    /// and `is_project_label_pinned`'s label branch key on: a saved-but-unpinned
+    /// entry never surfaces a header of its own, so counting it as backing would
+    /// open the gate on a header the toggle has no path to act on, and `p` would
+    /// silently do nothing instead of keeping its global meaning.
     fn is_synthetic_scratch_header(&self, label: &str) -> bool {
         label == SCRATCH_GROUP_LABEL
             && self.project_header_repo_path(label).is_none()
             && !self
                 .registered_projects
                 .iter()
-                .any(|p| crate::session::projects::repo_label(&p.path) == label)
+                .any(|p| p.pinned && crate::session::projects::repo_label(&p.path) == label)
     }
 
     /// The project-view header label under the cursor when it is a real,

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -6847,14 +6847,13 @@ impl HomeView {
     /// and `is_project_label_pinned`'s label branch key on: a saved-but-unpinned
     /// entry never surfaces a header of its own, so counting it as backing would
     /// open the gate on a header the toggle has no path to act on, and `p` would
-    /// silently do nothing instead of keeping its global meaning.
+    /// silently do nothing instead of keeping its global meaning. With no
+    /// backing repo path, `is_project_label_pinned` IS that pinned-label
+    /// lookup, so it is reused here rather than restating the predicate.
     fn is_synthetic_scratch_header(&self, label: &str) -> bool {
         label == SCRATCH_GROUP_LABEL
             && self.project_header_repo_path(label).is_none()
-            && !self
-                .registered_projects
-                .iter()
-                .any(|p| p.pinned && crate::session::projects::repo_label(&p.path) == label)
+            && !self.is_project_label_pinned(label)
     }
 
     /// The project-view header label under the cursor when it is a real,

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -48,6 +48,12 @@ use super::settings::SettingsView;
 use super::status_poller::{StatusPoller, StatusUpdate};
 use super::stop_poller::StopPoller;
 
+/// Header label the synthetic scratch bucket renders under in project view.
+/// Not an identity: a user's own repo whose basename happens to be `scratch`
+/// derives the same label from its path, so anything deciding whether a header
+/// has a backing repo must test the repo path, not this string (#3133).
+const SCRATCH_GROUP_LABEL: &str = "scratch";
+
 /// Extract a project group name from a session instance.
 /// Uses `worktree_info.main_repo_path` for worktree sessions (so all branches of the
 /// same repo group together), otherwise uses `project_path`. Returns the last path segment.
@@ -55,7 +61,7 @@ fn project_group_name(inst: &Instance) -> String {
     // Scratch sessions live under `<app_dir>/scratch/<instance-id>/`, so the last
     // path segment is the opaque instance id. Group them under a readable label.
     if inst.scratch {
-        return "scratch".to_string();
+        return SCRATCH_GROUP_LABEL.to_string();
     }
 
     crate::session::projects::repo_label(inst.repo_path())
@@ -6796,10 +6802,16 @@ impl HomeView {
     /// recorded path (repo deleted or moved, so `canonical_key` compares raw
     /// strings) render an unpinnable phantom header: pinned by label, judged
     /// by path.
+    ///
+    /// Scratch sessions are excluded for the same reason: their `repo_path()` is
+    /// the throwaway `<app_dir>/scratch/<id>` directory, not a repo anyone can
+    /// register. They share the `scratch` header with a user repo of that
+    /// basename (#3133), so letting one lend the header its path would both hide
+    /// the real repo and offer an app-internal directory up for pinning.
     pub(super) fn project_header_repo_path(&self, label: &str) -> Option<String> {
         self.instances
             .values()
-            .find(|i| !i.is_archived() && project_group_name(i) == label)
+            .find(|i| !i.is_archived() && !i.scratch && project_group_name(i) == label)
             .map(|i| crate::session::projects::canonical_key(i.repo_path()))
     }
 
@@ -6825,10 +6837,26 @@ impl HomeView {
         }
     }
 
+    /// True when project header `label` is nothing but the synthetic scratch
+    /// bucket, so there is no repo behind it to register or pin. Judged by
+    /// backing identity rather than by the label: scratch sessions and a user's
+    /// own repo named `scratch` derive the same header label, and that header is
+    /// a real project (#3133). A registry entry carrying the label also counts as
+    /// backing, so an empty pinned `scratch` project stays unpinnable-by-mistake
+    /// but reachable to unpin.
+    fn is_synthetic_scratch_header(&self, label: &str) -> bool {
+        label == SCRATCH_GROUP_LABEL
+            && self.project_header_repo_path(label).is_none()
+            && !self
+                .registered_projects
+                .iter()
+                .any(|p| crate::session::projects::repo_label(&p.path) == label)
+    }
+
     /// The project-view header label under the cursor when it is a real,
     /// pinnable project: project grouping is active, the cursor is on a group
-    /// header, and that header is neither the synthetic Archived section nor
-    /// the `scratch` bucket (scratch sessions have no backing repo to pin).
+    /// header, and that header is neither the synthetic Archived section nor the
+    /// synthetic `scratch` bucket (scratch sessions have no backing repo to pin).
     pub(super) fn project_group_at_cursor(&self) -> Option<String> {
         if self.group_by != GroupByMode::Project {
             return None;
@@ -6837,7 +6865,7 @@ impl HomeView {
             Some(Item::Group { path, name, .. })
                 if !crate::session::is_within_archived_section(path)
                     && !crate::session::is_within_trash_section(path)
-                    && name != "scratch" =>
+                    && !self.is_synthetic_scratch_header(name) =>
             {
                 Some(name.clone())
             }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -10105,6 +10105,107 @@ fn p_key_opens_projects_dialog_off_project_header() {
     );
 }
 
+/// A user's own repo whose basename is `scratch` must be pinnable, while the
+/// synthetic scratch bucket (sessions with no repo, living under
+/// `<app_dir>/scratch/<id>`) stays excluded. The gate used to reject the header
+/// by its display LABEL, which collapsed both cases together and left `p` on a
+/// real `~/scratch` repo falling through to the Projects dialog. See #3133.
+#[test]
+#[serial]
+fn scratch_label_pin_gate_keys_on_backing_repo_not_label() {
+    use crate::session::config::GroupByMode;
+    use crate::session::projects::canonical_key;
+
+    // (case, has a real repo named `scratch`, has a synthetic scratch session,
+    //  header is pinnable)
+    let cases = [
+        // The reporter's setup: a plain repo at `~/scratch`, no scratch sessions.
+        ("real repo only", true, false, true),
+        // Nothing but the synthetic bucket: no repo exists to register.
+        ("synthetic bucket only", false, true, false),
+        // Both derive the same label and so share one header today. The real
+        // repo backs it, so the header is pinnable and the pin must resolve to
+        // that repo rather than the app-internal scratch directory.
+        ("real repo plus scratch session", true, true, true),
+    ];
+
+    for (case, has_repo, has_scratch, pinnable) in cases {
+        let temp = TempDir::new().unwrap();
+        let _guard = setup_test_home(&temp);
+        let storage = Storage::new_unwatched("test").unwrap();
+
+        let mut instances = Vec::new();
+        if has_repo {
+            instances.push(Instance::new("work", "/repos/scratch"));
+        }
+        if has_scratch {
+            let mut throwaway = Instance::new("throwaway", "/app-dir/scratch/abc123");
+            throwaway.scratch = true;
+            instances.push(throwaway);
+        }
+        storage
+            .update(|i, g| {
+                *i = instances.to_vec();
+                *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+                Ok(())
+            })
+            .unwrap();
+
+        let mut view = HomeView::new(
+            Some("test".to_string()),
+            AvailableTools::with_tools(&["claude"]),
+            crate::file_watch::FileWatchService::noop(),
+        )
+        .unwrap();
+        view.group_by = GroupByMode::Project;
+        view.flat_items = view.build_flat_items();
+
+        let idx = view
+            .flat_items
+            .iter()
+            .position(|i| matches!(i, Item::Group { name, .. } if name == "scratch"))
+            .unwrap_or_else(|| panic!("{case}: scratch header must be present"));
+        view.cursor = idx;
+        view.update_selected();
+
+        assert_eq!(
+            view.project_group_at_cursor().is_some(),
+            pinnable,
+            "{case}: pin gate"
+        );
+
+        view.handle_key(key(KeyCode::Char('p')), None);
+
+        assert_eq!(
+            view.is_project_label_pinned("scratch"),
+            pinnable,
+            "{case}: pin state after pressing p"
+        );
+        // The chord is shared: when the header is not pinnable, `p` keeps its
+        // global meaning and opens the Projects dialog instead.
+        assert_eq!(
+            view.projects_dialog.is_some(),
+            !pinnable,
+            "{case}: projects dialog fallthrough"
+        );
+
+        let registered = crate::session::projects::load_global().unwrap();
+        if pinnable {
+            assert_eq!(registered.len(), 1, "{case}: one registry entry");
+            assert_eq!(
+                canonical_key(&registered[0].path),
+                canonical_key("/repos/scratch"),
+                "{case}: the pin must target the real repo, not the app scratch dir"
+            );
+        } else {
+            assert!(
+                registered.is_empty(),
+                "{case}: the synthetic bucket must not register anything, got {registered:?}"
+            );
+        }
+    }
+}
+
 /// Pin a project, archive its only session, then unpin: the empty header must
 /// leave the main flow (the archived session stays under the Archived section).
 #[test]

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -10117,19 +10117,50 @@ fn scratch_label_pin_gate_keys_on_backing_repo_not_label() {
     use crate::session::projects::canonical_key;
 
     // (case, has a real repo named `scratch`, has a synthetic scratch session,
-    //  header is pinnable)
+    //  a pre-existing registry entry for `/repos/scratch` and its pin flag,
+    //  the pin gate opens on the header, the header is pinned after `p`)
     let cases = [
         // The reporter's setup: a plain repo at `~/scratch`, no scratch sessions.
-        ("real repo only", true, false, true),
+        ("real repo only", true, false, None, true, true),
         // Nothing but the synthetic bucket: no repo exists to register.
-        ("synthetic bucket only", false, true, false),
+        ("synthetic bucket only", false, true, None, false, false),
         // Both derive the same label and so share one header today. The real
         // repo backs it, so the header is pinnable and the pin must resolve to
         // that repo rather than the app-internal scratch directory.
-        ("real repo plus scratch session", true, true, true),
+        (
+            "real repo plus scratch session",
+            true,
+            true,
+            None,
+            true,
+            true,
+        ),
+        // A saved-but-unpinned repo named `scratch` surfaces no header of its
+        // own, so the synthetic bucket is the only thing rendering this one and
+        // the toggle has no path to act on. `p` must keep its global meaning
+        // rather than resolve to a pin that silently does nothing.
+        (
+            "saved unpinned repo plus scratch session",
+            false,
+            true,
+            Some(false),
+            false,
+            false,
+        ),
+        // A pinned registry entry backs the header even with no live session of
+        // its own, so `p` must reach the unpin path instead of being swallowed
+        // as the synthetic bucket.
+        (
+            "pinned empty repo plus scratch session",
+            false,
+            true,
+            Some(true),
+            true,
+            false,
+        ),
     ];
 
-    for (case, has_repo, has_scratch, pinnable) in cases {
+    for (case, has_repo, has_scratch, saved, gate_open, pinned_after) in cases {
         let temp = TempDir::new().unwrap();
         let _guard = setup_test_home(&temp);
         let storage = Storage::new_unwatched("test").unwrap();
@@ -10151,6 +10182,21 @@ fn scratch_label_pin_gate_keys_on_backing_repo_not_label() {
             })
             .unwrap();
 
+        if let Some(pinned) = saved {
+            crate::session::projects::add(
+                "test",
+                crate::session::ProjectScope::Global,
+                crate::session::Project::new(
+                    "scratch",
+                    "/repos/scratch",
+                    crate::session::ProjectScope::Global,
+                )
+                .with_pinned(pinned),
+                false,
+            )
+            .unwrap();
+        }
+
         let mut view = HomeView::new(
             Some("test".to_string()),
             AvailableTools::with_tools(&["claude"]),
@@ -10170,7 +10216,7 @@ fn scratch_label_pin_gate_keys_on_backing_repo_not_label() {
 
         assert_eq!(
             view.project_group_at_cursor().is_some(),
-            pinnable,
+            gate_open,
             "{case}: pin gate"
         );
 
@@ -10178,29 +10224,34 @@ fn scratch_label_pin_gate_keys_on_backing_repo_not_label() {
 
         assert_eq!(
             view.is_project_label_pinned("scratch"),
-            pinnable,
+            pinned_after,
             "{case}: pin state after pressing p"
         );
-        // The chord is shared: when the header is not pinnable, `p` keeps its
-        // global meaning and opens the Projects dialog instead.
+        // The chord is shared: when the gate is closed, `p` keeps its global
+        // meaning and opens the Projects dialog instead.
         assert_eq!(
             view.projects_dialog.is_some(),
-            !pinnable,
+            !gate_open,
             "{case}: projects dialog fallthrough"
         );
 
+        // A registry entry exists iff one was seeded or the toggle created one;
+        // the synthetic bucket on its own must never register anything.
         let registered = crate::session::projects::load_global().unwrap();
-        if pinnable {
-            assert_eq!(registered.len(), 1, "{case}: one registry entry");
+        assert_eq!(
+            registered.len(),
+            usize::from(gate_open || saved.is_some()),
+            "{case}: registry entries, got {registered:?}"
+        );
+        if let Some(entry) = registered.first() {
             assert_eq!(
-                canonical_key(&registered[0].path),
+                canonical_key(&entry.path),
                 canonical_key("/repos/scratch"),
                 "{case}: the pin must target the real repo, not the app scratch dir"
             );
-        } else {
-            assert!(
-                registered.is_empty(),
-                "{case}: the synthetic bucket must not register anything, got {registered:?}"
+            assert_eq!(
+                entry.pinned, pinned_after,
+                "{case}: registry pin flag must track the header, got {registered:?}"
             );
         }
     }


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Fixes #3133.

**What was wrong.** The project-header pin gate refused any header whose *display label* was `scratch`:

```rust
Some(Item::Group { path, name, .. })
    if !crate::session::is_within_archived_section(path)
        && !crate::session::is_within_trash_section(path)
        && name != "scratch" =>
```

That correctly excludes AoE's synthetic scratch bucket, whose sessions live in throwaway `<app_dir>/scratch/<id>` directories with no repo to register. But a user's own repo at `~/scratch` derives the same label from its basename via `repo_label(path)`, so their genuine git repo was refused too. That is the reporter's setup: a real `scratch` directory they use the way AoE uses `Ctrl+T`, and the one project header they could not pin.

**The `p` complaint in the issue is the same bug, not a second one.** The reporter also reported that `p` on a project header opens a project window instead of pinning, and that `?` lists two actions bound to `p`. That is a *symptom* of the label gate, not an independent keybinding defect. `bindings.rs` declares `ToggleProjectPin` with `Context::ProjectGroupSelected`, and that context is computed as `project_group_at_cursor().is_some()` (`input.rs`). When the gate returned `None` on the scratch header, the context did not match, resolution fell through to the next `p` binding (`ActionId::Projects`, `Context::Always`), and the Projects dialog opened. That fallthrough is deliberate and correct; it fired only because the gate wrongly reported "not a project header." Restoring the gate restores pinning, so `p` now pins instead of opening the dialog. Please do not read the absence of a `bindings.rs` change as an incomplete fix.

**The fix.** Decide by backing identity rather than by rendered text, following the path-based shape of the existing `is_within_archived_section` / `is_within_trash_section` checks:

1. `SCRATCH_GROUP_LABEL` replaces the magic string that was duplicated between the producer (`project_group_name`) and the gate, with a doc comment stating the label is not an identity.
2. `project_header_repo_path` now also skips scratch sessions. Their `repo_path()` is the throwaway `<app_dir>/scratch/<id>` directory, which is not registrable. Without this, on a header shared with a real repo a scratch session could win the `find` and hand the pin toggle an app-internal path (`HomeView::instances` is an `IndexMap`, so the order is insertion order from the loaded session rows, deterministic but arbitrary). This only ever affects the `scratch` label, since `project_group_name` returns that label for every scratch session and nothing else.
3. New `is_synthetic_scratch_header(label)`, and the gate calls `!self.is_synthetic_scratch_header(name)`. A header is the synthetic bucket only when the label matches **and** no live non-scratch session backs it **and** no registry entry carries the label. The registry clause is what makes an empty pinned project named `scratch` reachable to unpin, which it previously was not.

**Deliberately out of scope: the merged header.** A real repo named `scratch` and the synthetic bucket still render as **one** header. I verified this empirically rather than only by reading code, with a throwaway probe that produced `headers=[("scratch", 2)]` for one real-repo session plus one scratch session. The mechanism: `build_flat_items_by_project` sets `inst.group_path = project_group_name(&inst)` and `GroupTree` keys groups by that path, so in project mode group **path == label**, and two identities collapsing to one string become one node.

This is excluded on purpose, not overlooked. Separating them means giving the synthetic bucket a sentinel path (like `ARCHIVED_SECTION_PATH`) and then mapping that sentinel to a display name across every surface that renders or matches a project group label: the row renderer, `project_header_repo_path`, `is_project_label_pinned`, `known_project_group_paths`, `archived_project_sub_path`, the collapse-state map, the context menu, and the command palette. That is a distinct defect with a much wider blast radius, and the guidelines say one concern per PR. It is also not part of #3133: the reporter asked to pin `scratch`, which now works. Tracked in #3237.

This fix is well defined in the merged header's presence: the real repo backs the header, so the pin targets the repo and the label-only scratch sessions ride along. It never resolves to the app-internal scratch directory, which is what change 2 above guarantees and what the third test case pins down.

**The other half of the `?` complaint, now also fixed here.** The reporter's first sentence was that both actions are listed as `p` in the `?` menu. That part is cosmetic but it is theirs, and closing the issue without it would leave it silently unaddressed, so it is in scope now:

- `shortcuts()` in `components/help.rs` emits one row per help-listed binding and never reads `b.context`, so the two `p` rows render unconditionally with nothing to tell them apart.
- The smallest honest fix is to have the guarded binding say when it applies, so its help desc becomes `Pin/unpin project (group header only)`, using the same "... only" idiom the Attention section heading already uses. Rendered:

```
  Actions
    p          Pin/unpin project (group header only)
  Other
    p          Projects
```

- No help-rendering machinery was added. Teaching the overlay to filter by live context would make its contents change out from under the reader depending on where the cursor was when they pressed `?`, which is a worse overlay, and the desc carries the same information for free. The new desc is shorter than the old one, so the column-width budget in `min_column_width` is unaffected.
- The old desc's parenthetical (`keep without sessions`) is not lost information: `docs/guides/multi-repo-workspaces.md` already documents what pinning does, and the gate was the confusing part.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

On documentation: no change needed. `docs/guides/scratch-sessions.md` describes the synthetic Scratch group but never claims it can be pinned, and nothing else in `docs/` documents the pin gate.

On screenshot: no image, and I want to be upfront rather than quietly check the box. The pin fix itself has nothing to show: it alters which action a keypress resolves to on one sidebar row, while the rendered header, its glyph set, and its styling are untouched, so a before/after pair would be two identical images. The one visible change is the `?` overlay row text, and the rendered overlay rows are quoted verbatim above (captured from a real `render_to_buffer` at 100x60, not hand-written).

**How this was tested.**

- `cargo fmt --check`: clean.
- `cargo clippy --all-targets`: no new warnings. Seven pre-existing ones remain (`dead_code` on `inject_test_update` in `session/poller.rs`, `items_after_test_module` in `mod.rs`, five `useless_vec` in `session/groups.rs`), all on lines this PR does not touch.
- `cargo test`: 4406 passed, 0 failed, 2 ignored, plus every integration target green.
- Not run with `--features serve`: this is a TUI-only change with no web dashboard or structured view code in the diff.
- **Verified the test fails without the fix.** Reverted `mod.rs` only and reran: `real repo only: pin gate  left: false  right: true`. Restored, and it passes.

One flake worth flagging rather than hiding: my first full-suite run had `tmux::tool_session::tests::wait_until_ready_errs_with_pane_tail_when_pane_dies_immediately` fail. I investigated instead of rerunning past it. It passes in isolation on a reverted baseline, passes in isolation with this change, and passed in both subsequent full-suite runs. It is a timing-sensitive tmux pane-death test that is load-dependent under roughly 4400 parallel tests, in a module this diff does not touch.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Zero `web/` files touched, so the coverage matrix mandate does not apply. Being a Rust-only diff, `codecov/patch` is N/A per the guidelines and inherits via `carryforward`.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: a unit test is the cheapest tier that can actually fail if this breaks, and it covers the behavior fully.

Added one table-driven unit test in `src/tui/home/tests.rs`, five rows, per the "one test per behavior, not per input" house style:

| Case | Asserts |
| --- | --- |
| `real repo only` | the reporter's setup; gate opens, `p` pins, the registry entry points at the repo |
| `synthetic bucket only` | gate stays closed, `p` keeps its global meaning and opens the Projects dialog, registry stays empty |
| `real repo plus scratch session` | gate opens and the pin resolves to the real repo, never the app scratch dir |
| `saved unpinned repo plus scratch session` | a saved-but-unpinned entry does not back the header, so the gate stays closed |
| `pinned empty repo plus scratch session` | a pinned entry does back it, so `p` unpins instead of opening the dialog |

Each row builds its own `TempDir` plus `AppDirGuard` because pinning writes the global registry, hence `#[serial]`.

Plus one test in `bindings.rs` for the help half: `shared_help_chords_document_their_guard` walks `BINDINGS` in both keymaps and requires that when two help-listed bindings resolve to the same key label, the context-guarded one states when it applies. That is deliberately an invariant rather than an assertion on the desc string, which would be a constant test the guidelines say not to write. It fails on the old desc (verified by reverting it: `"p" is shared, so the ProjectGroupSelected row must say when it applies`), and it will also fail if someone later adds another guarded binding onto a shared chord without documenting the guard, which is the #3133 class of bug.

An e2e test would cost roughly 2s forever on a strictly serial critical path to assert the same thing this unit test already proves, including the keypress path itself: the test drives `handle_key(KeyCode::Char('p'))`, so it exercises real binding resolution and the `Context::ProjectGroupSelected` fallthrough, not just the gate function in isolation.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Claude did the investigation, the fix, the test, and this description, driven by @njbrake, who set the scope boundaries (in particular the decision to exclude the merged-header defect and file it separately) and reviewed before anything was pushed. The empirical checks reported above (the fails-without-the-fix verification, the merged-header probe, the flake triage) were all actually run, not asserted.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed pinning for real repositories named `scratch`.
- Preserved the Projects action for synthetic scratch sessions.
- Prevented internal scratch paths from being registered as repositories.
- Clarified in the help overlay that project pinning applies to group headers.
- Added regression tests for real, synthetic, mixed, pinned, and unpinned cases.

## Benefits

Users can pin real `scratch` repositories from the project view without changing synthetic scratch behavior. The help overlay now explains the contextual `p` action more clearly.

## Technical details

Scratch detection now uses backing repository identity instead of the displayed label. Scratch sessions are excluded during repository path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
