### PR TITLE
fix(acp): infer background sub-agent completion when end_turn is absent

### DIFF
--- a/src/acp/background_agent.rs
+++ b/src/acp/background_agent.rs
@@ -150,6 +150,11 @@ struct Snapshot {
     /// sub-agent finished speaking" from "it's mid tool-call". See
     /// `infer_idle_outcome`.
     last_was_text: bool,
+    /// Tool-use ids with no matching `tool_result` yet. Tracked separately
+    /// from `tools`, which stops growing at `MAX_TOOLS` to bound the event
+    /// payload; completion state must stay accurate past that cap, so it
+    /// cannot be derived from the truncated list. Never sent on the wire.
+    unresolved_tools: HashSet<String>,
 }
 
 async fn run_tailer(agent_id: String, output_file: String, event_tx: Sender<Event>) {
@@ -345,8 +350,9 @@ fn fold_line(line: &str, snap: &mut Snapshot) {
     }
 }
 
-/// Record a tool call. Bumps the count always; appends a detailed entry
-/// until the cap so a huge sub-agent can't bloat the event payload.
+/// Record a tool call. Bumps the count and the unresolved set always;
+/// appends a detailed entry only until the cap, so a huge sub-agent can't
+/// bloat the event payload.
 fn fold_tool_use(block: &serde_json::Value, snap: &mut Snapshot) {
     snap.tool_count += 1;
     snap.last_was_text = false;
@@ -356,15 +362,18 @@ fn fold_tool_use(block: &serde_json::Value, snap: &mut Snapshot) {
         .unwrap_or("tool")
         .to_string();
     snap.last_tool = Some(name.clone());
-    if snap.tools.len() >= MAX_TOOLS {
-        return;
-    }
-    let title = block.get("input").and_then(tool_title);
     let id = block
         .get("id")
         .and_then(|i| i.as_str())
         .unwrap_or_default()
         .to_string();
+    // Tracked past the cap: `tools` is truncated to bound the event
+    // payload, but completion state must stay accurate for every call.
+    snap.unresolved_tools.insert(id.clone());
+    if snap.tools.len() >= MAX_TOOLS {
+        return;
+    }
+    let title = block.get("input").and_then(tool_title);
     snap.tools.push(ToolEntry {
         id,
         name,
@@ -373,7 +382,8 @@ fn fold_tool_use(block: &serde_json::Value, snap: &mut Snapshot) {
     });
 }
 
-/// Fill in a tool's outcome from its `tool_result`, matched by id.
+/// Fill in a tool's outcome from its `tool_result`, matched by id, and
+/// clear it from the unresolved set (which, unlike `tools`, is uncapped).
 fn fold_tool_result(block: &serde_json::Value, snap: &mut Snapshot) {
     let Some(id) = block.get("tool_use_id").and_then(|i| i.as_str()) else {
         return;
@@ -382,6 +392,7 @@ fn fold_tool_result(block: &serde_json::Value, snap: &mut Snapshot) {
         .get("is_error")
         .and_then(|e| e.as_bool())
         .unwrap_or(false);
+    snap.unresolved_tools.remove(id);
     if let Some(entry) = snap.tools.iter_mut().find(|t| t.id == id) {
         entry.ok = Some(!is_error);
     }
@@ -450,7 +461,7 @@ fn format_warning(snap: &Snapshot) -> Option<String> {
 /// treated as done, not stalled. A tool call still awaiting its result
 /// (`ok: None`) means the sub-agent was mid-action, never done.
 fn infer_idle_outcome(snap: &Snapshot) -> (BackgroundAgentStatus, Option<String>, Option<String>) {
-    let dangling_tool = snap.tools.iter().any(|t| t.ok.is_none());
+    let dangling_tool = !snap.unresolved_tools.is_empty();
     if snap.last_was_text && snap.last_text.is_some() && !dangling_tool {
         (
             BackgroundAgentStatus::Completed,
@@ -594,8 +605,8 @@ mod tests {
     /// sub-agent that actually finished from one genuinely hung.
     #[test]
     fn infer_idle_outcome_distinguishes_finished_from_hung() {
-        // (lines to fold, expected status, case description)
-        let cases: Vec<(Vec<&str>, BackgroundAgentStatus, &str)> = vec![
+        // (lines, expected status, expected result, warning substring, case)
+        let cases: Vec<(Vec<&str>, BackgroundAgentStatus, Option<&str>, &str, &str)> = vec![
             (
                 vec![
                     r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash"}]}}"#,
@@ -603,6 +614,8 @@ mod tests {
                     r#"{"type":"assistant","message":{"stop_reason":null,"content":[{"type":"text","text":"final report"}]}}"#,
                 ],
                 BackgroundAgentStatus::Completed,
+                Some("final report"),
+                "completion inferred from final text",
                 "final text block, no dangling tool, no end_turn marker: genuinely done (#3232)",
             ),
             (
@@ -611,21 +624,84 @@ mod tests {
                     r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash"}]}}"#,
                 ],
                 BackgroundAgentStatus::Stalled,
+                None,
+                "no transcript activity",
                 "last content is a tool call still awaiting its result: genuinely hung",
+            ),
+            (
+                vec![
+                    r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash"},{"type":"text","text":"spoke after the call"}]}}"#,
+                ],
+                BackgroundAgentStatus::Stalled,
+                None,
+                "no transcript activity",
+                "text after an unresolved tool call: still mid-action, not done",
             ),
             (
                 vec!["not json at all"],
                 BackgroundAgentStatus::Stalled,
+                None,
+                "no transcript activity",
                 "nothing parsed at all: genuinely hung",
             ),
         ];
-        for (lines, expected_status, desc) in cases {
+        for (lines, expected_status, expected_result, warn_contains, desc) in cases {
             let mut snap = Snapshot::default();
             for line in lines {
                 fold_line(line, &mut snap);
             }
-            let (status, ..) = infer_idle_outcome(&snap);
+            let (status, result, warning) = infer_idle_outcome(&snap);
             assert_eq!(status, expected_status, "{desc}");
+            assert_eq!(result.as_deref(), expected_result, "result for: {desc}");
+            let warning = warning.unwrap_or_default();
+            assert!(
+                warning.contains(warn_contains),
+                "warning for {desc}: expected {warn_contains:?}, got {warning:?}"
+            );
         }
+    }
+
+    /// `tools` stops growing at `MAX_TOOLS` to bound the event payload, so
+    /// completion state cannot be read off it: a call issued past the cap
+    /// would be invisible and a trailing text block would wrongly infer
+    /// `Completed`. `unresolved_tools` is uncapped for exactly this reason.
+    #[test]
+    fn infer_idle_outcome_sees_unresolved_tool_past_the_display_cap() {
+        let mut snap = Snapshot::default();
+        for i in 0..=MAX_TOOLS {
+            fold_line(
+                &format!(
+                    r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"t{i}","name":"Bash"}}]}}}}"#
+                ),
+                &mut snap,
+            );
+        }
+        // Resolve every call the capped display list actually holds, so the
+        // only unresolved one is the call past the cap.
+        for i in 0..MAX_TOOLS {
+            fold_line(
+                &format!(
+                    r#"{{"type":"user","message":{{"content":[{{"type":"tool_result","tool_use_id":"t{i}","is_error":false}}]}}}}"#
+                ),
+                &mut snap,
+            );
+        }
+        fold_line(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"all done"}]}}"#,
+            &mut snap,
+        );
+
+        assert_eq!(snap.tools.len(), MAX_TOOLS, "display list stays capped");
+        assert!(
+            snap.tools.iter().all(|t| t.ok.is_some()),
+            "every tool in the capped list is resolved, so the cap hides the dangling one"
+        );
+        assert_eq!(snap.tool_count as usize, MAX_TOOLS + 1);
+        let (status, ..) = infer_idle_outcome(&snap);
+        assert_eq!(
+            status,
+            BackgroundAgentStatus::Stalled,
+            "a tool call past the display cap is still unresolved, so not done"
+        );
     }
 }

--- a/src/acp/background_agent.rs
+++ b/src/acp/background_agent.rs
@@ -16,8 +16,12 @@
 //! - One task per agent, keyed by the launch. It self-terminates on
 //!   completion, on a hard-idle cap, or when `event_tx` closes (the
 //!   session went away), so it can never outlive its session.
-//! - Completion is set ONLY on a terminal `end_turn` assistant message.
-//!   Idle is reported as `Stalled`, never faked as `Completed`.
+//! - Completion is set on a terminal `end_turn` assistant message, or, at
+//!   the idle timeout, inferred from a substantial final text block with
+//!   no dangling tool call (Claude Code doesn't always tag the true final
+//!   record `end_turn`; see `infer_idle_outcome`, #3232). A genuine hang
+//!   (no final text, or a tool call never resolved) still reports
+//!   `Stalled`, never faked as done.
 //! - Progress is a throttled, coalesced snapshot (tool count + last
 //!   action), not one event per transcript line, so the SQLite event log
 //!   stays bounded while a mid-run reload still sees in-flight agents.
@@ -139,6 +143,13 @@ struct Snapshot {
     done: bool,
     parse_errors: u32,
     parsed_any: bool,
+    /// True when the most recently folded content block was `text`, false
+    /// when it was `tool_use`. Claude Code's async-Task transcripts don't
+    /// always tag the final assistant record `stop_reason: "end_turn"`, so
+    /// this is the fallback signal an idle-timeout uses to tell "the
+    /// sub-agent finished speaking" from "it's mid tool-call". See
+    /// `infer_idle_outcome`.
+    last_was_text: bool,
 }
 
 async fn run_tailer(agent_id: String, output_file: String, event_tx: Sender<Event>) {
@@ -196,14 +207,17 @@ async fn run_tailer(agent_id: String, output_file: String, event_tx: Sender<Even
 
         let idle = (now - last_growth).to_std().unwrap_or(Duration::ZERO);
         if idle >= ABORT_AFTER {
-            // Stopped tracking; never claim it finished.
+            // Stopped tracking. No end_turn marker was ever seen, but the
+            // transcript may still show the sub-agent actually finished;
+            // see infer_idle_outcome.
+            let (status, result, warning) = infer_idle_outcome(&snap);
             let _ = event_tx
                 .send(completed(
                     agent_id,
-                    BackgroundAgentStatus::Stalled,
+                    status,
                     snapshot_tools(&snap),
-                    snap.result.clone(),
-                    Some("no transcript activity; stopped tracking".into()),
+                    result,
+                    warning,
                 ))
                 .await;
             return;
@@ -304,6 +318,7 @@ fn fold_line(line: &str, snap: &mut Snapshot) {
                             let preview = preview(text);
                             if !preview.is_empty() {
                                 snap.last_text = Some(preview.clone());
+                                snap.last_was_text = true;
                                 if end_turn {
                                     snap.result = Some(preview);
                                 }
@@ -333,6 +348,7 @@ fn fold_line(line: &str, snap: &mut Snapshot) {
 /// until the cap so a huge sub-agent can't bloat the event payload.
 fn fold_tool_use(block: &serde_json::Value, snap: &mut Snapshot) {
     snap.tool_count += 1;
+    snap.last_was_text = false;
     let name = block
         .get("name")
         .and_then(|n| n.as_str())
@@ -422,6 +438,30 @@ fn format_warning(snap: &Snapshot) -> Option<String> {
         Some("sub-agent transcript format not recognized; details unavailable".into())
     } else {
         None
+    }
+}
+
+/// Decide what an idle-timeout (`ABORT_AFTER`, no `end_turn` ever seen)
+/// really means: a genuine hang, or a sub-agent that finished speaking and
+/// simply stopped writing. Claude Code's async-Task transcripts don't
+/// always tag the final assistant record `stop_reason: "end_turn"` (see
+/// #3232), so a substantial final text block with no dangling tool call is
+/// treated as done, not stalled. A tool call still awaiting its result
+/// (`ok: None`) means the sub-agent was mid-action, never done.
+fn infer_idle_outcome(snap: &Snapshot) -> (BackgroundAgentStatus, Option<String>, Option<String>) {
+    let dangling_tool = snap.tools.iter().any(|t| t.ok.is_none());
+    if snap.last_was_text && snap.last_text.is_some() && !dangling_tool {
+        (
+            BackgroundAgentStatus::Completed,
+            snap.last_text.clone(),
+            Some("no explicit end_turn marker; completion inferred from final text".into()),
+        )
+    } else {
+        (
+            BackgroundAgentStatus::Stalled,
+            snap.result.clone(),
+            Some("no transcript activity; stopped tracking".into()),
+        )
     }
 }
 
@@ -545,5 +585,46 @@ mod tests {
         let p = preview(&long);
         assert!(p.ends_with('…'));
         assert!(p.chars().count() <= TEXT_PREVIEW_CHARS + 1);
+    }
+
+    /// #3232: Claude Code's async-Task transcripts don't always tag the
+    /// final assistant record `stop_reason: "end_turn"`. `infer_idle_outcome`
+    /// is what an `ABORT_AFTER` idle-timeout falls back on to tell a
+    /// sub-agent that actually finished from one genuinely hung.
+    #[test]
+    fn infer_idle_outcome_distinguishes_finished_from_hung() {
+        // (lines to fold, expected status, case description)
+        let cases: Vec<(Vec<&str>, BackgroundAgentStatus, &str)> = vec![
+            (
+                vec![
+                    r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash"}]}}"#,
+                    r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","is_error":false}]}}"#,
+                    r#"{"type":"assistant","message":{"stop_reason":null,"content":[{"type":"text","text":"final report"}]}}"#,
+                ],
+                BackgroundAgentStatus::Completed,
+                "final text block, no dangling tool, no end_turn marker: genuinely done (#3232)",
+            ),
+            (
+                vec![
+                    r#"{"type":"assistant","message":{"content":[{"type":"text","text":"working on it"}]}}"#,
+                    r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash"}]}}"#,
+                ],
+                BackgroundAgentStatus::Stalled,
+                "last content is a tool call still awaiting its result: genuinely hung",
+            ),
+            (
+                vec!["not json at all"],
+                BackgroundAgentStatus::Stalled,
+                "nothing parsed at all: genuinely hung",
+            ),
+        ];
+        for (lines, expected_status, desc) in cases {
+            let mut snap = Snapshot::default();
+            for line in lines {
+                fold_line(line, &mut snap);
+            }
+            let (status, ..) = infer_idle_outcome(&snap);
+            assert_eq!(status, expected_status, "{desc}");
+        }
     }
 }

--- a/src/acp/background_agent.rs
+++ b/src/acp/background_agent.rs
@@ -191,7 +191,8 @@ async fn run_tailer(agent_id: String, output_file: String, event_tx: Sender<Even
         }
 
         if snap.done {
-            // A clean end_turn: the only "Completed" path.
+            // The explicit end_turn completion path. The idle timeout
+            // below can also infer completion; see infer_idle_outcome.
             let warning = format_warning(&snap);
             let _ = event_tx
                 .send(completed(

--- a/src/acp/state.rs
+++ b/src/acp/state.rs
@@ -359,9 +359,11 @@ pub enum StartupErrorDetail {
 }
 
 /// Lifecycle status of an async background sub-agent. `Completed` is the
-/// only "finished cleanly" state and is set ONLY on an `end_turn` in the
-/// transcript; idle/missing-file/parse states are reported honestly
-/// rather than faked as done. See the background-agent tailer.
+/// "finished cleanly" state: either the transcript's terminal record was
+/// tagged `end_turn`, or (since #3232) the idle timeout inferred it from a
+/// substantial final text block with no dangling tool call. Idle/missing-
+/// file/parse states are reported honestly rather than faked as done. See
+/// the background-agent tailer's `infer_idle_outcome`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BackgroundAgentStatus {
@@ -370,7 +372,8 @@ pub enum BackgroundAgentStatus {
     /// No transcript growth for the idle window; the agent may be
     /// blocked, rate-limited, or wedged. Never flips to `Completed`.
     Stalled,
-    /// Saw the terminal `end_turn` assistant message. The work is done.
+    /// Saw the terminal `end_turn` assistant message, or inferred done from
+    /// a final text block at the idle timeout. The work is done.
     Completed,
     /// The parent session ended before the agent finished; we stopped
     /// tracking it. Not a success, not a failure.

--- a/src/acp/state.rs
+++ b/src/acp/state.rs
@@ -871,7 +871,8 @@ pub enum Event {
         at: DateTime<Utc>,
     },
     /// Terminal state for a background sub-agent: `Completed` (saw
-    /// `end_turn`), `Stalled`, `Detached`, or `Error`.
+    /// `end_turn`, or inferred it at the idle timeout), `Stalled`,
+    /// `Detached`, or `Error`.
     BackgroundAgentCompleted {
         agent_id: String,
         status: BackgroundAgentStatus,

--- a/src/acp/state.rs
+++ b/src/acp/state.rs
@@ -370,7 +370,9 @@ pub enum BackgroundAgentStatus {
     /// Transcript is being written; the agent is working.
     Running,
     /// No transcript growth for the idle window; the agent may be
-    /// blocked, rate-limited, or wedged. Never flips to `Completed`.
+    /// blocked, rate-limited, or wedged. Provisional while the tailer
+    /// runs: the idle timeout may still infer `Completed` from a final
+    /// text block. Terminal only once the tailer stops tracking.
     Stalled,
     /// Saw the terminal `end_turn` assistant message, or inferred done from
     /// a final text block at the idle timeout. The work is done.


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Background sub-agents that had clearly finished their work were showing as **stalled** forever in the Background agents panel, never **done**. `stalled` is supposed to mean "stuck / no output", so this read as "these broke" for sub-agents that had in fact delivered full reports.

Root cause is in the transcript tailer. `src/acp/background_agent.rs` only ever set `Completed` on an assistant record tagged `stop_reason: "end_turn"`, but Claude Code's async-Task transcripts do not always tag the true final record that way. When the marker never arrives, `snap.done` stays false, the tailer keeps polling, and after `ABORT_AFTER` (300s) of no growth it gives up and emits a terminal `Stalled` with "no transcript activity; stopped tracking", even though the last thing the sub-agent did was write out its complete answer.

This was not rare: 24 of 186 `BackgroundAgentCompleted` events in the local event log (13%) were `stalled`, and the sampled ones show the same shape.

The fix adds `infer_idle_outcome`, consulted only on the idle-timeout path. If the last folded content block was `text`, there is a final text preview, and no tool call is still awaiting its result, the sub-agent finished speaking and is reported `Completed` with that text as the result, plus a warning noting completion was inferred rather than confirmed. A genuine hang (no final text, or a tool call that never resolved) still reports `Stalled`, so real failures are not swallowed into false "done". The clean `end_turn` path is untouched.

Verified against the four sub-agents in the reported session by replaying their real on-disk transcripts through the new logic: all four now resolve to `Completed` carrying their actual reports (`done=false`, `last_was_text=true`, `dangling=0` on every one), where before all four terminated `Stalled`.

Backend only. The web panel already renders `completed` as "done", so no frontend change was needed.

Closes #3232

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured-view session and have the agent dispatch async `Task` sub-agents (for example, ask it to launch a few parallel Explore agents over the repo).
- [ ] Watch the Background agents panel while they run: each shows `running` with a live tool count, unchanged from before.
- [ ] Let them finish and leave the session idle for over 5 minutes (`ABORT_AFTER`), so any sub-agent whose transcript lacked an `end_turn` marker reaches the timeout path.
- [ ] Confirm a sub-agent that produced a final report now shows **done** rather than **stalled**, and expanding the row shows its report text under `result`.
- [ ] Expand the row and confirm the `warning` field reads "no explicit end_turn marker; completion inferred from final text", so an inferred completion is still distinguishable from a clean one.
- [ ] Confirm a sub-agent interrupted mid tool call (stop the session while one is running, then wait out the timeout) still shows **stalled**, so genuine hangs are not reported as done.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

The change is entirely in the Rust tailer; no dashboard component or request shape changed. `BackgroundAgentsPanel.tsx` already renders the `completed` status as "done", so the panel needed no edit and its existing coverage still applies.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

Covered instead by a table-driven unit test, `infer_idle_outcome_distinguishes_finished_from_hung` in `src/acp/background_agent.rs`, exercising all three branches: finished-without-`end_turn` goes `Completed`, dangling tool call stays `Stalled`, nothing-parsed stays `Stalled`. An e2e test would have to wait out the real 300s `ABORT_AFTER` for no extra signal, since the decision is a pure function over the parsed snapshot.

One transparency note on the red/green proof: the reproducing test targets `infer_idle_outcome`, which this PR introduces, so on the pre-fix tree it fails to compile rather than failing an assertion. The behavioral proof that the bug is real and fixed came from replaying the four real transcripts from the reported session through the new logic, described in the Description.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement` skill)


**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls, reviewed each commit, and approved the plan before any code was written.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Background agents can now be marked `Completed` when their final transcript contains text without `stop_reason: "end_turn"`.
- Agents with missing text or unresolved tool calls remain `Stalled`.
- The system tracks unresolved tool calls beyond the display limit.
- Inferred completions include the final text and a warning.
- Lifecycle documentation and table-driven tests were updated.

## Benefits

This prevents valid background-agent reports from appearing stalled while preserving detection of incomplete work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->