### PR TITLE
fix(acp): carry per-option description through elicitation parsing

### DIFF
--- a/src/acp/elicitations.rs
+++ b/src/acp/elicitations.rs
@@ -116,6 +116,10 @@ pub struct ElicitationOption {
     pub value: String,
     /// Human-readable label.
     pub label: String,
+    /// Optional per-option description (e.g. AskUserQuestion's pros/cons
+    /// text). `None` for a bare enum/string option, which has no slot for
+    /// one in the wire schema.
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -376,6 +380,7 @@ fn parse_string_field(
                 .map(|o| ElicitationOption {
                     value: o.value.clone(),
                     label: o.title.clone(),
+                    description: o.description.clone(),
                 })
                 .collect(),
         )
@@ -387,6 +392,7 @@ fn parse_string_field(
                 .map(|v| ElicitationOption {
                     value: v.clone(),
                     label: v.clone(),
+                    description: None,
                 })
                 .collect(),
         )
@@ -422,6 +428,7 @@ fn parse_field(
                     .map(|o| ElicitationOption {
                         value: o.value.clone(),
                         label: o.title.clone(),
+                        description: o.description.clone(),
                     })
                     .collect(),
                 MultiSelectItems::String(u) => u
@@ -430,6 +437,7 @@ fn parse_field(
                     .map(|v| ElicitationOption {
                         value: v.clone(),
                         label: v.clone(),
+                        description: None,
                     })
                     .collect(),
                 // `MultiSelectItems` is non_exhaustive; a future item shape
@@ -986,10 +994,12 @@ mod tests {
                         ElicitationOption {
                             value: "Yes".into(),
                             label: "Yes".into(),
+                            description: None,
                         },
                         ElicitationOption {
                             value: "No".into(),
                             label: "No".into(),
+                            description: None,
                         },
                     ],
                     ..empty_question("question_0", ElicitationFieldKind::SingleSelect, true)
@@ -1000,10 +1010,12 @@ mod tests {
                         ElicitationOption {
                             value: "a".into(),
                             label: "A".into(),
+                            description: None,
                         },
                         ElicitationOption {
                             value: "b".into(),
                             label: "B".into(),
+                            description: None,
                         },
                     ],
                     ..empty_question("tags", ElicitationFieldKind::MultiSelect, false)
@@ -1083,12 +1095,14 @@ mod tests {
                     ElicitationOption {
                         value: "tok_blue".into(),
                         label: "Blue".into(),
+                        description: None,
                     },
                     // AskUserQuestion-style "label <sep> description": the bare
                     // value is kept, the description dropped from the summary.
                     ElicitationOption {
                         value: "Green".into(),
                         label: "Green \u{2014} the color green".into(),
+                        description: None,
                     },
                 ],
                 ..empty_question("color", ElicitationFieldKind::SingleSelect, true)

--- a/src/acp/elicitations.rs
+++ b/src/acp/elicitations.rs
@@ -847,6 +847,61 @@ mod tests {
     }
 
     #[test]
+    fn parses_option_descriptions_from_titled_variants() {
+        // A titled `oneOf` / multi-select option can carry a per-option
+        // description on the wire; an untitled one has no slot for one.
+        let schema = ElicitationSchema::new()
+            .property(
+                "question_0",
+                StringPropertySchema::new().one_of(vec![
+                    EnumOption::new("Yes", "Yes").description("Ships now"),
+                    EnumOption::new("No", "No"),
+                ]),
+                false,
+            )
+            .property(
+                "question_1",
+                MultiSelectPropertySchema::titled(vec![
+                    EnumOption::new("a", "Apple").description("Crisp"),
+                    EnumOption::new("b", "Banana"),
+                ]),
+                false,
+            );
+        let req = form_request(schema, "pick");
+        let e = parse_elicitation(Nonce::new(), &req, Utc::now()).unwrap();
+        let single = &e.questions[0];
+        assert_eq!(single.options[0].description.as_deref(), Some("Ships now"));
+        assert_eq!(single.options[1].description, None);
+        let multi = &e.questions[1];
+        assert_eq!(multi.options[0].description.as_deref(), Some("Crisp"));
+        assert_eq!(multi.options[1].description, None);
+    }
+
+    #[test]
+    fn bare_enum_and_multi_select_options_have_no_description() {
+        // A bare `enum`/string-array item is just a string on the wire; it
+        // has no slot to carry a description, unlike a titled EnumOption.
+        let schema = ElicitationSchema::new()
+            .property(
+                "question_0",
+                StringPropertySchema::new().enum_values(vec!["Yes".into(), "No".into()]),
+                false,
+            )
+            .property(
+                "question_1",
+                MultiSelectPropertySchema::new(vec!["a".into(), "b".into()]),
+                false,
+            );
+        let req = form_request(schema, "pick");
+        let e = parse_elicitation(Nonce::new(), &req, Utc::now()).unwrap();
+        for question in &e.questions {
+            for option in &question.options {
+                assert_eq!(option.description, None, "{}", option.value);
+            }
+        }
+    }
+
+    #[test]
     fn parses_multi_select_and_free_text_and_orders_numerically() {
         let schema = ElicitationSchema::new()
             .property(

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -1820,6 +1820,7 @@ mod tests {
                 .map(|o| crate::acp::elicitations::ElicitationOption {
                     value: o.to_string(),
                     label: o.to_string(),
+                    description: None,
                 })
                 .collect(),
             min_items: None,

--- a/web/src/components/acp/AskUserQuestionCard.test.tsx
+++ b/web/src/components/acp/AskUserQuestionCard.test.tsx
@@ -234,6 +234,59 @@ describe("AskUserQuestionCard extended field kinds", () => {
     expect(onResolve).toHaveBeenCalledWith({ action: "accept", answers: { question_0: "Red" } });
   });
 
+  it("renders a structured per-option description without any flattened label", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    const sel = q({
+      field_key: "question_0",
+      kind: "single_select",
+      title: "Pick",
+      options: [{ value: "Red", label: "Red", description: "the warm one" }],
+    });
+    render(<AskUserQuestionCard elicitation={makeElicitation([sel])} onResolve={onResolve} />);
+    expect(screen.getByText("Red")).toBeTruthy();
+    expect(screen.getByText("the warm one")).toBeTruthy();
+  });
+
+  it("prefers the structured description over the flattened label when both are present", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    const sel = q({
+      field_key: "question_0",
+      kind: "single_select",
+      title: "Pick",
+      options: [{ value: "Red", label: "Red — stale flattened text", description: "the warm one" }],
+    });
+    render(<AskUserQuestionCard elicitation={makeElicitation([sel])} onResolve={onResolve} />);
+    expect(screen.getByText("Red")).toBeTruthy();
+    expect(screen.getByText("the warm one")).toBeTruthy();
+    expect(screen.queryByText("stale flattened text")).toBeNull();
+  });
+
+  it("treats an empty structured description as present, suppressing the flattened fallback", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    const sel = q({
+      field_key: "question_0",
+      kind: "single_select",
+      title: "Pick",
+      options: [{ value: "Red", label: "Red — the warm one", description: "" }],
+    });
+    render(<AskUserQuestionCard elicitation={makeElicitation([sel])} onResolve={onResolve} />);
+    expect(screen.getByText("Red")).toBeTruthy();
+    expect(screen.queryByText("the warm one")).toBeNull();
+  });
+
+  it("treats a null structured description as absent, falling back to the flattened label", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    const sel = q({
+      field_key: "question_0",
+      kind: "single_select",
+      title: "Pick",
+      options: [{ value: "Red", label: "Red — the warm one", description: null }],
+    });
+    render(<AskUserQuestionCard elicitation={makeElicitation([sel])} onResolve={onResolve} />);
+    expect(screen.getByText("Red")).toBeTruthy();
+    expect(screen.getByText("the warm one")).toBeTruthy();
+  });
+
   it("pre-fills defaults across kinds", () => {
     const onResolve = vi.fn().mockResolvedValue(undefined);
     const questions = [

--- a/web/src/components/acp/AskUserQuestionCard.tsx
+++ b/web/src/components/acp/AskUserQuestionCard.tsx
@@ -86,19 +86,21 @@ function inputTypeFor(format: string | null | undefined): string {
   }
 }
 
-/** The adapter flattens an AskUserQuestion option's `description` into the
- *  enum title as `"<label> — <description>"` (the structured option is
- *  lost on the wire). The bare label survives as the option `value`, so when
- *  the human label is exactly `value` + that separator we can recover the
- *  two-tier label/description; otherwise the title is shown verbatim (a
- *  generic MCP enum where `value` is a code and `label` is the display text). */
+/** A titled option can carry its description in the structured `description`
+ *  field (current adapters); prefer that. An older adapter shape flattened
+ *  it into the enum title instead, as `"<label> — <description>"` with the
+ *  bare label surviving as the option `value`, so when no structured
+ *  description is present and the human label matches that pattern we
+ *  recover the two-tier label/description from it; otherwise the title is
+ *  shown verbatim (a generic MCP enum where `value` is a code and `label` is
+ *  the display text). */
 const OPTION_DESC_SEP = " — ";
 function optionParts(opt: ElicitationOption): { label: string; description?: string } {
   const prefix = `${opt.value}${OPTION_DESC_SEP}`;
   if (opt.label.startsWith(prefix) && opt.label.length > prefix.length) {
-    return { label: opt.value, description: opt.label.slice(prefix.length) };
+    return { label: opt.value, description: opt.description ?? opt.label.slice(prefix.length) };
   }
-  return { label: opt.label };
+  return { label: opt.label, description: opt.description ?? undefined };
 }
 
 const labelOf = (q: ElicitationQuestion) => q.title || q.field_key;

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -205,6 +205,7 @@ export type ElicitationFieldKind = "free_text" | "single_select" | "multi_select
 export interface ElicitationOption {
   value: string;
   label: string;
+  description?: string | null;
 }
 
 /** A pre-fill / submitted value. Mirror of `AnswerValue` (untagged): a


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`AskUserQuestion` prompts can carry a per-option description (pros/cons text), but aoe's own elicitation parser was silently dropping it. The ACP wire schema (`agent-client-protocol-schema` 1.4.0) models a titled enum option as `EnumOption { value, title, description }`, used for both single-select `oneOf` and titled multi-select. aoe's `ElicitationOption` struct only had `value`/`label`, so both parse sites discarded `description` when mapping into it, and it never reached the web card even though the card already had a rendering slot for one (recovered via a legacy convention where an older adapter shape flattened the description into the label string).

This PR adds `description: Option<String>` to `ElicitationOption`, forwards it from both titled parse sites in `src/acp/elicitations.rs` (bare enum/string options genuinely have no slot for one on the wire, so they stay `None`), mirrors the field on the TS `ElicitationOption` type, and updates `AskUserQuestionCard.tsx`'s `optionParts()` to prefer the structured field over the legacy label-flattening fallback (which stays in place for any adapter still emitting the old shape).

Closes #3234

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Skipped a test, because: this is a pure presentation/parsing fix (no browser-specific behavior, no backend round-trip change), already covered by the existing `acp.elicitation-card` Vitest matrix entry; extended its spec file (`AskUserQuestionCard.test.tsx`) directly instead of adding Playwright coverage.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle. (The one TUI file touched is a test-helper struct-literal update to keep it compiling; no TUI behavior changed. The TUI's `ChoicePicker` elicitation rendering was left out of scope, see below.)

## How to test

- [ ] Trigger an `AskUserQuestion` prompt from an agent that supplies per-option descriptions (structured `EnumOption.description`) and confirm each option shows its description text under the label in the web dashboard's elicitation card.
- [ ] Trigger a multi-select `AskUserQuestion` prompt (checkboxes) with per-option descriptions and confirm each checkbox option shows its description too.
- [ ] Confirm an option whose label still uses the legacy `"<value> — <description>"` flattened form (no structured `description` field) still renders correctly, unchanged from before this PR.

## Out of scope (noted in the linked issue)

- TUI structured-view's `ChoicePicker` (a generic single-line list shared with the Mode/Link pickers) is not being extended to show a second description line.
- Deleting the legacy label-flattening fallback in `optionParts()` entirely; kept as a safety net for any adapter still emitting the old shape.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill, with a `/debate` cross-model review of the fix shape before implementation)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (including resolving the one open disagreement from the `/debate` review toward the simpler always-strip-legacy-prefix behavior), and will run the manual test steps above.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Preserves per-option descriptions during ACP elicitation parsing and displays them in the web elicitation card.

- Adds description support to Rust and TypeScript `ElicitationOption` types.
- Preserves descriptions for titled single-select and multi-select options.
- Uses structured descriptions before the legacy flattened label format.
- Keeps fallback support for older adapters.
- Adds parsing and rendering regression tests.
- Leaves bare enum and string options without descriptions because the ACP format does not provide them.

This keeps option guidance visible to users and prevents information loss between ACP responses and the web interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->