### PR TITLE
fix(update): warn when daemon verification is inconclusive

### DIFF
--- a/docs/development/internals/structured-view.md
+++ b/docs/development/internals/structured-view.md
@@ -23,7 +23,7 @@ Survival across restart means a daemon on a new binary could re-adopt workers ru
 - Older build, no in-flight turn: terminated and respawned on the new binary immediately.
 - Older build, mid-turn: adopted so the turn keeps streaming, respawned at the next idle boundary (never hard-killed).
 
-`aoe acp ps` tags a not-yet-respawned worker `(stale)`. The new binary takes effect only once the daemon restarts; `aoe update` offers that restart, and `aoe serve --restart` replays the host/port/mode/auth/passphrase it was launched with. Restart only touches daemons started by `aoe serve --daemon`; foreground/systemd/launchd daemons are left to their manager. See #1754, #1794.
+`aoe acp ps` tags a not-yet-respawned worker `(stale)`. The new binary takes effect only once the daemon restarts; `aoe update` offers that restart, and `aoe serve --restart` replays the host/port/mode/auth/passphrase it was launched with. Restart only touches daemons started by `aoe serve --daemon`; foreground/systemd/launchd daemons are left to their manager. A daemon whose process cannot be verified at all (most often another user's, where `kill(pid, 0)` returns `EPERM`) is neither restarted nor treated as absent: `aoe update` warns that a daemon may still be running the old build and names its owner as the one who has to restart it, and the `serve.*` lifecycle files are preserved rather than swept. See #1754, #1794, #3225.
 
 ## Session deletion semantics
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3347,12 +3347,12 @@ fn path_copy_below_floor(command: &str, path: &std::path::Path) -> bool {
 /// This runs on the synchronous spawn path, so it cannot reuse
 /// `version_probe`'s async `tokio::time::timeout`; it polls instead. The
 /// bound matters: an adapter that waits on stdin or a network login would
-/// otherwise block session spawn forever. This synchronous path allows five
-/// seconds so a loaded host can schedule the child before the deadline; any
-/// failure or timeout yields `None` so the caller keeps the user's own copy.
+/// otherwise block session spawn forever. It mirrors `version_probe`'s 2s
+/// budget; any failure or timeout yields `None` so the caller keeps the
+/// user's own copy.
 #[cfg(feature = "serve")]
 fn probe_version_bounded(path: &std::path::Path) -> Option<String> {
-    const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+    const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
     const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
 
     let mut child = std::process::Command::new(path)

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3347,12 +3347,12 @@ fn path_copy_below_floor(command: &str, path: &std::path::Path) -> bool {
 /// This runs on the synchronous spawn path, so it cannot reuse
 /// `version_probe`'s async `tokio::time::timeout`; it polls instead. The
 /// bound matters: an adapter that waits on stdin or a network login would
-/// otherwise block session spawn forever. Mirrors `version_probe`'s 2s
-/// budget, and any failure or timeout yields `None` so the caller keeps the
-/// user's own copy.
+/// otherwise block session spawn forever. This synchronous path allows five
+/// seconds so a loaded host can schedule the child before the deadline; any
+/// failure or timeout yields `None` so the caller keeps the user's own copy.
 #[cfg(feature = "serve")]
 fn probe_version_bounded(path: &std::path::Path) -> Option<String> {
-    const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+    const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
     const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
 
     let mut child = std::process::Command::new(path)

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -493,13 +493,6 @@ fn serve_launch_path() -> Result<PathBuf> {
     Ok(dir.join("serve.launch"))
 }
 
-/// True when a `serve.launch` file exists, i.e. a daemon started by
-/// `aoe serve --daemon` recorded its launch state. `aoe update` uses this
-/// to decide whether a running daemon is one it may restart.
-pub fn serve_launch_exists() -> bool {
-    serve_launch_path().map(|p| p.exists()).unwrap_or(false)
-}
-
 /// Write `serve.launch` with owner-only (0600) permissions: it records
 /// the daemon's bind host/port, tunnel URL, auth posture, and profile,
 /// which should not be world-readable on a shared machine.
@@ -520,6 +513,10 @@ fn read_serve_launch() -> Result<ServeLaunch> {
     let raw =
         std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
     serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+pub(crate) fn serve_launch_matches(pid: u32) -> bool {
+    read_serve_launch().is_ok_and(|launch| launch.pid == pid)
 }
 
 /// Recall the daemon passphrase for a restart: the plaintext
@@ -635,22 +632,48 @@ fn read_serve_mode_label() -> Option<&'static str> {
     }
 }
 
-/// Cross-platform check that `pid` belongs to an aoe / agent-of-empires
-/// process. PIDs get recycled, so `kill(pid, 0) == Ok` is not enough on
-/// its own — we also want to know it's actually *our* daemon.
-///
-/// Returns `true` if the process looks like ours, `false` otherwise.
-/// If we can't determine either way (platform lacks the lookup, ps
-/// missing), we return `true` so behavior matches the legacy Linux path
-/// of trusting the PID file rather than falsely flagging a real daemon
-/// as foreign.
-fn verify_pid_is_aoe(pid: i32) -> bool {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DaemonProcessIdentity {
+    Verified,
+    Foreign,
+    Indeterminate,
+}
+
+fn command_is_aoe_serve(command: &[u8]) -> bool {
+    let args: Vec<&[u8]> = if command.contains(&0) {
+        command
+            .split(|byte| *byte == 0)
+            .filter(|arg| !arg.is_empty())
+            .collect()
+    } else {
+        command
+            .split(|byte| byte.is_ascii_whitespace())
+            .filter(|arg| !arg.is_empty())
+            .collect()
+    };
+    let Some(executable) = args.first() else {
+        return false;
+    };
+    let basename = executable
+        .rsplit(|byte| *byte == b'/')
+        .next()
+        .unwrap_or(executable);
+    matches!(basename, b"aoe" | b"agent-of-empires")
+        && args.iter().skip(1).any(|arg| *arg == b"serve")
+}
+
+/// Cross-platform check that `pid` belongs to an `aoe serve` process.
+/// PIDs get recycled, so a successful signal probe alone cannot authorize
+/// process control.
+fn inspect_daemon_process(pid: i32) -> DaemonProcessIdentity {
     // Linux fast path: read /proc directly, no subprocess.
     let proc_path = format!("/proc/{}/cmdline", pid);
     if std::path::Path::new(&proc_path).exists() {
-        if let Ok(cmdline) = std::fs::read_to_string(&proc_path) {
-            return cmdline.contains("aoe") || cmdline.contains("agent-of-empires");
-        }
+        return match std::fs::read(&proc_path) {
+            Ok(cmdline) if command_is_aoe_serve(&cmdline) => DaemonProcessIdentity::Verified,
+            Ok(_) => DaemonProcessIdentity::Foreign,
+            Err(_) => DaemonProcessIdentity::Indeterminate,
+        };
     }
 
     // macOS / other: shell out to `ps`. `-o command=` prints the full
@@ -659,14 +682,20 @@ fn verify_pid_is_aoe(pid: i32) -> bool {
         .args(["-o", "command=", "-p", &pid.to_string()])
         .output()
     {
-        Ok(out) if out.status.success() => {
-            let s = String::from_utf8_lossy(&out.stdout);
-            s.contains("aoe") || s.contains("agent-of-empires")
+        Ok(out) if out.status.success() && command_is_aoe_serve(&out.stdout) => {
+            DaemonProcessIdentity::Verified
         }
-        // ps failed or unavailable — we can't verify, so trust the PID
-        // file rather than ghosting a real daemon.
-        _ => true,
+        Ok(out) if out.status.success() => DaemonProcessIdentity::Foreign,
+        _ => DaemonProcessIdentity::Indeterminate,
     }
+}
+
+fn verify_pid_is_aoe(pid: i32) -> bool {
+    inspect_daemon_process(pid) == DaemonProcessIdentity::Verified
+}
+
+fn parse_positive_pid(raw: &str) -> Option<i32> {
+    raw.trim().parse().ok().filter(|pid| *pid > 0)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -696,37 +725,53 @@ fn remove_stale_serve_state(pid_path: &std::path::Path) {
     }
 }
 
-/// Returns Some(pid) if the daemon's PID file exists AND the process is
-/// still alive AND it looks like one of our aoe processes. Cleans up
-/// stale PID files it finds. The TUI uses this both to jump straight to
-/// the Active state when the Remote Access dialog opens and to render
-/// the "● Remote on" status-bar indicator.
-pub fn daemon_pid() -> Option<u32> {
-    let path = pid_file_path().ok()?;
-    let pid_str = std::fs::read_to_string(&path).ok()?;
-    let pid: i32 = pid_str.trim().parse().ok()?;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DaemonStatus {
+    Absent,
+    Verified(u32),
+    Unverified,
+}
+
+pub(crate) fn daemon_status() -> DaemonStatus {
+    let Ok(path) = pid_file_path() else {
+        return DaemonStatus::Unverified;
+    };
+    let pid_str = match std::fs::read_to_string(&path) {
+        Ok(pid) => pid,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return DaemonStatus::Absent,
+        Err(_) => return DaemonStatus::Unverified,
+    };
+    let Some(pid) = parse_positive_pid(&pid_str) else {
+        return DaemonStatus::Unverified;
+    };
 
     let probe = nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None);
     match classify_daemon_probe(probe) {
-        DaemonProbeDisposition::VerifyIdentity => {
-            if verify_pid_is_aoe(pid) {
-                Some(pid as u32)
-            } else {
-                // PID was recycled by an unrelated process, so our daemon
-                // is dead. Clean up the stale file so subsequent callers
-                // don't keep false-positive-ing.
+        DaemonProbeDisposition::VerifyIdentity => match inspect_daemon_process(pid) {
+            DaemonProcessIdentity::Verified => DaemonStatus::Verified(pid as u32),
+            DaemonProcessIdentity::Foreign => {
                 remove_stale_serve_state(&path);
-                None
+                DaemonStatus::Absent
             }
-        }
+            DaemonProcessIdentity::Indeterminate => DaemonStatus::Unverified,
+        },
         DaemonProbeDisposition::Stale => {
             remove_stale_serve_state(&path);
-            None
+            DaemonStatus::Absent
         }
         // EPERM proves the process may still exist, while other errors are
         // likewise insufficient evidence of staleness. Preserve lifecycle
         // state, but do not return an unverified PID to control callers.
-        DaemonProbeDisposition::Indeterminate => None,
+        DaemonProbeDisposition::Indeterminate => DaemonStatus::Unverified,
+    }
+}
+
+/// Returns the PID only when the process can be verified as `aoe serve`.
+/// The TUI uses this to detect and display a running local daemon.
+pub fn daemon_pid() -> Option<u32> {
+    match daemon_status() {
+        DaemonStatus::Verified(pid) => Some(pid),
+        DaemonStatus::Absent | DaemonStatus::Unverified => None,
     }
 }
 
@@ -1328,10 +1373,8 @@ pub(crate) async fn stop_daemon() -> Result<()> {
     }
 
     let pid_str = tokio::fs::read_to_string(&path).await?;
-    let pid: i32 = pid_str
-        .trim()
-        .parse()
-        .map_err(|_| anyhow::anyhow!("Invalid PID in {}: {}", path.display(), pid_str.trim()))?;
+    let pid = parse_positive_pid(&pid_str)
+        .ok_or_else(|| anyhow::anyhow!("Invalid PID in {}: {}", path.display(), pid_str.trim()))?;
     tracing::info!(target: "serve.shutdown", pid, "sending SIGTERM to daemon");
 
     // Verify PID belongs to an aoe process on all platforms
@@ -1492,6 +1535,34 @@ mod tests {
         ];
         for (result, expected) in cases {
             assert_eq!(classify_daemon_probe(result), expected);
+        }
+    }
+
+    #[test]
+    fn daemon_command_requires_exact_executable_and_serve_subcommand() {
+        let cases: &[(&[u8], bool)] = &[
+            (b"/usr/local/bin/aoe\0serve\0--daemon\0", true),
+            (b"agent-of-empires serve --daemon", true),
+            (b"aoe update", false),
+            (b"/tmp/aoe-helper serve", false),
+            (b"runner --label aoe serve", false),
+        ];
+        for (command, expected) in cases {
+            assert_eq!(command_is_aoe_serve(command), *expected, "{command:?}");
+        }
+    }
+
+    #[test]
+    fn daemon_pid_must_be_positive() {
+        let cases = [
+            ("42", Some(42)),
+            (" 7\n", Some(7)),
+            ("0", None),
+            ("-1", None),
+            ("x", None),
+        ];
+        for (raw, expected) in cases {
+            assert_eq!(parse_positive_pid(raw), expected, "{raw:?}");
         }
     }
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -425,8 +425,14 @@ pub fn pid_file_path() -> Result<PathBuf> {
 /// `AOE_SERVE_PASSPHRASE` at restart time.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ServeLaunch {
+    /// Informational only: nothing branches on it. Compatibility is handled
+    /// field by field instead (`#[serde(default)]` for fields added later, and
+    /// `launch_authorizes` accepting a record with no `instance_id`), which
+    /// keeps a record written by an older or newer build usable rather than
+    /// rejecting it wholesale.
     pub schema: u32,
     pub pid: u32,
+    /// Absent in records written before instance IDs existed (schema 1).
     #[serde(default)]
     pub instance_id: Option<String>,
     pub profile: String,
@@ -740,7 +746,6 @@ fn command_is_aoe_serve(command: &[u8]) -> bool {
                 index += 1;
             }
             b"serve" => return true,
-            arg if arg.starts_with(b"-") => return false,
             _ => return false,
         }
     }
@@ -792,21 +797,6 @@ fn command_mentions_aoe_executable(command: &[u8]) -> bool {
         || command
             .windows(17)
             .any(|window| window == b"agent-of-empires ")
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum StopTargetDisposition {
-    StopVerifiedDaemon,
-    CleanStaleState,
-    PreserveStateAndError,
-}
-
-fn classify_stop_target(identity: DaemonProcessIdentity) -> StopTargetDisposition {
-    match identity {
-        DaemonProcessIdentity::Verified => StopTargetDisposition::StopVerifiedDaemon,
-        DaemonProcessIdentity::Foreign => StopTargetDisposition::CleanStaleState,
-        DaemonProcessIdentity::Indeterminate => StopTargetDisposition::PreserveStateAndError,
-    }
 }
 
 fn parse_positive_pid(raw: &str) -> Option<i32> {
@@ -1495,8 +1485,8 @@ pub(crate) async fn stop_daemon() -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("Invalid PID in {}: {}", path.display(), pid_str.trim()))?;
     tracing::info!(target: "serve.shutdown", pid, "sending SIGTERM to daemon");
 
-    match classify_stop_target(inspect_daemon_process(pid)) {
-        StopTargetDisposition::StopVerifiedDaemon => {
+    match inspect_daemon_process(pid) {
+        DaemonProcessIdentity::Verified => {
             if serve_launch_contradicts(pid as u32) {
                 bail!(
                     "PID {} is an aoe serve process, but not the daemon recorded in \
@@ -1505,14 +1495,14 @@ pub(crate) async fn stop_daemon() -> Result<()> {
                 );
             }
         }
-        StopTargetDisposition::CleanStaleState => {
+        DaemonProcessIdentity::Foreign => {
             remove_stale_serve_state(&path);
             bail!(
                 "PID {} belongs to a different process (stale PID file). Cleaned up.",
                 pid
             );
         }
-        StopTargetDisposition::PreserveStateAndError => {
+        DaemonProcessIdentity::Indeterminate => {
             bail!(
                 "Could not verify whether PID {} is an aoe serve daemon; \
                  preserving serve state. Retry once process inspection works.",
@@ -2184,27 +2174,5 @@ mod tests {
         launch.auth_mode = AuthMode::Token;
         launch.remote = false;
         assert!(!launch_needs_passphrase(&launch));
-    }
-
-    #[test]
-    fn stop_target_classification_is_fail_closed() {
-        let cases = [
-            (
-                DaemonProcessIdentity::Verified,
-                StopTargetDisposition::StopVerifiedDaemon,
-            ),
-            (
-                DaemonProcessIdentity::Foreign,
-                StopTargetDisposition::CleanStaleState,
-            ),
-            (
-                DaemonProcessIdentity::Indeterminate,
-                StopTargetDisposition::PreserveStateAndError,
-            ),
-        ];
-
-        for (identity, expected) in cases {
-            assert_eq!(classify_stop_target(identity), expected, "{identity:?}");
-        }
     }
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -669,6 +669,33 @@ fn verify_pid_is_aoe(pid: i32) -> bool {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DaemonProbeDisposition {
+    VerifyIdentity,
+    Stale,
+    Indeterminate,
+}
+
+fn classify_daemon_probe(
+    result: std::result::Result<(), nix::errno::Errno>,
+) -> DaemonProbeDisposition {
+    match result {
+        Ok(()) => DaemonProbeDisposition::VerifyIdentity,
+        Err(nix::errno::Errno::ESRCH) => DaemonProbeDisposition::Stale,
+        Err(_) => DaemonProbeDisposition::Indeterminate,
+    }
+}
+
+fn remove_stale_serve_state(pid_path: &std::path::Path) {
+    let _ = std::fs::remove_file(pid_path);
+    if let Ok(dir) = crate::session::get_app_dir() {
+        let _ = std::fs::remove_file(dir.join("serve.url"));
+        let _ = std::fs::remove_file(dir.join("serve.mode"));
+        let _ = std::fs::remove_file(dir.join("serve.passphrase"));
+        let _ = std::fs::remove_file(dir.join("serve.launch"));
+    }
+}
+
 /// Returns Some(pid) if the daemon's PID file exists AND the process is
 /// still alive AND it looks like one of our aoe processes. Cleans up
 /// stale PID files it finds. The TUI uses this both to jump straight to
@@ -679,36 +706,27 @@ pub fn daemon_pid() -> Option<u32> {
     let pid_str = std::fs::read_to_string(&path).ok()?;
     let pid: i32 = pid_str.trim().parse().ok()?;
 
-    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None) {
-        Ok(()) => {
+    let probe = nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None);
+    match classify_daemon_probe(probe) {
+        DaemonProbeDisposition::VerifyIdentity => {
             if verify_pid_is_aoe(pid) {
                 Some(pid as u32)
             } else {
                 // PID was recycled by an unrelated process — our daemon
                 // is dead. Clean up the stale file so subsequent callers
                 // don't keep false-positive-ing.
-                let _ = std::fs::remove_file(&path);
-                if let Ok(dir) = crate::session::get_app_dir() {
-                    let _ = std::fs::remove_file(dir.join("serve.url"));
-                    let _ = std::fs::remove_file(dir.join("serve.mode"));
-                    let _ = std::fs::remove_file(dir.join("serve.passphrase"));
-                    let _ = std::fs::remove_file(dir.join("serve.launch"));
-                }
+                remove_stale_serve_state(&path);
                 None
             }
         }
-        Err(_) => {
-            // Stale PID file; the ESRCH case is handled the same as any
-            // other error — the process is not reachable.
-            let _ = std::fs::remove_file(&path);
-            if let Ok(dir) = crate::session::get_app_dir() {
-                let _ = std::fs::remove_file(dir.join("serve.url"));
-                let _ = std::fs::remove_file(dir.join("serve.mode"));
-                let _ = std::fs::remove_file(dir.join("serve.passphrase"));
-                let _ = std::fs::remove_file(dir.join("serve.launch"));
-            }
+        DaemonProbeDisposition::Stale => {
+            remove_stale_serve_state(&path);
             None
         }
+        // EPERM proves the process may still exist, while other errors are
+        // likewise insufficient evidence of staleness. Preserve lifecycle
+        // state, but do not return an unverified PID to control callers.
+        DaemonProbeDisposition::Indeterminate => None,
     }
 }
 
@@ -1456,6 +1474,25 @@ mod tests {
     #[test]
     fn cloudflared_required_when_no_tailscale_flag_set() {
         assert!(cloudflared_required(true, false, true));
+    }
+
+    #[test]
+    fn daemon_probe_only_marks_missing_process_as_stale() {
+        let cases = [
+            (Ok(()), DaemonProbeDisposition::VerifyIdentity),
+            (Err(nix::errno::Errno::ESRCH), DaemonProbeDisposition::Stale),
+            (
+                Err(nix::errno::Errno::EPERM),
+                DaemonProbeDisposition::Indeterminate,
+            ),
+            (
+                Err(nix::errno::Errno::EIO),
+                DaemonProbeDisposition::Indeterminate,
+            ),
+        ];
+        for (result, expected) in cases {
+            assert_eq!(classify_daemon_probe(result), expected);
+        }
     }
 
     #[test]

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -528,6 +528,25 @@ pub(crate) fn serve_launch_matches(pid: u32) -> bool {
     })
 }
 
+/// `true` when `serve.launch` claims this PID as our daemon but the live
+/// process carries a different instance ID, which is the PID-recycle
+/// signature. A missing launch record (a foreground `aoe serve` writes only
+/// the PID file) or a record for a different PID is not a contradiction, so
+/// stopping those still falls back to executable + subcommand verification.
+fn launch_contradicts(launch: &ServeLaunch, pid: u32, instance_is_live: bool) -> bool {
+    launch.pid == pid && launch.instance_id.is_some() && !instance_is_live
+}
+
+fn serve_launch_contradicts(pid: u32) -> bool {
+    read_serve_launch().is_ok_and(|launch| {
+        let instance_is_live = launch
+            .instance_id
+            .as_deref()
+            .is_some_and(|instance_id| live_daemon_instance_matches(pid, instance_id));
+        launch_contradicts(&launch, pid, instance_is_live)
+    })
+}
+
 fn environment_has_daemon_instance(environment: &[u8], instance_id: &str) -> bool {
     let expected = format!("{SERVE_INSTANCE_ENV}={instance_id}");
     if environment.contains(&0) {
@@ -1453,7 +1472,15 @@ pub(crate) async fn stop_daemon() -> Result<()> {
     tracing::info!(target: "serve.shutdown", pid, "sending SIGTERM to daemon");
 
     match classify_stop_target(inspect_daemon_process(pid)) {
-        StopTargetDisposition::StopVerifiedDaemon => {}
+        StopTargetDisposition::StopVerifiedDaemon => {
+            if serve_launch_contradicts(pid as u32) {
+                bail!(
+                    "PID {} is an aoe serve process, but not the daemon recorded in \
+                     serve.launch (recycled PID); preserving serve state.",
+                    pid
+                );
+            }
+        }
         StopTargetDisposition::CleanStaleState => {
             tokio::fs::remove_file(&path).await?;
             bail!(
@@ -1873,6 +1900,33 @@ mod tests {
             no_tailscale: true,
             allowed_host: vec!["aoe.example.com".to_string()],
             allowed_origin: vec!["https://aoe.example.com:8443".to_string()],
+        }
+    }
+
+    #[test]
+    fn launch_contradiction_only_flags_recycled_pids() {
+        let cases = [
+            // Recorded PID, live instance gone: the PID was recycled by another
+            // aoe serve, so refuse to signal it.
+            (4242, Some("instance-1"), false, true),
+            (4242, Some("instance-1"), true, false),
+            // A launch record for a different PID says nothing about this one.
+            (99, Some("instance-1"), false, false),
+            // No instance ID recorded (foreground `aoe serve`, or a pre-upgrade
+            // launch file): fall back to executable + subcommand verification.
+            (4242, None, false, false),
+        ];
+        for (launch_pid, instance_id, instance_is_live, expected) in cases {
+            let launch = ServeLaunch {
+                pid: launch_pid,
+                instance_id: instance_id.map(str::to_string),
+                ..sample_launch()
+            };
+            assert_eq!(
+                launch_contradicts(&launch, 4242, instance_is_live),
+                expected,
+                "pid {launch_pid} instance {instance_id:?} live {instance_is_live}"
+            );
         }
     }
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -730,6 +730,9 @@ fn command_is_aoe_serve(command: &[u8]) -> bool {
         return false;
     }
 
+    // The top-level globals declared on `Cli` in `src/cli/definition.rs`, so a
+    // value like `--profile work` is not mistaken for the subcommand.
+    // `parser_knows_every_top_level_global` fails if that list changes.
     let mut index = 1;
     while let Some(arg) = args.get(index) {
         match *arg {
@@ -1915,6 +1918,37 @@ mod tests {
             allowed_host: vec!["aoe.example.com".to_string()],
             allowed_origin: vec!["https://aoe.example.com:8443".to_string()],
         }
+    }
+
+    /// `command_is_aoe_serve` hand-parses the top-level globals to find the
+    /// subcommand position in a raw command line. A global added to `Cli`
+    /// without being taught there stops a real daemon's command line from
+    /// parsing, which classifies it `Foreign` and deletes its lifecycle state,
+    /// so derive the set from clap and fail here instead.
+    #[test]
+    fn parser_knows_every_top_level_global() {
+        use clap::CommandFactory;
+        let mut globals: Vec<(String, Option<char>)> = crate::cli::definition::Cli::command()
+            .get_arguments()
+            .filter(|arg| arg.is_global_set())
+            .map(|arg| {
+                (
+                    arg.get_long().unwrap_or_default().to_string(),
+                    arg.get_short(),
+                )
+            })
+            .collect();
+        globals.sort();
+        assert_eq!(
+            globals,
+            vec![
+                ("daemon-url".to_string(), None),
+                ("profile".to_string(), Some('p')),
+            ],
+            "a top-level global changed; teach command_is_aoe_serve about it before \
+             updating this list, or an `aoe serve` command line carrying the new \
+             option will be classified as a foreign process",
+        );
     }
 
     #[test]

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -751,8 +751,19 @@ fn inspect_daemon_process(pid: i32) -> DaemonProcessIdentity {
     }
 }
 
-fn verify_pid_is_aoe(pid: i32) -> bool {
-    inspect_daemon_process(pid) == DaemonProcessIdentity::Verified
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StopTargetDisposition {
+    StopVerifiedDaemon,
+    CleanStaleState,
+    PreserveStateAndError,
+}
+
+fn classify_stop_target(identity: DaemonProcessIdentity) -> StopTargetDisposition {
+    match identity {
+        DaemonProcessIdentity::Verified => StopTargetDisposition::StopVerifiedDaemon,
+        DaemonProcessIdentity::Foreign => StopTargetDisposition::CleanStaleState,
+        DaemonProcessIdentity::Indeterminate => StopTargetDisposition::PreserveStateAndError,
+    }
 }
 
 fn parse_positive_pid(raw: &str) -> Option<i32> {
@@ -1441,13 +1452,22 @@ pub(crate) async fn stop_daemon() -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("Invalid PID in {}: {}", path.display(), pid_str.trim()))?;
     tracing::info!(target: "serve.shutdown", pid, "sending SIGTERM to daemon");
 
-    // Verify PID belongs to an aoe process on all platforms
-    if !verify_pid_is_aoe(pid) {
-        tokio::fs::remove_file(&path).await?;
-        bail!(
-            "PID {} belongs to a different process (stale PID file). Cleaned up.",
-            pid
-        );
+    match classify_stop_target(inspect_daemon_process(pid)) {
+        StopTargetDisposition::StopVerifiedDaemon => {}
+        StopTargetDisposition::CleanStaleState => {
+            tokio::fs::remove_file(&path).await?;
+            bail!(
+                "PID {} belongs to a different process (stale PID file). Cleaned up.",
+                pid
+            );
+        }
+        StopTargetDisposition::PreserveStateAndError => {
+            bail!(
+                "Could not verify whether PID {} is an aoe serve daemon; \
+                 preserving serve state. Retry once process inspection works.",
+                pid
+            );
+        }
     }
 
     // Send SIGTERM
@@ -2047,5 +2067,27 @@ mod tests {
         launch.auth_mode = AuthMode::Token;
         launch.remote = false;
         assert!(!launch_needs_passphrase(&launch));
+    }
+
+    #[test]
+    fn stop_target_classification_is_fail_closed() {
+        let cases = [
+            (
+                DaemonProcessIdentity::Verified,
+                StopTargetDisposition::StopVerifiedDaemon,
+            ),
+            (
+                DaemonProcessIdentity::Foreign,
+                StopTargetDisposition::CleanStaleState,
+            ),
+            (
+                DaemonProcessIdentity::Indeterminate,
+                StopTargetDisposition::PreserveStateAndError,
+            ),
+        ];
+
+        for (identity, expected) in cases {
+            assert_eq!(classify_stop_target(identity), expected, "{identity:?}");
+        }
     }
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -518,14 +518,24 @@ fn read_serve_launch() -> Result<ServeLaunch> {
     serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
 }
 
+/// Whether this launch record authorizes aoe to restart the process at `pid`.
+/// A record written before instance IDs existed has only the PID to go on;
+/// rejecting it would tell the user their daemon was externally launched, which
+/// is both false and hides the `aoe serve --restart` that does work for it.
+fn launch_authorizes(launch: &ServeLaunch, pid: u32, instance_is_live: bool) -> bool {
+    launch.pid == pid && !launch_contradicts(launch, pid, instance_is_live)
+}
+
 pub(crate) fn serve_launch_matches(pid: u32) -> bool {
-    read_serve_launch().is_ok_and(|launch| {
-        launch.pid == pid
-            && launch
-                .instance_id
-                .as_deref()
-                .is_some_and(|instance_id| live_daemon_instance_matches(pid, instance_id))
-    })
+    read_serve_launch()
+        .is_ok_and(|launch| launch_authorizes(&launch, pid, instance_is_live(&launch, pid)))
+}
+
+fn instance_is_live(launch: &ServeLaunch, pid: u32) -> bool {
+    launch
+        .instance_id
+        .as_deref()
+        .is_some_and(|instance_id| live_daemon_instance_matches(pid, instance_id))
 }
 
 /// `true` when `serve.launch` claims this PID as our daemon but the live
@@ -538,13 +548,8 @@ fn launch_contradicts(launch: &ServeLaunch, pid: u32, instance_is_live: bool) ->
 }
 
 fn serve_launch_contradicts(pid: u32) -> bool {
-    read_serve_launch().is_ok_and(|launch| {
-        let instance_is_live = launch
-            .instance_id
-            .as_deref()
-            .is_some_and(|instance_id| live_daemon_instance_matches(pid, instance_id));
-        launch_contradicts(&launch, pid, instance_is_live)
-    })
+    read_serve_launch()
+        .is_ok_and(|launch| launch_contradicts(&launch, pid, instance_is_live(&launch, pid)))
 }
 
 fn environment_has_daemon_instance(environment: &[u8], instance_id: &str) -> bool {
@@ -1905,27 +1910,36 @@ mod tests {
 
     #[test]
     fn launch_contradiction_only_flags_recycled_pids() {
+        // (recorded pid, recorded instance, instance is live, contradicts, authorizes)
         let cases = [
             // Recorded PID, live instance gone: the PID was recycled by another
             // aoe serve, so refuse to signal it.
-            (4242, Some("instance-1"), false, true),
-            (4242, Some("instance-1"), true, false),
-            // A launch record for a different PID says nothing about this one.
-            (99, Some("instance-1"), false, false),
-            // No instance ID recorded (foreground `aoe serve`, or a pre-upgrade
-            // launch file): fall back to executable + subcommand verification.
-            (4242, None, false, false),
+            (4242, Some("instance-1"), false, true, false),
+            (4242, Some("instance-1"), true, false, true),
+            // A launch record for a different PID says nothing about this one, so
+            // it is not a contradiction, but it authorizes nothing either.
+            (99, Some("instance-1"), false, false, false),
+            // No instance ID recorded (a record written before instance IDs
+            // existed): the PID match is all the evidence there is, and it is
+            // what pre-upgrade builds acted on.
+            (4242, None, false, false, true),
         ];
-        for (launch_pid, instance_id, instance_is_live, expected) in cases {
+        for (launch_pid, instance_id, live, contradicts, authorizes) in cases {
             let launch = ServeLaunch {
                 pid: launch_pid,
                 instance_id: instance_id.map(str::to_string),
                 ..sample_launch()
             };
+            let label = format!("pid {launch_pid} instance {instance_id:?} live {live}");
             assert_eq!(
-                launch_contradicts(&launch, 4242, instance_is_live),
-                expected,
-                "pid {launch_pid} instance {instance_id:?} live {instance_is_live}"
+                launch_contradicts(&launch, 4242, live),
+                contradicts,
+                "contradicts: {label}"
+            );
+            assert_eq!(
+                launch_authorizes(&launch, 4242, live),
+                authorizes,
+                "authorizes: {label}"
             );
         }
     }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -712,7 +712,7 @@ pub fn daemon_pid() -> Option<u32> {
             if verify_pid_is_aoe(pid) {
                 Some(pid as u32)
             } else {
-                // PID was recycled by an unrelated process — our daemon
+                // PID was recycled by an unrelated process, so our daemon
                 // is dead. Clean up the stale file so subsequent callers
                 // don't keep false-positive-ing.
                 remove_stale_serve_state(&path);

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -427,6 +427,8 @@ pub fn pid_file_path() -> Result<PathBuf> {
 pub struct ServeLaunch {
     pub schema: u32,
     pub pid: u32,
+    #[serde(default)]
+    pub instance_id: Option<String>,
     pub profile: String,
     pub host: String,
     pub port: u16,
@@ -448,7 +450,8 @@ pub struct ServeLaunch {
     pub allowed_origin: Vec<String>,
 }
 
-const SERVE_LAUNCH_SCHEMA: u32 = 1;
+const SERVE_LAUNCH_SCHEMA: u32 = 2;
+const SERVE_INSTANCE_ENV: &str = "AOE_SERVE_INSTANCE_ID";
 
 impl ServeLaunch {
     /// Rebuild the `ServeArgs` needed to relaunch this daemon. The
@@ -516,7 +519,42 @@ fn read_serve_launch() -> Result<ServeLaunch> {
 }
 
 pub(crate) fn serve_launch_matches(pid: u32) -> bool {
-    read_serve_launch().is_ok_and(|launch| launch.pid == pid)
+    read_serve_launch().is_ok_and(|launch| {
+        launch.pid == pid
+            && launch
+                .instance_id
+                .as_deref()
+                .is_some_and(|instance_id| live_daemon_instance_matches(pid, instance_id))
+    })
+}
+
+fn environment_has_daemon_instance(environment: &[u8], instance_id: &str) -> bool {
+    let expected = format!("{SERVE_INSTANCE_ENV}={instance_id}");
+    if environment.contains(&0) {
+        environment
+            .split(|byte| *byte == 0)
+            .any(|entry| entry == expected.as_bytes())
+    } else {
+        environment
+            .split(|byte| byte.is_ascii_whitespace())
+            .any(|entry| entry == expected.as_bytes())
+    }
+}
+
+fn live_daemon_instance_matches(pid: u32, instance_id: &str) -> bool {
+    let proc_path = format!("/proc/{pid}/environ");
+    if std::path::Path::new(&proc_path).exists() {
+        return std::fs::read(proc_path)
+            .ok()
+            .is_some_and(|environment| environment_has_daemon_instance(&environment, instance_id));
+    }
+
+    std::process::Command::new("ps")
+        .args(["-ww", "-E", "-o", "command=", "-p", &pid.to_string()])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .is_some_and(|output| environment_has_daemon_instance(&output.stdout, instance_id))
 }
 
 /// Recall the daemon passphrase for a restart: the plaintext
@@ -1141,7 +1179,9 @@ fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
     use std::process::{Command, Stdio};
 
     let exe = std::env::current_exe()?;
+    let instance_id = uuid::Uuid::new_v4().to_string();
     let mut cmd = Command::new(exe);
+    cmd.env(SERVE_INSTANCE_ENV, &instance_id);
     cmd.args([
         "serve",
         "--daemon-child",
@@ -1264,6 +1304,7 @@ fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
     let launch = ServeLaunch {
         schema: SERVE_LAUNCH_SCHEMA,
         pid,
+        instance_id: Some(instance_id),
         profile: profile.to_string(),
         host: args.host.clone(),
         port: args.resolved_port(),
@@ -1567,6 +1608,24 @@ mod tests {
     }
 
     #[test]
+    fn daemon_instance_requires_an_exact_environment_entry() {
+        let cases: &[(&[u8], &str, bool)] = &[
+            (b"HOME=/tmp\0AOE_SERVE_INSTANCE_ID=abc\0", "abc", true),
+            (b"aoe serve AOE_SERVE_INSTANCE_ID=abc", "abc", true),
+            (b"AOE_SERVE_INSTANCE_ID=other\0", "abc", false),
+            (b"PREFIX_AOE_SERVE_INSTANCE_ID=abc\0", "abc", false),
+            (b"AOE_SERVE_INSTANCE_ID=abc-suffix", "abc", false),
+        ];
+        for (environment, instance_id, expected) in cases {
+            assert_eq!(
+                environment_has_daemon_instance(environment, instance_id),
+                *expected,
+                "{environment:?}"
+            );
+        }
+    }
+
+    #[test]
     fn cloudflared_required_when_named_tunnel_pinned() {
         assert!(cloudflared_required(false, true, true));
     }
@@ -1753,6 +1812,7 @@ mod tests {
         ServeLaunch {
             schema: SERVE_LAUNCH_SCHEMA,
             pid: 4242,
+            instance_id: Some("instance-1".to_string()),
             profile: "work".to_string(),
             host: "0.0.0.0".to_string(),
             port: 9090,
@@ -1775,6 +1835,7 @@ mod tests {
         let json = serde_json::to_string(&launch).expect("serialize");
         let back: ServeLaunch = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.pid, launch.pid);
+        assert_eq!(back.instance_id, launch.instance_id);
         assert_eq!(back.profile, launch.profile);
         assert_eq!(back.host, launch.host);
         assert_eq!(back.port, launch.port);

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -696,8 +696,31 @@ fn command_is_aoe_serve(command: &[u8]) -> bool {
         .rsplit(|byte| *byte == b'/')
         .next()
         .unwrap_or(executable);
-    matches!(basename, b"aoe" | b"agent-of-empires")
-        && args.iter().skip(1).any(|arg| *arg == b"serve")
+    if !matches!(basename, b"aoe" | b"agent-of-empires") {
+        return false;
+    }
+
+    let mut index = 1;
+    while let Some(arg) = args.get(index) {
+        match *arg {
+            b"-p" | b"--profile" | b"--daemon-url" => {
+                index += 2;
+                if index > args.len() {
+                    return false;
+                }
+            }
+            arg if arg.starts_with(b"--profile=")
+                || arg.starts_with(b"--daemon-url=")
+                || (arg.starts_with(b"-p") && arg.len() > 2) =>
+            {
+                index += 1;
+            }
+            b"serve" => return true,
+            arg if arg.starts_with(b"-") => return false,
+            _ => return false,
+        }
+    }
+    false
 }
 
 /// Cross-platform check that `pid` belongs to an `aoe serve` process.
@@ -1584,7 +1607,11 @@ mod tests {
         let cases: &[(&[u8], bool)] = &[
             (b"/usr/local/bin/aoe\0serve\0--daemon\0", true),
             (b"agent-of-empires serve --daemon", true),
+            (b"aoe --profile work serve --daemon", true),
+            (b"aoe --profile=work serve --daemon", true),
             (b"aoe update", false),
+            (b"aoe --profile serve update", false),
+            (b"aoe --some-option serve update", false),
             (b"/tmp/aoe-helper serve", false),
             (b"runner --label aoe serve", false),
         ];

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -1482,7 +1482,7 @@ pub(crate) async fn stop_daemon() -> Result<()> {
             }
         }
         StopTargetDisposition::CleanStaleState => {
-            tokio::fs::remove_file(&path).await?;
+            remove_stale_serve_state(&path);
             bail!(
                 "PID {} belongs to a different process (stale PID file). Cleaned up.",
                 pid

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -762,17 +762,36 @@ fn inspect_daemon_process(pid: i32) -> DaemonProcessIdentity {
     }
 
     // macOS / other: shell out to `ps`. `-o command=` prints the full
-    // command (path + args) with no header.
+    // command (path + args) with no header, and `-ww` stops it being clipped
+    // at the terminal width before `serve` shows up.
     match std::process::Command::new("ps")
-        .args(["-o", "command=", "-p", &pid.to_string()])
+        .args(["-ww", "-o", "command=", "-p", &pid.to_string()])
         .output()
     {
-        Ok(out) if out.status.success() && command_is_aoe_serve(&out.stdout) => {
-            DaemonProcessIdentity::Verified
+        Ok(out) if !out.status.success() => DaemonProcessIdentity::Indeterminate,
+        Ok(out) if command_is_aoe_serve(&out.stdout) => DaemonProcessIdentity::Verified,
+        Ok(out) if command_mentions_aoe_executable(&out.stdout) => {
+            DaemonProcessIdentity::Indeterminate
         }
-        Ok(out) if out.status.success() => DaemonProcessIdentity::Foreign,
-        _ => DaemonProcessIdentity::Indeterminate,
+        Ok(_) => DaemonProcessIdentity::Foreign,
+        Err(_) => DaemonProcessIdentity::Indeterminate,
     }
+}
+
+/// Loose companion to `command_is_aoe_serve`, for the `ps` path only. `ps`
+/// joins argv with spaces, so an executable path or option value that itself
+/// contains a space cannot be split back into argv and the strict parse fails
+/// on a genuine daemon. When the raw output still names an aoe executable,
+/// report `Indeterminate` rather than `Foreign`: the two costs are not
+/// symmetric, since `Foreign` deletes `serve.launch` and `serve.passphrase`
+/// and so throws away the only way to restart a daemon that is still running.
+/// A trailing space is required so a mention in an unrelated argument
+/// (`vim src/aoe.rs`) still classifies as foreign.
+fn command_mentions_aoe_executable(command: &[u8]) -> bool {
+    command.windows(4).any(|window| window == b"aoe ")
+        || command
+            .windows(17)
+            .any(|window| window == b"agent-of-empires ")
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1905,6 +1924,36 @@ mod tests {
             no_tailscale: true,
             allowed_host: vec!["aoe.example.com".to_string()],
             allowed_origin: vec!["https://aoe.example.com:8443".to_string()],
+        }
+    }
+
+    #[test]
+    fn space_joined_ps_output_is_unverifiable_not_foreign() {
+        let cases = [
+            // `ps` cannot round-trip these back into argv, so the strict parse
+            // fails; they must not reach the state-destroying Foreign branch.
+            (&b"/Users/me/My Apps/aoe serve --daemon-child"[..], true),
+            (
+                &b"/usr/local/bin/aoe -p my profile serve --daemon-child"[..],
+                true,
+            ),
+            // Clipped before `serve` (what `ps` did without `-ww`).
+            (
+                &b"/usr/local/bin/aoe --profile work --host 0.0.0.0 --port"[..],
+                true,
+            ),
+            (&b"/opt/homebrew/bin/agent-of-empires serve"[..], true),
+            // An unrelated process that merely mentions aoe is still foreign.
+            (&b"/usr/bin/vim src/aoe.rs"[..], false),
+            (&b"/usr/bin/python3 manage.py runserver"[..], false),
+        ];
+        for (command, expected) in cases {
+            assert_eq!(
+                command_mentions_aoe_executable(command),
+                expected,
+                "{}",
+                String::from_utf8_lossy(command)
+            );
         }
     }
 

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -135,9 +135,15 @@ pub async fn run(args: UpdateArgs) -> Result<()> {
 #[cfg(feature = "serve")]
 #[derive(Debug, PartialEq, Eq)]
 enum RestartDecision {
-    /// Nothing to restart automatically: no self-managed daemon is up, or
-    /// the context (non-interactive, no `-y`) cannot drive a restart.
+    /// No daemon process or persisted PID state was found.
     NotApplicable,
+    /// A self-managed daemon was found, but this invocation cannot prompt.
+    ManualSelfManaged,
+    /// A verified foreground or supervisor-managed daemon must be restarted
+    /// by the process that launched it.
+    ManualExternal,
+    /// PID state exists, but the process could not be verified safely.
+    ManualUnverified,
     /// Interactive terminal: ask before restarting.
     Prompt,
     /// Restart without asking (`-y`).
@@ -151,21 +157,28 @@ enum RestartDecision {
 /// testable.
 #[cfg(feature = "serve")]
 fn restart_decision(
-    running: bool,
+    verified_running: bool,
+    pid_state_present: bool,
     launch_present: bool,
     is_tty: bool,
     yes: bool,
 ) -> RestartDecision {
-    if !running || !launch_present {
-        return RestartDecision::NotApplicable;
+    if !verified_running {
+        return if pid_state_present {
+            RestartDecision::ManualUnverified
+        } else {
+            RestartDecision::NotApplicable
+        };
+    }
+    if !launch_present {
+        return RestartDecision::ManualExternal;
     }
     if yes {
         RestartDecision::Auto
     } else if is_tty {
         RestartDecision::Prompt
     } else {
-        // Non-TTY without -y: cannot prompt, so fall back to the hint.
-        RestartDecision::NotApplicable
+        RestartDecision::ManualSelfManaged
     }
 }
 
@@ -177,22 +190,23 @@ fn restart_decision(
 #[cfg(feature = "serve")]
 fn handle_daemon_restart_after_update(binary_path: &Path, yes: bool) -> Result<()> {
     use crate::cli::serve;
-    let running = serve::daemon_pid().is_some();
+    // Snapshot this before daemon_pid() probes and potentially removes stale
+    // state. Even unreadable or unverifiable PID state is enough to require a
+    // warning, but never enough to authorize process control.
+    let pid_state_present = serve::pid_file_path().is_ok_and(|path| path.exists());
+    let verified_running = serve::daemon_pid().is_some();
     let launch_present = serve::serve_launch_exists();
-    match restart_decision(running, launch_present, io::stdin().is_terminal(), yes) {
-        RestartDecision::NotApplicable => {
-            // Nothing running means no hint is needed. Otherwise point at
-            // the right manual step: a self-managed daemon we just cannot
-            // drive right now (non-interactive, no -y) restarts with
-            // `aoe serve --restart`, but a foreground or supervised daemon
-            // (no launch state) must be bounced by its own manager, for
-            // which --restart would correctly refuse.
-            if running && launch_present {
-                println!("{}", daemon_restart_hint());
-            } else if running {
-                println!("{}", external_restart_hint());
-            }
-        }
+    match restart_decision(
+        verified_running,
+        pid_state_present,
+        launch_present,
+        io::stdin().is_terminal(),
+        yes,
+    ) {
+        RestartDecision::NotApplicable => {}
+        RestartDecision::ManualSelfManaged => println!("{}", daemon_restart_hint()),
+        RestartDecision::ManualExternal => println!("{}", external_restart_hint()),
+        RestartDecision::ManualUnverified => println!("{}", unverified_restart_hint()),
         RestartDecision::Prompt => {
             print!("Restart the running aoe serve daemon now? [Y/n] ");
             io::stdout().flush()?;
@@ -215,10 +229,21 @@ fn handle_daemon_restart_after_update(binary_path: &Path, yes: bool) -> Result<(
 /// point the user at the supervisor that owns the process instead.
 #[cfg(feature = "serve")]
 fn external_restart_hint() -> &'static str {
-    "  An `aoe serve` daemon is running but was not started by\n  \
+    "  WARNING: an `aoe serve` daemon is running but was not started by\n  \
      `aoe serve --daemon`; restart it through whatever launched it (your\n  \
      service manager, or the terminal it runs in) so it picks up the new\n  \
      binary."
+}
+
+/// Conservative fallback when daemon PID state exists but cannot be verified.
+/// It covers both self-managed and external launch models without authorizing
+/// control of an unverified process.
+#[cfg(feature = "serve")]
+fn unverified_restart_hint() -> &'static str {
+    "  WARNING: aoe found daemon state but could not verify the running process.\n  \
+     Existing `aoe serve` processes keep running the old build until restarted.\n  \
+     If started with `aoe serve --daemon`, run `aoe serve --restart`; otherwise\n  \
+     restart it through its terminal or service manager."
 }
 
 /// Spawn the freshly installed binary as `aoe serve --restart`. Best
@@ -252,7 +277,7 @@ fn restart_via_new_binary(binary_path: &Path) {
 /// build automatically (see #1754). Surfacing this avoids the silent
 /// mixed-version trap where a freshly-shipped fix appears not to work.
 fn daemon_restart_hint() -> &'static str {
-    "  If `aoe serve` is running, restart it (`aoe serve --restart`) so the daemon\n  \
+    "  WARNING: if `aoe serve` is running, restart it (`aoe serve --restart`) so the daemon\n  \
      picks up the new binary. Acp workers from the old build finish their\n  \
      current turn, then respawn on the new build."
 }
@@ -285,6 +310,7 @@ mod tests {
     #[test]
     fn daemon_hint_mentions_restart_and_respawn() {
         let hint = daemon_restart_hint();
+        assert!(hint.contains("WARNING:"));
         // Points the user at the restart that actually applies the binary.
         assert!(hint.contains("aoe serve --restart"));
         // Sets the expectation that workers converge to the new build.
@@ -295,30 +321,36 @@ mod tests {
     #[test]
     fn restart_decision_matrix() {
         use super::{restart_decision, RestartDecision};
-        // Nothing running: never restart.
+        // No process or PID state: nothing to restart or warn about.
         assert_eq!(
-            restart_decision(false, false, true, true),
+            restart_decision(false, false, false, true, true),
             RestartDecision::NotApplicable
+        );
+        // Persisted daemon state must not be treated as proof that no
+        // old-build server may still be running.
+        assert_eq!(
+            restart_decision(false, true, false, false, true),
+            RestartDecision::ManualUnverified
         );
         // Running but no launch state (foreground / supervised): hands off.
         assert_eq!(
-            restart_decision(true, false, true, true),
-            RestartDecision::NotApplicable
+            restart_decision(true, true, false, true, true),
+            RestartDecision::ManualExternal
         );
         // Self-managed daemon + -y: restart without asking.
         assert_eq!(
-            restart_decision(true, true, false, true),
+            restart_decision(true, true, true, false, true),
             RestartDecision::Auto
         );
         // Self-managed daemon on a TTY without -y: prompt.
         assert_eq!(
-            restart_decision(true, true, true, false),
+            restart_decision(true, true, true, true, false),
             RestartDecision::Prompt
         );
         // Self-managed daemon, non-TTY, no -y: cannot prompt, fall back.
         assert_eq!(
-            restart_decision(true, true, false, false),
-            RestartDecision::NotApplicable
+            restart_decision(true, true, true, false, false),
+            RestartDecision::ManualSelfManaged
         );
     }
 }

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -190,11 +190,13 @@ fn restart_decision(
 #[cfg(feature = "serve")]
 fn handle_daemon_restart_after_update(binary_path: &Path, yes: bool) -> Result<()> {
     use crate::cli::serve;
-    // Snapshot this before daemon_pid() probes and potentially removes stale
-    // state. Even unreadable or unverifiable PID state is enough to require a
-    // warning, but never enough to authorize process control.
-    let pid_state_present = serve::pid_file_path().is_ok_and(|path| path.exists());
     let verified_running = serve::daemon_pid().is_some();
+    // Probe first so verifiably stale state is swept. Unreadable or otherwise
+    // unverifiable state remains enough to require a warning, but never enough
+    // to authorize process control.
+    let pid_state_present = serve::pid_file_path()
+        .map(|path| path.try_exists().unwrap_or(true))
+        .unwrap_or(false);
     let launch_present = serve::serve_launch_exists();
     match restart_decision(
         verified_running,
@@ -315,6 +317,13 @@ mod tests {
         assert!(hint.contains("aoe serve --restart"));
         // Sets the expectation that workers converge to the new build.
         assert!(hint.to_lowercase().contains("respawn"));
+
+        #[cfg(feature = "serve")]
+        {
+            let fallback = super::unverified_restart_hint();
+            assert!(fallback.contains("aoe serve --restart"));
+            assert!(fallback.contains("terminal or service manager"));
+        }
     }
 
     #[cfg(feature = "serve")]

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -162,11 +162,11 @@ enum UpdateDaemonState {
     Unverified,
 }
 
-/// Decide whether to restart the daemon after an update. A daemon is only
-/// restartable when it is both running AND left a `serve.launch` behind
-/// (i.e. it was started by `aoe serve --daemon`, not run in the
-/// foreground or under a service supervisor). Pure so the matrix is unit
-/// testable.
+/// Decide whether to restart the daemon after an update, given the daemon's
+/// classified state. Only `SelfManaged` is restartable, i.e. running with a
+/// `serve.launch` record that authorizes this PID; every other state prints a
+/// hint naming the owner that has to do the restart. Pure so the matrix is
+/// unit testable.
 #[cfg(feature = "serve")]
 fn restart_decision(daemon: UpdateDaemonState, is_tty: bool, yes: bool) -> RestartDecision {
     match daemon {
@@ -229,14 +229,17 @@ fn external_restart_hint() -> &'static str {
 }
 
 /// Conservative fallback when daemon PID state exists but cannot be verified.
-/// It covers both self-managed and external launch models without authorizing
-/// control of an unverified process.
+/// The dominant cause is `kill(pid, 0)` returning `EPERM`, i.e. a daemon owned
+/// by another user, so the hint names ownership rather than `aoe serve
+/// --restart`: that command runs the same verification and refuses an
+/// unverified daemon, which would leave the user chasing a contradiction.
 #[cfg(feature = "serve")]
 fn unverified_restart_hint() -> &'static str {
     "  WARNING: aoe found daemon state but could not verify the running process.\n  \
      Existing `aoe serve` processes keep running the old build until restarted.\n  \
-     If started with `aoe serve --daemon`, run `aoe serve --restart`; otherwise\n  \
-     restart it through its terminal or service manager."
+     This usually means the daemon belongs to another user (a root service unit,\n  \
+     or `sudo aoe serve`), and `aoe serve --restart` refuses what it cannot\n  \
+     verify: restart it as its owner, or through its terminal or service manager."
 }
 
 #[cfg(feature = "serve")]
@@ -318,8 +321,10 @@ mod tests {
 
         #[cfg(feature = "serve")]
         {
+            // The unverified case is usually another user's daemon, so the hint
+            // must name ownership instead of promising a restart that refuses.
             let fallback = super::unverified_restart_hint();
-            assert!(fallback.contains("aoe serve --restart"));
+            assert!(fallback.contains("belongs to another user"));
             assert!(fallback.contains("terminal or service manager"));
         }
     }

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -124,8 +124,11 @@ pub async fn run(args: UpdateArgs) -> Result<()> {
         // resolve from this process, so we never auto-restart; point the
         // user at the manual step when a daemon is up.
         #[cfg(feature = "serve")]
-        if crate::cli::serve::daemon_pid().is_some() {
-            println!("{}", daemon_restart_hint());
+        if !matches!(
+            crate::cli::serve::daemon_status(),
+            crate::cli::serve::DaemonStatus::Absent
+        ) {
+            println!("{}", manual_update_restart_hint());
         }
     }
     Ok(())
@@ -150,35 +153,29 @@ enum RestartDecision {
     Auto,
 }
 
+#[cfg(feature = "serve")]
+#[derive(Clone, Copy, Debug)]
+enum UpdateDaemonState {
+    Absent,
+    SelfManaged,
+    External,
+    Unverified,
+}
+
 /// Decide whether to restart the daemon after an update. A daemon is only
 /// restartable when it is both running AND left a `serve.launch` behind
 /// (i.e. it was started by `aoe serve --daemon`, not run in the
 /// foreground or under a service supervisor). Pure so the matrix is unit
 /// testable.
 #[cfg(feature = "serve")]
-fn restart_decision(
-    verified_running: bool,
-    pid_state_present: bool,
-    launch_present: bool,
-    is_tty: bool,
-    yes: bool,
-) -> RestartDecision {
-    if !verified_running {
-        return if pid_state_present {
-            RestartDecision::ManualUnverified
-        } else {
-            RestartDecision::NotApplicable
-        };
-    }
-    if !launch_present {
-        return RestartDecision::ManualExternal;
-    }
-    if yes {
-        RestartDecision::Auto
-    } else if is_tty {
-        RestartDecision::Prompt
-    } else {
-        RestartDecision::ManualSelfManaged
+fn restart_decision(daemon: UpdateDaemonState, is_tty: bool, yes: bool) -> RestartDecision {
+    match daemon {
+        UpdateDaemonState::Absent => RestartDecision::NotApplicable,
+        UpdateDaemonState::External => RestartDecision::ManualExternal,
+        UpdateDaemonState::Unverified => RestartDecision::ManualUnverified,
+        UpdateDaemonState::SelfManaged if yes => RestartDecision::Auto,
+        UpdateDaemonState::SelfManaged if is_tty => RestartDecision::Prompt,
+        UpdateDaemonState::SelfManaged => RestartDecision::ManualSelfManaged,
     }
 }
 
@@ -190,21 +187,15 @@ fn restart_decision(
 #[cfg(feature = "serve")]
 fn handle_daemon_restart_after_update(binary_path: &Path, yes: bool) -> Result<()> {
     use crate::cli::serve;
-    let verified_running = serve::daemon_pid().is_some();
-    // Probe first so verifiably stale state is swept. Unreadable or otherwise
-    // unverifiable state remains enough to require a warning, but never enough
-    // to authorize process control.
-    let pid_state_present = serve::pid_file_path()
-        .map(|path| path.try_exists().unwrap_or(true))
-        .unwrap_or(false);
-    let launch_present = serve::serve_launch_exists();
-    match restart_decision(
-        verified_running,
-        pid_state_present,
-        launch_present,
-        io::stdin().is_terminal(),
-        yes,
-    ) {
+    let daemon = match serve::daemon_status() {
+        serve::DaemonStatus::Absent => UpdateDaemonState::Absent,
+        serve::DaemonStatus::Unverified => UpdateDaemonState::Unverified,
+        serve::DaemonStatus::Verified(pid) if serve::serve_launch_matches(pid) => {
+            UpdateDaemonState::SelfManaged
+        }
+        serve::DaemonStatus::Verified(_) => UpdateDaemonState::External,
+    };
+    match restart_decision(daemon, io::stdin().is_terminal(), yes) {
         RestartDecision::NotApplicable => {}
         RestartDecision::ManualSelfManaged => println!("{}", daemon_restart_hint()),
         RestartDecision::ManualExternal => println!("{}", external_restart_hint()),
@@ -246,6 +237,13 @@ fn unverified_restart_hint() -> &'static str {
      Existing `aoe serve` processes keep running the old build until restarted.\n  \
      If started with `aoe serve --daemon`, run `aoe serve --restart`; otherwise\n  \
      restart it through its terminal or service manager."
+}
+
+#[cfg(feature = "serve")]
+fn manual_update_restart_hint() -> &'static str {
+    "  WARNING: existing `aoe serve` processes keep running the old build until\n  \
+     restarted. If started with `aoe serve --daemon`, run `aoe serve --restart`;\n  \
+     otherwise restart it through its terminal or service manager."
 }
 
 /// Spawn the freshly installed binary as `aoe serve --restart`. Best
@@ -329,37 +327,47 @@ mod tests {
     #[cfg(feature = "serve")]
     #[test]
     fn restart_decision_matrix() {
-        use super::{restart_decision, RestartDecision};
-        // No process or PID state: nothing to restart or warn about.
-        assert_eq!(
-            restart_decision(false, false, false, true, true),
-            RestartDecision::NotApplicable
-        );
-        // Persisted daemon state must not be treated as proof that no
-        // old-build server may still be running.
-        assert_eq!(
-            restart_decision(false, true, false, false, true),
-            RestartDecision::ManualUnverified
-        );
-        // Running but no launch state (foreground / supervised): hands off.
-        assert_eq!(
-            restart_decision(true, true, false, true, true),
-            RestartDecision::ManualExternal
-        );
-        // Self-managed daemon + -y: restart without asking.
-        assert_eq!(
-            restart_decision(true, true, true, false, true),
-            RestartDecision::Auto
-        );
-        // Self-managed daemon on a TTY without -y: prompt.
-        assert_eq!(
-            restart_decision(true, true, true, true, false),
-            RestartDecision::Prompt
-        );
-        // Self-managed daemon, non-TTY, no -y: cannot prompt, fall back.
-        assert_eq!(
-            restart_decision(true, true, true, false, false),
-            RestartDecision::ManualSelfManaged
-        );
+        use super::{restart_decision, RestartDecision, UpdateDaemonState};
+        let cases = [
+            (
+                UpdateDaemonState::Absent,
+                true,
+                true,
+                RestartDecision::NotApplicable,
+            ),
+            (
+                UpdateDaemonState::Unverified,
+                false,
+                true,
+                RestartDecision::ManualUnverified,
+            ),
+            (
+                UpdateDaemonState::External,
+                true,
+                true,
+                RestartDecision::ManualExternal,
+            ),
+            (
+                UpdateDaemonState::SelfManaged,
+                false,
+                true,
+                RestartDecision::Auto,
+            ),
+            (
+                UpdateDaemonState::SelfManaged,
+                true,
+                false,
+                RestartDecision::Prompt,
+            ),
+            (
+                UpdateDaemonState::SelfManaged,
+                false,
+                false,
+                RestartDecision::ManualSelfManaged,
+            ),
+        ];
+        for (daemon, is_tty, yes, expected) in cases {
+            assert_eq!(restart_decision(daemon, is_tty, yes), expected);
+        }
     }
 }

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -319,6 +319,8 @@ mod tests {
         // Sets the expectation that workers converge to the new build.
         assert!(hint.to_lowercase().contains("respawn"));
 
+        // Every hint has to name a recovery path the reader can actually take,
+        // since each one is printed in place of the restart aoe declined to do.
         #[cfg(feature = "serve")]
         {
             // The unverified case is usually another user's daemon, so the hint
@@ -326,6 +328,20 @@ mod tests {
             let fallback = super::unverified_restart_hint();
             assert!(fallback.contains("belongs to another user"));
             assert!(fallback.contains("terminal or service manager"));
+
+            // An externally launched daemon must be sent to its launcher, not
+            // to `aoe serve --restart`, which refuses a daemon it did not start.
+            let external = super::external_restart_hint();
+            assert!(external.contains("WARNING:"));
+            assert!(!external.contains("aoe serve --restart"));
+            assert!(external.contains("service manager"));
+
+            // The manual-install path cannot know how the daemon was launched,
+            // so it has to cover both recoveries.
+            let manual = super::manual_update_restart_hint();
+            assert!(manual.contains("WARNING:"));
+            assert!(manual.contains("aoe serve --restart"));
+            assert!(manual.contains("terminal or service manager"));
         }
     }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description
<!-- Describe your changes and the problem they solve -->

`aoe update` previously treated a failed daemon *liveness* probe as proof that no server was running. `daemon_pid()` swept the `serve.*` lifecycle files and reported absence whenever `kill(pid, 0)` returned any error other than `ESRCH`, and `EPERM` (another user's daemon, e.g. a root service unit or `sudo aoe serve`) hits exactly that path. The update then completed silently and left the old daemon build running indefinitely, with the state needed to restart it already deleted.

(Identity verification failed in the *opposite* direction: `verify_pid_is_aoe` returned `true` when it could not verify, so an unverifiable process was treated as present.)

The update flow now distinguishes verified self-managed daemons, externally managed daemons, unverified daemon state, and confirmed stale state. It keeps automatic restart restricted to verified `aoe serve --daemon` processes, prints prominent launch-appropriate warnings for the other live or uncertain cases, and preserves lifecycle files when process probing is inconclusive. Only `ESRCH` or a positively foreign PID triggers stale-state cleanup.

This is a behavior change for every `daemon_pid()` caller, not just `update`: it is now fail-closed everywhere. `killall`, `aoe url`, ACP discovery, and the TUI's daemon indicators report no daemon when the process cannot be verified (e.g. another user's), where before an unverifiable PID was reported as present.

Closes #3225

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the regression is the pure post-update decision policy; existing e2e tests separately cover tarball replacement and daemon restart, while cross-user permission simulation is unreliable in privileged CI

## How to test

- [ ] Start `aoe serve --daemon`, run `aoe update -y` when an update is available, and confirm the daemon restarts with a new PID.
- [ ] Start `aoe serve` in the foreground or through a service manager, run `aoe update -y`, and confirm a prominent warning directs you to restart it through its launcher.
- [ ] Leave an unverifiable `serve.pid` in the app directory (or point it at another user's process), run `aoe update -y`, and confirm the warning names the owning user as the one who must restart it, attempts no process control, and leaves every `serve.*` file in place.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Codex with the agent-of-empires `/aoe-implement` workflow


**Any Additional AI Details you'd like to share:**

Codex investigated the existing restart implementation, facilitated a multi-model design review, implemented the approved plan, and ran validation under my direction.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved `aoe update` daemon detection and restart handling.
- Restart only verified, self-managed `aoe serve --daemon` processes.
- Bind launch state to the daemon instance for safer verification.
- Preserve lifecycle files when daemon status is uncertain.
- Remove stale state only for confirmed stale or foreign PIDs.
- Add clear warnings for externally managed or unverifiable daemons.
- Extend the version probe timeout from two to five seconds.
- Add tests and documentation for daemon checks and recovery.

## Benefits

Updates no longer leave an outdated daemon running without notice. Uncertain process states no longer cause unsafe restarts or cleanup. Users receive clear guidance when manual action is required.

## Further enhancement

Future work could add lifecycle commands that integrate directly with external supervisors and automation tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

