### PR TITLE
feat(skills): manage and share skills across agents from TUI, web, and CLI

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,87 @@ in the TUI's Serve panel). Three transports are accepted:
 Read-only mode (`aoe serve --read-only`) blocks every write endpoint
 with `403 read_only`. Read endpoints work normally.
 
+## Skills
+
+AoE discovers Agent Skills packages from its managed store and supported
+user-level agent directories. A skill is a directory containing a valid
+`SKILL.md` with `name` and `description` YAML frontmatter. External packages are
+read-only. Adopt one to create an editable copy under AoE's managed store.
+
+Physical source roots are stable ids:
+
+| Source id | Directory | Consumers |
+| --- | --- | --- |
+| `claude-user` | `~/.claude/skills` | Claude, OpenCode |
+| `agents-standard` | `~/.agents/skills` | Codex, OpenCode |
+| `gemini-user` | `~/.gemini/skills` | Gemini |
+| `opencode-user` | `~/.config/opencode/skills` | OpenCode |
+| `kimi-legacy` | `~/.kimi-code/skills` | Kimi legacy installations |
+| `aoe-managed` | `<app-dir>/skills` | AoE-managed packages |
+
+### GET /api/skills
+
+Returns every discovered skill plus the external root registry. Skills with the
+same directory name remain separate source-qualified entries.
+
+```json
+{
+  "skills": [
+    {
+      "directory": "review",
+      "name": "Review",
+      "description": "Review code carefully",
+      "provenance": { "kind": "external", "root": "claude-user" },
+      "provenanceLabel": "external:claude-user",
+      "writable": false
+    }
+  ],
+  "roots": []
+}
+```
+
+### GET /api/skills/{source}/{directory}
+
+Reads one source-qualified package and returns its full `SKILL.md` in the
+`content` field. Use `aoe-managed` for a managed skill or one of the external
+source ids above.
+
+### POST /api/skills
+
+Creates a managed skill and scaffolds its `SKILL.md`.
+
+```json
+{ "directory": "release-check", "description": "Validate a release candidate" }
+```
+
+### PUT /api/skills/{directory}
+
+Replaces a managed skill's `SKILL.md` after validating its frontmatter and
+1 MiB size limit.
+
+```json
+{ "content": "---\nname: release-check\ndescription: Validate a release candidate\n---\n" }
+```
+
+### DELETE /api/skills/{directory}
+
+Deletes a valid managed skill package. External packages cannot be deleted
+through AoE.
+
+### POST /api/skills/{source}/{directory}/adopt
+
+Copies an external package into the managed store without changing the source.
+The optional `destination` field changes the managed directory name.
+
+```json
+{ "destination": "team-review" }
+```
+
+All skill mutations require a read-write server and an elevated authenticated
+session when login is enabled. They are unavailable in CityHall mode. Adoption
+rejects symlinks, special files, packages over 64 MiB, individual files over
+32 MiB, more than 1,024 files, and directory nesting deeper than 16 levels.
+
 ## GET /api/sessions
 
 List sessions. Returns every session by default, including trashed and

--- a/docs/api.md
+++ b/docs/api.md
@@ -96,6 +96,44 @@ The optional `destination` field changes the managed directory name.
 { "destination": "team-review" }
 ```
 
+### POST /api/skills/sync
+
+Copies managed skills into the agents' own skills directories, so a skill
+authored once in AoE is available to every agent. Pass `roots` to limit the
+sync; omit it to reach every root.
+
+```json
+{ "roots": ["claude-user", "gemini-user"] }
+```
+
+Returns one outcome per skill per root rather than stopping at the first
+conflict.
+
+```json
+{
+  "ok": true,
+  "outcomes": [
+    { "root": "claude-user", "directory": "review", "status": "created", "message": null }
+  ]
+}
+```
+
+`status` is `created`, `updated`, `unchanged`, `removed`, `conflict`, or
+`error`.
+
+A propagated copy carries an `.aoe-managed.json` marker naming its root, its
+skill, and the package digest at the time it was written. That marker is the
+only thing that lets AoE later replace or remove the directory, and only while
+the copy still matches the recorded digest. So a skill you wrote by hand, or a
+propagated copy you have since edited, is reported as a `conflict` and left
+exactly as it is; it is never overwritten, and it is never removed when its
+managed source is deleted. A copy carrying a valid marker is listed once, as its
+managed original, rather than twice.
+
+Setting `skills.auto_propagate` runs the same sync at session launch for the
+agent being launched. It is off by default because it writes into your real
+agent config directories.
+
 All skill mutations require a read-write server and an elevated authenticated
 session when login is enabled. They are unavailable in CityHall mode. Adoption
 rejects symlinks, special files, packages over 64 MiB, individual files over

--- a/docs/api.md
+++ b/docs/api.md
@@ -103,8 +103,18 @@ authored once in AoE is available to every agent. Pass `roots` to limit the
 sync; omit it to reach every root.
 
 ```json
-{ "roots": ["claude-user", "gemini-user"] }
+{ "roots": ["claude-user", "gemini-user"], "replace": ["review"] }
 ```
+
+`replace` names skills AoE should take over, overwriting a skill it does not
+manage or a propagated copy that was edited in place. It is the only way past
+the never-overwrite rule below, so it must name each skill explicitly; an
+omitted or empty `replace` overwrites nothing. A replaced entry becomes
+AoE-owned, so later syncs keep it current on their own. Replacing a symlinked
+entry moves the link aside and leaves whatever it pointed at alone, so a skill
+managed by another tool keeps its own store.
+
+Automatic syncs never replace anything.
 
 Returns one outcome per skill per root rather than stopping at the first
 conflict.
@@ -129,6 +139,10 @@ propagated copy you have since edited, is reported as a `conflict` and left
 exactly as it is; it is never overwritten, and it is never removed when its
 managed source is deleted. A copy carrying a valid marker is listed once, as its
 managed original, rather than twice.
+
+This is also what makes AoE safe to run alongside a symlink-based skill manager
+such as `skillshare`: a symlinked skill directory is something AoE did not
+deploy, so it is reported and left in place rather than followed or replaced.
 
 Setting `skills.auto_propagate` runs the same sync at session launch for the
 agent being launched. It is off by default because it writes into your real

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,7 +55,16 @@ same directory name remain separate source-qualified entries.
       "writable": false
     }
   ],
-  "roots": []
+  "roots": [
+    {
+      "id": "claude-user",
+      "label": "Claude",
+      "relativePath": ".claude/skills",
+      "consumers": ["claude", "opencode"],
+      "primaryAgent": "claude",
+      "legacy": false
+    }
+  ]
 }
 ```
 
@@ -103,8 +112,11 @@ authored once in AoE is available to every agent. Pass `roots` to limit the
 sync; omit it to reach every root.
 
 ```json
-{ "roots": ["claude-user", "gemini-user"], "replace": ["review"] }
+{ "roots": ["claude-user", "gemini-user"], "directories": ["review"], "replace": ["review"] }
 ```
+
+`directories` narrows the sync to those skills, leaving every other one and
+its copies alone; omit it to reconcile the whole store.
 
 `replace` names skills AoE should take over, overwriting a skill it does not
 manage or a propagated copy that was edited in place. It is the only way past

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -93,6 +93,13 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe telemetry reset-id`↴](#aoe-telemetry-reset-id)
 * [`aoe mcp`↴](#aoe-mcp)
 * [`aoe mcp list`↴](#aoe-mcp-list)
+* [`aoe skill`↴](#aoe-skill)
+* [`aoe skill list`↴](#aoe-skill-list)
+* [`aoe skill view`↴](#aoe-skill-view)
+* [`aoe skill add`↴](#aoe-skill-add)
+* [`aoe skill edit`↴](#aoe-skill-edit)
+* [`aoe skill adopt`↴](#aoe-skill-adopt)
+* [`aoe skill remove`↴](#aoe-skill-remove)
 * [`aoe serve`↴](#aoe-serve)
 * [`aoe url`↴](#aoe-url)
 * [`aoe acp`↴](#aoe-acp)
@@ -149,6 +156,7 @@ Run without arguments to launch the TUI dashboard.
 * `cityhall` — Export and apply the CityHall config bundle (settings + projects)
 * `telemetry` — Manage anonymous opt-in usage telemetry
 * `mcp` — Inspect the effective MCP server set (provenance, conflicts, drift)
+* `skill` — Query and manage agent skills
 * `serve` — Start a web dashboard for remote session access
 * `url` — Print the current dashboard URL of a running `aoe serve` daemon
 * `acp` — Manage the ACP structured-view workers (doctor, ps, logs, prompt, approve, ...)
@@ -1374,6 +1382,115 @@ List the merged effective MCP server set with provenance, plus any conflicts and
 
 * `--agent <AGENT>` — Agent whose effective set to resolve. Defaults to the configured default tool. MCP forwarding is per-agent because the agent-native layer differs
 * `--json` — Output machine-readable JSON instead of a table
+
+
+
+## `aoe skill`
+
+Query and manage agent skills
+
+**Usage:** `aoe skill <COMMAND>`
+
+###### **Subcommands:**
+
+* `list` — List discovered skills and their source roots
+* `view` — Print one skill's SKILL.md
+* `add` — Create a new AoE-managed skill
+* `edit` — Edit an AoE-managed skill
+* `adopt` — Copy an external skill into AoE's managed store
+* `remove` — Delete an AoE-managed skill
+
+
+
+## `aoe skill list`
+
+List discovered skills and their source roots
+
+**Usage:** `aoe skill list [OPTIONS]`
+
+###### **Options:**
+
+* `--json` — Output machine-readable JSON
+
+
+
+## `aoe skill view`
+
+Print one skill's SKILL.md
+
+**Usage:** `aoe skill view [OPTIONS] <DIRECTORY>`
+
+###### **Arguments:**
+
+* `<DIRECTORY>` — Skill directory name
+
+###### **Options:**
+
+* `--source <SOURCE>` — Source root id, or aoe-managed
+
+  Default value: `aoe-managed`
+* `--json` — Output metadata and content as JSON
+
+
+
+## `aoe skill add`
+
+Create a new AoE-managed skill
+
+**Usage:** `aoe skill add [OPTIONS] <DIRECTORY>`
+
+###### **Arguments:**
+
+* `<DIRECTORY>` — Skill directory name
+
+###### **Options:**
+
+* `--description <DESCRIPTION>` — Short description used in the generated SKILL.md
+
+
+
+## `aoe skill edit`
+
+Edit an AoE-managed skill
+
+**Usage:** `aoe skill edit [OPTIONS] <DIRECTORY>`
+
+###### **Arguments:**
+
+* `<DIRECTORY>` — Managed skill directory name
+
+###### **Options:**
+
+* `--file <PATH>` — Read replacement SKILL.md from this file. Use - for stdin
+
+
+
+## `aoe skill adopt`
+
+Copy an external skill into AoE's managed store
+
+**Usage:** `aoe skill adopt [OPTIONS] <SOURCE> <DIRECTORY>`
+
+###### **Arguments:**
+
+* `<SOURCE>` — External source root id, such as claude-user or agents-standard
+* `<DIRECTORY>` — Source skill directory name
+
+###### **Options:**
+
+* `--as <DESTINATION>` — Destination directory name in AoE's managed store
+
+
+
+## `aoe skill remove`
+
+Delete an AoE-managed skill
+
+**Usage:** `aoe skill remove <DIRECTORY>`
+
+###### **Arguments:**
+
+* `<DIRECTORY>` — Managed skill directory name
 
 
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1506,6 +1506,7 @@ Copy AoE-managed skills into the agents' own skills directories
 
 * `--root <ID>` — Limit the sync to these source roots. Repeatable. Defaults to all of them
 * `--replace <DIRECTORY>` — Take over this skill in the agents' directories, overwriting a skill AoE does not manage or a propagated copy that was edited there. Repeatable. Without it a sync never overwrites anything it did not itself write
+* `--only <DIRECTORY>` — Reconcile only this skill. Repeatable. Defaults to every managed skill
 * `--json` — Output the per-skill outcomes as JSON
 
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1505,6 +1505,7 @@ Copy AoE-managed skills into the agents' own skills directories
 ###### **Options:**
 
 * `--root <ID>` — Limit the sync to these source roots. Repeatable. Defaults to all of them
+* `--replace <DIRECTORY>` — Take over this skill in the agents' directories, overwriting a skill AoE does not manage or a propagated copy that was edited there. Repeatable. Without it a sync never overwrites anything it did not itself write
 * `--json` — Output the per-skill outcomes as JSON
 
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -100,6 +100,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe skill edit`↴](#aoe-skill-edit)
 * [`aoe skill adopt`↴](#aoe-skill-adopt)
 * [`aoe skill remove`↴](#aoe-skill-remove)
+* [`aoe skill sync`↴](#aoe-skill-sync)
 * [`aoe serve`↴](#aoe-serve)
 * [`aoe url`↴](#aoe-url)
 * [`aoe acp`↴](#aoe-acp)
@@ -1399,6 +1400,7 @@ Query and manage agent skills
 * `edit` — Edit an AoE-managed skill
 * `adopt` — Copy an external skill into AoE's managed store
 * `remove` — Delete an AoE-managed skill
+* `sync` — Copy AoE-managed skills into the agents' own skills directories
 
 
 
@@ -1491,6 +1493,19 @@ Delete an AoE-managed skill
 ###### **Arguments:**
 
 * `<DIRECTORY>` — Managed skill directory name
+
+
+
+## `aoe skill sync`
+
+Copy AoE-managed skills into the agents' own skills directories
+
+**Usage:** `aoe skill sync [OPTIONS]`
+
+###### **Options:**
+
+* `--root <ID>` — Limit the sync to these source roots. Repeatable. Defaults to all of them
+* `--json` — Output the per-skill outcomes as JSON
 
 
 

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -722,6 +722,13 @@ alone. It previously took a `directory` and copied one named skill, refusing any
 existing target; propagation is now root-level, so a single skill is no longer an
 addressable unit.
 
+It deliberately does not consult `skills.auto_propagate`. That setting gates
+the automatic path, where AoE would write into an agent's directory without
+being asked; an explicit `skills.propagate` call is a request, like
+`aoe skill sync`, which is not gated either. The gate on writing out of the
+store is the `fs.write` capability, which the user granted when they approved
+the plugin.
+
 Every `fs.*`/`skills.*` write inherits read-only safety for free: the plugin host
 is not spawned at all in read-only serve mode (`src/server/mod.rs` gates
 `PluginHost::new` on `!read_only`), so no per-method read-only check is needed.

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -713,10 +713,14 @@ host-discovered (read-only) target with `FORBIDDEN` (adopt it first). `adopt`
 copies a host-discovered skill into the managed store, leaving the original.
 The copy rejects links, special files, and packages outside the same byte,
 file-count, per-file, and nesting limits enforced by the REST API.
-`skills.propagate { directory, agent }` is the one method that writes
-OUT of the store: it copies a managed skill into a supported agent's host skills
-dir; it never overwrites an existing target, and the marker/dedupe/opt-in policy
-is deferred to the plugin side.
+`skills.propagate { agent }` is the one method that writes OUT of the store: it
+reconciles every managed skill into the skills dir that agent is the primary
+consumer of, and returns one `outcomes` entry per skill. It replaces or removes
+only copies AoE itself deployed that still match the digest recorded in their
+`.aoe-managed.json` marker; anything else is reported as a conflict and left
+alone. It previously took a `directory` and copied one named skill, refusing any
+existing target; propagation is now root-level, so a single skill is no longer an
+addressable unit.
 
 Every `fs.*`/`skills.*` write inherits read-only safety for free: the plugin host
 is not spawned at all in read-only serve mode (`src/server/mod.rs` gates

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -697,15 +697,23 @@ canonical-ancestor check, and symlinks are refused. No arbitrary host path is
 reachable; a host-discovered agent skills dir (`~/.claude/skills`,
 `~/.kimi-code/skills`) is not an `fs.*` root, so `fs.write` can never mutate a
 read-only host skill.
+The complete discovery registry also includes `~/.agents/skills`,
+`~/.gemini/skills`, and `~/.config/opencode/skills`.
 
-`skills.*` (#2984) manage the skill set modelled in `src/session/skills_model.rs`.
+`skills.*` (#2984, #3050) manage the skill set modelled in
+`src/session/skills_model.rs`.
 A skill's identity is its directory name, and skills are source-qualified by
 provenance, so `skills.list` returns every host-discovered and managed skill
-without shadow-merging. `skills.read { source, directory }` returns one skill's
-`SKILL.md`. `create` / `edit` / `delete` mutate the managed store in place and
-refuse a host-discovered (read-only) target with `FORBIDDEN` (adopt it first).
-`adopt` copies a host-discovered skill INTO the managed store, leaving the
-original. `skills.propagate { directory, agent }` is the one method that writes
+without shadow-merging. External provenance is keyed by the physical root, for
+example `{ "kind": "external", "root": "claude-user" }`, rather than by an
+agent name because multiple agents consume `~/.agents/skills`.
+`skills.read { source, directory }` returns one skill's `SKILL.md`. `create` /
+`edit` / `delete` mutate the managed store in place and refuse a
+host-discovered (read-only) target with `FORBIDDEN` (adopt it first). `adopt`
+copies a host-discovered skill into the managed store, leaving the original.
+The copy rejects links, special files, and packages outside the same byte,
+file-count, per-file, and nesting limits enforced by the REST API.
+`skills.propagate { directory, agent }` is the one method that writes
 OUT of the store: it copies a managed skill into a supported agent's host skills
 dir; it never overwrites an existing target, and the marker/dedupe/opt-in policy
 is deferred to the plugin side.

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -29,6 +29,7 @@ use super::send::SendArgs;
 use super::serve::ServeArgs;
 use super::session::SessionCommands;
 use super::settings::SettingsCommands;
+use super::skill::SkillCommands;
 use super::sounds::SoundsCommands;
 use super::status::StatusArgs;
 use super::telemetry::TelemetryCommands;
@@ -200,6 +201,12 @@ pub enum Commands {
         command: McpCommands,
     },
 
+    /// Query and manage agent skills
+    Skill {
+        #[command(subcommand)]
+        command: SkillCommands,
+    },
+
     /// Start a web dashboard for remote session access
     #[cfg(feature = "serve")]
     Serve(ServeArgs),
@@ -276,6 +283,7 @@ pub const CLI_COMMAND_NAMES: &[&str] = &[
     "cityhall",
     "telemetry",
     "mcp",
+    "skill",
     "serve",
     "url",
     "acp",
@@ -323,6 +331,7 @@ pub fn command_name(command: &Commands) -> Option<&'static str> {
         Commands::Cityhall { .. } => "cityhall",
         Commands::Telemetry { .. } => "telemetry",
         Commands::Mcp { .. } => "mcp",
+        Commands::Skill { .. } => "skill",
         #[cfg(feature = "serve")]
         Commands::Serve(_) => "serve",
         #[cfg(feature = "serve")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,6 +27,7 @@ pub mod send;
 pub mod serve;
 pub mod session;
 pub mod settings;
+pub mod skill;
 pub mod sounds;
 pub mod status;
 pub mod telemetry;

--- a/src/cli/skill.rs
+++ b/src/cli/skill.rs
@@ -1,0 +1,268 @@
+//! `aoe skill` CLI for discovering and managing agent skills.
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+use clap::{Args, Subcommand};
+
+use crate::session::skills_model::{self, SkillError, SkillProvenance};
+
+#[derive(Subcommand, Debug)]
+pub enum SkillCommands {
+    /// List discovered skills and their source roots.
+    List(SkillListArgs),
+    /// Print one skill's SKILL.md.
+    View(SkillViewArgs),
+    /// Create a new AoE-managed skill.
+    Add(SkillAddArgs),
+    /// Edit an AoE-managed skill.
+    Edit(SkillEditArgs),
+    /// Copy an external skill into AoE's managed store.
+    Adopt(SkillAdoptArgs),
+    /// Delete an AoE-managed skill.
+    Remove(SkillRemoveArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct SkillListArgs {
+    /// Output machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct SkillViewArgs {
+    /// Skill directory name.
+    directory: String,
+    /// Source root id, or aoe-managed.
+    #[arg(long, default_value = "aoe-managed")]
+    source: String,
+    /// Output metadata and content as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct SkillAddArgs {
+    /// Skill directory name.
+    directory: String,
+    /// Short description used in the generated SKILL.md.
+    #[arg(long)]
+    description: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct SkillEditArgs {
+    /// Managed skill directory name.
+    directory: String,
+    /// Read replacement SKILL.md from this file. Use - for stdin.
+    #[arg(long, value_name = "PATH")]
+    file: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+pub struct SkillAdoptArgs {
+    /// External source root id, such as claude-user or agents-standard.
+    source: String,
+    /// Source skill directory name.
+    directory: String,
+    /// Destination directory name in AoE's managed store.
+    #[arg(long = "as")]
+    destination: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct SkillRemoveArgs {
+    /// Managed skill directory name.
+    directory: String,
+}
+
+pub fn run(command: SkillCommands) -> Result<()> {
+    match command {
+        SkillCommands::List(args) => list(args),
+        SkillCommands::View(args) => view(args),
+        SkillCommands::Add(args) => add(args),
+        SkillCommands::Edit(args) => edit(args),
+        SkillCommands::Adopt(args) => adopt(args),
+        SkillCommands::Remove(args) => remove(args),
+    }
+}
+
+fn list(args: SkillListArgs) -> Result<()> {
+    let skills = skills_model::discover_all()?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "skills": skills,
+                "roots": skills_model::skill_roots(),
+            }))?
+        );
+        return Ok(());
+    }
+    if skills.is_empty() {
+        println!("No skills found.");
+        return Ok(());
+    }
+    println!("{:<24} {:<20} NAME", "DIRECTORY", "SOURCE");
+    for skill in skills {
+        println!(
+            "{:<24} {:<20} {}",
+            skill.directory,
+            skill.provenance.label(),
+            skill.name
+        );
+    }
+    Ok(())
+}
+
+fn view(args: SkillViewArgs) -> Result<()> {
+    let (home, app_dir) = skills_dirs()?;
+    let provenance = parse_source(&args.source)?;
+    let skill = skills_model::read_skill(&home, &app_dir, &provenance, &args.directory)
+        .map_err(skill_error)?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&skill)?);
+    } else {
+        print!("{}", skill.content);
+    }
+    Ok(())
+}
+
+fn add(args: SkillAddArgs) -> Result<()> {
+    let (_, app_dir) = skills_dirs()?;
+    skills_model::create_skill(&app_dir, &args.directory, args.description.as_deref())
+        .map_err(skill_error)?;
+    println!("Created managed skill {}.", args.directory);
+    Ok(())
+}
+
+fn edit(args: SkillEditArgs) -> Result<()> {
+    let (home, app_dir) = skills_dirs()?;
+    let content = match args.file {
+        Some(path) if path.as_os_str() == "-" => {
+            let mut content = String::new();
+            std::io::stdin().read_to_string(&mut content)?;
+            content
+        }
+        Some(path) => std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?,
+        None => edit_with_editor(&home, &app_dir, &args.directory)?,
+    };
+    skills_model::edit_skill(&home, &app_dir, &args.directory, &content).map_err(skill_error)?;
+    println!("Updated managed skill {}.", args.directory);
+    Ok(())
+}
+
+fn edit_with_editor(
+    home: &std::path::Path,
+    app_dir: &std::path::Path,
+    directory: &str,
+) -> Result<String> {
+    let skill = skills_model::read_skill(home, app_dir, &SkillProvenance::AoeManaged, directory)
+        .map_err(skill_error)?;
+    let temp = tempfile::tempdir()?;
+    let path = temp.path().join("SKILL.md");
+    std::fs::write(&path, skill.content)?;
+    let editor = std::env::var("VISUAL")
+        .or_else(|_| std::env::var("EDITOR"))
+        .unwrap_or_else(|_| "vi".to_string());
+    let mut parts = shell_words::split(&editor).context("failed to parse editor command")?;
+    if parts.is_empty() {
+        bail!("editor command is empty");
+    }
+    let program = parts.remove(0);
+    let status = Command::new(program)
+        .args(parts)
+        .arg(&path)
+        .status()
+        .context("failed to launch editor")?;
+    if !status.success() {
+        bail!("editor exited with status {status}");
+    }
+    std::fs::read_to_string(path).context("failed to read edited SKILL.md")
+}
+
+fn adopt(args: SkillAdoptArgs) -> Result<()> {
+    let (home, app_dir) = skills_dirs()?;
+    let provenance = parse_external_source(&args.source)?;
+    let destination = skills_model::adopt_skill(
+        &home,
+        &app_dir,
+        &provenance,
+        &args.directory,
+        args.destination.as_deref(),
+    )
+    .map_err(skill_error)?;
+    println!(
+        "Adopted {} as managed skill {}.",
+        args.directory, destination
+    );
+    Ok(())
+}
+
+fn remove(args: SkillRemoveArgs) -> Result<()> {
+    let (home, app_dir) = skills_dirs()?;
+    skills_model::delete_skill(&home, &app_dir, &args.directory).map_err(skill_error)?;
+    println!("Removed managed skill {}.", args.directory);
+    Ok(())
+}
+
+fn skills_dirs() -> Result<(PathBuf, PathBuf)> {
+    let home = dirs::home_dir().context("could not resolve home dir for skills")?;
+    Ok((home, crate::session::get_app_dir()?))
+}
+
+fn parse_source(source: &str) -> Result<SkillProvenance> {
+    if source == "aoe-managed" {
+        Ok(SkillProvenance::AoeManaged)
+    } else {
+        parse_external_source(source)
+    }
+}
+
+fn parse_external_source(source: &str) -> Result<SkillProvenance> {
+    if skills_model::skill_root(source).is_none() {
+        let roots = skills_model::skill_roots()
+            .iter()
+            .map(|root| root.id)
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!("unknown skill source {source:?}; expected one of: {roots}");
+    }
+    Ok(SkillProvenance::External {
+        root: source.to_string(),
+    })
+}
+
+fn skill_error(error: SkillError) -> anyhow::Error {
+    match error {
+        SkillError::InvalidInput(message)
+        | SkillError::NotFound(message)
+        | SkillError::Collision(message)
+        | SkillError::ReadOnly(message) => anyhow::anyhow!("{message}"),
+        SkillError::Io(error) => error,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_parser_accepts_managed_and_known_roots() {
+        assert_eq!(
+            parse_source("aoe-managed").unwrap(),
+            SkillProvenance::AoeManaged
+        );
+        assert_eq!(
+            parse_source("agents-standard").unwrap(),
+            SkillProvenance::External {
+                root: "agents-standard".to_string()
+            }
+        );
+        assert!(parse_source("unknown").is_err());
+    }
+}

--- a/src/cli/skill.rs
+++ b/src/cli/skill.rs
@@ -91,6 +91,9 @@ pub struct SkillSyncArgs {
     /// Without it a sync never overwrites anything it did not itself write.
     #[arg(long = "replace", value_name = "DIRECTORY")]
     replace: Vec<String>,
+    /// Reconcile only this skill. Repeatable. Defaults to every managed skill.
+    #[arg(long = "only", value_name = "DIRECTORY")]
+    only: Vec<String>,
     /// Output the per-skill outcomes as JSON.
     #[arg(long)]
     json: bool,
@@ -248,14 +251,17 @@ fn remove(args: SkillRemoveArgs) -> Result<()> {
 
 fn sync(args: SkillSyncArgs) -> Result<()> {
     let (home, app_dir) = skills_dirs()?;
-    let replace: std::collections::HashSet<String> = args.replace.into_iter().collect();
+    let options = skills_model::SyncOptions {
+        replace: args.replace.into_iter().collect(),
+        only: args.only.into_iter().collect(),
+    };
     let outcomes = if args.roots.is_empty() {
-        skills_model::sync_all_roots(&home, &app_dir, &replace)
+        skills_model::sync_all_roots(&home, &app_dir, &options)
     } else {
         let mut out = Vec::new();
         for root in &args.roots {
             out.extend(
-                skills_model::sync_root(&home, &app_dir, root, &replace).map_err(skill_error)?,
+                skills_model::sync_root(&home, &app_dir, root, &options).map_err(skill_error)?,
             );
         }
         out

--- a/src/cli/skill.rs
+++ b/src/cli/skill.rs
@@ -159,13 +159,13 @@ fn add(args: SkillAddArgs) -> Result<()> {
 
 fn edit(args: SkillEditArgs) -> Result<()> {
     let (home, app_dir) = skills_dirs()?;
+    // Every input path is bounded before it becomes a String. edit_skill
+    // enforces the same limit, but only after the whole input is already in
+    // memory, so an oversized file or an endless stdin stream would be read in
+    // full just to be rejected.
     let content = match args.file {
-        Some(path) if path.as_os_str() == "-" => {
-            let mut content = String::new();
-            std::io::stdin().read_to_string(&mut content)?;
-            content
-        }
-        Some(path) => std::fs::read_to_string(&path)
+        Some(path) if path.as_os_str() == "-" => read_stdin_capped()?,
+        Some(path) => skills_model::read_file_capped(&path, skills_model::MAX_SKILL_MD_BYTES)
             .with_context(|| format!("failed to read {}", path.display()))?,
         None => edit_with_editor(&home, &app_dir, &args.directory)?,
     };
@@ -200,7 +200,25 @@ fn edit_with_editor(
     if !status.success() {
         bail!("editor exited with status {status}");
     }
-    std::fs::read_to_string(path).context("failed to read edited SKILL.md")
+    skills_model::read_file_capped(&path, skills_model::MAX_SKILL_MD_BYTES)
+        .context("failed to read edited SKILL.md")
+}
+
+/// Read stdin, refusing more than the `SKILL.md` limit. Reads through one
+/// handle and rejects an overflow byte, so a stream that never ends cannot
+/// exhaust memory before validation runs.
+fn read_stdin_capped() -> Result<String> {
+    let mut buf = Vec::new();
+    std::io::stdin()
+        .take(skills_model::MAX_SKILL_MD_BYTES + 1)
+        .read_to_end(&mut buf)?;
+    if buf.len() as u64 > skills_model::MAX_SKILL_MD_BYTES {
+        bail!(
+            "SKILL.md is too large: the limit is {} bytes",
+            skills_model::MAX_SKILL_MD_BYTES
+        );
+    }
+    String::from_utf8(buf).context("stdin is not valid UTF-8")
 }
 
 fn adopt(args: SkillAdoptArgs) -> Result<()> {

--- a/src/cli/skill.rs
+++ b/src/cli/skill.rs
@@ -86,6 +86,11 @@ pub struct SkillSyncArgs {
     /// Limit the sync to these source roots. Repeatable. Defaults to all of them.
     #[arg(long = "root", value_name = "ID")]
     roots: Vec<String>,
+    /// Take over this skill in the agents' directories, overwriting a skill AoE
+    /// does not manage or a propagated copy that was edited there. Repeatable.
+    /// Without it a sync never overwrites anything it did not itself write.
+    #[arg(long = "replace", value_name = "DIRECTORY")]
+    replace: Vec<String>,
     /// Output the per-skill outcomes as JSON.
     #[arg(long)]
     json: bool,
@@ -225,12 +230,15 @@ fn remove(args: SkillRemoveArgs) -> Result<()> {
 
 fn sync(args: SkillSyncArgs) -> Result<()> {
     let (home, app_dir) = skills_dirs()?;
+    let replace: std::collections::HashSet<String> = args.replace.into_iter().collect();
     let outcomes = if args.roots.is_empty() {
-        skills_model::sync_all_roots(&home, &app_dir)
+        skills_model::sync_all_roots(&home, &app_dir, &replace)
     } else {
         let mut out = Vec::new();
         for root in &args.roots {
-            out.extend(skills_model::sync_root(&home, &app_dir, root).map_err(skill_error)?);
+            out.extend(
+                skills_model::sync_root(&home, &app_dir, root, &replace).map_err(skill_error)?,
+            );
         }
         out
     };

--- a/src/cli/skill.rs
+++ b/src/cli/skill.rs
@@ -23,6 +23,8 @@ pub enum SkillCommands {
     Adopt(SkillAdoptArgs),
     /// Delete an AoE-managed skill.
     Remove(SkillRemoveArgs),
+    /// Copy AoE-managed skills into the agents' own skills directories.
+    Sync(SkillSyncArgs),
 }
 
 #[derive(Args, Debug)]
@@ -79,6 +81,16 @@ pub struct SkillRemoveArgs {
     directory: String,
 }
 
+#[derive(Args, Debug)]
+pub struct SkillSyncArgs {
+    /// Limit the sync to these source roots. Repeatable. Defaults to all of them.
+    #[arg(long = "root", value_name = "ID")]
+    roots: Vec<String>,
+    /// Output the per-skill outcomes as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
 pub fn run(command: SkillCommands) -> Result<()> {
     match command {
         SkillCommands::List(args) => list(args),
@@ -87,6 +99,7 @@ pub fn run(command: SkillCommands) -> Result<()> {
         SkillCommands::Edit(args) => edit(args),
         SkillCommands::Adopt(args) => adopt(args),
         SkillCommands::Remove(args) => remove(args),
+        SkillCommands::Sync(args) => sync(args),
     }
 }
 
@@ -207,6 +220,47 @@ fn remove(args: SkillRemoveArgs) -> Result<()> {
     let (home, app_dir) = skills_dirs()?;
     skills_model::delete_skill(&home, &app_dir, &args.directory).map_err(skill_error)?;
     println!("Removed managed skill {}.", args.directory);
+    Ok(())
+}
+
+fn sync(args: SkillSyncArgs) -> Result<()> {
+    let (home, app_dir) = skills_dirs()?;
+    let outcomes = if args.roots.is_empty() {
+        skills_model::sync_all_roots(&home, &app_dir)
+    } else {
+        let mut out = Vec::new();
+        for root in &args.roots {
+            out.extend(skills_model::sync_root(&home, &app_dir, root).map_err(skill_error)?);
+        }
+        out
+    };
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&outcomes)?);
+    } else if outcomes.is_empty() {
+        println!("No AoE-managed skills to share.");
+    } else {
+        println!("{:<24} {:<20} {:<10} DETAIL", "DIRECTORY", "ROOT", "STATUS");
+        for outcome in &outcomes {
+            println!(
+                "{:<24} {:<20} {:<10} {}",
+                outcome.directory,
+                outcome.root,
+                format!("{:?}", outcome.status).to_lowercase(),
+                outcome.message.as_deref().unwrap_or("")
+            );
+        }
+    }
+
+    // A conflict is a normal, reportable result: the user's own file is intact.
+    // Only a genuine failure to write is worth a non-zero exit.
+    let failed = outcomes
+        .iter()
+        .filter(|o| o.status == skills_model::SyncStatus::Error)
+        .count();
+    if failed > 0 {
+        bail!("{failed} skill(s) could not be shared");
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,6 +405,7 @@ async fn run(
             let profile = cli.profile.clone().unwrap_or_default();
             return cli::mcp::run(&profile, command).await;
         }
+        Some(Commands::Skill { command }) => return cli::skill::run(command),
         Some(Commands::Uninstall(args)) => return cli::uninstall::run(args).await,
         Some(Commands::Update(args)) => return cli::update::run(args).await,
         // Pure redirect; needs no app data, so it must short-circuit before

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -1607,13 +1607,18 @@ fn skills_adopt(params: &Value) -> Result<Value, DispatchError> {
     Ok(json!({ "ok": true, "directory": dest_name }))
 }
 
+/// Reconcile the whole managed store into one agent's skills root. Breaking
+/// change from the previous per-skill `directory` form (#3053): propagation is
+/// now a root-level reconcile, so a single skill is no longer an addressable
+/// unit and the caller gets one outcome per skill instead.
 fn skills_propagate(params: &Value) -> Result<Value, DispatchError> {
-    let directory = str_param(params, "directory")?;
     let agent = str_param(params, "agent")?;
     let (home, app_dir) = skills_dirs()?;
-    crate::session::skills_model::propagate_skill(&home, &app_dir, directory, agent)
-        .map_err(skill_dispatch_error)?;
-    Ok(json!({ "ok": true }))
+    let outcomes = crate::session::skills_model::sync_for_agent(&home, &app_dir, agent)
+        .ok_or_else(|| {
+            DispatchError::invalid_params(format!("no skills location known for agent {agent:?}"))
+        })?;
+    Ok(json!({ "ok": true, "outcomes": outcomes }))
 }
 
 /// Parse the `slot` param into a typed [`UiSlot`]. An unknown slot is bad

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -3094,7 +3094,7 @@ mod tests {
             &state,
             &c,
             "skills.adopt",
-            &json!({"source": {"kind": "agent-native", "agent": "claude"}, "directory": "review"}),
+            &json!({"source": {"kind": "external", "root": "claude-user"}, "directory": "review"}),
         )
         .unwrap();
         // Host original untouched; managed copy now readable.
@@ -3137,7 +3137,7 @@ mod tests {
             ("skills.delete", json!({"directory": "x"})),
             (
                 "skills.adopt",
-                json!({"source": {"kind": "agent-native", "agent": "claude"}, "directory": "x"}),
+                json!({"source": {"kind": "external", "root": "claude-user"}, "directory": "x"}),
             ),
             (
                 "skills.propagate",

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod plugin_settings;
 pub mod plugins;
 mod projects;
 pub(crate) mod sessions;
+mod skills;
 pub(crate) mod system;
 mod telemetry;
 
@@ -61,6 +62,7 @@ pub use sessions::{
     update_session_notifications, update_session_pin, update_session_snooze, update_session_unread,
     update_workspace_ordering, CleanupDefaults, OutputQuery, SendMessageRequest, SessionResponse,
 };
+pub use skills::{adopt_skill, create_skill, delete_skill, edit_skill, list_skills, read_skill};
 // Shared by the status poll loop's auto-unread persistence; not a route handler.
 pub(crate) use sessions::persist_session_update;
 // Trash retention sweep, driven by the daemon's hourly loop; not a route handler.

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -62,7 +62,9 @@ pub use sessions::{
     update_session_notifications, update_session_pin, update_session_snooze, update_session_unread,
     update_workspace_ordering, CleanupDefaults, OutputQuery, SendMessageRequest, SessionResponse,
 };
-pub use skills::{adopt_skill, create_skill, delete_skill, edit_skill, list_skills, read_skill};
+pub use skills::{
+    adopt_skill, create_skill, delete_skill, edit_skill, list_skills, read_skill, sync_skills,
+};
 // Shared by the status poll loop's auto-unread persistence; not a route handler.
 pub(crate) use sessions::persist_session_update;
 // Trash retention sweep, driven by the daemon's hourly loop; not a route handler.

--- a/src/server/api/skills.rs
+++ b/src/server/api/skills.rs
@@ -84,7 +84,7 @@ impl FromRequestParts<std::sync::Arc<AppState>> for SkillMutationGuard {
     }
 }
 
-fn source_provenance(source: &str) -> Result<SkillProvenance, Response> {
+fn source_provenance(source: &str) -> Result<SkillProvenance, String> {
     if source == "aoe-managed" {
         return Ok(SkillProvenance::AoeManaged);
     }
@@ -92,13 +92,7 @@ fn source_provenance(source: &str) -> Result<SkillProvenance, Response> {
         .map(|_| SkillProvenance::External {
             root: source.to_string(),
         })
-        .ok_or_else(|| {
-            error_response(
-                StatusCode::BAD_REQUEST,
-                "invalid_skill_source",
-                format!("Unknown skill source {source:?}"),
-            )
-        })
+        .ok_or_else(|| format!("Unknown skill source {source:?}"))
 }
 
 /// `GET /api/skills`: discover skills across every supported host root.
@@ -133,7 +127,9 @@ pub async fn list_skills() -> Response {
 pub async fn read_skill(Path((source, directory)): Path<(String, String)>) -> Response {
     let provenance = match source_provenance(&source) {
         Ok(value) => value,
-        Err(response) => return response,
+        Err(message) => {
+            return error_response(StatusCode::BAD_REQUEST, "invalid_skill_source", message)
+        }
     };
     let result = tokio::task::spawn_blocking(move || {
         let home = dirs::home_dir().ok_or_else(|| {
@@ -220,7 +216,9 @@ pub async fn adopt_skill(
 ) -> Response {
     let provenance = match source_provenance(&source) {
         Ok(value) => value,
-        Err(response) => return response,
+        Err(message) => {
+            return error_response(StatusCode::BAD_REQUEST, "invalid_skill_source", message)
+        }
     };
     let result = tokio::task::spawn_blocking(move || {
         let home = dirs::home_dir().ok_or_else(|| {

--- a/src/server/api/skills.rs
+++ b/src/server/api/skills.rs
@@ -1,0 +1,294 @@
+//! Skills management REST API.
+
+use axum::extract::{FromRequestParts, Path};
+use axum::http::{request::Parts, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Deserialize;
+use serde_json::json;
+
+use super::AppState;
+use crate::server::auth::{handler_elevated, AuthenticatedSession, LoopbackTrusted};
+use crate::session::skills_model::{self, SkillError, SkillProvenance};
+
+fn error_response(status: StatusCode, code: &str, message: String) -> Response {
+    (status, Json(json!({ "error": code, "message": message }))).into_response()
+}
+
+fn skill_error(error: SkillError) -> Response {
+    match error {
+        SkillError::InvalidInput(message) => {
+            error_response(StatusCode::BAD_REQUEST, "invalid_skill", message)
+        }
+        SkillError::NotFound(message) => {
+            error_response(StatusCode::NOT_FOUND, "skill_not_found", message)
+        }
+        SkillError::Collision(message) => {
+            error_response(StatusCode::CONFLICT, "skill_exists", message)
+        }
+        SkillError::ReadOnly(message) => {
+            error_response(StatusCode::FORBIDDEN, "skill_read_only", message)
+        }
+        SkillError::Io(error) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal",
+            format!("{error:#}"),
+        ),
+    }
+}
+
+fn task_error(error: tokio::task::JoinError) -> Response {
+    error_response(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "internal",
+        error.to_string(),
+    )
+}
+
+async fn mutation_gate(
+    state: &AppState,
+    session: Option<&AuthenticatedSession>,
+    loopback_trusted: bool,
+) -> Result<(), Response> {
+    if state.read_only {
+        return Err(super::read_only_response());
+    }
+    if let Some(response) = super::cityhall_block(state) {
+        return Err(response);
+    }
+    if !handler_elevated(state, session, loopback_trusted).await {
+        return Err(error_response(
+            StatusCode::FORBIDDEN,
+            "elevation_required",
+            "Re-enter the passphrase to continue".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Parts-only extractor that rejects forbidden mutations before Axum reads or
+/// parses the request body.
+pub struct SkillMutationGuard;
+
+impl FromRequestParts<std::sync::Arc<AppState>> for SkillMutationGuard {
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &std::sync::Arc<AppState>,
+    ) -> Result<Self, Self::Rejection> {
+        let session = parts.extensions.get::<AuthenticatedSession>();
+        let loopback_trusted = parts.extensions.get::<LoopbackTrusted>().is_some();
+        mutation_gate(state, session, loopback_trusted).await?;
+        Ok(Self)
+    }
+}
+
+fn source_provenance(source: &str) -> Result<SkillProvenance, Response> {
+    if source == "aoe-managed" {
+        return Ok(SkillProvenance::AoeManaged);
+    }
+    skills_model::skill_root(source)
+        .map(|_| SkillProvenance::External {
+            root: source.to_string(),
+        })
+        .ok_or_else(|| {
+            error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_skill_source",
+                format!("Unknown skill source {source:?}"),
+            )
+        })
+}
+
+/// `GET /api/skills`: discover skills across every supported host root.
+pub async fn list_skills() -> Response {
+    match tokio::task::spawn_blocking(skills_model::discover_all).await {
+        Ok(Ok(skills)) => Json(json!({
+            "skills": skills.into_iter().map(|skill| {
+                let provenance_label = skill.provenance.label();
+                let writable = skill.provenance.is_writable();
+                json!({
+                    "directory": skill.directory,
+                    "name": skill.name,
+                    "description": skill.description,
+                    "provenance": skill.provenance,
+                    "provenanceLabel": provenance_label,
+                    "writable": writable,
+                })
+            }).collect::<Vec<_>>(),
+            "roots": skills_model::skill_roots(),
+        }))
+        .into_response(),
+        Ok(Err(error)) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal",
+            format!("{error:#}"),
+        ),
+        Err(error) => task_error(error),
+    }
+}
+
+/// `GET /api/skills/{source}/{directory}`: read one source-qualified skill.
+pub async fn read_skill(Path((source, directory)): Path<(String, String)>) -> Response {
+    let provenance = match source_provenance(&source) {
+        Ok(value) => value,
+        Err(response) => return response,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let home = dirs::home_dir().ok_or_else(|| {
+            SkillError::Io(anyhow::anyhow!("could not resolve home dir for skills"))
+        })?;
+        let app_dir = crate::session::get_app_dir().map_err(SkillError::Io)?;
+        skills_model::read_skill(&home, &app_dir, &provenance, &directory)
+    })
+    .await;
+    match result {
+        Ok(Ok(skill)) => Json(skill).into_response(),
+        Ok(Err(error)) => skill_error(error),
+        Err(error) => task_error(error),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CreateSkillBody {
+    directory: String,
+    description: Option<String>,
+}
+
+/// `POST /api/skills`: create a new AoE-managed skill.
+pub async fn create_skill(
+    _guard: SkillMutationGuard,
+    Json(body): Json<CreateSkillBody>,
+) -> Response {
+    let directory = body.directory;
+    let response_directory = directory.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let app_dir = crate::session::get_app_dir().map_err(SkillError::Io)?;
+        skills_model::create_skill(&app_dir, &directory, body.description.as_deref())
+    })
+    .await;
+    mutation_response(result, Some(response_directory))
+}
+
+#[derive(Deserialize)]
+pub struct EditSkillBody {
+    content: String,
+}
+
+/// `PUT /api/skills/{directory}`: edit an AoE-managed skill.
+pub async fn edit_skill(
+    _guard: SkillMutationGuard,
+    Path(directory): Path<String>,
+    Json(body): Json<EditSkillBody>,
+) -> Response {
+    let result = tokio::task::spawn_blocking(move || {
+        let home = dirs::home_dir().ok_or_else(|| {
+            SkillError::Io(anyhow::anyhow!("could not resolve home dir for skills"))
+        })?;
+        let app_dir = crate::session::get_app_dir().map_err(SkillError::Io)?;
+        skills_model::edit_skill(&home, &app_dir, &directory, &body.content)
+    })
+    .await;
+    mutation_response(result, None)
+}
+
+/// `DELETE /api/skills/{directory}`: delete an AoE-managed skill.
+pub async fn delete_skill(_guard: SkillMutationGuard, Path(directory): Path<String>) -> Response {
+    let result = tokio::task::spawn_blocking(move || {
+        let home = dirs::home_dir().ok_or_else(|| {
+            SkillError::Io(anyhow::anyhow!("could not resolve home dir for skills"))
+        })?;
+        let app_dir = crate::session::get_app_dir().map_err(SkillError::Io)?;
+        skills_model::delete_skill(&home, &app_dir, &directory)
+    })
+    .await;
+    mutation_response(result, None)
+}
+
+#[derive(Default, Deserialize)]
+pub struct AdoptSkillBody {
+    destination: Option<String>,
+}
+
+/// `POST /api/skills/{source}/{directory}/adopt`: copy an external skill into
+/// the AoE-managed store.
+pub async fn adopt_skill(
+    _guard: SkillMutationGuard,
+    Path((source, directory)): Path<(String, String)>,
+    Json(body): Json<AdoptSkillBody>,
+) -> Response {
+    let provenance = match source_provenance(&source) {
+        Ok(value) => value,
+        Err(response) => return response,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let home = dirs::home_dir().ok_or_else(|| {
+            SkillError::Io(anyhow::anyhow!("could not resolve home dir for skills"))
+        })?;
+        let app_dir = crate::session::get_app_dir().map_err(SkillError::Io)?;
+        skills_model::adopt_skill(
+            &home,
+            &app_dir,
+            &provenance,
+            &directory,
+            body.destination.as_deref(),
+        )
+    })
+    .await;
+    match result {
+        Ok(Ok(directory)) => (
+            StatusCode::CREATED,
+            Json(json!({ "ok": true, "directory": directory })),
+        )
+            .into_response(),
+        Ok(Err(error)) => skill_error(error),
+        Err(error) => task_error(error),
+    }
+}
+
+fn mutation_response(
+    result: Result<Result<(), SkillError>, tokio::task::JoinError>,
+    directory: Option<String>,
+) -> Response {
+    match result {
+        Ok(Ok(())) => Json(json!({ "ok": true, "directory": directory })).into_response(),
+        Ok(Err(error)) => skill_error(error),
+        Err(error) => task_error(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_ids_and_domain_errors_map_to_api_contract() {
+        assert_eq!(
+            source_provenance("claude-user").unwrap(),
+            SkillProvenance::External {
+                root: "claude-user".to_string()
+            }
+        );
+        assert!(source_provenance("unknown").is_err());
+
+        let cases = [
+            (
+                SkillError::InvalidInput("bad".into()),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                SkillError::NotFound("missing".into()),
+                StatusCode::NOT_FOUND,
+            ),
+            (SkillError::Collision("exists".into()), StatusCode::CONFLICT),
+            (
+                SkillError::ReadOnly("readonly".into()),
+                StatusCode::FORBIDDEN,
+            ),
+        ];
+        for (error, expected) in cases {
+            assert_eq!(skill_error(error).status(), expected);
+        }
+    }
+}

--- a/src/server/api/skills.rs
+++ b/src/server/api/skills.rs
@@ -251,6 +251,12 @@ pub struct SyncSkillsBody {
     /// what "share with all agents" does.
     #[serde(default)]
     roots: Vec<String>,
+    /// Skills the caller has explicitly asked AoE to take over, overwriting a
+    /// skill AoE does not manage or a propagated copy edited in place. Empty
+    /// means overwrite nothing, which is the default and what every automatic
+    /// sync uses.
+    #[serde(default)]
+    replace: Vec<String>,
 }
 
 /// `POST /api/skills/sync`: reconcile the managed store into agent skills dirs.
@@ -273,12 +279,13 @@ pub async fn sync_skills(_guard: SkillMutationGuard, Json(body): Json<SyncSkills
             SkillError::Io(anyhow::anyhow!("could not resolve home dir for skills"))
         })?;
         let app_dir = crate::session::get_app_dir().map_err(SkillError::Io)?;
+        let replace: std::collections::HashSet<String> = body.replace.into_iter().collect();
         if body.roots.is_empty() {
-            Ok(skills_model::sync_all_roots(&home, &app_dir))
+            Ok(skills_model::sync_all_roots(&home, &app_dir, &replace))
         } else {
             let mut out = Vec::new();
             for root in &body.roots {
-                out.extend(skills_model::sync_root(&home, &app_dir, root)?);
+                out.extend(skills_model::sync_root(&home, &app_dir, root, &replace)?);
             }
             Ok(out)
         }

--- a/src/server/api/skills.rs
+++ b/src/server/api/skills.rs
@@ -245,6 +245,52 @@ pub async fn adopt_skill(
     }
 }
 
+#[derive(Default, Deserialize)]
+pub struct SyncSkillsBody {
+    /// Roots to reconcile. Omitted or empty means every known root, which is
+    /// what "share with all agents" does.
+    #[serde(default)]
+    roots: Vec<String>,
+}
+
+/// `POST /api/skills/sync`: reconcile the managed store into agent skills dirs.
+///
+/// Returns one outcome per skill per root rather than failing on the first
+/// conflict: a destination AoE does not own is a normal result the user needs to
+/// see, not an error that should abandon the remaining roots.
+pub async fn sync_skills(_guard: SkillMutationGuard, Json(body): Json<SyncSkillsBody>) -> Response {
+    for root in &body.roots {
+        if skills_model::skill_root(root).is_none() {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_skill_source",
+                format!("Unknown skill root {root:?}"),
+            );
+        }
+    }
+    let result = tokio::task::spawn_blocking(move || {
+        let home = dirs::home_dir().ok_or_else(|| {
+            SkillError::Io(anyhow::anyhow!("could not resolve home dir for skills"))
+        })?;
+        let app_dir = crate::session::get_app_dir().map_err(SkillError::Io)?;
+        if body.roots.is_empty() {
+            Ok(skills_model::sync_all_roots(&home, &app_dir))
+        } else {
+            let mut out = Vec::new();
+            for root in &body.roots {
+                out.extend(skills_model::sync_root(&home, &app_dir, root)?);
+            }
+            Ok(out)
+        }
+    })
+    .await;
+    match result {
+        Ok(Ok(outcomes)) => Json(json!({ "ok": true, "outcomes": outcomes })).into_response(),
+        Ok(Err(error)) => skill_error(error),
+        Err(error) => task_error(error),
+    }
+}
+
 fn mutation_response(
     result: Result<Result<(), SkillError>, tokio::task::JoinError>,
     directory: Option<String>,

--- a/src/server/api/skills.rs
+++ b/src/server/api/skills.rs
@@ -257,6 +257,11 @@ pub struct SyncSkillsBody {
     /// sync uses.
     #[serde(default)]
     replace: Vec<String>,
+    /// When non-empty, reconcile only these skills. This is what makes sharing
+    /// a single skill a single-skill operation rather than a full sync whose
+    /// report is filtered afterwards.
+    #[serde(default)]
+    directories: Vec<String>,
 }
 
 /// `POST /api/skills/sync`: reconcile the managed store into agent skills dirs.
@@ -279,13 +284,16 @@ pub async fn sync_skills(_guard: SkillMutationGuard, Json(body): Json<SyncSkills
             SkillError::Io(anyhow::anyhow!("could not resolve home dir for skills"))
         })?;
         let app_dir = crate::session::get_app_dir().map_err(SkillError::Io)?;
-        let replace: std::collections::HashSet<String> = body.replace.into_iter().collect();
+        let options = skills_model::SyncOptions {
+            replace: body.replace.into_iter().collect(),
+            only: body.directories.into_iter().collect(),
+        };
         if body.roots.is_empty() {
-            Ok(skills_model::sync_all_roots(&home, &app_dir, &replace))
+            Ok(skills_model::sync_all_roots(&home, &app_dir, &options))
         } else {
             let mut out = Vec::new();
             for root in &body.roots {
-                out.extend(skills_model::sync_root(&home, &app_dir, root, &replace)?);
+                out.extend(skills_model::sync_root(&home, &app_dir, root, &options)?);
             }
             Ok(out)
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1676,6 +1676,9 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/mcp/servers/{name}/drop", post(api::drop_mcp_server))
         // Unified skills management surface (#3050).
         .route("/api/skills", get(api::list_skills).post(api::create_skill))
+        // Static, so it wins over `/api/skills/{directory}` and a managed skill
+        // may still be named "sync" (that route is PUT/DELETE only).
+        .route("/api/skills/sync", post(api::sync_skills))
         .route("/api/skills/{source}/{directory}", get(api::read_skill))
         .route(
             "/api/skills/{source}/{directory}/adopt",
@@ -2475,6 +2478,7 @@ const CITYHALL_MUTATION_DENY: &[(&str, &str)] = &[
     ("POST", "/api/mcp/servers/{name}/resolve"),
     // Skills mutations.
     ("POST", "/api/skills"),
+    ("POST", "/api/skills/sync"),
     ("PUT", "/api/skills/{directory}"),
     ("DELETE", "/api/skills/{directory}"),
     ("POST", "/api/skills/{source}/{directory}/adopt"),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1674,6 +1674,17 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/mcp/servers/{name}/keep", post(api::keep_mcp_server))
         .route("/api/mcp/servers/{name}/drop", post(api::drop_mcp_server))
+        // Unified skills management surface (#3050).
+        .route("/api/skills", get(api::list_skills).post(api::create_skill))
+        .route("/api/skills/{source}/{directory}", get(api::read_skill))
+        .route(
+            "/api/skills/{source}/{directory}/adopt",
+            post(api::adopt_skill),
+        )
+        .route(
+            "/api/skills/{directory}",
+            put(api::edit_skill).delete(api::delete_skill),
+        )
         .route(
             "/api/sessions/{id}",
             patch(api::rename_session).delete(api::delete_session),
@@ -2462,6 +2473,11 @@ const CITYHALL_MUTATION_DENY: &[(&str, &str)] = &[
     ("POST", "/api/mcp/servers/{name}/drop"),
     ("POST", "/api/mcp/servers/{name}/keep"),
     ("POST", "/api/mcp/servers/{name}/resolve"),
+    // Skills mutations.
+    ("POST", "/api/skills"),
+    ("PUT", "/api/skills/{directory}"),
+    ("DELETE", "/api/skills/{directory}"),
+    ("POST", "/api/skills/{source}/{directory}/adopt"),
     // Plugin lifecycle.
     ("POST", "/api/plugins/install"),
     ("POST", "/api/plugins/install/preview"),

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -23,6 +23,8 @@ pub struct Config {
 
     #[serde(default)]
     pub telemetry: TelemetryConfig,
+    #[serde(default)]
+    pub skills: SkillsConfig,
 
     #[serde(default)]
     pub worktree: WorktreeConfig,
@@ -1858,6 +1860,31 @@ pub struct UpdatesConfig {
 
 fn default_true() -> bool {
     true
+}
+
+/// Cross-agent sharing of AoE-managed skills. Off by default, and deliberately
+/// so: turning it on lets AoE create, replace, and remove directories inside the
+/// user's real agent config dirs (`~/.claude/skills` and friends). That is a
+/// distinct privilege from editing AoE's own store, so it is opt-in rather than
+/// opt-out; an upgrade must never start writing there on its own.
+///
+/// AoE only ever touches copies it deployed and that are still byte-identical to
+/// what it deployed, so a hand-written skill, or a propagated one the user has
+/// since edited, is preserved.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, SettingsSection)]
+#[setting_section(name = "skills", category = "Skills")]
+pub struct SkillsConfig {
+    /// Copy AoE-managed skills into an agent's own skills directory when
+    /// launching a session for it, so a skill authored once in AoE is available
+    /// to every agent. Defaults to `false`.
+    #[serde(default)]
+    #[setting(
+        label = "Share skills with agents",
+        widget = "toggle",
+        web = "elevation:writes into the agent config directories in your home dir",
+        global_only
+    )]
+    pub auto_propagate: bool,
 }
 
 /// Anonymous, opt-in usage telemetry. Off by default; mirrors the privacy

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -871,7 +871,7 @@ fn sync_managed_skills_into_sandbox(
         &target,
         app_dir,
         root.id,
-        &crate::session::skills_model::no_replacements(),
+        &crate::session::skills_model::SyncOptions::default(),
     );
     crate::session::skills_model::log_sync_outcomes(
         &format!("sandbox:{}", mount.tool_name),

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -865,7 +865,14 @@ fn sync_managed_skills_into_sandbox(
         return;
     };
     let target = sandbox_dir.join(suffix.trim_start_matches('/'));
-    let outcomes = crate::session::skills_model::sync_skills_into(&target, app_dir, root.id);
+    // Never replaces: a container starting must not overwrite a skill the user
+    // put in the sandbox by hand.
+    let outcomes = crate::session::skills_model::sync_skills_into(
+        &target,
+        app_dir,
+        root.id,
+        &crate::session::skills_model::no_replacements(),
+    );
     crate::session::skills_model::log_sync_outcomes(
         &format!("sandbox:{}", mount.tool_name),
         &outcomes,

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -815,7 +815,49 @@ fn prepare_sandbox_dir(mount: &AgentConfigMount, home: &Path) -> Result<std::pat
         }
     }
 
+    sync_managed_skills_into_sandbox(mount, &sandbox_dir);
+
     Ok(sandbox_dir)
+}
+
+/// Reconcile AoE-managed skills into this agent's sandbox skills dir (#3053).
+///
+/// Deliberately not folded into `copy_dirs`: that path is host-to-sandbox and
+/// runs only on a sandbox's first launch, so a skill authored after the
+/// container first ran would never reach it. Managed skills are a small,
+/// AoE-owned tree, so reconciling them on every launch is cheap and safe in a
+/// way re-copying the whole config tree is not. `copy_dirs` keeps doing its own
+/// job of importing the user's hand-written host skills on first run.
+///
+/// The sandbox target is derived from the agent's own skills root, which must
+/// live under the dir the sandbox mirrors. Codex reads `~/.agents/skills`, which
+/// is outside its `.codex` mount, so it has no sandbox target and is host-only
+/// for now.
+fn sync_managed_skills_into_sandbox(mount: &AgentConfigMount, sandbox_dir: &Path) {
+    let config = crate::session::config::Config::load_or_warn();
+    if !config.skills.auto_propagate {
+        return;
+    }
+    let Some(root) = crate::session::skills_model::primary_root_for_agent(mount.tool_name) else {
+        return;
+    };
+    let Some(suffix) = root.relative_path.strip_prefix(mount.host_rel) else {
+        tracing::debug!(target: "session.skills",
+            agent = mount.tool_name,
+            root = root.id,
+            "skills root is outside the sandboxed config dir; host only"
+        );
+        return;
+    };
+    let Ok(app_dir) = crate::session::get_app_dir() else {
+        return;
+    };
+    let target = sandbox_dir.join(suffix.trim_start_matches('/'));
+    let outcomes = crate::session::skills_model::sync_skills_into(&target, &app_dir, root.id);
+    crate::session::skills_model::log_sync_outcomes(
+        &format!("sandbox:{}", mount.tool_name),
+        &outcomes,
+    );
 }
 
 /// Compute volume mount paths for Docker container.
@@ -3160,6 +3202,38 @@ mod tests {
         copy_dir_recursive(&src, &dest).unwrap();
         assert_eq!(fs::read_to_string(dest.join("good.txt")).unwrap(), "good");
         assert!(!dest.join("dangling").exists());
+    }
+
+    /// The sandbox skills target is derived by stripping an agent's config dir
+    /// off its skills root, so the two static tables have to stay in agreement.
+    /// This fails when someone edits `SKILL_ROOTS` or `AGENT_CONFIG_MOUNTS`
+    /// without the other, which would silently drop sandbox propagation.
+    #[test]
+    fn test_sandbox_skills_target_derives_from_the_agent_mount() {
+        use crate::session::skills_model::primary_root_for_agent;
+
+        // (agent, expected suffix under the sandbox dir, or None for host-only)
+        let cases = [
+            ("claude", Some("skills")),
+            ("gemini", Some("skills")),
+            ("opencode", Some("skills")),
+            ("kimi", Some("skills")),
+            // Codex reads ~/.agents/skills, which is not under its .codex mount.
+            ("codex", None),
+        ];
+        for (agent, expected) in cases {
+            let root = primary_root_for_agent(agent)
+                .unwrap_or_else(|| panic!("no skills root for {agent}"));
+            let mount = AGENT_CONFIG_MOUNTS
+                .iter()
+                .find(|m| m.tool_name == agent && root.relative_path.starts_with(m.host_rel));
+            let suffix = mount.and_then(|m| {
+                root.relative_path
+                    .strip_prefix(m.host_rel)
+                    .map(|s| s.trim_start_matches('/'))
+            });
+            assert_eq!(suffix, expected, "{agent}");
+        }
     }
 
     #[test]

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -815,7 +815,16 @@ fn prepare_sandbox_dir(mount: &AgentConfigMount, home: &Path) -> Result<std::pat
         }
     }
 
-    sync_managed_skills_into_sandbox(mount, &sandbox_dir);
+    let config = crate::session::config::Config::load_or_warn();
+    let app_dir = crate::session::get_app_dir().ok();
+    if let Some(app_dir) = app_dir {
+        sync_managed_skills_into_sandbox(
+            mount,
+            &sandbox_dir,
+            &app_dir,
+            config.skills.auto_propagate,
+        );
+    }
 
     Ok(sandbox_dir)
 }
@@ -833,9 +842,15 @@ fn prepare_sandbox_dir(mount: &AgentConfigMount, home: &Path) -> Result<std::pat
 /// live under the dir the sandbox mirrors. Codex reads `~/.agents/skills`, which
 /// is outside its `.codex` mount, so it has no sandbox target and is host-only
 /// for now.
-fn sync_managed_skills_into_sandbox(mount: &AgentConfigMount, sandbox_dir: &Path) {
-    let config = crate::session::config::Config::load_or_warn();
-    if !config.skills.auto_propagate {
+/// `auto_propagate` is passed in rather than read here so the opt-in gate is
+/// directly testable; a leaf function that reaches for global config cannot be.
+fn sync_managed_skills_into_sandbox(
+    mount: &AgentConfigMount,
+    sandbox_dir: &Path,
+    app_dir: &Path,
+    auto_propagate: bool,
+) {
+    if !auto_propagate {
         return;
     }
     let Some(root) = crate::session::skills_model::primary_root_for_agent(mount.tool_name) else {
@@ -849,11 +864,8 @@ fn sync_managed_skills_into_sandbox(mount: &AgentConfigMount, sandbox_dir: &Path
         );
         return;
     };
-    let Ok(app_dir) = crate::session::get_app_dir() else {
-        return;
-    };
     let target = sandbox_dir.join(suffix.trim_start_matches('/'));
-    let outcomes = crate::session::skills_model::sync_skills_into(&target, &app_dir, root.id);
+    let outcomes = crate::session::skills_model::sync_skills_into(&target, app_dir, root.id);
     crate::session::skills_model::log_sync_outcomes(
         &format!("sandbox:{}", mount.tool_name),
         &outcomes,
@@ -3202,6 +3214,30 @@ mod tests {
         copy_dir_recursive(&src, &dest).unwrap();
         assert_eq!(fs::read_to_string(dest.join("good.txt")).unwrap(), "good");
         assert!(!dest.join("dangling").exists());
+    }
+
+    /// Propagation writes into the user's agent config dirs, so nothing may be
+    /// written until they opt in. Also covers the sandbox reconcile actually
+    /// landing once they have.
+    #[test]
+    fn test_sandbox_skills_sync_requires_opt_in() {
+        let dir = TempDir::new().unwrap();
+        let app_dir = dir.path().join("app");
+        let sandbox = dir.path().join("sandbox");
+        crate::session::skills_model::create_skill(&app_dir, "shared", Some("d")).unwrap();
+        let mount = AGENT_CONFIG_MOUNTS
+            .iter()
+            .find(|m| m.tool_name == "claude")
+            .unwrap();
+
+        sync_managed_skills_into_sandbox(mount, &sandbox, &app_dir, false);
+        assert!(
+            !sandbox.join("skills").exists(),
+            "must not write into an agent config dir before the user opts in"
+        );
+
+        sync_managed_skills_into_sandbox(mount, &sandbox, &app_dir, true);
+        assert!(sandbox.join("skills/shared/SKILL.md").is_file());
     }
 
     /// The sandbox skills target is derived by stripping an agent's config dir

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3153,6 +3153,7 @@ impl Instance {
         let agent = crate::agents::get_agent(&self.tool)
             .or_else(|| crate::agents::get_agent(&self.detect_as));
         self.install_agent_status_hooks(agent);
+        self.propagate_managed_skills();
 
         let (cmd, is_existing) = if self.is_sandboxed() {
             let container = self.get_container_for_instance()?;
@@ -3284,6 +3285,34 @@ impl Instance {
     /// For sandboxed sessions hooks are installed via `build_container_config`,
     /// so this only acts on host sessions by writing to the user's home directory.
     /// Respects the `agent_status_hooks` config setting.
+    /// Make AoE-managed skills available to the agent this session launches, by
+    /// reconciling the managed store into that agent's own skills directory
+    /// (#3053). Skills reach an agent only as files on disk, so there is nothing
+    /// to forward over a protocol; the copy is the mechanism.
+    ///
+    /// Off unless the user opted in, because it writes into their real agent
+    /// config dirs. Best-effort: a root that is missing, read-only, or holds a
+    /// conflicting skill is logged and never blocks the launch. A sandboxed
+    /// session gets its own copy from `build_container_config`, which reconciles
+    /// into the sandbox dir rather than relying on this host pass.
+    fn propagate_managed_skills(&self) {
+        let profile = self.effective_profile();
+        let config = super::profile_config::resolve_config_or_warn(&profile);
+        if !config.skills.auto_propagate {
+            return;
+        }
+        let (Some(home), Ok(app_dir)) = (dirs::home_dir(), super::get_app_dir()) else {
+            tracing::warn!(target: "session.skills", "skipping skill propagation: no home or app dir");
+            return;
+        };
+        let Some(outcomes) = super::skills_model::sync_for_agent(&home, &app_dir, &self.tool)
+        else {
+            tracing::debug!(target: "session.skills", agent = %self.tool, "no skills location known for agent");
+            return;
+        };
+        super::skills_model::log_sync_outcomes(&self.tool, &outcomes);
+    }
+
     fn install_agent_status_hooks(&self, agent: Option<&'static crate::agents::AgentDef>) {
         let profile = self.effective_profile();
         let config = super::profile_config::resolve_config_or_warn(&profile);

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3280,11 +3280,6 @@ impl Instance {
         }
     }
 
-    /// Install status-detection hooks for agents that support them.
-    ///
-    /// For sandboxed sessions hooks are installed via `build_container_config`,
-    /// so this only acts on host sessions by writing to the user's home directory.
-    /// Respects the `agent_status_hooks` config setting.
     /// Make AoE-managed skills available to the agent this session launches, by
     /// reconciling the managed store into that agent's own skills directory
     /// (#3053). Skills reach an agent only as files on disk, so there is nothing
@@ -3296,8 +3291,12 @@ impl Instance {
     /// session gets its own copy from `build_container_config`, which reconciles
     /// into the sandbox dir rather than relying on this host pass.
     fn propagate_managed_skills(&self) {
-        let profile = self.effective_profile();
-        let config = super::profile_config::resolve_config_or_warn(&profile);
+        // Read the global config, not the profile chain. `auto_propagate` is
+        // declared `global_only`, and the sandbox path reads it globally too, so
+        // resolving it per profile here would let a profile enable host
+        // propagation while the same profile's sandboxed sessions ignored it,
+        // and would widen a privilege the settings UI never offers per profile.
+        let config = super::config::Config::load_or_warn();
         if !config.skills.auto_propagate {
             return;
         }
@@ -3313,6 +3312,11 @@ impl Instance {
         super::skills_model::log_sync_outcomes(&self.tool, &outcomes);
     }
 
+    /// Install status-detection hooks for agents that support them.
+    ///
+    /// For sandboxed sessions hooks are installed via `build_container_config`,
+    /// so this only acts on host sessions by writing to the user's home directory.
+    /// Respects the `agent_status_hooks` config setting.
     fn install_agent_status_hooks(&self, agent: Option<&'static crate::agents::AgentDef>) {
         let profile = self.effective_profile();
         let config = super::profile_config::resolve_config_or_warn(&profile);

--- a/src/session/settings_schema/registry.rs
+++ b/src/session/settings_schema/registry.rs
@@ -4,7 +4,7 @@
 
 use super::FieldDescriptor;
 use crate::session::config::{
-    AcpConfig, AuthConfig, DiffConfig, LoggingConfig, SandboxConfig, SessionConfig,
+    AcpConfig, AuthConfig, DiffConfig, LoggingConfig, SandboxConfig, SessionConfig, SkillsConfig,
     TelemetryConfig, ThemeConfig, TmuxConfig, UpdatesConfig, WebConfig, WorktreeConfig,
 };
 use crate::sound::SoundConfig;
@@ -26,6 +26,7 @@ pub fn schema() -> Vec<FieldDescriptor> {
     out.extend(AuthConfig::settings_descriptors());
     out.extend(AcpConfig::settings_descriptors());
     out.extend(DiffConfig::settings_descriptors());
+    out.extend(SkillsConfig::settings_descriptors());
     out.extend(LoggingConfig::settings_descriptors());
     out
 }

--- a/src/session/skills_model.rs
+++ b/src/session/skills_model.rs
@@ -765,31 +765,62 @@ pub fn sync_skills_into(
     target_dir: &Path,
     app_dir: &Path,
     root_id: &str,
-    replace: &HashSet<String>,
+    options: &SyncOptions,
 ) -> Vec<SyncOutcome> {
     let managed_root = app_dir.join("skills");
     recover_abandoned(target_dir, ABANDONED_AFTER);
+    let scoped = !options.only.is_empty();
     let mut out = Vec::new();
     let mut managed = Vec::new();
     for skill in list_managed(&managed_root) {
         managed.push(skill.clone());
+        if scoped && !options.only.contains(&skill) {
+            continue;
+        }
         out.push(sync_one(
             &managed_root,
             target_dir,
             root_id,
             &skill,
-            replace.contains(&skill),
+            options.replace.contains(&skill),
         ));
     }
-    out.extend(remove_orphans(target_dir, root_id, &managed));
+    // A scoped sync must not withdraw another skill's copies: the user asked
+    // about one skill, so the rest of the root is none of its business.
+    if !scoped {
+        out.extend(remove_orphans(target_dir, root_id, &managed));
+    }
     out.sort_by(|a, b| a.directory.cmp(&b.directory));
     out
 }
 
-/// The empty set: sync without permission to overwrite anything AoE does not
-/// already own. What every automatic caller passes.
-pub fn no_replacements() -> HashSet<String> {
-    HashSet::new()
+/// What a sync is allowed to do beyond the default of "add what is missing and
+/// keep what AoE already owns current".
+///
+/// The default is the safe one, which is what every automatic caller uses:
+/// overwrite nothing it does not own, and consider every managed skill.
+#[derive(Debug, Default, Clone)]
+pub struct SyncOptions {
+    /// Skills the user has explicitly asked AoE to take over, so a destination
+    /// AoE does not own is overwritten instead of reported. Nothing else grants
+    /// that, which is why an automatic path leaving this empty cannot destroy
+    /// user data.
+    pub replace: HashSet<String>,
+    /// When non-empty, reconcile only these skills and leave every other one
+    /// alone, including its orphans. This is what makes sharing a single skill
+    /// a single-skill operation on disk rather than a full sync whose report is
+    /// filtered afterwards.
+    pub only: HashSet<String>,
+}
+
+impl SyncOptions {
+    /// Reconcile one skill and nothing else.
+    pub fn only(directory: &str) -> Self {
+        Self {
+            only: HashSet::from([directory.to_string()]),
+            ..Self::default()
+        }
+    }
 }
 
 /// Managed skill directory names that would actually be discovered: a real
@@ -1001,19 +1032,19 @@ pub fn sync_root(
     home: &Path,
     app_dir: &Path,
     root_id: &str,
-    replace: &HashSet<String>,
+    options: &SyncOptions,
 ) -> Result<Vec<SyncOutcome>, SkillError> {
     let target = external_skill_dir(home, root_id)?;
-    Ok(sync_skills_into(&target, app_dir, root_id, replace))
+    Ok(sync_skills_into(&target, app_dir, root_id, options))
 }
 
 /// Reconcile the managed store into every host root, so a skill authored once
 /// is present for every agent AoE knows a skills location for.
-pub fn sync_all_roots(home: &Path, app_dir: &Path, replace: &HashSet<String>) -> Vec<SyncOutcome> {
+pub fn sync_all_roots(home: &Path, app_dir: &Path, options: &SyncOptions) -> Vec<SyncOutcome> {
     SKILL_ROOTS
         .iter()
         .flat_map(|root| {
-            sync_skills_into(&home.join(root.relative_path), app_dir, root.id, replace)
+            sync_skills_into(&home.join(root.relative_path), app_dir, root.id, options)
         })
         .collect()
 }
@@ -1029,7 +1060,7 @@ pub fn sync_for_agent(home: &Path, app_dir: &Path, agent: &str) -> Option<Vec<Sy
         &home.join(root.relative_path),
         app_dir,
         root.id,
-        &no_replacements(),
+        &SyncOptions::default(),
     ))
 }
 
@@ -1619,13 +1650,13 @@ mod tests {
         create_skill(&app, "shared", Some("d")).unwrap();
         let target = home.join(".kimi-code/skills");
 
-        let first = sync_skills_into(&target, &app, "kimi-legacy", &no_replacements());
+        let first = sync_skills_into(&target, &app, "kimi-legacy", &SyncOptions::default());
         assert_eq!(status_of(&first, "shared"), SyncStatus::Created);
         assert!(target.join("shared/SKILL.md").is_file());
         assert!(target.join("shared").join(PROPAGATION_MARKER).is_file());
 
         // Idempotent: nothing changed at the source, so nothing is rewritten.
-        let second = sync_skills_into(&target, &app, "kimi-legacy", &no_replacements());
+        let second = sync_skills_into(&target, &app, "kimi-legacy", &SyncOptions::default());
         assert_eq!(status_of(&second, "shared"), SyncStatus::Unchanged);
 
         // Source edited: the clean copy is replaced.
@@ -1636,7 +1667,7 @@ mod tests {
             "---\nname: shared\ndescription: d2\n---\n\nnew body\n",
         )
         .unwrap();
-        let third = sync_skills_into(&target, &app, "kimi-legacy", &no_replacements());
+        let third = sync_skills_into(&target, &app, "kimi-legacy", &SyncOptions::default());
         assert_eq!(status_of(&third, "shared"), SyncStatus::Updated);
         assert!(std::fs::read_to_string(target.join("shared/SKILL.md"))
             .unwrap()
@@ -1653,7 +1684,7 @@ mod tests {
 
         // A hand-written host skill of the same name: preserved, reported.
         write_skill(&target, "review", "review", "the user's own");
-        let out = sync_skills_into(&target, &app, "claude-user", &no_replacements());
+        let out = sync_skills_into(&target, &app, "claude-user", &SyncOptions::default());
         assert_eq!(status_of(&out, "review"), SyncStatus::Conflict);
         assert!(std::fs::read_to_string(target.join("review/SKILL.md"))
             .unwrap()
@@ -1667,7 +1698,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             status_of(
-                &sync_skills_into(&target, &app, "claude-user", &no_replacements()),
+                &sync_skills_into(&target, &app, "claude-user", &SyncOptions::default()),
                 "review"
             ),
             SyncStatus::Conflict
@@ -1677,7 +1708,7 @@ mod tests {
         std::fs::write(target.join("review").join(PROPAGATION_MARKER), "not json").unwrap();
         assert_eq!(
             status_of(
-                &sync_skills_into(&target, &app, "claude-user", &no_replacements()),
+                &sync_skills_into(&target, &app, "claude-user", &SyncOptions::default()),
                 "review"
             ),
             SyncStatus::Conflict
@@ -1691,7 +1722,7 @@ mod tests {
         let app = tmp.path().join("app");
         let target = home.join(".claude/skills");
         create_skill(&app, "review", Some("d")).unwrap();
-        sync_skills_into(&target, &app, "claude-user", &no_replacements());
+        sync_skills_into(&target, &app, "claude-user", &SyncOptions::default());
 
         // The user edits the propagated copy in place. AoE deployed it, but its
         // content is no longer what AoE deployed, so it is theirs now.
@@ -1711,7 +1742,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             status_of(
-                &sync_skills_into(&target, &app, "claude-user", &no_replacements()),
+                &sync_skills_into(&target, &app, "claude-user", &SyncOptions::default()),
                 "review"
             ),
             SyncStatus::Conflict
@@ -1724,7 +1755,7 @@ mod tests {
         delete_skill(&home, &app, "review").unwrap();
         assert_eq!(
             status_of(
-                &sync_skills_into(&target, &app, "claude-user", &no_replacements()),
+                &sync_skills_into(&target, &app, "claude-user", &SyncOptions::default()),
                 "review"
             ),
             SyncStatus::Conflict
@@ -1752,7 +1783,7 @@ mod tests {
         std::fs::create_dir_all(&target).unwrap();
         std::os::unix::fs::symlink(&other_store, target.join("shared")).unwrap();
 
-        let out = sync_skills_into(&target, &app, "claude-user", &no_replacements());
+        let out = sync_skills_into(&target, &app, "claude-user", &SyncOptions::default());
         assert_eq!(status_of(&out, "shared"), SyncStatus::Conflict);
         assert!(std::fs::symlink_metadata(target.join("shared"))
             .unwrap()
@@ -1775,7 +1806,10 @@ mod tests {
             create_skill(&app, dir, Some("managed")).unwrap();
             write_skill(&target, dir, dir, "the user's own");
         }
-        let replace = HashSet::from(["taken".to_string()]);
+        let replace = SyncOptions {
+            replace: HashSet::from(["taken".to_string()]),
+            ..Default::default()
+        };
 
         let out = sync_skills_into(&target, &app, "claude-user", &replace);
         assert_eq!(status_of(&out, "taken"), SyncStatus::Updated);
@@ -1783,7 +1817,7 @@ mod tests {
         // Now AoE-owned, so ordinary syncs keep it current from here on.
         assert_eq!(
             status_of(
-                &sync_skills_into(&target, &app, "claude-user", &no_replacements()),
+                &sync_skills_into(&target, &app, "claude-user", &SyncOptions::default()),
                 "taken"
             ),
             SyncStatus::Unchanged
@@ -1822,7 +1856,10 @@ mod tests {
         std::fs::create_dir_all(&target).unwrap();
         std::os::unix::fs::symlink(&other_store, target.join("shared")).unwrap();
 
-        let replace = HashSet::from(["shared".to_string()]);
+        let replace = SyncOptions {
+            replace: HashSet::from(["shared".to_string()]),
+            ..Default::default()
+        };
         assert_eq!(
             status_of(
                 &sync_skills_into(&target, &app, "claude-user", &replace),
@@ -1879,6 +1916,32 @@ mod tests {
         );
     }
 
+    /// Sharing one skill must be a one-skill operation on disk, not a full sync
+    /// whose report is filtered afterwards.
+    #[test]
+    fn a_scoped_sync_touches_only_the_named_skill() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        let target = home.join(".claude/skills");
+        create_skill(&app, "wanted", Some("d")).unwrap();
+        create_skill(&app, "other", Some("d")).unwrap();
+        // An orphan of a different skill, which a full sync would withdraw.
+        sync_skills_into(&target, &app, "claude-user", &SyncOptions::default());
+        delete_skill(&home, &app, "other").unwrap();
+
+        let out = sync_skills_into(&target, &app, "claude-user", &SyncOptions::only("wanted"));
+        assert_eq!(
+            out.iter().map(|o| o.directory.as_str()).collect::<Vec<_>>(),
+            vec!["wanted"],
+            "a scoped sync reports only its own skill"
+        );
+        assert!(
+            target.join("other").exists(),
+            "another skill's orphan is not this skill's business"
+        );
+    }
+
     #[test]
     fn sync_removes_clean_orphans_only() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1888,11 +1951,11 @@ mod tests {
         create_skill(&app, "doomed", Some("d")).unwrap();
         // A hand-written neighbour that must survive the orphan pass.
         write_skill(&target, "mine", "mine", "hand written");
-        sync_skills_into(&target, &app, "gemini-user", &no_replacements());
+        sync_skills_into(&target, &app, "gemini-user", &SyncOptions::default());
         assert!(target.join("doomed/SKILL.md").is_file());
 
         delete_skill(&home, &app, "doomed").unwrap();
-        let out = sync_skills_into(&target, &app, "gemini-user", &no_replacements());
+        let out = sync_skills_into(&target, &app, "gemini-user", &SyncOptions::default());
         assert_eq!(status_of(&out, "doomed"), SyncStatus::Removed);
         assert!(!target.join("doomed").exists());
         // Not ours, never an orphan, and not even reported.
@@ -1910,7 +1973,7 @@ mod tests {
             &home.join(".claude/skills"),
             &app,
             "claude-user",
-            &no_replacements(),
+            &SyncOptions::default(),
         );
 
         let found = discover(&home, &app);
@@ -1929,7 +1992,7 @@ mod tests {
             &home.join(".claude/skills"),
             &app,
             "claude-user",
-            &no_replacements(),
+            &SyncOptions::default(),
         );
 
         adopt_skill(
@@ -2011,7 +2074,7 @@ mod tests {
         assert!(sync_for_agent(&home, &app, "cursor").is_none());
 
         // Every root has a primary agent, so sync-all reaches all of them.
-        sync_all_roots(&home, &app, &no_replacements());
+        sync_all_roots(&home, &app, &SyncOptions::default());
         for root in skill_roots() {
             assert!(
                 home.join(root.relative_path).join("shared").exists(),

--- a/src/session/skills_model.rs
+++ b/src/session/skills_model.rs
@@ -908,6 +908,38 @@ fn describe(error: SkillError) -> String {
     }
 }
 
+/// Log what a background reconcile did. Conflicts warn (the user has a skill
+/// AoE could not place, which they may want to resolve); routine work is debug,
+/// so an opted-in launch does not narrate itself on every session.
+pub fn log_sync_outcomes(context: &str, outcomes: &[SyncOutcome]) {
+    for outcome in outcomes {
+        match outcome.status {
+            SyncStatus::Conflict | SyncStatus::Error => {
+                warn!(
+                    target: "session.skills",
+                    context,
+                    root = %outcome.root,
+                    directory = %outcome.directory,
+                    status = ?outcome.status,
+                    message = outcome.message.as_deref().unwrap_or(""),
+                    "skill not propagated"
+                );
+            }
+            SyncStatus::Unchanged => {}
+            _ => {
+                tracing::debug!(
+                    target: "session.skills",
+                    context,
+                    root = %outcome.root,
+                    directory = %outcome.directory,
+                    status = ?outcome.status,
+                    "propagated skill"
+                );
+            }
+        }
+    }
+}
+
 /// Reconcile the managed store into one host root.
 pub fn sync_root(
     home: &Path,
@@ -1628,6 +1660,34 @@ mod tests {
 
         std::fs::write(dir.join("extra.md"), "x").unwrap();
         assert_ne!(package_digest(&dir).unwrap(), bare, "other files count");
+    }
+
+    #[test]
+    fn every_root_names_a_real_agent_and_owns_it_alone() {
+        for root in SKILL_ROOTS {
+            assert!(
+                crate::agents::get_agent(root.primary_agent).is_some(),
+                "{} names primary agent {:?}, which is not in the agent registry",
+                root.id,
+                root.primary_agent
+            );
+            assert!(
+                root.consumers.contains(&root.primary_agent),
+                "{} is primary for {:?} but does not list it as a consumer",
+                root.id,
+                root.primary_agent
+            );
+            // One root per agent, or sync_for_agent would silently pick one.
+            assert_eq!(
+                SKILL_ROOTS
+                    .iter()
+                    .filter(|r| r.primary_agent == root.primary_agent)
+                    .count(),
+                1,
+                "{:?} is the primary agent of more than one root",
+                root.primary_agent
+            );
+        }
     }
 
     #[test]

--- a/src/session/skills_model.rs
+++ b/src/session/skills_model.rs
@@ -24,6 +24,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use tracing::warn;
 use uuid::Uuid;
 
@@ -37,7 +38,11 @@ const MAX_SKILL_PACKAGE_FILES: usize = 1024;
 const MAX_SKILL_PACKAGE_DEPTH: usize = 16;
 
 /// A physical host directory from which AoE discovers skills. `consumers` names
-/// the agents that can load the directory; it does not change skill identity.
+/// every agent that can load the directory; it does not change skill identity.
+/// `primary_agent` is the single agent this root is the canonical home for, and
+/// is what [`sync_for_agent`] keys on: an agent that reads several roots
+/// (opencode reads three) must still receive one copy, not one per readable
+/// root.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SkillRoot {
@@ -45,6 +50,7 @@ pub struct SkillRoot {
     pub label: &'static str,
     pub relative_path: &'static str,
     pub consumers: &'static [&'static str],
+    pub primary_agent: &'static str,
     pub legacy: bool,
 }
 
@@ -54,6 +60,7 @@ const SKILL_ROOTS: &[SkillRoot] = &[
         label: "Claude",
         relative_path: ".claude/skills",
         consumers: &["claude", "opencode"],
+        primary_agent: "claude",
         legacy: false,
     },
     SkillRoot {
@@ -61,6 +68,7 @@ const SKILL_ROOTS: &[SkillRoot] = &[
         label: "Agent Skills",
         relative_path: ".agents/skills",
         consumers: &["codex", "opencode"],
+        primary_agent: "codex",
         legacy: false,
     },
     SkillRoot {
@@ -68,6 +76,7 @@ const SKILL_ROOTS: &[SkillRoot] = &[
         label: "Gemini",
         relative_path: ".gemini/skills",
         consumers: &["gemini"],
+        primary_agent: "gemini",
         legacy: false,
     },
     SkillRoot {
@@ -75,6 +84,7 @@ const SKILL_ROOTS: &[SkillRoot] = &[
         label: "OpenCode",
         relative_path: ".config/opencode/skills",
         consumers: &["opencode"],
+        primary_agent: "opencode",
         legacy: false,
     },
     SkillRoot {
@@ -82,6 +92,7 @@ const SKILL_ROOTS: &[SkillRoot] = &[
         label: "Kimi (legacy)",
         relative_path: ".kimi-code/skills",
         consumers: &["kimi"],
+        primary_agent: "kimi",
         legacy: true,
     },
 ];
@@ -92,6 +103,12 @@ pub fn skill_roots() -> &'static [SkillRoot] {
 
 pub fn skill_root(id: &str) -> Option<&'static SkillRoot> {
     SKILL_ROOTS.iter().find(|root| root.id == id)
+}
+
+/// The root an agent's managed skills are written to. `None` for an agent with
+/// no known skills location, which is most of the registry.
+pub fn primary_root_for_agent(agent: &str) -> Option<&'static SkillRoot> {
+    SKILL_ROOTS.iter().find(|root| root.primary_agent == agent)
 }
 
 /// Where a skill was discovered. The read-only host layers carry a root key;
@@ -275,6 +292,13 @@ pub fn discover_all() -> Result<Vec<DiscoveredSkill>> {
 /// Enumerate immediate child dirs of `root` that hold a `SKILL.md`, parse each,
 /// and push the metadata. Symlinked children, dot-directories (including our own
 /// `.tmp-*` staging dirs), and symlinked `SKILL.md` files are skipped.
+///
+/// A host directory carrying a valid [`PROPAGATION_MARKER`] for this root is a
+/// copy AoE propagated from the managed store, so it is skipped too: it is the
+/// same logical skill as the managed entry and listing both would double-count
+/// it. A marker that is malformed, or bound to another root or directory, does
+/// not count; that directory is listed as an ordinary host skill rather than
+/// being hidden on unverified metadata.
 fn collect_from_dir(root: &Path, provenance: &SkillProvenance, out: &mut Vec<DiscoveredSkill>) {
     let entries = match std::fs::read_dir(root) {
         Ok(e) => e,
@@ -292,6 +316,11 @@ fn collect_from_dir(root: &Path, provenance: &SkillProvenance, out: &mut Vec<Dis
         match entry.file_type() {
             Ok(ft) if ft.is_dir() => {}
             _ => continue,
+        }
+        if let SkillProvenance::External { root: root_id } = provenance {
+            if marker_at(&entry.path(), root_id, &name).is_some() {
+                continue;
+            }
         }
         let skill_md = entry.path().join("SKILL.md");
         match std::fs::symlink_metadata(&skill_md) {
@@ -470,7 +499,17 @@ pub fn adopt_skill(
     let staging = new_staging_dir(&managed)?;
     let result = copy_tree_no_symlinks(&src_dir, &staging)
         .map_err(SkillError::Io)
-        .and_then(|()| rename_staging(&staging, &final_path, dest_name));
+        .and_then(|()| {
+            // Adopting a copy AoE propagated produces an ordinary managed
+            // skill, not one carrying a deployment marker. Leaving the marker in
+            // the store would let the source claim ownership of a host
+            // directory it never deployed.
+            std::fs::remove_file(staging.join(PROPAGATION_MARKER)).or_else(|e| match e.kind() {
+                std::io::ErrorKind::NotFound => Ok(()),
+                _ => Err(e),
+            })?;
+            rename_staging(&staging, &final_path, dest_name)
+        });
     if result.is_err() {
         let _ = std::fs::remove_dir_all(&staging);
     }
@@ -478,43 +517,426 @@ pub fn adopt_skill(
     Ok(dest_name.to_string())
 }
 
-/// Copy a managed skill into a target agent's host skills dir. The minimal host
-/// primitive behind `plugin-skills#4`: managed source only, known agent key
-/// only, destination must not already exist (no overwrite, no merge). Copied
-/// through a staging dir; symlinks in the source are refused. Marker/dedupe and
-/// opt-in policy are deliberately NOT handled here.
-pub fn propagate_skill(
+/// Marker AoE writes inside every propagated copy, naming the root and skill it
+/// was deployed as and the digest of the package at deploy time. It is the only
+/// thing that authorizes AoE to later replace or delete that directory, so it is
+/// a reserved filename the managed store may never contain: a source package
+/// carrying a hand-written marker could otherwise forge ownership of a host
+/// directory it does not own.
+pub const PROPAGATION_MARKER: &str = ".aoe-managed.json";
+
+const MARKER_VERSION: u32 = 1;
+
+/// Domain-separation header for [`package_digest`]. Bump when the hashed fields
+/// change so an old digest cannot silently compare equal under new rules.
+const PACKAGE_DIGEST_PREFIX: &[u8] = b"aoe-skill-package-v1\0";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PropagationMarker {
+    version: u32,
+    root: String,
+    directory: String,
+    digest: String,
+}
+
+/// What a sync did, or refused to do, to one skill under one root. A sync never
+/// aborts on the first conflict, so a caller gets one of these per skill.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncOutcome {
+    pub root: String,
+    pub directory: String,
+    pub status: SyncStatus,
+    /// Why, for the statuses that need a reason. `None` otherwise.
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SyncStatus {
+    Created,
+    Updated,
+    Unchanged,
+    Removed,
+    /// The destination exists and is not ours to touch. Never an error: the
+    /// user's file is intact, which is the point.
+    Conflict,
+    Error,
+}
+
+/// How a destination directory relates to AoE.
+#[derive(Debug, PartialEq, Eq)]
+enum Ownership {
+    Absent,
+    /// Ours, and byte-identical to what AoE deployed. Safe to replace or remove.
+    Clean {
+        digest: String,
+    },
+    /// Ours by marker, but the package changed since AoE wrote it. The user
+    /// edited a propagated copy; preserve it.
+    Drifted,
+    /// Not ours: no marker, an unreadable or unsupported one, or one bound to a
+    /// different root or directory. Never touch it.
+    Foreign,
+}
+
+/// Deterministic `sha256:<hex>` over a skill package, excluding the propagation
+/// marker so a deployed copy hashes equal to the source it came from.
+///
+/// Deliberately not [`crate::plugin::integrity::tree_hash`]: that is a plugin
+/// primitive with its own domain prefix and exclusions, and it buffers whole
+/// files, which would defeat the package byte limits skills enforce. This
+/// streams and honours [`COPY_LIMITS`], matching what [`copy_tree_no_symlinks`]
+/// would accept.
+fn package_digest(dir: &Path) -> Result<String, SkillError> {
+    let mut entries = Vec::new();
+    collect_digest_entries(dir, dir, 0, &mut entries)?;
+    entries.sort();
+
+    let mut hasher = Sha256::new();
+    hasher.update(PACKAGE_DIGEST_PREFIX);
+    let mut budget = CopyBudget::default();
+    for (rel, path) in &entries {
+        budget.files += 1;
+        if budget.files > COPY_LIMITS.files {
+            return Err(SkillError::InvalidInput(
+                "skill package exceeds the maximum file count".to_string(),
+            ));
+        }
+        let remaining = COPY_LIMITS.total_bytes.saturating_sub(budget.bytes);
+        let allowed = remaining.min(COPY_LIMITS.file_bytes);
+        hasher.update(b"file\0");
+        hasher.update(rel.as_bytes());
+        hasher.update(b"\0");
+
+        let file = std::fs::File::open(path)?;
+        let mut reader = file.take(allowed + 1);
+        let mut buf = [0u8; 64 * 1024];
+        let mut len: u64 = 0;
+        loop {
+            let read = reader.read(&mut buf)?;
+            if read == 0 {
+                break;
+            }
+            len += read as u64;
+            if len > allowed {
+                return Err(SkillError::InvalidInput(
+                    "skill package exceeds a file or total byte limit".to_string(),
+                ));
+            }
+            hasher.update(&buf[..read]);
+        }
+        hasher.update(len.to_le_bytes());
+        budget.bytes += len;
+    }
+
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(7 + digest.len() * 2);
+    out.push_str("sha256:");
+    for byte in digest {
+        use std::fmt::Write;
+        let _ = write!(out, "{byte:02x}");
+    }
+    Ok(out)
+}
+
+/// Gather `(forward-slash relative path, absolute path)` for every file under
+/// `dir`, skipping the marker at the package root. A symlink or special file is
+/// an error, not a silent skip, so nothing that would be copied escapes the
+/// digest.
+fn collect_digest_entries(
+    root: &Path,
+    dir: &Path,
+    depth: usize,
+    out: &mut Vec<(String, PathBuf)>,
+) -> Result<(), SkillError> {
+    if depth > COPY_LIMITS.depth {
+        return Err(SkillError::InvalidInput(
+            "skill package exceeds the maximum directory depth".to_string(),
+        ));
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        if dir == root && entry.file_name() == PROPAGATION_MARKER {
+            continue;
+        }
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_symlink() {
+            return Err(SkillError::InvalidInput(format!(
+                "skill package contains a symlink ({})",
+                path.display()
+            )));
+        }
+        if file_type.is_dir() {
+            collect_digest_entries(root, &path, depth + 1, out)?;
+        } else if file_type.is_file() {
+            let rel = path
+                .strip_prefix(root)
+                .expect("entry path is under root")
+                .to_str()
+                .ok_or_else(|| {
+                    SkillError::InvalidInput(format!(
+                        "skill package has a non-UTF-8 path ({})",
+                        path.display()
+                    ))
+                })?
+                .replace('\\', "/");
+            out.push((rel, path));
+        } else {
+            return Err(SkillError::InvalidInput(format!(
+                "skill package contains a special file ({})",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Read `dest`'s marker and confirm it binds to exactly this root and directory.
+/// A marker that is missing, unparseable, of an unsupported version, or copied
+/// in from somewhere else is not ours.
+fn marker_at(dest: &Path, root_id: &str, directory: &str) -> Option<PropagationMarker> {
+    let path = dest.join(PROPAGATION_MARKER);
+    match std::fs::symlink_metadata(&path) {
+        Ok(m) if m.file_type().is_file() => {}
+        _ => return None,
+    }
+    let raw = read_file_capped(&path, MAX_SKILL_MD_BYTES).ok()?;
+    let marker: PropagationMarker = serde_json::from_str(&raw).ok()?;
+    if marker.version != MARKER_VERSION || marker.root != root_id || marker.directory != directory {
+        return None;
+    }
+    Some(marker)
+}
+
+/// Classify a propagation destination. Anything AoE cannot positively prove it
+/// deployed, unchanged, is [`Ownership::Foreign`] or [`Ownership::Drifted`] and
+/// is left alone.
+fn ownership(dest: &Path, root_id: &str, directory: &str) -> Ownership {
+    match std::fs::symlink_metadata(dest) {
+        Ok(m) if m.file_type().is_symlink() || !m.is_dir() => return Ownership::Foreign,
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ownership::Absent,
+        Err(_) => return Ownership::Foreign,
+    }
+    let Some(marker) = marker_at(dest, root_id, directory) else {
+        return Ownership::Foreign;
+    };
+    match package_digest(dest) {
+        Ok(digest) if digest == marker.digest => Ownership::Clean { digest },
+        // Unreadable or over-limit reads as drift: refuse to destroy what we
+        // cannot verify.
+        Ok(_) | Err(_) => Ownership::Drifted,
+    }
+}
+
+/// Reconcile every AoE-managed skill into `target_dir`, attributing ownership to
+/// `root_id`. `target_dir` is a skills root: a host one (`~/.claude/skills`) or
+/// a sandbox's, so one reconciler serves both.
+///
+/// Creates what is missing, replaces what AoE deployed and has since changed at
+/// the source, removes what AoE deployed and no longer has a source, and
+/// preserves everything else. A per-skill failure is reported and does not stop
+/// the rest.
+pub fn sync_skills_into(target_dir: &Path, app_dir: &Path, root_id: &str) -> Vec<SyncOutcome> {
+    let managed_root = app_dir.join("skills");
+    let mut out = Vec::new();
+    let mut managed = Vec::new();
+    for skill in list_managed(&managed_root) {
+        managed.push(skill.clone());
+        out.push(sync_one(&managed_root, target_dir, root_id, &skill));
+    }
+    out.extend(remove_orphans(target_dir, root_id, &managed));
+    out.sort_by(|a, b| a.directory.cmp(&b.directory));
+    out
+}
+
+/// Managed skill directory names that would actually be discovered: a real
+/// directory holding a parseable `SKILL.md`.
+fn list_managed(managed_root: &Path) -> Vec<String> {
+    let mut discovered = Vec::new();
+    collect_from_dir(managed_root, &SkillProvenance::AoeManaged, &mut discovered);
+    discovered.into_iter().map(|s| s.directory).collect()
+}
+
+fn sync_one(managed_root: &Path, target_dir: &Path, root_id: &str, directory: &str) -> SyncOutcome {
+    let outcome = |status, message: Option<String>| SyncOutcome {
+        root: root_id.to_string(),
+        directory: directory.to_string(),
+        status,
+        message,
+    };
+    let src = match resolve_skill_dir(managed_root, directory) {
+        Ok(path) => path,
+        Err(e) => return outcome(SyncStatus::Error, Some(describe(e))),
+    };
+    let src_digest = match package_digest(&src) {
+        Ok(d) => d,
+        Err(e) => return outcome(SyncStatus::Error, Some(describe(e))),
+    };
+    let dest = target_dir.join(directory);
+    match ownership(&dest, root_id, directory) {
+        Ownership::Foreign => outcome(
+            SyncStatus::Conflict,
+            Some("a skill AoE does not manage already exists here".to_string()),
+        ),
+        Ownership::Drifted => outcome(
+            SyncStatus::Conflict,
+            Some("the propagated copy was edited in place; preserving it".to_string()),
+        ),
+        Ownership::Clean { digest } if digest == src_digest => outcome(SyncStatus::Unchanged, None),
+        Ownership::Clean { .. } => {
+            match install(&src, &dest, target_dir, root_id, directory, &src_digest) {
+                Ok(()) => outcome(SyncStatus::Updated, None),
+                Err(e) => outcome(SyncStatus::Error, Some(describe(e))),
+            }
+        }
+        Ownership::Absent => {
+            match install(&src, &dest, target_dir, root_id, directory, &src_digest) {
+                Ok(()) => outcome(SyncStatus::Created, None),
+                Err(e) => outcome(SyncStatus::Error, Some(describe(e))),
+            }
+        }
+    }
+}
+
+/// Stage a copy of `src` beside `dest`, stamp the marker, then swap it in. An
+/// existing `dest` is moved aside first and restored if the swap fails, so a
+/// failure mid-update never leaves the root without the skill.
+fn install(
+    src: &Path,
+    dest: &Path,
+    target_dir: &Path,
+    root_id: &str,
+    directory: &str,
+    digest: &str,
+) -> Result<(), SkillError> {
+    validate_skill_md_at(src, directory)?;
+    std::fs::create_dir_all(target_dir)?;
+    let staging = new_staging_dir(target_dir)?;
+    let build = (|| -> Result<(), SkillError> {
+        copy_tree_no_symlinks(src, &staging).map_err(SkillError::Io)?;
+        let marker = PropagationMarker {
+            version: MARKER_VERSION,
+            root: root_id.to_string(),
+            directory: directory.to_string(),
+            digest: digest.to_string(),
+        };
+        let encoded = serde_json::to_string_pretty(&marker)
+            .map_err(|e| SkillError::Io(anyhow::Error::new(e)))?;
+        std::fs::write(staging.join(PROPAGATION_MARKER), encoded)?;
+        Ok(())
+    })();
+    if let Err(e) = build {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(e);
+    }
+
+    let backup = dest
+        .exists()
+        .then(|| target_dir.join(format!(".tmp-{}", Uuid::new_v4())));
+    if let Some(backup) = &backup {
+        if let Err(e) = std::fs::rename(dest, backup) {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(e.into());
+        }
+    }
+    match std::fs::rename(&staging, dest) {
+        Ok(()) => {
+            if let Some(backup) = &backup {
+                let _ = std::fs::remove_dir_all(backup);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&staging);
+            if let Some(backup) = &backup {
+                // Put the user's directory back before surfacing the failure.
+                let _ = std::fs::rename(backup, dest);
+            }
+            Err(e.into())
+        }
+    }
+}
+
+/// Drop copies AoE deployed whose managed source is gone. A drifted copy is kept
+/// and reported: the user edited it, so deleting it would destroy their work.
+fn remove_orphans(target_dir: &Path, root_id: &str, managed: &[String]) -> Vec<SyncOutcome> {
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(target_dir) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') || managed.iter().any(|m| *m == name) {
+            continue;
+        }
+        let outcome = |status, message: Option<String>| SyncOutcome {
+            root: root_id.to_string(),
+            directory: name.clone(),
+            status,
+            message,
+        };
+        match ownership(&entry.path(), root_id, &name) {
+            Ownership::Clean { .. } => match std::fs::remove_dir_all(entry.path()) {
+                Ok(()) => out.push(outcome(SyncStatus::Removed, None)),
+                Err(e) => out.push(outcome(SyncStatus::Error, Some(e.to_string()))),
+            },
+            Ownership::Drifted => out.push(outcome(
+                SyncStatus::Conflict,
+                Some(
+                    "its managed source is gone but the copy was edited; preserving it".to_string(),
+                ),
+            )),
+            // Not ours, so not an orphan. Silent: every hand-written skill in
+            // the root would otherwise be reported on every sync.
+            Ownership::Foreign | Ownership::Absent => {}
+        }
+    }
+    out
+}
+
+fn describe(error: SkillError) -> String {
+    match error {
+        SkillError::InvalidInput(m)
+        | SkillError::NotFound(m)
+        | SkillError::Collision(m)
+        | SkillError::ReadOnly(m) => m,
+        SkillError::Io(e) => e.to_string(),
+    }
+}
+
+/// Reconcile the managed store into one host root.
+pub fn sync_root(
     home: &Path,
     app_dir: &Path,
-    directory: &str,
-    agent: &str,
-) -> Result<(), SkillError> {
-    validate_dir_name(directory)?;
-    let src = resolve_skill_dir(&app_dir.join("skills"), directory)?;
-    validate_skill_md_at(&src, directory)?;
-    let root = match agent {
-        "claude" => "claude-user",
-        "kimi" => "kimi-legacy",
-        _ => {
-            return Err(SkillError::InvalidInput(format!(
-                "unsupported skills agent {agent:?}"
-            )))
-        }
-    };
-    let target_root = external_skill_dir(home, root)?;
-    let dest = target_root.join(directory);
-    if dest.exists() {
-        return Err(SkillError::Collision(format!("{agent}:{directory}")));
-    }
-    std::fs::create_dir_all(&target_root)?;
-    let staging = new_staging_dir(&target_root)?;
-    let result = copy_tree_no_symlinks(&src, &staging)
-        .map_err(SkillError::Io)
-        .and_then(|()| rename_staging(&staging, &dest, &format!("{agent}:{directory}")));
-    if result.is_err() {
-        let _ = std::fs::remove_dir_all(&staging);
-    }
-    result
+    root_id: &str,
+) -> Result<Vec<SyncOutcome>, SkillError> {
+    let target = external_skill_dir(home, root_id)?;
+    Ok(sync_skills_into(&target, app_dir, root_id))
+}
+
+/// Reconcile the managed store into every host root, so a skill authored once
+/// is present for every agent AoE knows a skills location for.
+pub fn sync_all_roots(home: &Path, app_dir: &Path) -> Vec<SyncOutcome> {
+    SKILL_ROOTS
+        .iter()
+        .flat_map(|root| sync_skills_into(&home.join(root.relative_path), app_dir, root.id))
+        .collect()
+}
+
+/// Reconcile the managed store into the one root `agent` is the primary
+/// consumer of. `None` when AoE knows no skills location for that agent, which
+/// is most of the agent registry.
+pub fn sync_for_agent(home: &Path, app_dir: &Path, agent: &str) -> Option<Vec<SyncOutcome>> {
+    let root = primary_root_for_agent(agent)?;
+    Some(sync_skills_into(
+        &home.join(root.relative_path),
+        app_dir,
+        root.id,
+    ))
 }
 
 fn external_skill_dir(home: &Path, root: &str) -> Result<PathBuf, SkillError> {
@@ -1017,31 +1439,225 @@ mod tests {
         ));
     }
 
+    fn status_of(outcomes: &[SyncOutcome], directory: &str) -> SyncStatus {
+        outcomes
+            .iter()
+            .find(|o| o.directory == directory)
+            .unwrap_or_else(|| panic!("no outcome for {directory:?} in {outcomes:?}"))
+            .status
+    }
+
     #[test]
-    fn propagate_lands_in_target_and_refuses_existing() {
+    fn sync_creates_updates_and_leaves_unchanged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        create_skill(&app, "shared", Some("d")).unwrap();
+        let target = home.join(".kimi-code/skills");
+
+        let first = sync_skills_into(&target, &app, "kimi-legacy");
+        assert_eq!(status_of(&first, "shared"), SyncStatus::Created);
+        assert!(target.join("shared/SKILL.md").is_file());
+        assert!(target.join("shared").join(PROPAGATION_MARKER).is_file());
+
+        // Idempotent: nothing changed at the source, so nothing is rewritten.
+        let second = sync_skills_into(&target, &app, "kimi-legacy");
+        assert_eq!(status_of(&second, "shared"), SyncStatus::Unchanged);
+
+        // Source edited: the clean copy is replaced.
+        edit_skill(
+            &home,
+            &app,
+            "shared",
+            "---\nname: shared\ndescription: d2\n---\n\nnew body\n",
+        )
+        .unwrap();
+        let third = sync_skills_into(&target, &app, "kimi-legacy");
+        assert_eq!(status_of(&third, "shared"), SyncStatus::Updated);
+        assert!(std::fs::read_to_string(target.join("shared/SKILL.md"))
+            .unwrap()
+            .contains("new body"));
+    }
+
+    #[test]
+    fn sync_never_touches_what_aoe_did_not_deploy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        let target = home.join(".claude/skills");
+        create_skill(&app, "review", Some("d")).unwrap();
+
+        // A hand-written host skill of the same name: preserved, reported.
+        write_skill(&target, "review", "review", "the user's own");
+        let out = sync_skills_into(&target, &app, "claude-user");
+        assert_eq!(status_of(&out, "review"), SyncStatus::Conflict);
+        assert!(std::fs::read_to_string(target.join("review/SKILL.md"))
+            .unwrap()
+            .contains("the user's own"));
+
+        // A marker bound to a different root does not grant ownership here.
+        std::fs::write(
+            target.join("review").join(PROPAGATION_MARKER),
+            r#"{"version":1,"root":"gemini-user","directory":"review","digest":"sha256:x"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            status_of(&sync_skills_into(&target, &app, "claude-user"), "review"),
+            SyncStatus::Conflict
+        );
+
+        // So does a malformed one.
+        std::fs::write(target.join("review").join(PROPAGATION_MARKER), "not json").unwrap();
+        assert_eq!(
+            status_of(&sync_skills_into(&target, &app, "claude-user"), "review"),
+            SyncStatus::Conflict
+        );
+    }
+
+    #[test]
+    fn sync_preserves_a_propagated_copy_the_user_edited() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        let target = home.join(".claude/skills");
+        create_skill(&app, "review", Some("d")).unwrap();
+        sync_skills_into(&target, &app, "claude-user");
+
+        // The user edits the propagated copy in place. AoE deployed it, but its
+        // content is no longer what AoE deployed, so it is theirs now.
+        std::fs::write(
+            target.join("review/SKILL.md"),
+            "---\nname: review\ndescription: d\n---\n\nmy edits\n",
+        )
+        .unwrap();
+
+        // Source changes: still not overwritten.
+        edit_skill(
+            &home,
+            &app,
+            "review",
+            "---\nname: review\ndescription: d3\n---\n\nupstream\n",
+        )
+        .unwrap();
+        assert_eq!(
+            status_of(&sync_skills_into(&target, &app, "claude-user"), "review"),
+            SyncStatus::Conflict
+        );
+        assert!(std::fs::read_to_string(target.join("review/SKILL.md"))
+            .unwrap()
+            .contains("my edits"));
+
+        // Source deleted: still not deleted, because the edits would go with it.
+        delete_skill(&home, &app, "review").unwrap();
+        assert_eq!(
+            status_of(&sync_skills_into(&target, &app, "claude-user"), "review"),
+            SyncStatus::Conflict
+        );
+        assert!(target.join("review/SKILL.md").is_file());
+    }
+
+    #[test]
+    fn sync_removes_clean_orphans_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        let target = home.join(".gemini/skills");
+        create_skill(&app, "doomed", Some("d")).unwrap();
+        // A hand-written neighbour that must survive the orphan pass.
+        write_skill(&target, "mine", "mine", "hand written");
+        sync_skills_into(&target, &app, "gemini-user");
+        assert!(target.join("doomed/SKILL.md").is_file());
+
+        delete_skill(&home, &app, "doomed").unwrap();
+        let out = sync_skills_into(&target, &app, "gemini-user");
+        assert_eq!(status_of(&out, "doomed"), SyncStatus::Removed);
+        assert!(!target.join("doomed").exists());
+        // Not ours, never an orphan, and not even reported.
+        assert!(target.join("mine/SKILL.md").is_file());
+        assert!(!out.iter().any(|o| o.directory == "mine"));
+    }
+
+    #[test]
+    fn propagated_copies_are_not_double_counted_by_discovery() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        create_skill(&app, "shared", Some("d")).unwrap();
+        sync_skills_into(&home.join(".claude/skills"), &app, "claude-user");
+
+        let found = discover(&home, &app);
+        let shared: Vec<_> = found.iter().filter(|s| s.directory == "shared").collect();
+        assert_eq!(shared.len(), 1, "expected one entry, got {shared:?}");
+        assert_eq!(shared[0].provenance, SkillProvenance::AoeManaged);
+    }
+
+    #[test]
+    fn adopting_a_propagated_copy_drops_its_deployment_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        create_skill(&app, "shared", Some("d")).unwrap();
+        sync_skills_into(&home.join(".claude/skills"), &app, "claude-user");
+
+        adopt_skill(
+            &home,
+            &app,
+            &SkillProvenance::External {
+                root: "claude-user".to_string(),
+            },
+            "shared",
+            Some("forked"),
+        )
+        .unwrap();
+        assert!(app.join("skills/forked/SKILL.md").is_file());
+        assert!(
+            !app.join("skills/forked").join(PROPAGATION_MARKER).exists(),
+            "a managed skill must never carry a deployment marker"
+        );
+    }
+
+    #[test]
+    fn package_digest_ignores_the_marker_and_tracks_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("pkg");
+        write_skill(tmp.path(), "pkg", "pkg", "d");
+        let bare = package_digest(&dir).unwrap();
+
+        std::fs::write(dir.join(PROPAGATION_MARKER), "{}").unwrap();
+        assert_eq!(package_digest(&dir).unwrap(), bare, "marker is excluded");
+
+        std::fs::write(dir.join("extra.md"), "x").unwrap();
+        assert_ne!(package_digest(&dir).unwrap(), bare, "other files count");
+    }
+
+    #[test]
+    fn agent_scoped_sync_targets_one_root_per_agent() {
         let tmp = tempfile::tempdir().unwrap();
         let home = tmp.path().join("home");
         let app = tmp.path().join("app");
         create_skill(&app, "shared", Some("d")).unwrap();
 
-        propagate_skill(&home, &app, "shared", "kimi").unwrap();
-        assert!(home.join(".kimi-code/skills/shared/SKILL.md").is_file());
+        // opencode reads three roots but is primary for exactly one, so it gets
+        // one copy rather than one per readable root.
+        sync_for_agent(&home, &app, "opencode").unwrap();
+        assert!(home
+            .join(".config/opencode/skills/shared/SKILL.md")
+            .is_file());
+        assert!(!home.join(".claude/skills/shared").exists());
+        assert!(!home.join(".agents/skills/shared").exists());
 
-        // No overwrite: a second propagate to the same target is a collision.
-        assert!(matches!(
-            propagate_skill(&home, &app, "shared", "kimi"),
-            Err(SkillError::Collision(_))
-        ));
-        // Unknown agent is rejected.
-        assert!(matches!(
-            propagate_skill(&home, &app, "shared", "codex"),
-            Err(SkillError::InvalidInput(_))
-        ));
-        // Missing managed source is NotFound.
-        assert!(matches!(
-            propagate_skill(&home, &app, "absent", "kimi"),
-            Err(SkillError::NotFound(_))
-        ));
+        // An agent with no known skills location is not an error, just absent.
+        assert!(sync_for_agent(&home, &app, "cursor").is_none());
+
+        // Every root has a primary agent, so sync-all reaches all of them.
+        sync_all_roots(&home, &app);
+        for root in skill_roots() {
+            assert!(
+                home.join(root.relative_path).join("shared").exists(),
+                "{} missing",
+                root.id
+            );
+        }
     }
 
     #[test]

--- a/src/session/skills_model.rs
+++ b/src/session/skills_model.rs
@@ -768,6 +768,7 @@ pub fn sync_skills_into(
     replace: &HashSet<String>,
 ) -> Vec<SyncOutcome> {
     let managed_root = app_dir.join("skills");
+    recover_abandoned(target_dir, ABANDONED_AFTER);
     let mut out = Vec::new();
     let mut managed = Vec::new();
     for skill in list_managed(&managed_root) {
@@ -890,7 +891,7 @@ fn install(
 
     let backup = dest
         .exists()
-        .then(|| target_dir.join(format!(".tmp-{}", Uuid::new_v4())));
+        .then(|| target_dir.join(format!("{BACKUP_PREFIX}{}.{directory}", Uuid::new_v4())));
     if let Some(backup) = &backup {
         if let Err(e) = std::fs::rename(dest, backup) {
             let _ = std::fs::remove_dir_all(&staging);
@@ -1150,9 +1151,79 @@ fn absent_write_target(home: &Path, directory: &str) -> SkillError {
 /// into its final place by the caller; the `.tmp-` prefix keeps discovery from
 /// ever surfacing a half-built skill.
 fn new_staging_dir(parent: &Path) -> Result<PathBuf, SkillError> {
-    let path = parent.join(format!(".tmp-{}", Uuid::new_v4()));
+    let path = parent.join(format!("{STAGING_PREFIX}{}", Uuid::new_v4()));
     std::fs::create_dir(&path)?;
     Ok(path)
+}
+
+/// Staging holds a copy of the source, so it is always reproducible and safe to
+/// delete. A backup holds the directory that was in the destination, which for
+/// a replaced skill is the user's own content and the only copy of it while the
+/// swap is in flight; the two are named apart so recovery can tell them apart.
+const STAGING_PREFIX: &str = ".tmp-stage-";
+const BACKUP_PREFIX: &str = ".tmp-backup-";
+
+/// How old a leftover has to be before it is treated as abandoned rather than
+/// as another process's work in progress. A live swap lasts milliseconds.
+const ABANDONED_AFTER: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+
+/// Clean up after a process that died mid-swap.
+///
+/// A crash between staging and the final rename leaves a staging directory
+/// behind; a crash between moving the destination aside and renaming staging
+/// into place leaves a backup holding the only copy of what used to be there.
+/// The first is litter. The second is the user's data sitting under a dot-name
+/// nothing ever reads, so it is restored rather than swept.
+///
+/// Only leftovers older than `abandoned_after` are touched, so a reconcile
+/// running concurrently in another process keeps its in-flight directories.
+fn recover_abandoned(target_dir: &Path, abandoned_after: std::time::Duration) {
+    let Ok(entries) = std::fs::read_dir(target_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let is_stage = name.starts_with(STAGING_PREFIX);
+        let is_backup = name.starts_with(BACKUP_PREFIX);
+        if !is_stage && !is_backup {
+            continue;
+        }
+        let recent = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .and_then(|t| t.elapsed().map_err(std::io::Error::other))
+            .map(|age| age < abandoned_after)
+            .unwrap_or(true);
+        if recent {
+            continue;
+        }
+        if is_stage {
+            let _ = std::fs::remove_dir_all(entry.path());
+            continue;
+        }
+        // `.tmp-backup-<uuid>.<directory>`: recover the name it was moved from.
+        // Split on '.', not '-': a uuid is full of hyphens and a directory name
+        // may contain them too, while neither may contain a dot.
+        let Some(directory) = name
+            .strip_prefix(BACKUP_PREFIX)
+            .and_then(|rest| rest.split_once('.'))
+            .map(|(_uuid, directory)| directory)
+        else {
+            continue;
+        };
+        let dest = target_dir.join(directory);
+        if dest.exists() {
+            // The swap landed and only the cleanup was lost.
+            let _ = std::fs::remove_dir_all(entry.path());
+        } else if std::fs::rename(entry.path(), &dest).is_ok() {
+            warn!(
+                target: "session.skills",
+                directory,
+                root = %target_dir.display(),
+                "restored a skill left behind by an interrupted sync"
+            );
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -1766,6 +1837,46 @@ mod tests {
         assert!(std::fs::read_to_string(other_store.join("SKILL.md"))
             .unwrap()
             .contains("someone else's"));
+    }
+
+    /// A process killed mid-swap leaves either a staging copy (litter) or a
+    /// backup holding the only copy of what used to be in the destination. The
+    /// first is swept, the second is put back, and neither happens to a
+    /// leftover young enough to belong to a sync still running elsewhere.
+    #[test]
+    fn abandoned_leftovers_are_swept_or_restored() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("skills");
+        std::fs::create_dir_all(&target).unwrap();
+        let stage = format!("{STAGING_PREFIX}{}", Uuid::new_v4());
+        let backup = format!("{BACKUP_PREFIX}{}.review", Uuid::new_v4());
+        write_skill(&target, &stage, "x", "d");
+        write_skill(&target, &backup, "review", "the user's own");
+
+        // A live swap lasts milliseconds, so nothing is old enough to touch.
+        recover_abandoned(&target, std::time::Duration::from_secs(60 * 60));
+        assert!(
+            target.join(&stage).exists(),
+            "a recent leftover belongs to a live sync"
+        );
+        assert!(target.join(&backup).exists());
+
+        // Treat everything as abandoned.
+        recover_abandoned(&target, std::time::Duration::ZERO);
+        assert!(
+            !target.join(&stage).exists(),
+            "an abandoned staging copy is reproducible litter"
+        );
+        assert!(
+            !target.join(&backup).exists(),
+            "the backup is moved, not left behind"
+        );
+        assert!(
+            std::fs::read_to_string(target.join("review/SKILL.md"))
+                .unwrap()
+                .contains("the user's own"),
+            "the backup held the only copy, so it is restored under its own name"
+        );
     }
 
     #[test]

--- a/src/session/skills_model.rs
+++ b/src/session/skills_model.rs
@@ -138,6 +138,22 @@ impl SkillProvenance {
     pub fn is_writable(&self) -> bool {
         matches!(self, SkillProvenance::AoeManaged)
     }
+
+    /// The short source name shown to a user, e.g. `AoE`, `Claude`, `Gemini`.
+    /// Distinct from [`Self::label`], which is the stable machine-facing
+    /// string. The web surfaces derive the same wording from the root registry
+    /// they already fetch, so a skill reads the same in the TUI panel, the
+    /// skills manager, the slash picker, and its tool card (#3052).
+    pub fn source_label(&self) -> &'static str {
+        match self {
+            SkillProvenance::AoeManaged => "AoE",
+            SkillProvenance::External { root } => skill_root(root)
+                .map(|entry| entry.label)
+                // An unknown root cannot be labelled, but it is still a real
+                // directory on disk, so say so rather than showing nothing.
+                .unwrap_or("Unknown"),
+        }
+    }
 }
 
 /// One discovered skill's list-safe metadata: its identity (`directory`), its

--- a/src/session/skills_model.rs
+++ b/src/session/skills_model.rs
@@ -925,7 +925,7 @@ fn remove_orphans(target_dir: &Path, root_id: &str, managed: &[String]) -> Vec<S
     };
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
-        if name.starts_with('.') || managed.iter().any(|m| *m == name) {
+        if name.starts_with('.') || managed.contains(&name) {
             continue;
         }
         let outcome = |status, message: Option<String>| SyncOutcome {

--- a/src/session/skills_model.rs
+++ b/src/session/skills_model.rs
@@ -1,11 +1,11 @@
-//! Always-compiled, plugin-facing model of the agent-skill set (#2984).
+//! Always-compiled model of skills discovered by AoE.
 //!
-//! A "skill" is a `SKILL.md` folder (the Claude Code / kimi concept): YAML
+//! A "skill" is a `SKILL.md` folder used by supported coding agents: YAML
 //! frontmatter (`name`, `description`, plus optional metadata) between `---`
 //! fences, then a markdown body, living in a per-skill directory. AoE has never
 //! had a Rust model for these; they were only bulk-copied into sandboxes
-//! (`src/session/container_config.rs`). This module is the single resolver the
-//! plugin host RPCs (`src/plugin/host_api.rs`) read and mutate.
+//! (`src/session/container_config.rs`). This module is the single resolver used
+//! by the server, CLI, and plugin host.
 //!
 //! Two provenance layers, mirroring [`super::mcp_model::McpProvenance`]:
 //! host-discovered skills in each agent's own skills dir (`~/.claude/skills`,
@@ -19,6 +19,7 @@
 //! source-qualified. This module does NOT define precedence/shadowing between
 //! layers: [`discover`] returns every source-qualified entry as-is.
 
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
@@ -30,30 +31,87 @@ use uuid::Uuid;
 /// cannot make the host read an unbounded amount into memory.
 pub const MAX_SKILL_MD_BYTES: u64 = 1024 * 1024;
 
-/// Host-discovered skill dirs, keyed by agent registry name. The `agent` string
-/// is both the provenance label and the `skills.propagate` target key. Same
-/// small-const-table pattern as [`super::mcp_model`]'s `native_config_for`.
-const AGENT_SKILL_DIRS: &[(&str, &str)] =
-    &[("claude", ".claude/skills"), ("kimi", ".kimi-code/skills")];
+const MAX_SKILL_PACKAGE_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_SKILL_PACKAGE_FILE_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_SKILL_PACKAGE_FILES: usize = 1024;
+const MAX_SKILL_PACKAGE_DEPTH: usize = 16;
 
-/// Where a skill was discovered. The read-only host layers carry the agent key;
+/// A physical host directory from which AoE discovers skills. `consumers` names
+/// the agents that can load the directory; it does not change skill identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillRoot {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub relative_path: &'static str,
+    pub consumers: &'static [&'static str],
+    pub legacy: bool,
+}
+
+const SKILL_ROOTS: &[SkillRoot] = &[
+    SkillRoot {
+        id: "claude-user",
+        label: "Claude",
+        relative_path: ".claude/skills",
+        consumers: &["claude", "opencode"],
+        legacy: false,
+    },
+    SkillRoot {
+        id: "agents-standard",
+        label: "Agent Skills",
+        relative_path: ".agents/skills",
+        consumers: &["codex", "opencode"],
+        legacy: false,
+    },
+    SkillRoot {
+        id: "gemini-user",
+        label: "Gemini",
+        relative_path: ".gemini/skills",
+        consumers: &["gemini"],
+        legacy: false,
+    },
+    SkillRoot {
+        id: "opencode-user",
+        label: "OpenCode",
+        relative_path: ".config/opencode/skills",
+        consumers: &["opencode"],
+        legacy: false,
+    },
+    SkillRoot {
+        id: "kimi-legacy",
+        label: "Kimi (legacy)",
+        relative_path: ".kimi-code/skills",
+        consumers: &["kimi"],
+        legacy: true,
+    },
+];
+
+pub fn skill_roots() -> &'static [SkillRoot] {
+    SKILL_ROOTS
+}
+
+pub fn skill_root(id: &str) -> Option<&'static SkillRoot> {
+    SKILL_ROOTS.iter().find(|root| root.id == id)
+}
+
+/// Where a skill was discovered. The read-only host layers carry a root key;
 /// the single writable layer is [`SkillProvenance::AoeManaged`]. Serializes to a
-/// tagged object (`{ "kind": "agent-native", "agent": "claude" }` /
+/// tagged object (`{ "kind": "external", "root": "claude-user" }` /
 /// `{ "kind": "aoe-managed" }`) so it round-trips as both `skills.list` output
 /// and a source-qualified `skills.read` / `skills.adopt` parameter.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum SkillProvenance {
-    AgentNative { agent: String },
+    External { root: String },
     AoeManaged,
 }
 
 impl SkillProvenance {
-    /// The provenance string shown in logs, e.g. `agent-native:claude`,
+    /// The provenance string shown in logs, e.g. `external:claude-user`,
     /// `aoe-managed`.
     pub fn label(&self) -> String {
         match self {
-            SkillProvenance::AgentNative { agent } => format!("agent-native:{agent}"),
+            SkillProvenance::External { root } => format!("external:{root}"),
             SkillProvenance::AoeManaged => "aoe-managed".to_string(),
         }
     }
@@ -68,7 +126,8 @@ impl SkillProvenance {
 /// One discovered skill's list-safe metadata: its identity (`directory`), its
 /// frontmatter `name`/`description`, and where it came from. The body is not
 /// included; `skills.read` returns that.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DiscoveredSkill {
     pub provenance: SkillProvenance,
     pub directory: String,
@@ -77,7 +136,8 @@ pub struct DiscoveredSkill {
 }
 
 /// A skill read in full: its metadata plus the raw `SKILL.md` content.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ReadSkill {
     pub provenance: SkillProvenance,
     pub directory: String,
@@ -178,17 +238,17 @@ fn home_dir() -> Result<PathBuf> {
     dirs::home_dir().context("could not resolve home dir for skills discovery")
 }
 
-/// Discover every skill across all host-discovered agent dirs and the managed
+/// Discover every skill across all host-discovered roots and the managed
 /// store, source-qualified and sorted deterministically (by provenance label,
 /// then directory). A malformed or unreadable skill warns and is skipped; it
 /// never fails the whole scan. Roots are injected so tests need no real `$HOME`.
 pub fn discover(home: &Path, app_dir: &Path) -> Vec<DiscoveredSkill> {
     let mut out = Vec::new();
-    for (agent, rel) in AGENT_SKILL_DIRS {
+    for root in SKILL_ROOTS {
         collect_from_dir(
-            &home.join(rel),
-            &SkillProvenance::AgentNative {
-                agent: (*agent).to_string(),
+            &home.join(root.relative_path),
+            &SkillProvenance::External {
+                root: root.id.to_string(),
             },
             &mut out,
         );
@@ -319,12 +379,12 @@ pub fn create_skill(
     let staging = new_staging_dir(&managed)?;
     let result = (|| {
         std::fs::write(staging.join("SKILL.md"), &content)?;
-        std::fs::rename(&staging, &final_path)
+        rename_staging(&staging, &final_path, directory)
     })();
     if result.is_err() {
         let _ = std::fs::remove_dir_all(&staging);
     }
-    result.map_err(Into::into)
+    result
 }
 
 /// Overwrite a managed skill's `SKILL.md` with validated content. A
@@ -366,19 +426,13 @@ pub fn edit_skill(
 /// symlinked managed entry is refused.
 pub fn delete_skill(home: &Path, app_dir: &Path, directory: &str) -> Result<(), SkillError> {
     validate_dir_name(directory)?;
-    let managed_path = app_dir.join("skills").join(directory);
-    let meta = match std::fs::symlink_metadata(&managed_path) {
-        Ok(m) => m,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return Err(absent_write_target(home, directory))
-        }
-        Err(e) => return Err(e.into()),
+    let managed_root = app_dir.join("skills");
+    let managed_path = match resolve_skill_dir(&managed_root, directory) {
+        Ok(path) => path,
+        Err(SkillError::NotFound(_)) => return Err(absent_write_target(home, directory)),
+        Err(error) => return Err(error),
     };
-    if meta.file_type().is_symlink() {
-        return Err(SkillError::InvalidInput(
-            "refusing to delete a symlinked skill entry".to_string(),
-        ));
-    }
+    validate_skill_md_at(&managed_path, directory)?;
     std::fs::remove_dir_all(&managed_path)?;
     Ok(())
 }
@@ -395,15 +449,15 @@ pub fn adopt_skill(
     dest: Option<&str>,
 ) -> Result<String, SkillError> {
     validate_dir_name(directory)?;
-    let agent = match source {
-        SkillProvenance::AgentNative { agent } => agent,
+    let root = match source {
+        SkillProvenance::External { root } => root,
         SkillProvenance::AoeManaged => {
             return Err(SkillError::InvalidInput(
                 "cannot adopt an already AoE-managed skill".to_string(),
             ))
         }
     };
-    let src_dir = resolve_skill_dir(&agent_skill_dir(home, agent)?, directory)?;
+    let src_dir = resolve_skill_dir(&external_skill_dir(home, root)?, directory)?;
     validate_skill_md_at(&src_dir, directory)?;
     let dest_name = dest.unwrap_or(directory);
     validate_dir_name(dest_name)?;
@@ -415,11 +469,12 @@ pub fn adopt_skill(
     std::fs::create_dir_all(&managed)?;
     let staging = new_staging_dir(&managed)?;
     let result = copy_tree_no_symlinks(&src_dir, &staging)
-        .and_then(|()| std::fs::rename(&staging, &final_path).map_err(Into::into));
+        .map_err(SkillError::Io)
+        .and_then(|()| rename_staging(&staging, &final_path, dest_name));
     if result.is_err() {
         let _ = std::fs::remove_dir_all(&staging);
     }
-    result.map_err(SkillError::Io)?;
+    result?;
     Ok(dest_name.to_string())
 }
 
@@ -437,7 +492,16 @@ pub fn propagate_skill(
     validate_dir_name(directory)?;
     let src = resolve_skill_dir(&app_dir.join("skills"), directory)?;
     validate_skill_md_at(&src, directory)?;
-    let target_root = agent_skill_dir(home, agent)?;
+    let root = match agent {
+        "claude" => "claude-user",
+        "kimi" => "kimi-legacy",
+        _ => {
+            return Err(SkillError::InvalidInput(format!(
+                "unsupported skills agent {agent:?}"
+            )))
+        }
+    };
+    let target_root = external_skill_dir(home, root)?;
     let dest = target_root.join(directory);
     if dest.exists() {
         return Err(SkillError::Collision(format!("{agent}:{directory}")));
@@ -445,32 +509,29 @@ pub fn propagate_skill(
     std::fs::create_dir_all(&target_root)?;
     let staging = new_staging_dir(&target_root)?;
     let result = copy_tree_no_symlinks(&src, &staging)
-        .and_then(|()| std::fs::rename(&staging, &dest).map_err(Into::into));
+        .map_err(SkillError::Io)
+        .and_then(|()| rename_staging(&staging, &dest, &format!("{agent}:{directory}")));
     if result.is_err() {
         let _ = std::fs::remove_dir_all(&staging);
     }
-    result.map_err(SkillError::Io)
+    result
 }
 
-/// The host skills dir for a known agent key, or [`SkillError::InvalidInput`]
-/// for an unsupported agent.
-fn agent_skill_dir(home: &Path, agent: &str) -> Result<PathBuf, SkillError> {
-    AGENT_SKILL_DIRS
-        .iter()
-        .find(|(a, _)| *a == agent)
-        .map(|(_, rel)| home.join(rel))
-        .ok_or_else(|| SkillError::InvalidInput(format!("unsupported skills agent {agent:?}")))
+fn external_skill_dir(home: &Path, root: &str) -> Result<PathBuf, SkillError> {
+    skill_root(root)
+        .map(|entry| home.join(entry.relative_path))
+        .ok_or_else(|| SkillError::InvalidInput(format!("unsupported skills root {root:?}")))
 }
 
 /// The designated root that a source-qualified skill's directory must live
-/// under (the agent's host skills dir, or the managed store).
+/// under (the external host root, or the managed store).
 fn skill_root_for(
     home: &Path,
     app_dir: &Path,
     provenance: &SkillProvenance,
 ) -> Result<PathBuf, SkillError> {
     match provenance {
-        SkillProvenance::AgentNative { agent } => agent_skill_dir(home, agent),
+        SkillProvenance::External { root } => external_skill_dir(home, root),
         SkillProvenance::AoeManaged => Ok(app_dir.join("skills")),
     }
 }
@@ -479,7 +540,6 @@ fn skill_root_for(
 /// handle and rejects an overflow byte, so a file that grows after a metadata
 /// check cannot slip past the bound (the metadata-then-read TOCTOU).
 pub fn read_file_capped(path: &Path, max: u64) -> Result<String> {
-    use std::io::Read;
     let file = std::fs::File::open(path)?;
     let mut buf = Vec::new();
     file.take(max + 1).read_to_end(&mut buf)?;
@@ -556,8 +616,13 @@ fn validate_skill_md_at(dir: &Path, directory: &str) -> Result<(), SkillError> {
 /// skill of the same directory is read-only (adopt first), otherwise it is
 /// simply absent.
 fn absent_write_target(home: &Path, directory: &str) -> SkillError {
-    for (_, rel) in AGENT_SKILL_DIRS {
-        if home.join(rel).join(directory).join("SKILL.md").is_file() {
+    for root in SKILL_ROOTS {
+        if home
+            .join(root.relative_path)
+            .join(directory)
+            .join("SKILL.md")
+            .is_file()
+        {
             return SkillError::ReadOnly(format!(
                 "skill {directory:?} is host-discovered and read-only; adopt it first"
             ));
@@ -575,9 +640,43 @@ fn new_staging_dir(parent: &Path) -> Result<PathBuf, SkillError> {
     Ok(path)
 }
 
-/// Recursively copy `src` into `dst`, refusing symlinks and special files so a
-/// skill package can never smuggle a link that escapes the destination tree.
+#[derive(Clone, Copy)]
+struct CopyLimits {
+    total_bytes: u64,
+    file_bytes: u64,
+    files: usize,
+    depth: usize,
+}
+
+const COPY_LIMITS: CopyLimits = CopyLimits {
+    total_bytes: MAX_SKILL_PACKAGE_BYTES,
+    file_bytes: MAX_SKILL_PACKAGE_FILE_BYTES,
+    files: MAX_SKILL_PACKAGE_FILES,
+    depth: MAX_SKILL_PACKAGE_DEPTH,
+};
+
+#[derive(Default)]
+struct CopyBudget {
+    bytes: u64,
+    files: usize,
+}
+
+/// Recursively copy `src` into `dst`, refusing links, special files, and
+/// packages large enough to exhaust disk or memory through an adoption request.
 fn copy_tree_no_symlinks(src: &Path, dst: &Path) -> Result<(), anyhow::Error> {
+    copy_tree_bounded(src, dst, 0, &mut CopyBudget::default(), COPY_LIMITS)
+}
+
+fn copy_tree_bounded(
+    src: &Path,
+    dst: &Path,
+    depth: usize,
+    budget: &mut CopyBudget,
+    limits: CopyLimits,
+) -> Result<(), anyhow::Error> {
+    if depth > limits.depth {
+        bail!("skill package exceeds the maximum directory depth");
+    }
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;
@@ -587,14 +686,38 @@ fn copy_tree_no_symlinks(src: &Path, dst: &Path) -> Result<(), anyhow::Error> {
         if ft.is_symlink() {
             bail!("refusing to copy symlink {}", from.display());
         } else if ft.is_dir() {
-            copy_tree_no_symlinks(&from, &to)?;
+            copy_tree_bounded(&from, &to, depth + 1, budget, limits)?;
         } else if ft.is_file() {
-            std::fs::copy(&from, &to)?;
+            budget.files += 1;
+            if budget.files > limits.files {
+                bail!("skill package exceeds the maximum file count");
+            }
+            let remaining = limits.total_bytes.saturating_sub(budget.bytes);
+            let allowed = remaining.min(limits.file_bytes);
+            let input = std::fs::File::open(&from)?;
+            let mut output = std::fs::File::create(&to)?;
+            let copied = std::io::copy(&mut input.take(allowed + 1), &mut output)?;
+            if copied > allowed {
+                bail!("skill package exceeds a file or total byte limit");
+            }
+            output.flush()?;
+            std::fs::set_permissions(&to, entry.metadata()?.permissions())?;
+            budget.bytes += copied;
         } else {
             bail!("refusing to copy special file {}", from.display());
         }
     }
     Ok(())
+}
+
+fn rename_staging(staging: &Path, destination: &Path, collision: &str) -> Result<(), SkillError> {
+    match std::fs::rename(staging, destination) {
+        Ok(()) => Ok(()),
+        Err(_) if std::fs::symlink_metadata(destination).is_ok() => {
+            Err(SkillError::Collision(collision.to_string()))
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 /// Atomically replace `path`'s contents by writing a sibling temp file and
@@ -691,6 +814,9 @@ mod tests {
         let home = tmp.path().join("home");
         let app = tmp.path().join("app");
         write_skill(&home.join(".claude/skills"), "review", "review", "d");
+        write_skill(&home.join(".agents/skills"), "standard", "standard", "d");
+        write_skill(&home.join(".gemini/skills"), "gem", "gem", "d");
+        write_skill(&home.join(".config/opencode/skills"), "open", "open", "d");
         write_skill(&home.join(".kimi-code/skills"), "review", "review", "d");
         write_skill(&app.join("skills"), "mine", "mine", "d");
 
@@ -704,9 +830,15 @@ mod tests {
         assert_eq!(
             ids,
             vec![
-                ("agent-native:claude".to_string(), "review".to_string()),
-                ("agent-native:kimi".to_string(), "review".to_string()),
                 ("aoe-managed".to_string(), "mine".to_string()),
+                (
+                    "external:agents-standard".to_string(),
+                    "standard".to_string()
+                ),
+                ("external:claude-user".to_string(), "review".to_string()),
+                ("external:gemini-user".to_string(), "gem".to_string()),
+                ("external:kimi-legacy".to_string(), "review".to_string()),
+                ("external:opencode-user".to_string(), "open".to_string()),
             ]
         );
     }
@@ -789,8 +921,8 @@ mod tests {
         adopt_skill(
             &home,
             &app,
-            &SkillProvenance::AgentNative {
-                agent: "claude".to_string(),
+            &SkillProvenance::External {
+                root: "claude-user".to_string(),
             },
             "review",
             None,
@@ -827,8 +959,8 @@ mod tests {
         let dest = adopt_skill(
             &home,
             &app,
-            &SkillProvenance::AgentNative {
-                agent: "claude".to_string(),
+            &SkillProvenance::External {
+                root: "claude-user".to_string(),
             },
             "review",
             None,
@@ -875,8 +1007,8 @@ mod tests {
             adopt_skill(
                 &home,
                 &app,
-                &SkillProvenance::AgentNative {
-                    agent: "claude".to_string()
+                &SkillProvenance::External {
+                    root: "claude-user".to_string()
                 },
                 "review",
                 None
@@ -930,6 +1062,14 @@ mod tests {
             delete_skill(&home, &app, "nope"),
             Err(SkillError::NotFound(_))
         ));
+
+        let malformed = app.join("skills/not-a-skill");
+        std::fs::create_dir_all(&malformed).unwrap();
+        assert!(matches!(
+            delete_skill(&home, &app, "not-a-skill"),
+            Err(SkillError::NotFound(_))
+        ));
+        assert!(malformed.exists());
     }
 
     #[test]
@@ -963,8 +1103,8 @@ mod tests {
             adopt_skill(
                 &home,
                 &app,
-                &SkillProvenance::AgentNative {
-                    agent: "claude".to_string()
+                &SkillProvenance::External {
+                    root: "claude-user".to_string()
                 },
                 "big",
                 None
@@ -972,6 +1112,53 @@ mod tests {
             Err(SkillError::InvalidInput(_))
         ));
         assert!(!app.join("skills/big").exists());
+    }
+
+    #[test]
+    fn package_copy_enforces_file_count_byte_and_depth_limits() {
+        let tmp = tempfile::tempdir().unwrap();
+        let limits = CopyLimits {
+            total_bytes: 8,
+            file_bytes: 8,
+            files: 1,
+            depth: 1,
+        };
+
+        let files_src = tmp.path().join("files-src");
+        std::fs::create_dir_all(&files_src).unwrap();
+        std::fs::write(files_src.join("one"), "1").unwrap();
+        std::fs::write(files_src.join("two"), "2").unwrap();
+        assert!(copy_tree_bounded(
+            &files_src,
+            &tmp.path().join("files-dst"),
+            0,
+            &mut CopyBudget::default(),
+            limits,
+        )
+        .is_err());
+
+        let bytes_src = tmp.path().join("bytes-src");
+        std::fs::create_dir_all(&bytes_src).unwrap();
+        std::fs::write(bytes_src.join("large"), "123456789").unwrap();
+        assert!(copy_tree_bounded(
+            &bytes_src,
+            &tmp.path().join("bytes-dst"),
+            0,
+            &mut CopyBudget::default(),
+            limits,
+        )
+        .is_err());
+
+        let depth_src = tmp.path().join("depth-src");
+        std::fs::create_dir_all(depth_src.join("one/two")).unwrap();
+        assert!(copy_tree_bounded(
+            &depth_src,
+            &tmp.path().join("depth-dst"),
+            0,
+            &mut CopyBudget::default(),
+            limits,
+        )
+        .is_err());
     }
 
     #[cfg(unix)]
@@ -1015,8 +1202,8 @@ mod tests {
             adopt_skill(
                 &home,
                 &app,
-                &SkillProvenance::AgentNative {
-                    agent: "claude".to_string()
+                &SkillProvenance::External {
+                    root: "claude-user".to_string()
                 },
                 "evil",
                 None

--- a/src/session/skills_model.rs
+++ b/src/session/skills_model.rs
@@ -19,6 +19,7 @@
 //! source-qualified. This module does NOT define precedence/shadowing between
 //! layers: [`discover`] returns every source-qualified entry as-is.
 
+use std::collections::HashSet;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
@@ -755,17 +756,39 @@ fn ownership(dest: &Path, root_id: &str, directory: &str) -> Ownership {
 /// the source, removes what AoE deployed and no longer has a source, and
 /// preserves everything else. A per-skill failure is reported and does not stop
 /// the rest.
-pub fn sync_skills_into(target_dir: &Path, app_dir: &Path, root_id: &str) -> Vec<SyncOutcome> {
+///
+/// `replace` names the skills the user has explicitly asked AoE to take over, so
+/// a destination AoE does not own is overwritten instead of reported. Nothing
+/// else grants that: a caller that passes an empty set cannot destroy user data,
+/// which is why every automatic path does exactly that.
+pub fn sync_skills_into(
+    target_dir: &Path,
+    app_dir: &Path,
+    root_id: &str,
+    replace: &HashSet<String>,
+) -> Vec<SyncOutcome> {
     let managed_root = app_dir.join("skills");
     let mut out = Vec::new();
     let mut managed = Vec::new();
     for skill in list_managed(&managed_root) {
         managed.push(skill.clone());
-        out.push(sync_one(&managed_root, target_dir, root_id, &skill));
+        out.push(sync_one(
+            &managed_root,
+            target_dir,
+            root_id,
+            &skill,
+            replace.contains(&skill),
+        ));
     }
     out.extend(remove_orphans(target_dir, root_id, &managed));
     out.sort_by(|a, b| a.directory.cmp(&b.directory));
     out
+}
+
+/// The empty set: sync without permission to overwrite anything AoE does not
+/// already own. What every automatic caller passes.
+pub fn no_replacements() -> HashSet<String> {
+    HashSet::new()
 }
 
 /// Managed skill directory names that would actually be discovered: a real
@@ -776,7 +799,13 @@ fn list_managed(managed_root: &Path) -> Vec<String> {
     discovered.into_iter().map(|s| s.directory).collect()
 }
 
-fn sync_one(managed_root: &Path, target_dir: &Path, root_id: &str, directory: &str) -> SyncOutcome {
+fn sync_one(
+    managed_root: &Path,
+    target_dir: &Path,
+    root_id: &str,
+    directory: &str,
+    replace: bool,
+) -> SyncOutcome {
     let outcome = |status, message: Option<String>| SyncOutcome {
         root: root_id.to_string(),
         directory: directory.to_string(),
@@ -792,7 +821,17 @@ fn sync_one(managed_root: &Path, target_dir: &Path, root_id: &str, directory: &s
         Err(e) => return outcome(SyncStatus::Error, Some(describe(e))),
     };
     let dest = target_dir.join(directory);
-    match ownership(&dest, root_id, directory) {
+    let owned = ownership(&dest, root_id, directory);
+    // The user asked for this one by name, so take it over. Installing renames
+    // the existing entry aside first, which for a symlink moves the link and
+    // leaves whatever it pointed at intact.
+    if replace && matches!(owned, Ownership::Foreign | Ownership::Drifted) {
+        return match install(&src, &dest, target_dir, root_id, directory, &src_digest) {
+            Ok(()) => outcome(SyncStatus::Updated, Some("replaced on request".to_string())),
+            Err(e) => outcome(SyncStatus::Error, Some(describe(e))),
+        };
+    }
+    match owned {
         Ownership::Foreign => outcome(
             SyncStatus::Conflict,
             Some("a skill AoE does not manage already exists here".to_string()),
@@ -961,17 +1000,20 @@ pub fn sync_root(
     home: &Path,
     app_dir: &Path,
     root_id: &str,
+    replace: &HashSet<String>,
 ) -> Result<Vec<SyncOutcome>, SkillError> {
     let target = external_skill_dir(home, root_id)?;
-    Ok(sync_skills_into(&target, app_dir, root_id))
+    Ok(sync_skills_into(&target, app_dir, root_id, replace))
 }
 
 /// Reconcile the managed store into every host root, so a skill authored once
 /// is present for every agent AoE knows a skills location for.
-pub fn sync_all_roots(home: &Path, app_dir: &Path) -> Vec<SyncOutcome> {
+pub fn sync_all_roots(home: &Path, app_dir: &Path, replace: &HashSet<String>) -> Vec<SyncOutcome> {
     SKILL_ROOTS
         .iter()
-        .flat_map(|root| sync_skills_into(&home.join(root.relative_path), app_dir, root.id))
+        .flat_map(|root| {
+            sync_skills_into(&home.join(root.relative_path), app_dir, root.id, replace)
+        })
         .collect()
 }
 
@@ -980,10 +1022,13 @@ pub fn sync_all_roots(home: &Path, app_dir: &Path) -> Vec<SyncOutcome> {
 /// is most of the agent registry.
 pub fn sync_for_agent(home: &Path, app_dir: &Path, agent: &str) -> Option<Vec<SyncOutcome>> {
     let root = primary_root_for_agent(agent)?;
+    // Never replaces: a session launching must not overwrite a skill the user
+    // wrote by hand, no matter what the managed store contains.
     Some(sync_skills_into(
         &home.join(root.relative_path),
         app_dir,
         root.id,
+        &no_replacements(),
     ))
 }
 
@@ -1503,13 +1548,13 @@ mod tests {
         create_skill(&app, "shared", Some("d")).unwrap();
         let target = home.join(".kimi-code/skills");
 
-        let first = sync_skills_into(&target, &app, "kimi-legacy");
+        let first = sync_skills_into(&target, &app, "kimi-legacy", &no_replacements());
         assert_eq!(status_of(&first, "shared"), SyncStatus::Created);
         assert!(target.join("shared/SKILL.md").is_file());
         assert!(target.join("shared").join(PROPAGATION_MARKER).is_file());
 
         // Idempotent: nothing changed at the source, so nothing is rewritten.
-        let second = sync_skills_into(&target, &app, "kimi-legacy");
+        let second = sync_skills_into(&target, &app, "kimi-legacy", &no_replacements());
         assert_eq!(status_of(&second, "shared"), SyncStatus::Unchanged);
 
         // Source edited: the clean copy is replaced.
@@ -1520,7 +1565,7 @@ mod tests {
             "---\nname: shared\ndescription: d2\n---\n\nnew body\n",
         )
         .unwrap();
-        let third = sync_skills_into(&target, &app, "kimi-legacy");
+        let third = sync_skills_into(&target, &app, "kimi-legacy", &no_replacements());
         assert_eq!(status_of(&third, "shared"), SyncStatus::Updated);
         assert!(std::fs::read_to_string(target.join("shared/SKILL.md"))
             .unwrap()
@@ -1537,7 +1582,7 @@ mod tests {
 
         // A hand-written host skill of the same name: preserved, reported.
         write_skill(&target, "review", "review", "the user's own");
-        let out = sync_skills_into(&target, &app, "claude-user");
+        let out = sync_skills_into(&target, &app, "claude-user", &no_replacements());
         assert_eq!(status_of(&out, "review"), SyncStatus::Conflict);
         assert!(std::fs::read_to_string(target.join("review/SKILL.md"))
             .unwrap()
@@ -1550,14 +1595,20 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            status_of(&sync_skills_into(&target, &app, "claude-user"), "review"),
+            status_of(
+                &sync_skills_into(&target, &app, "claude-user", &no_replacements()),
+                "review"
+            ),
             SyncStatus::Conflict
         );
 
         // So does a malformed one.
         std::fs::write(target.join("review").join(PROPAGATION_MARKER), "not json").unwrap();
         assert_eq!(
-            status_of(&sync_skills_into(&target, &app, "claude-user"), "review"),
+            status_of(
+                &sync_skills_into(&target, &app, "claude-user", &no_replacements()),
+                "review"
+            ),
             SyncStatus::Conflict
         );
     }
@@ -1569,7 +1620,7 @@ mod tests {
         let app = tmp.path().join("app");
         let target = home.join(".claude/skills");
         create_skill(&app, "review", Some("d")).unwrap();
-        sync_skills_into(&target, &app, "claude-user");
+        sync_skills_into(&target, &app, "claude-user", &no_replacements());
 
         // The user edits the propagated copy in place. AoE deployed it, but its
         // content is no longer what AoE deployed, so it is theirs now.
@@ -1588,7 +1639,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            status_of(&sync_skills_into(&target, &app, "claude-user"), "review"),
+            status_of(
+                &sync_skills_into(&target, &app, "claude-user", &no_replacements()),
+                "review"
+            ),
             SyncStatus::Conflict
         );
         assert!(std::fs::read_to_string(target.join("review/SKILL.md"))
@@ -1598,10 +1652,120 @@ mod tests {
         // Source deleted: still not deleted, because the edits would go with it.
         delete_skill(&home, &app, "review").unwrap();
         assert_eq!(
-            status_of(&sync_skills_into(&target, &app, "claude-user"), "review"),
+            status_of(
+                &sync_skills_into(&target, &app, "claude-user", &no_replacements()),
+                "review"
+            ),
             SyncStatus::Conflict
         );
         assert!(target.join("review/SKILL.md").is_file());
+    }
+
+    #[test]
+    fn sync_leaves_a_symlinked_skill_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        let target = home.join(".claude/skills");
+        create_skill(&app, "shared", Some("d")).unwrap();
+
+        // Another manager (skillshare and friends) links its own store into the
+        // agent's dir. AoE must not follow or replace that link.
+        let other_store = tmp.path().join("other/shared");
+        write_skill(
+            &tmp.path().join("other"),
+            "shared",
+            "shared",
+            "someone else's",
+        );
+        std::fs::create_dir_all(&target).unwrap();
+        std::os::unix::fs::symlink(&other_store, target.join("shared")).unwrap();
+
+        let out = sync_skills_into(&target, &app, "claude-user", &no_replacements());
+        assert_eq!(status_of(&out, "shared"), SyncStatus::Conflict);
+        assert!(std::fs::symlink_metadata(target.join("shared"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert!(std::fs::read_to_string(other_store.join("SKILL.md"))
+            .unwrap()
+            .contains("someone else's"));
+    }
+
+    /// Naming a skill takes it over, which is the only way past the
+    /// never-overwrite rule. The automatic paths cannot reach it.
+    #[test]
+    fn replace_takes_over_only_what_the_user_named() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        let target = home.join(".claude/skills");
+        for dir in ["taken", "spared"] {
+            create_skill(&app, dir, Some("managed")).unwrap();
+            write_skill(&target, dir, dir, "the user's own");
+        }
+        let replace = HashSet::from(["taken".to_string()]);
+
+        let out = sync_skills_into(&target, &app, "claude-user", &replace);
+        assert_eq!(status_of(&out, "taken"), SyncStatus::Updated);
+        assert!(target.join("taken").join(PROPAGATION_MARKER).is_file());
+        // Now AoE-owned, so ordinary syncs keep it current from here on.
+        assert_eq!(
+            status_of(
+                &sync_skills_into(&target, &app, "claude-user", &no_replacements()),
+                "taken"
+            ),
+            SyncStatus::Unchanged
+        );
+
+        // Not named, so untouched even in the same run.
+        assert_eq!(status_of(&out, "spared"), SyncStatus::Conflict);
+        assert!(std::fs::read_to_string(target.join("spared/SKILL.md"))
+            .unwrap()
+            .contains("the user's own"));
+
+        // A launching session passes no replacements, so it cannot take over
+        // the skill the user still owns.
+        sync_for_agent(&home, &app, "claude").unwrap();
+        assert!(std::fs::read_to_string(target.join("spared/SKILL.md"))
+            .unwrap()
+            .contains("the user's own"));
+    }
+
+    /// Replacing a symlinked entry moves the link aside, so a skill managed by
+    /// another tool keeps its store even when AoE takes over the name.
+    #[test]
+    fn replace_moves_a_symlink_without_touching_its_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        let target = home.join(".claude/skills");
+        create_skill(&app, "shared", Some("managed")).unwrap();
+        write_skill(
+            &tmp.path().join("other"),
+            "shared",
+            "shared",
+            "someone else's",
+        );
+        let other_store = tmp.path().join("other/shared");
+        std::fs::create_dir_all(&target).unwrap();
+        std::os::unix::fs::symlink(&other_store, target.join("shared")).unwrap();
+
+        let replace = HashSet::from(["shared".to_string()]);
+        assert_eq!(
+            status_of(
+                &sync_skills_into(&target, &app, "claude-user", &replace),
+                "shared"
+            ),
+            SyncStatus::Updated
+        );
+        assert!(!std::fs::symlink_metadata(target.join("shared"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert!(std::fs::read_to_string(other_store.join("SKILL.md"))
+            .unwrap()
+            .contains("someone else's"));
     }
 
     #[test]
@@ -1613,11 +1777,11 @@ mod tests {
         create_skill(&app, "doomed", Some("d")).unwrap();
         // A hand-written neighbour that must survive the orphan pass.
         write_skill(&target, "mine", "mine", "hand written");
-        sync_skills_into(&target, &app, "gemini-user");
+        sync_skills_into(&target, &app, "gemini-user", &no_replacements());
         assert!(target.join("doomed/SKILL.md").is_file());
 
         delete_skill(&home, &app, "doomed").unwrap();
-        let out = sync_skills_into(&target, &app, "gemini-user");
+        let out = sync_skills_into(&target, &app, "gemini-user", &no_replacements());
         assert_eq!(status_of(&out, "doomed"), SyncStatus::Removed);
         assert!(!target.join("doomed").exists());
         // Not ours, never an orphan, and not even reported.
@@ -1631,7 +1795,12 @@ mod tests {
         let home = tmp.path().join("home");
         let app = tmp.path().join("app");
         create_skill(&app, "shared", Some("d")).unwrap();
-        sync_skills_into(&home.join(".claude/skills"), &app, "claude-user");
+        sync_skills_into(
+            &home.join(".claude/skills"),
+            &app,
+            "claude-user",
+            &no_replacements(),
+        );
 
         let found = discover(&home, &app);
         let shared: Vec<_> = found.iter().filter(|s| s.directory == "shared").collect();
@@ -1645,7 +1814,12 @@ mod tests {
         let home = tmp.path().join("home");
         let app = tmp.path().join("app");
         create_skill(&app, "shared", Some("d")).unwrap();
-        sync_skills_into(&home.join(".claude/skills"), &app, "claude-user");
+        sync_skills_into(
+            &home.join(".claude/skills"),
+            &app,
+            "claude-user",
+            &no_replacements(),
+        );
 
         adopt_skill(
             &home,
@@ -1726,7 +1900,7 @@ mod tests {
         assert!(sync_for_agent(&home, &app, "cursor").is_none());
 
         // Every root has a primary agent, so sync-all reaches all of them.
-        sync_all_roots(&home, &app);
+        sync_all_roots(&home, &app, &no_replacements());
         for root in skill_roots() {
             assert!(
                 home.join(root.relative_path).join("shared").exists(),

--- a/src/tui/dialogs/mod.rs
+++ b/src/tui/dialogs/mod.rs
@@ -26,6 +26,7 @@ mod restart;
 mod send_message;
 #[cfg(feature = "serve")]
 mod serve;
+mod skills_manager;
 mod snooze_duration;
 pub mod sort_picker;
 mod telemetry_consent;
@@ -64,6 +65,7 @@ pub use send_message::SendMessageDialog;
 pub(crate) use serve::start_local_daemon_and_wait;
 #[cfg(feature = "serve")]
 pub use serve::{ServeAction, ServeView};
+pub use skills_manager::SkillsManagerDialog;
 pub use snooze_duration::SnoozeDurationDialog;
 pub use sort_picker::SortPickerDialog;
 pub use telemetry_consent::TelemetryConsentDialog;

--- a/src/tui/dialogs/skills_manager.rs
+++ b/src/tui/dialogs/skills_manager.rs
@@ -449,9 +449,17 @@ impl SkillsManagerDialog {
                             format!("{:<24}", row.directory),
                             Style::default().fg(theme.text),
                         ),
+                        // AoE's own skills carry the accent so they are
+                        // pickable out of the list at a glance, matching the
+                        // branded badge the dashboard gives them; every other
+                        // source stays dim so the managed ones stand out.
                         Span::styled(
                             format!("{:<10}", row.provenance.source_label()),
-                            Style::default().fg(theme.dimmed),
+                            Style::default().fg(if row.provenance.is_writable() {
+                                theme.accent
+                            } else {
+                                theme.dimmed
+                            }),
                         ),
                         Span::styled(format!("{:<24}", row.name), Style::default().fg(theme.text)),
                         Span::styled(row.description.clone(), Style::default().fg(theme.dimmed)),

--- a/src/tui/dialogs/skills_manager.rs
+++ b/src/tui/dialogs/skills_manager.rs
@@ -18,8 +18,15 @@ use ratatui::widgets::*;
 use ratatui_textarea::TextArea;
 
 use super::{centered_rect, DialogResult};
-use crate::session::skills_model::{self, DiscoveredSkill, SkillError, SyncStatus};
+use crate::session::skills_model::{self, DiscoveredSkill, SkillError, SyncOutcome, SyncStatus};
 use crate::tui::styles::Theme;
+use crate::tui::worker::Worker;
+
+/// One share request handed to the worker thread.
+struct SyncRequest {
+    home: PathBuf,
+    app_dir: PathBuf,
+}
 
 /// The floating popup owning the keyboard; at most one at a time.
 enum Popup {
@@ -43,6 +50,12 @@ pub struct SkillsManagerDialog {
     popup: Option<Popup>,
     home: PathBuf,
     app_dir: PathBuf,
+    /// Spawned on the first share, so a panel that is only browsed never
+    /// starts a thread. Reconciling every skill against every root walks and
+    /// digests whole packages, so it cannot run on the thread that draws
+    /// frames and reads keys without freezing both.
+    sync_worker: Option<Worker<SyncRequest, Vec<SyncOutcome>>>,
+    syncing: bool,
 }
 
 impl Default for SkillsManagerDialog {
@@ -63,6 +76,41 @@ fn describe_skill_error(error: SkillError) -> String {
     }
 }
 
+/// Compact counts line for a share, e.g. "Shared: 3 created, 1 conflict(s)."
+fn summarize_sync(outcomes: &[SyncOutcome]) -> String {
+    let mut counts = [0usize; 6];
+    for outcome in outcomes {
+        let idx = match outcome.status {
+            SyncStatus::Created => 0,
+            SyncStatus::Updated => 1,
+            SyncStatus::Unchanged => 2,
+            SyncStatus::Removed => 3,
+            SyncStatus::Conflict => 4,
+            SyncStatus::Error => 5,
+        };
+        counts[idx] += 1;
+    }
+    let labels = [
+        "created",
+        "updated",
+        "unchanged",
+        "removed",
+        "conflict(s)",
+        "error(s)",
+    ];
+    let parts: Vec<String> = counts
+        .iter()
+        .zip(labels)
+        .filter(|(count, _)| **count > 0)
+        .map(|(count, label)| format!("{count} {label}"))
+        .collect();
+    if parts.is_empty() {
+        "Nothing to share.".to_string()
+    } else {
+        format!("Shared: {}.", parts.join(", "))
+    }
+}
+
 impl SkillsManagerDialog {
     pub fn new() -> Self {
         let home = dirs::home_dir().unwrap_or_default();
@@ -74,9 +122,25 @@ impl SkillsManagerDialog {
             popup: None,
             home,
             app_dir,
+            sync_worker: None,
+            syncing: false,
         };
         dialog.reload();
         dialog
+    }
+
+    /// Drain a finished share. Returns whether anything changed, so the caller
+    /// only redraws when it must, matching the other pollers.
+    pub fn tick(&mut self) -> bool {
+        let Some(worker) = &self.sync_worker else {
+            return false;
+        };
+        let Ok(outcomes) = worker.try_recv() else {
+            return false;
+        };
+        self.syncing = false;
+        self.reload_after(summarize_sync(&outcomes));
+        true
     }
 
     fn reload(&mut self) {
@@ -377,43 +441,25 @@ impl SkillsManagerDialog {
     /// Reconcile every managed skill into every agent's skills directory and
     /// summarize the outcome counts.
     fn share_all(&mut self) {
-        let outcomes = skills_model::sync_all_roots(
-            &self.home,
-            &self.app_dir,
-            &skills_model::no_replacements(),
-        );
-        let mut counts = [0usize; 6];
-        for outcome in &outcomes {
-            let idx = match outcome.status {
-                SyncStatus::Created => 0,
-                SyncStatus::Updated => 1,
-                SyncStatus::Unchanged => 2,
-                SyncStatus::Removed => 3,
-                SyncStatus::Conflict => 4,
-                SyncStatus::Error => 5,
-            };
-            counts[idx] += 1;
+        if self.syncing {
+            self.info = Some("Already sharing.".to_string());
+            return;
         }
-        let labels = [
-            "created",
-            "updated",
-            "unchanged",
-            "removed",
-            "conflict(s)",
-            "error(s)",
-        ];
-        let parts: Vec<String> = counts
-            .iter()
-            .zip(labels)
-            .filter(|(count, _)| **count > 0)
-            .map(|(count, label)| format!("{count} {label}"))
-            .collect();
-        let summary = if parts.is_empty() {
-            "Nothing to share.".to_string()
-        } else {
-            format!("Shared: {}.", parts.join(", "))
-        };
-        self.reload_after(summary);
+        let worker = self.sync_worker.get_or_insert_with(|| {
+            Worker::spawn("aoe-skills-sync", |request: SyncRequest| {
+                skills_model::sync_all_roots(
+                    &request.home,
+                    &request.app_dir,
+                    &skills_model::SyncOptions::default(),
+                )
+            })
+        });
+        worker.request(SyncRequest {
+            home: self.home.clone(),
+            app_dir: self.app_dir.clone(),
+        });
+        self.syncing = true;
+        self.info = Some("Sharing with all agents...".to_string());
     }
 
     pub fn render(&self, f: &mut Frame, area: Rect, theme: &Theme) {
@@ -704,6 +750,8 @@ mod tests {
             popup: None,
             home,
             app_dir,
+            sync_worker: None,
+            syncing: false,
         };
         dialog.reload();
         dialog.selected = dialog
@@ -735,6 +783,8 @@ mod tests {
             popup: None,
             home,
             app_dir,
+            sync_worker: None,
+            syncing: false,
         };
         dialog.reload();
 

--- a/src/tui/dialogs/skills_manager.rs
+++ b/src/tui/dialogs/skills_manager.rs
@@ -359,7 +359,11 @@ impl SkillsManagerDialog {
     /// Reconcile every managed skill into every agent's skills directory and
     /// summarize the outcome counts.
     fn share_all(&mut self) {
-        let outcomes = skills_model::sync_all_roots(&self.home, &self.app_dir);
+        let outcomes = skills_model::sync_all_roots(
+            &self.home,
+            &self.app_dir,
+            &skills_model::no_replacements(),
+        );
         let mut counts = [0usize; 6];
         for outcome in &outcomes {
             let idx = match outcome.status {

--- a/src/tui/dialogs/skills_manager.rs
+++ b/src/tui/dialogs/skills_manager.rs
@@ -143,6 +143,24 @@ impl SkillsManagerDialog {
         }
     }
 
+    /// Take a bracketed paste. Only the editor and the create prompt accept
+    /// text; anywhere else in the panel a paste is a no-op, which still has to
+    /// be swallowed here rather than falling through to the home view's other
+    /// dialogs while this one is open.
+    pub fn handle_paste(&mut self, text: &str) {
+        match &mut self.popup {
+            Some(Popup::Edit { text_area, .. }) => {
+                text_area.insert_str(text);
+            }
+            Some(Popup::Create { name }) => {
+                // A directory name is one line, so a multi-line paste takes its
+                // first line rather than smuggling newlines into a path.
+                name.push_str(text.lines().next().unwrap_or_default());
+            }
+            _ => {}
+        }
+    }
+
     fn handle_popup_key(&mut self, key: KeyEvent) -> DialogResult<()> {
         let Some(popup) = self.popup.take() else {
             return DialogResult::Continue;
@@ -701,6 +719,52 @@ mod tests {
     /// `e`/`x` are writable-only (AoE-managed rows open a popup; host rows are
     /// refused with an explanation), `a` is the mirror image (host rows adopt
     /// straight through; a managed row is refused as already-managed).
+    /// A paste belongs to whatever the panel currently has open, and nowhere
+    /// else: with no popup it must be swallowed rather than leaking to the
+    /// home view's other dialogs.
+    #[test]
+    fn paste_lands_in_the_open_popup_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app_dir = tmp.path().join("app");
+        skills_model::create_skill(&app_dir, "managed1", Some("d")).unwrap();
+        let mut dialog = SkillsManagerDialog {
+            rows: Vec::new(),
+            selected: 0,
+            info: None,
+            popup: None,
+            home,
+            app_dir,
+        };
+        dialog.reload();
+
+        dialog.handle_paste("ignored");
+        assert!(dialog.popup.is_none(), "a paste must not open a popup");
+
+        // A directory name is one line, so a multi-line paste is truncated
+        // rather than smuggling a newline into a path.
+        dialog.popup = Some(Popup::Create {
+            name: String::new(),
+        });
+        dialog.handle_paste("my-skill\nsecond line");
+        match &dialog.popup {
+            Some(Popup::Create { name }) => assert_eq!(name, "my-skill"),
+            _ => panic!("expected the create popup to still be open"),
+        }
+
+        dialog.popup = Some(Popup::Edit {
+            directory: "managed1".to_string(),
+            text_area: Box::new(TextArea::default()),
+        });
+        dialog.handle_paste("pasted body");
+        match &dialog.popup {
+            Some(Popup::Edit { text_area, .. }) => {
+                assert!(text_area.lines().join("\n").contains("pasted body"));
+            }
+            _ => panic!("expected the edit popup to still be open"),
+        }
+    }
+
     #[test]
     fn provenance_gates_edit_delete_and_adopt() {
         let cases = [

--- a/src/tui/dialogs/skills_manager.rs
+++ b/src/tui/dialogs/skills_manager.rs
@@ -1,0 +1,719 @@
+//! Skills manager: list every discovered skill (the AoE-managed store plus
+//! every host-discovered agent skills directory), view a skill's `SKILL.md`,
+//! and run the managed-skill lifecycle in-TUI: create, edit, delete, adopt a
+//! host skill into the managed store, and share every managed skill out to
+//! every agent's skills directory. The TUI twin of `aoe skill` and the
+//! backend model in `crate::session::skills_model`.
+//!
+//! `home`/`app_dir` are resolved once at construction and reused for every
+//! action rather than re-resolved per keypress, so the mutating helpers below
+//! take no I/O-resolution path of their own (and so a test can hand them a
+//! tempdir directly).
+
+use std::path::PathBuf;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+use ratatui_textarea::TextArea;
+
+use super::{centered_rect, DialogResult};
+use crate::session::skills_model::{self, DiscoveredSkill, SkillError, SyncStatus};
+use crate::tui::styles::Theme;
+
+/// The floating popup owning the keyboard; at most one at a time.
+enum Popup {
+    /// Read-only view of a skill's `SKILL.md` (Enter on a row).
+    View { content: String, scroll: u16 },
+    /// Editing a managed skill's `SKILL.md`.
+    Edit {
+        directory: String,
+        text_area: Box<TextArea<'static>>,
+    },
+    /// Creating a new managed skill: the directory name being typed.
+    Create { name: String },
+    /// Confirming deletion of a managed skill.
+    ConfirmDelete { directory: String },
+}
+
+pub struct SkillsManagerDialog {
+    rows: Vec<DiscoveredSkill>,
+    selected: usize,
+    info: Option<String>,
+    popup: Option<Popup>,
+    home: PathBuf,
+    app_dir: PathBuf,
+}
+
+impl Default for SkillsManagerDialog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Map a [`SkillError`] to the message shown in `info`, the same wording the
+/// CLI and the web API surface for the same failures.
+fn describe_skill_error(error: SkillError) -> String {
+    match error {
+        SkillError::InvalidInput(m)
+        | SkillError::NotFound(m)
+        | SkillError::Collision(m)
+        | SkillError::ReadOnly(m) => m,
+        SkillError::Io(e) => format!("{e:#}"),
+    }
+}
+
+impl SkillsManagerDialog {
+    pub fn new() -> Self {
+        let home = dirs::home_dir().unwrap_or_default();
+        let app_dir = crate::session::get_app_dir().unwrap_or_default();
+        let mut dialog = Self {
+            rows: Vec::new(),
+            selected: 0,
+            info: None,
+            popup: None,
+            home,
+            app_dir,
+        };
+        dialog.reload();
+        dialog
+    }
+
+    fn reload(&mut self) {
+        self.rows = skills_model::discover(&self.home, &self.app_dir);
+        if self.selected >= self.rows.len() {
+            self.selected = self.rows.len().saturating_sub(1);
+        }
+    }
+
+    fn reload_after(&mut self, message: String) {
+        self.reload();
+        self.info = Some(message);
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
+        self.info = None;
+        if self.popup.is_some() {
+            return self.handle_popup_key(key);
+        }
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => DialogResult::Cancel,
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.rows.is_empty() {
+                    self.selected = (self.selected + 1).min(self.rows.len() - 1);
+                }
+                DialogResult::Continue
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.selected = self.selected.saturating_sub(1);
+                DialogResult::Continue
+            }
+            KeyCode::Enter => {
+                self.open_view();
+                DialogResult::Continue
+            }
+            KeyCode::Char('e') => {
+                self.start_edit();
+                DialogResult::Continue
+            }
+            KeyCode::Char('a') => {
+                self.start_adopt();
+                DialogResult::Continue
+            }
+            KeyCode::Char('n') => {
+                self.popup = Some(Popup::Create {
+                    name: String::new(),
+                });
+                DialogResult::Continue
+            }
+            KeyCode::Char('x') => {
+                self.start_delete();
+                DialogResult::Continue
+            }
+            KeyCode::Char('s') => {
+                self.share_all();
+                DialogResult::Continue
+            }
+            KeyCode::Char('r') => {
+                self.reload();
+                self.info = Some("Refreshed.".to_string());
+                DialogResult::Continue
+            }
+            _ => DialogResult::Continue,
+        }
+    }
+
+    fn handle_popup_key(&mut self, key: KeyEvent) -> DialogResult<()> {
+        let Some(popup) = self.popup.take() else {
+            return DialogResult::Continue;
+        };
+        match popup {
+            Popup::View { content, scroll } => self.handle_view_key(key, content, scroll),
+            Popup::Edit {
+                directory,
+                text_area,
+            } => self.handle_edit_key(key, directory, text_area),
+            Popup::Create { name } => self.handle_create_key(key, name),
+            Popup::ConfirmDelete { directory } => self.handle_confirm_delete_key(key, directory),
+        }
+    }
+
+    fn handle_view_key(&mut self, key: KeyEvent, content: String, scroll: u16) -> DialogResult<()> {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => {}
+            KeyCode::Down | KeyCode::Char('j') => {
+                let max = content.lines().count().saturating_sub(1) as u16;
+                self.popup = Some(Popup::View {
+                    scroll: scroll.saturating_add(1).min(max),
+                    content,
+                });
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.popup = Some(Popup::View {
+                    scroll: scroll.saturating_sub(1),
+                    content,
+                });
+            }
+            _ => {
+                self.popup = Some(Popup::View { content, scroll });
+            }
+        }
+        DialogResult::Continue
+    }
+
+    fn handle_edit_key(
+        &mut self,
+        key: KeyEvent,
+        directory: String,
+        mut text_area: Box<TextArea<'static>>,
+    ) -> DialogResult<()> {
+        match key.code {
+            KeyCode::Esc => {}
+            KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                let content = text_area.lines().join("\n");
+                match skills_model::edit_skill(&self.home, &self.app_dir, &directory, &content) {
+                    Ok(()) => self.reload_after(format!("Saved {directory}.")),
+                    Err(e) => {
+                        self.info = Some(describe_skill_error(e));
+                        self.popup = Some(Popup::Edit {
+                            directory,
+                            text_area,
+                        });
+                    }
+                }
+            }
+            _ => {
+                text_area.input(key);
+                self.popup = Some(Popup::Edit {
+                    directory,
+                    text_area,
+                });
+            }
+        }
+        DialogResult::Continue
+    }
+
+    fn handle_create_key(&mut self, key: KeyEvent, mut name: String) -> DialogResult<()> {
+        match key.code {
+            KeyCode::Esc => {}
+            KeyCode::Enter => {
+                let directory = name.trim().to_string();
+                if directory.is_empty() {
+                    self.info = Some("Enter a directory name.".to_string());
+                    self.popup = Some(Popup::Create { name });
+                    return DialogResult::Continue;
+                }
+                match skills_model::create_skill(&self.app_dir, &directory, None) {
+                    Ok(()) => self.reload_after(format!("Created {directory}.")),
+                    Err(e) => {
+                        self.info = Some(describe_skill_error(e));
+                        self.popup = Some(Popup::Create { name });
+                    }
+                }
+            }
+            KeyCode::Backspace => {
+                name.pop();
+                self.popup = Some(Popup::Create { name });
+            }
+            // Only a plain keypress is text. Without this, a chord like Ctrl+U
+            // types its letter into the name instead of being ignored.
+            KeyCode::Char(c)
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                name.push(c);
+                self.popup = Some(Popup::Create { name });
+            }
+            _ => {
+                self.popup = Some(Popup::Create { name });
+            }
+        }
+        DialogResult::Continue
+    }
+
+    fn handle_confirm_delete_key(&mut self, key: KeyEvent, directory: String) -> DialogResult<()> {
+        match key.code {
+            KeyCode::Char('y') | KeyCode::Enter => {
+                match skills_model::delete_skill(&self.home, &self.app_dir, &directory) {
+                    Ok(()) => self.reload_after(format!("Deleted {directory}.")),
+                    Err(e) => self.info = Some(describe_skill_error(e)),
+                }
+            }
+            KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('q') => {}
+            _ => {
+                self.popup = Some(Popup::ConfirmDelete { directory });
+            }
+        }
+        DialogResult::Continue
+    }
+
+    /// Open the read-only view popup for the selected row (any provenance).
+    fn open_view(&mut self) {
+        let Some(row) = self.rows.get(self.selected) else {
+            return;
+        };
+        let provenance = row.provenance.clone();
+        let directory = row.directory.clone();
+        match skills_model::read_skill(&self.home, &self.app_dir, &provenance, &directory) {
+            Ok(skill) => {
+                self.popup = Some(Popup::View {
+                    content: skill.content,
+                    scroll: 0,
+                });
+            }
+            Err(e) => self.info = Some(describe_skill_error(e)),
+        }
+    }
+
+    /// Open the edit popup for the selected row. Only an AoE-managed row is
+    /// writable; a host row must be adopted first.
+    fn start_edit(&mut self) {
+        let Some(row) = self.rows.get(self.selected) else {
+            return;
+        };
+        if !row.provenance.is_writable() {
+            self.info = Some(format!(
+                "{} is {}-managed; adopt it into AoE first.",
+                row.directory,
+                row.provenance.source_label()
+            ));
+            return;
+        }
+        let provenance = row.provenance.clone();
+        let directory = row.directory.clone();
+        match skills_model::read_skill(&self.home, &self.app_dir, &provenance, &directory) {
+            Ok(skill) => {
+                let lines: Vec<String> = if skill.content.is_empty() {
+                    vec![String::new()]
+                } else {
+                    skill.content.lines().map(str::to_string).collect()
+                };
+                let mut text_area = Box::new(TextArea::new(lines));
+                text_area.set_cursor_line_style(Style::default());
+                self.popup = Some(Popup::Edit {
+                    directory,
+                    text_area,
+                });
+            }
+            Err(e) => self.info = Some(describe_skill_error(e)),
+        }
+    }
+
+    /// Adopt the selected row into the managed store. Only a host row can be
+    /// adopted; an already-managed row is refused with an explanation.
+    fn start_adopt(&mut self) {
+        let Some(row) = self.rows.get(self.selected) else {
+            return;
+        };
+        if row.provenance.is_writable() {
+            self.info = Some(format!("{} is already AoE-managed.", row.directory));
+            return;
+        }
+        let provenance = row.provenance.clone();
+        let directory = row.directory.clone();
+        match skills_model::adopt_skill(&self.home, &self.app_dir, &provenance, &directory, None) {
+            Ok(dest) => self.reload_after(format!("Adopted {directory} as {dest}.")),
+            Err(e) => self.info = Some(describe_skill_error(e)),
+        }
+    }
+
+    /// Open the delete confirmation for the selected row. Only an AoE-managed
+    /// row can be deleted.
+    fn start_delete(&mut self) {
+        let Some(row) = self.rows.get(self.selected) else {
+            return;
+        };
+        if !row.provenance.is_writable() {
+            self.info = Some(format!(
+                "AoE does not manage {} ({}); nothing to delete.",
+                row.directory,
+                row.provenance.source_label()
+            ));
+            return;
+        }
+        let directory = row.directory.clone();
+        self.popup = Some(Popup::ConfirmDelete { directory });
+    }
+
+    /// Reconcile every managed skill into every agent's skills directory and
+    /// summarize the outcome counts.
+    fn share_all(&mut self) {
+        let outcomes = skills_model::sync_all_roots(&self.home, &self.app_dir);
+        let mut counts = [0usize; 6];
+        for outcome in &outcomes {
+            let idx = match outcome.status {
+                SyncStatus::Created => 0,
+                SyncStatus::Updated => 1,
+                SyncStatus::Unchanged => 2,
+                SyncStatus::Removed => 3,
+                SyncStatus::Conflict => 4,
+                SyncStatus::Error => 5,
+            };
+            counts[idx] += 1;
+        }
+        let labels = [
+            "created",
+            "updated",
+            "unchanged",
+            "removed",
+            "conflict(s)",
+            "error(s)",
+        ];
+        let parts: Vec<String> = counts
+            .iter()
+            .zip(labels)
+            .filter(|(count, _)| **count > 0)
+            .map(|(count, label)| format!("{count} {label}"))
+            .collect();
+        let summary = if parts.is_empty() {
+            "Nothing to share.".to_string()
+        } else {
+            format!("Shared: {}.", parts.join(", "))
+        };
+        self.reload_after(summary);
+    }
+
+    pub fn render(&self, f: &mut Frame, area: Rect, theme: &Theme) {
+        let width = area.width.clamp(40, 100);
+        let height = area.height.clamp(12, 28);
+        let rect = centered_rect(area, width, height);
+        f.render_widget(Clear, rect);
+        let block = Block::default()
+            .title(" Skills ")
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.accent))
+            .padding(Padding::horizontal(1));
+        let inner = block.inner(rect);
+        f.render_widget(block, rect);
+        self.render_list(f, inner, theme);
+        match &self.popup {
+            Some(Popup::View { content, scroll }) => {
+                self.render_view(f, rect, theme, content, *scroll)
+            }
+            Some(Popup::Edit {
+                directory,
+                text_area,
+            }) => self.render_edit(f, rect, theme, directory, text_area),
+            Some(Popup::Create { name }) => self.render_create(f, rect, theme, name),
+            Some(Popup::ConfirmDelete { directory }) => {
+                self.render_confirm_delete(f, rect, theme, directory)
+            }
+            None => {}
+        }
+    }
+
+    fn render_list(&self, f: &mut Frame, area: Rect, theme: &Theme) {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(3), Constraint::Length(2)])
+            .split(area);
+
+        if self.rows.is_empty() {
+            f.render_widget(
+                Paragraph::new("No skills found.").style(Style::default().fg(theme.dimmed)),
+                chunks[0],
+            );
+        } else {
+            let items: Vec<ListItem> = self
+                .rows
+                .iter()
+                .map(|row| {
+                    let spans = vec![
+                        Span::styled(
+                            format!("{:<24}", row.directory),
+                            Style::default().fg(theme.text),
+                        ),
+                        Span::styled(
+                            format!("{:<10}", row.provenance.source_label()),
+                            Style::default().fg(theme.dimmed),
+                        ),
+                        Span::styled(format!("{:<24}", row.name), Style::default().fg(theme.text)),
+                        Span::styled(row.description.clone(), Style::default().fg(theme.dimmed)),
+                    ];
+                    ListItem::new(Line::from(spans))
+                })
+                .collect();
+            let list = List::new(items)
+                .highlight_style(
+                    Style::default()
+                        .bg(theme.selection)
+                        .add_modifier(Modifier::BOLD),
+                )
+                .highlight_symbol("> ");
+            let mut state = ListState::default();
+            state.select(Some(self.selected));
+            f.render_stateful_widget(list, chunks[0], &mut state);
+        }
+
+        self.render_footer(f, chunks[1], theme);
+    }
+
+    fn render_footer(&self, f: &mut Frame, area: Rect, theme: &Theme) {
+        let (text, color) = if let Some(i) = self.info.as_deref() {
+            (i.to_string(), theme.waiting)
+        } else {
+            let mut hints = vec!["enter view", "n new", "s share", "r refresh"];
+            if let Some(row) = self.rows.get(self.selected) {
+                if row.provenance.is_writable() {
+                    hints.push("e edit");
+                    hints.push("x delete");
+                } else {
+                    hints.push("a adopt");
+                }
+            }
+            hints.push("esc close");
+            (hints.join(" · "), theme.dimmed)
+        };
+        let footer = Paragraph::new(text)
+            .style(Style::default().fg(color))
+            .wrap(Wrap { trim: true });
+        f.render_widget(footer, area);
+    }
+
+    fn render_view(&self, f: &mut Frame, area: Rect, theme: &Theme, content: &str, scroll: u16) {
+        f.render_widget(Clear, area);
+        let block = Block::default()
+            .title(" SKILL.md ")
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.accent))
+            .padding(Padding::horizontal(1));
+        let inner = block.inner(area);
+        f.render_widget(block, area);
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(inner);
+        let body = Paragraph::new(content.to_string())
+            .wrap(Wrap { trim: false })
+            .scroll((scroll, 0));
+        f.render_widget(body, chunks[0]);
+        f.render_widget(
+            Paragraph::new("j/k scroll · esc close").style(Style::default().fg(theme.dimmed)),
+            chunks[1],
+        );
+    }
+
+    fn render_edit(
+        &self,
+        f: &mut Frame,
+        area: Rect,
+        theme: &Theme,
+        directory: &str,
+        text_area: &TextArea<'static>,
+    ) {
+        f.render_widget(Clear, area);
+        let block = Block::default()
+            .title(format!(" Edit {directory} "))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.accent))
+            .padding(Padding::horizontal(1));
+        let inner = block.inner(area);
+        f.render_widget(block, area);
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(inner);
+        let mut clone = text_area.clone();
+        clone.set_style(Style::default().fg(theme.text));
+        clone.set_cursor_style(Style::default().fg(theme.background).bg(theme.accent));
+        f.render_widget(&clone, chunks[0]);
+        if chunks[0].width > 0 && chunks[0].height > 0 {
+            let cursor = clone.screen_cursor();
+            let max_x = chunks[0]
+                .x
+                .saturating_add(chunks[0].width.saturating_sub(1));
+            let max_y = chunks[0]
+                .y
+                .saturating_add(chunks[0].height.saturating_sub(1));
+            let cursor_x = chunks[0].x.saturating_add(cursor.col as u16).min(max_x);
+            let cursor_y = chunks[0].y.saturating_add(cursor.row as u16).min(max_y);
+            f.set_cursor_position(Position::new(cursor_x, cursor_y));
+        }
+        f.render_widget(
+            Paragraph::new("ctrl+s save · esc cancel").style(Style::default().fg(theme.dimmed)),
+            chunks[1],
+        );
+    }
+
+    fn render_create(&self, f: &mut Frame, area: Rect, theme: &Theme, name: &str) {
+        let lines = vec![
+            Line::from(Span::styled(
+                "New skill directory name:",
+                Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+            )),
+            Line::from(Span::styled(
+                format!("{name}▌"),
+                Style::default().fg(theme.accent),
+            )),
+        ];
+        self.draw_notice(
+            f,
+            area,
+            theme,
+            " New skill ",
+            lines,
+            "enter create · esc cancel",
+        );
+    }
+
+    fn render_confirm_delete(&self, f: &mut Frame, area: Rect, theme: &Theme, directory: &str) {
+        let lines = vec![
+            Line::from(Span::styled(
+                format!("Delete {directory}?"),
+                Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+            )),
+            Line::from(Span::styled(
+                "Removes it from AoE's managed store.",
+                Style::default().fg(theme.dimmed),
+            )),
+        ];
+        self.draw_notice(
+            f,
+            area,
+            theme,
+            " Delete skill ",
+            lines,
+            "y delete · esc cancel",
+        );
+    }
+
+    /// A small fixed-size centered notice: a couple of body lines plus a
+    /// pinned decision-key footer line, for the two popups short enough to
+    /// never need scrolling.
+    fn draw_notice(
+        &self,
+        f: &mut Frame,
+        area: Rect,
+        theme: &Theme,
+        title: &str,
+        mut lines: Vec<Line>,
+        footer: &'static str,
+    ) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            footer,
+            Style::default().fg(theme.dimmed),
+        )));
+        let width = area.width.clamp(1, 60);
+        let height = ((lines.len() as u16).saturating_add(2)).min(area.height);
+        let rect = centered_rect(area, width, height);
+        f.render_widget(Clear, rect);
+        let block = Block::default()
+            .title(title.to_string())
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.accent))
+            .padding(Padding::horizontal(1));
+        let inner = block.inner(rect);
+        f.render_widget(block, rect);
+        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn write_host_skill(home: &std::path::Path, directory: &str) {
+        let dir = home.join(".claude/skills").join(directory);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SKILL.md"),
+            format!("---\nname: {directory}\ndescription: d\n---\n\nbody\n"),
+        )
+        .unwrap();
+    }
+
+    /// Build a dialog over a fresh tempdir seeded with one AoE-managed skill
+    /// (`managed1`) and one host-discovered skill (`host1`), select
+    /// `directory`'s row, and press `code`. Returns the resulting `info`
+    /// message and whether a popup opened.
+    fn press_on(directory: &str, code: KeyCode) -> (Option<String>, bool) {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app_dir = tmp.path().join("app");
+        skills_model::create_skill(&app_dir, "managed1", Some("d")).unwrap();
+        write_host_skill(&home, "host1");
+
+        let mut dialog = SkillsManagerDialog {
+            rows: Vec::new(),
+            selected: 0,
+            info: None,
+            popup: None,
+            home,
+            app_dir,
+        };
+        dialog.reload();
+        dialog.selected = dialog
+            .rows
+            .iter()
+            .position(|r| r.directory == directory)
+            .unwrap_or_else(|| panic!("row {directory:?} not discovered"));
+
+        dialog.handle_key(key(code));
+        (dialog.info, dialog.popup.is_some())
+    }
+
+    /// `e`/`x` are writable-only (AoE-managed rows open a popup; host rows are
+    /// refused with an explanation), `a` is the mirror image (host rows adopt
+    /// straight through; a managed row is refused as already-managed).
+    #[test]
+    fn provenance_gates_edit_delete_and_adopt() {
+        let cases = [
+            ('e', "managed1", true, None),
+            ('e', "host1", false, Some("adopt it into AoE first")),
+            ('x', "managed1", true, None),
+            ('x', "host1", false, Some("does not manage")),
+            ('a', "host1", false, Some("Adopted")),
+            ('a', "managed1", false, Some("already AoE-managed")),
+        ];
+        for (key_char, directory, expect_popup, info_contains) in cases {
+            let (info, popup_open) = press_on(directory, KeyCode::Char(key_char));
+            assert_eq!(
+                popup_open, expect_popup,
+                "key {key_char:?} on {directory:?}: expected popup_open={expect_popup}, got {popup_open}"
+            );
+            if let Some(expected) = info_contains {
+                let info = info.unwrap_or_else(|| {
+                    panic!("key {key_char:?} on {directory:?}: expected info containing {expected:?}, got none")
+                });
+                assert!(
+                    info.contains(expected),
+                    "key {key_char:?} on {directory:?}: info {info:?} does not contain {expected:?}"
+                );
+            }
+        }
+    }
+}

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -68,6 +68,8 @@ pub enum ActionId {
     NextWaiting,
     /// Open the plugin manager (palette only; no default chord).
     Plugins,
+    /// Open the skills manager (palette only; no default chord).
+    Skills,
     /// Pin or unpin the selected project header (project view only). Pinning
     /// registers the repo so the project persists in the view without any
     /// sessions; unpinning removes the registry entry.
@@ -931,6 +933,21 @@ pub static BINDINGS: &[Binding] = &[
             serve_only: false,
         }),
     },
+    // Palette-only: no default chord in either mode; the manager opens from
+    // the command palette (or the web Settings Skills tab).
+    Binding {
+        id: ActionId::Skills,
+        non_strict: &[],
+        strict: &[],
+        context: Context::Always,
+        help: None,
+        palette: Some(PaletteMeta {
+            title: "Manage skills",
+            keywords: &["skill", "skills", "prompt"],
+            group: PaletteGroup::Settings,
+            serve_only: false,
+        }),
+    },
     // Palette-only: Shift+F collides with strict-mode ToggleFavorite under
     // Attention sort and the home keyspace is saturated, so fork is reached
     // from the command palette and the context menu only.
@@ -1008,6 +1025,7 @@ pub fn palette_id(id: ActionId) -> &'static str {
         ActionId::ToggleProjectPin => "toggle-project-pin",
         ActionId::Tips => "tips",
         ActionId::Plugins => "plugins",
+        ActionId::Skills => "skills",
         ActionId::Fork => "fork",
         ActionId::AutoName => "auto-name",
     }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2389,6 +2389,16 @@ impl HomeView {
             return None;
         }
 
+        if let Some(dialog) = &mut self.skills_manager_dialog {
+            match dialog.handle_key(key) {
+                DialogResult::Continue => {}
+                DialogResult::Cancel | DialogResult::Submit(()) => {
+                    self.skills_manager_dialog = None;
+                }
+            }
+            return None;
+        }
+
         if let Some(dialog) = &mut self.group_picker_dialog {
             match dialog.handle_key(key) {
                 DialogResult::Continue => {}
@@ -2866,6 +2876,9 @@ impl HomeView {
             }
             ActionId::Plugins => {
                 self.plugin_manager_dialog = Some(crate::tui::dialogs::PluginManagerDialog::new());
+            }
+            ActionId::Skills => {
+                self.skills_manager_dialog = Some(crate::tui::dialogs::SkillsManagerDialog::new());
             }
             ActionId::Restart => self.open_restart_dialog(),
             ActionId::Update => return self.run_update(update_info),

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -5933,6 +5933,14 @@ impl HomeView {
                 return;
             }
         }
+        // Before send_message_dialog below: with the skills manager open and
+        // its editor focused, a paste that fell through to that branch would
+        // open a message dialog aimed at whatever session was selected before
+        // the panel opened, and render both overlays at once.
+        if let Some(ref mut dialog) = self.skills_manager_dialog {
+            dialog.handle_paste(text);
+            return;
+        }
         if let Some(ref mut dialog) = self.rename_dialog {
             dialog.handle_paste(text);
             return;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -531,6 +531,7 @@ pub struct HomeView {
     pub(super) project_session_picker_dialog: Option<ProjectSessionPickerDialog>,
     pub(super) projects_dialog: Option<ProjectsDialog>,
     pub(super) plugin_manager_dialog: Option<crate::tui::dialogs::PluginManagerDialog>,
+    pub(super) skills_manager_dialog: Option<crate::tui::dialogs::SkillsManagerDialog>,
     pub(super) command_palette: Option<CommandPaletteDialog>,
     #[cfg(feature = "serve")]
     pub(super) serve_view: Option<ServeView>,
@@ -2174,6 +2175,7 @@ impl HomeView {
             project_session_picker_dialog: None,
             projects_dialog: None,
             plugin_manager_dialog: None,
+            skills_manager_dialog: None,
             command_palette: None,
             #[cfg(feature = "serve")]
             serve_view: None,
@@ -4495,6 +4497,7 @@ impl HomeView {
             || self.projects_dialog.is_some()
             || self.attach_project_dialog.is_some()
             || self.plugin_manager_dialog.is_some()
+            || self.skills_manager_dialog.is_some()
             || self.command_palette.is_some()
             || self.tool_picker_dialog.is_some()
             || self.send_message_dialog.is_some()
@@ -4561,6 +4564,7 @@ impl HomeView {
             || self.projects_dialog.is_some()
             || self.attach_project_dialog.is_some()
             || self.plugin_manager_dialog.is_some()
+            || self.skills_manager_dialog.is_some()
             || self.command_palette.is_some()
             || self.tool_picker_dialog.is_some()
             || self.send_message_dialog.is_some()

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -4403,6 +4403,13 @@ impl HomeView {
             }
         }
 
+        // Poll the skills manager's in-flight share.
+        if let Some(dialog) = &mut self.skills_manager_dialog {
+            if dialog.tick() {
+                changed = true;
+            }
+        }
+
         // Drain hook progress into the creating buffer when no dialog is open
         if self.new_dialog.is_none() {
             if let Some(ref stub_id) = self.creating_stub_id {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -901,6 +901,7 @@ impl HomeView {
             project_session_picker_dialog,
             projects_dialog,
             plugin_manager_dialog,
+            skills_manager_dialog,
             command_palette,
             tool_picker_dialog,
             send_message_dialog,
@@ -1349,6 +1350,7 @@ impl HomeView {
             || self.project_session_picker_dialog.is_some()
             || self.projects_dialog.is_some()
             || self.plugin_manager_dialog.is_some()
+            || self.skills_manager_dialog.is_some()
             || self.command_palette.is_some()
             || self.send_message_dialog.is_some()
             || self.update_confirm_dialog.is_some()

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -185,11 +185,51 @@ fn test_cli_skill_management_flow() {
     assert!(view.status.success());
     assert_eq!(String::from_utf8(view.stdout).unwrap(), edited);
 
+    // Sharing puts the managed skill in every agent's own skills dir, and the
+    // copy is listed as its managed original rather than as a second external
+    // skill of the same name.
+    let sync = h.run_cli(&["skill", "sync", "--json"]);
+    assert!(
+        sync.status.success(),
+        "skill sync failed: {}",
+        String::from_utf8_lossy(&sync.stderr)
+    );
+    for root in ["gemini/skills", "agents/skills", "config/opencode/skills"] {
+        let landed = h.home_path().join(format!(".{root}/review/SKILL.md"));
+        assert!(landed.is_file(), "{} missing after sync", landed.display());
+    }
+    let listed: serde_json::Value =
+        serde_json::from_slice(&h.run_cli(&["skill", "list", "--json"]).stdout).unwrap();
+    let sources: Vec<&str> = listed["skills"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|s| s["directory"] == "review")
+        .map(|s| s["provenance"]["root"].as_str().unwrap_or("aoe-managed"))
+        .collect();
+    // The copies AoE just wrote are not listed again: they are the managed
+    // skill, not three more external ones. The user's own claude-user package
+    // is untouched, so it is still its own entry, and sync reported it as a
+    // conflict rather than replacing it.
+    assert_eq!(
+        sources,
+        vec!["aoe-managed", "claude-user"],
+        "propagated copies must not be double-counted"
+    );
+
+    // Deleting the managed source and re-syncing withdraws the copies it made.
     let remove = h.run_cli(&["skill", "remove", "review"]);
     assert!(remove.status.success());
     assert!(!crate::harness::app_dir_in(h.home_path())
         .join("skills/review")
         .exists());
+    assert!(h.run_cli(&["skill", "sync"]).status.success());
+    assert!(!h.home_path().join(".gemini/skills/review").exists());
+    // The user's own skill, which AoE never deployed, is left where it was.
+    assert_eq!(
+        std::fs::read_to_string(source.join("SKILL.md")).unwrap(),
+        original
+    );
 }
 
 /// Native Codex entries with `enabled = false` remain known to drift tracking

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -139,6 +139,59 @@ fn test_cli_mcp_list_provenance_and_redaction() {
     assert_eq!(native_only["envNames"], serde_json::json!(["TOKEN"]));
 }
 
+/// #3050: the CLI can discover, adopt, view, edit, and remove a skill while
+/// keeping the external source untouched.
+#[test]
+#[parallel]
+fn test_cli_skill_management_flow() {
+    let h = TuiTestHarness::new("cli_skill_management");
+    let source = h.home_path().join(".claude/skills/review");
+    std::fs::create_dir_all(&source).unwrap();
+    let original = "---\nname: review\ndescription: Review code\n---\n\nOriginal body\n";
+    std::fs::write(source.join("SKILL.md"), original).unwrap();
+
+    let list = h.run_cli(&["skill", "list", "--json"]);
+    assert!(
+        list.status.success(),
+        "skill list failed: {}",
+        String::from_utf8_lossy(&list.stderr)
+    );
+    let listed: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert!(listed["skills"].as_array().unwrap().iter().any(|skill| {
+        skill["directory"] == "review"
+            && skill["provenance"]["root"] == "claude-user"
+            && skill["provenance"]["kind"] == "external"
+    }));
+
+    let adopt = h.run_cli(&["skill", "adopt", "claude-user", "review"]);
+    assert!(
+        adopt.status.success(),
+        "skill adopt failed: {}",
+        String::from_utf8_lossy(&adopt.stderr)
+    );
+    assert_eq!(
+        std::fs::read_to_string(source.join("SKILL.md")).unwrap(),
+        original
+    );
+
+    let edited = "---\nname: review\ndescription: Updated\n---\n\nEdited body\n";
+    let edit = h.run_cli_with_stdin(&["skill", "edit", "review", "--file", "-"], edited);
+    assert!(
+        edit.status.success(),
+        "skill edit failed: {}",
+        String::from_utf8_lossy(&edit.stderr)
+    );
+    let view = h.run_cli(&["skill", "view", "review"]);
+    assert!(view.status.success());
+    assert_eq!(String::from_utf8(view.stdout).unwrap(), edited);
+
+    let remove = h.run_cli(&["skill", "remove", "review"]);
+    assert!(remove.status.success());
+    assert!(!crate::harness::app_dir_in(h.home_path())
+        .join("skills/review")
+        .exists());
+}
+
 /// Native Codex entries with `enabled = false` remain known to drift tracking
 /// but do not appear in the effective set printed by `aoe mcp list`.
 #[test]

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -217,6 +217,33 @@ fn test_cli_skill_management_flow() {
         "propagated copies must not be double-counted"
     );
 
+    // The user's own claude-user package is a conflict, so an ordinary sync
+    // leaves it alone; naming it takes it over, and it stays current after.
+    let conflicted = h.run_cli(&["skill", "sync", "--root", "claude-user", "--json"]);
+    let outcomes: serde_json::Value = serde_json::from_slice(&conflicted.stdout).unwrap();
+    assert_eq!(outcomes[0]["status"], "conflict", "{outcomes}");
+    assert_eq!(
+        std::fs::read_to_string(source.join("SKILL.md")).unwrap(),
+        original
+    );
+
+    let replaced = h.run_cli(&[
+        "skill",
+        "sync",
+        "--root",
+        "claude-user",
+        "--replace",
+        "review",
+        "--json",
+    ]);
+    let outcomes: serde_json::Value = serde_json::from_slice(&replaced.stdout).unwrap();
+    assert_eq!(outcomes[0]["status"], "updated", "{outcomes}");
+    assert_eq!(
+        std::fs::read_to_string(source.join("SKILL.md")).unwrap(),
+        edited,
+        "replace should install the managed content"
+    );
+
     // Deleting the managed source and re-syncing withdraws the copies it made.
     let remove = h.run_cli(&["skill", "remove", "review"]);
     assert!(remove.status.success());
@@ -225,10 +252,12 @@ fn test_cli_skill_management_flow() {
         .exists());
     assert!(h.run_cli(&["skill", "sync"]).status.success());
     assert!(!h.home_path().join(".gemini/skills/review").exists());
-    // The user's own skill, which AoE never deployed, is left where it was.
-    assert_eq!(
-        std::fs::read_to_string(source.join("SKILL.md")).unwrap(),
-        original
+    // Including the claude-user copy: taking it over above made it AoE-owned,
+    // so withdrawing is symmetric with having deployed it. The never-overwrite
+    // rule is what the conflict assertion earlier covers.
+    assert!(
+        !source.exists(),
+        "a replaced copy is AoE-owned, so it withdraws with its source"
     );
 }
 

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -58,6 +58,7 @@ mod resume_fallback;
 mod sandbox;
 mod serve;
 mod settings;
+mod skills_tui;
 mod structured_tui_flows_e2e;
 mod tool_sessions;
 mod tui_launch;

--- a/tests/e2e/skills_tui.rs
+++ b/tests/e2e/skills_tui.rs
@@ -1,0 +1,71 @@
+//! E2E coverage for the native in-TUI skills manager: the command palette
+//! opens it, a host-discovered skill shows its agent source label, editing or
+//! deleting a host row is refused until it is adopted into AoE's managed
+//! store, and a managed row can then be deleted behind a confirmation.
+use std::time::Duration;
+
+use serial_test::parallel;
+
+use crate::harness::{require_tmux, TuiTestHarness};
+
+/// Open the skills manager through the palette, mirroring
+/// `plugins.rs::open_manager`.
+fn open_manager(h: &TuiTestHarness) {
+    h.wait_for(" aoe ");
+    h.send_keys("C-k");
+    h.wait_for("Commands");
+    h.type_text("skills");
+    h.wait_for("Manage skills");
+    h.send_keys("Enter");
+    h.wait_for(" Skills ");
+}
+
+/// The full lifecycle a skill goes through in the manager: discovered as a
+/// read-only host row, refused for edit/delete until adopted, then deletable
+/// as a managed row.
+#[test]
+#[parallel]
+fn test_tui_skills_manager_adopt_and_delete_lifecycle() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("skills_manager_lifecycle");
+
+    let skill_dir = h.home_path().join(".claude/skills/review");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: review\ndescription: Code review helper\n---\n\n# review\n\nbody\n",
+    )
+    .unwrap();
+
+    h.spawn_tui();
+    open_manager(&h);
+
+    // The host skill shows up with its agent's source label.
+    h.assert_screen_contains("review");
+    h.assert_screen_contains("Claude");
+
+    // Editing a host row is refused: it must be adopted first.
+    h.send_keys("e");
+    h.wait_for("adopt it into AoE first");
+
+    // Adopting copies it into the managed store; the new row shows the AoE
+    // source label alongside the untouched original. Waiting on the adopt
+    // confirmation rather than on "AoE" matters: the refusal above still says
+    // "adopt it into AoE first", so a bare "AoE" would match the stale line.
+    h.send_keys("a");
+    h.wait_for("Adopted review");
+    h.assert_screen_contains("AoE");
+
+    // The managed (AoE) row sorts first, so the cursor already sits on it;
+    // deleting goes behind a confirmation popup.
+    h.send_keys("x");
+    h.wait_for(" Delete skill ");
+    h.assert_screen_contains("y delete");
+    h.send_keys("y");
+    h.wait_for("Deleted review");
+    h.wait_for_absent("AoE", Duration::from_secs(5));
+
+    // The original host skill is untouched by the delete.
+    h.assert_screen_contains("Claude");
+}

--- a/tests/serve_cityhall_lockdown.rs
+++ b/tests/serve_cityhall_lockdown.rs
@@ -132,6 +132,7 @@ async fn sensitive_routes_are_blocked() {
         ),
         (Method::DELETE, "/api/skills/review", ""),
         (Method::POST, "/api/skills/claude-user/review/adopt", "{}"),
+        (Method::POST, "/api/skills/sync", "{}"),
         (
             Method::POST,
             "/api/plugins/install",

--- a/tests/serve_cityhall_lockdown.rs
+++ b/tests/serve_cityhall_lockdown.rs
@@ -124,6 +124,14 @@ async fn sensitive_routes_are_blocked() {
             "/api/mcp/servers/x/drop",
             r#"{"agent":"claude"}"#,
         ),
+        (Method::POST, "/api/skills", r#"{"directory":"review"}"#),
+        (
+            Method::PUT,
+            "/api/skills/review",
+            r#"{"content":"---\nname: review\ndescription: d\n---\n"}"#,
+        ),
+        (Method::DELETE, "/api/skills/review", ""),
+        (Method::POST, "/api/skills/claude-user/review/adopt", "{}"),
         (
             Method::POST,
             "/api/plugins/install",

--- a/web/src/components/McpServers.tsx
+++ b/web/src/components/McpServers.tsx
@@ -8,6 +8,7 @@ import {
   type McpServerView,
   type McpConflictView,
 } from "../lib/api";
+import { ProvenanceBadge } from "./ProvenanceBadge";
 
 /** One-line redacted connection detail: command/args or url, plus secret NAMES. */
 function detail(s: McpServerView): string {
@@ -17,14 +18,6 @@ function detail(s: McpServerView): string {
   if (s.headerNames && s.headerNames.length) tags.push(`headers: ${s.headerNames.join(", ")}`);
   if (tags.length) base += `  [${tags.join("; ")}]`;
   return base;
-}
-
-function ProvenanceBadge({ label }: { label: string }) {
-  return (
-    <span className="font-mono text-[11px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-surface-700 text-text-secondary">
-      {label}
-    </span>
-  );
 }
 
 function ServerRow({ s }: { s: McpServerView }) {

--- a/web/src/components/ProvenanceBadge.tsx
+++ b/web/src/components/ProvenanceBadge.tsx
@@ -1,10 +1,26 @@
 /** Small uppercase pill naming where something came from (an MCP server's
  *  provenance, a skill's source root, etc). Shared across the skills manager,
  *  the `/` slash-command picker, and the skill tool-call card so provenance
- *  reads identically everywhere it appears (#3052). */
-export function ProvenanceBadge({ label }: { label: string }) {
+ *  reads identically everywhere it appears (#3052).
+ *
+ *  `tone` is how a surface says "this one is ours": AoE-managed skills carry
+ *  the brand tint so they are pickable out of a list at a glance, while every
+ *  other source stays neutral so the branded one is the thing that stands out.
+ *  Neutral is the default, which keeps the MCP panel exactly as it was.
+ */
+export function ProvenanceBadge({ label, tone = "neutral" }: { label: string; tone?: "neutral" | "primary" }) {
+  // Neutral was surface-700 on text-secondary, which measured 1.73:1 against a
+  // light theme and 4.07:1 against the default dark one, so the pill was at or
+  // below the AA floor everywhere. surface-800 on text-primary measures 6.6:1
+  // or better across the light, default, and rose-pine palettes.
+  const toneClass = tone === "primary" ? "bg-brand-600/15 text-brand-300" : "bg-surface-800 text-text-primary";
   return (
-    <span className="font-mono text-[11px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-surface-700 text-text-secondary">
+    // data-tone so a test can assert the distinction is being drawn without
+    // pinning the exact utility classes, which are free to change.
+    <span
+      data-tone={tone}
+      className={`font-mono text-[11px] uppercase tracking-wider px-1.5 py-0.5 rounded ${toneClass}`}
+    >
       {label}
     </span>
   );

--- a/web/src/components/ProvenanceBadge.tsx
+++ b/web/src/components/ProvenanceBadge.tsx
@@ -19,7 +19,7 @@ export function ProvenanceBadge({ label, tone = "neutral" }: { label: string; to
     // pinning the exact utility classes, which are free to change.
     <span
       data-tone={tone}
-      className={`font-mono text-[11px] uppercase tracking-wider px-1.5 py-0.5 rounded ${toneClass}`}
+      className={`font-mono text-[11px] uppercase tracking-wider px-1.5 py-0.5 rounded-full ${toneClass}`}
     >
       {label}
     </span>

--- a/web/src/components/ProvenanceBadge.tsx
+++ b/web/src/components/ProvenanceBadge.tsx
@@ -1,0 +1,11 @@
+/** Small uppercase pill naming where something came from (an MCP server's
+ *  provenance, a skill's source root, etc). Shared across the skills manager,
+ *  the `/` slash-command picker, and the skill tool-call card so provenance
+ *  reads identically everywhere it appears (#3052). */
+export function ProvenanceBadge({ label }: { label: string }) {
+  return (
+    <span className="font-mono text-[11px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-surface-700 text-text-secondary">
+      {label}
+    </span>
+  );
+}

--- a/web/src/components/ProvenanceBadge.tsx
+++ b/web/src/components/ProvenanceBadge.tsx
@@ -6,7 +6,9 @@
  *  `tone` is how a surface says "this one is ours": AoE-managed skills carry
  *  the brand tint so they are pickable out of a list at a glance, while every
  *  other source stays neutral so the branded one is the thing that stands out.
- *  Neutral is the default, which keeps the MCP panel exactly as it was.
+ *  Neutral is the default, so the MCP panel opts into nothing; extracting this
+ *  component did still change how its badge looks, picking up the contrast fix
+ *  and the full radius documented below.
  */
 export function ProvenanceBadge({ label, tone = "neutral" }: { label: string; tone?: "neutral" | "primary" }) {
   // Neutral was surface-700 on text-secondary, which measured 1.73:1 against a

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { ConnectedDevices } from "./ConnectedDevices";
 import { McpServers } from "./McpServers";
+import { SkillsManager } from "./SkillsManager";
 import { NotificationSettings } from "./NotificationSettings";
 import { SecuritySettings } from "./SecuritySettings";
 import { TerminalSettings } from "./TerminalSettings";
@@ -48,6 +49,7 @@ export type TabId =
   | "devices"
   | "structured-view"
   | "mcp"
+  | "skills"
   | "logging"
   | "plugins"
   | "cityhall";
@@ -160,6 +162,7 @@ export function buildSidebar(pluginPages: PluginPageNav[] = []): SidebarItem[] {
     { kind: "tab", id: "session", label: "Session" },
     { kind: "tab", id: "structured-view", label: "Structured view" },
     { kind: "tab", id: "mcp", label: "MCP servers" },
+    { kind: "tab", id: "skills", label: "Skills" },
     { kind: "divider", label: "Environment" },
     { kind: "tab", id: "sandbox", label: "Sandbox" },
     { kind: "tab", id: "worktree", label: "Worktree" },
@@ -261,6 +264,7 @@ const ALL_TAB_IDS = new Set<TabId>([
   "devices",
   "structured-view",
   "mcp",
+  "skills",
   "logging",
   "plugins",
   "cityhall",
@@ -574,6 +578,7 @@ export function SettingsView({
       activeTab !== "devices" &&
       activeTab !== "structured-view" &&
       activeTab !== "mcp" &&
+      activeTab !== "skills" &&
       activeTab !== "plugins" &&
       activeTab !== "telemetry" &&
       activeTab !== "cityhall" &&
@@ -798,6 +803,8 @@ export function SettingsView({
         return <ConnectedDevices />;
       case "mcp":
         return <McpServers readOnly={cityhall} />;
+      case "skills":
+        return <SkillsManager />;
       case "structured-view": {
         if (!settings) {
           return <div className="text-sm text-text-dim">Loading settings...</div>;

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -910,7 +910,10 @@ export function SettingsView({
 
         {/* Content area */}
         <div className="flex-1 overflow-y-auto">
-          <div className="p-6 max-w-2xl mx-auto space-y-5">
+          {/* Skills renders its own two-pane layout and needs the full window
+              width; every other tab keeps a generous but capped width so
+              label-to-control gaps don't stretch across an ultrawide monitor. */}
+          <div className={activeNavId === "skills" ? "p-6 space-y-5" : "p-6 max-w-5xl mx-auto space-y-5"}>
             <h2 className="text-lg font-semibold text-text-bright">{currentTabLabel}</h2>
 
             {offline && (

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -804,7 +804,7 @@ export function SettingsView({
       case "mcp":
         return <McpServers readOnly={cityhall} />;
       case "skills":
-        return <SkillsManager />;
+        return <SkillsManager readOnly={readOnly || cityhall} />;
       case "structured-view": {
         if (!settings) {
           return <div className="text-sm text-text-dim">Loading settings...</div>;

--- a/web/src/components/SkillsManager.tsx
+++ b/web/src/components/SkillsManager.tsx
@@ -39,6 +39,7 @@ export function SkillsManager() {
   const [draft, setDraft] = useState("");
   const [search, setSearch] = useState("");
   const [root, setRoot] = useState("all");
+  const [hideManagedExternal, setHideManagedExternal] = useState(true);
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [loadError, setLoadError] = useState(false);
@@ -131,6 +132,7 @@ export function SkillsManager() {
       return;
     }
     setNotice("Skill adopted into AoE's managed store.");
+    setRoot("all");
     await load(`aoe-managed:${result.directory ?? selected.directory}`);
   };
 
@@ -163,10 +165,14 @@ export function SkillsManager() {
   };
 
   const normalized = search.trim().toLowerCase();
+  const managedDirectories = new Set(
+    data?.skills.filter((skill) => skill.provenance.kind === "aoe-managed").map((skill) => skill.directory) ?? [],
+  );
   const visible =
     data?.skills.filter(
       (skill) =>
         (root === "all" || sourceId(skill) === root) &&
+        (!hideManagedExternal || skill.provenance.kind === "aoe-managed" || !managedDirectories.has(skill.directory)) &&
         (!normalized ||
           skill.directory.toLowerCase().includes(normalized) ||
           skill.name.toLowerCase().includes(normalized) ||
@@ -253,6 +259,15 @@ export function SkillsManager() {
                 </option>
               ))}
             </select>
+            <label className="flex items-center gap-2 text-[11px] text-text-secondary">
+              <input
+                type="checkbox"
+                checked={hideManagedExternal}
+                onChange={(event) => setHideManagedExternal(event.target.checked)}
+                className="h-3.5 w-3.5 rounded border-surface-600 bg-surface-900 text-brand-500"
+              />
+              Hide external skills already managed
+            </label>
           </div>
           <div className="max-h-[28rem] overflow-y-auto lg:max-h-[40rem]">
             {visible.map((skill) => (

--- a/web/src/components/SkillsManager.tsx
+++ b/web/src/components/SkillsManager.tsx
@@ -126,7 +126,7 @@ function SkillGroup({
  *  second tab (e.g. usage statistics) is a one-entry change. */
 const DETAIL_TABS = [{ id: "content", label: "SKILL.md" }] as const;
 
-export function SkillsManager() {
+export function SkillsManager({ readOnly = false }: { readOnly?: boolean } = {}) {
   const [data, setData] = useState<SkillsResponse | null>(null);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [detail, setDetail] = useState<SkillDetail | null>(null);
@@ -252,14 +252,14 @@ export function SkillsManager() {
     await load(selectedKey ?? undefined);
   };
 
-  /** Share only the selected skill, filtering the sync response down to its
-   *  directory so the outcome panel reports what happened to the one the
-   *  user is looking at, not the whole library. */
+  /** Share only the selected skill: the server reconciles just that
+   *  directory and skips orphan removal for the rest of the library, so the
+   *  outcome panel reports exactly what happened to the one the user is
+   *  looking at. */
   const shareSkill = async () => {
     if (!selected) return;
-    const { directory } = selected;
     setBusy(true);
-    const result = await syncSkills({});
+    const result = await syncSkills({ directories: [selected.directory] });
     setBusy(false);
     if (!result.ok) {
       setSyncOutcomes(null);
@@ -267,7 +267,7 @@ export function SkillsManager() {
       return;
     }
     setNotice(null);
-    setSyncOutcomes(result.outcomes.filter((outcome) => outcome.directory === directory));
+    setSyncOutcomes(result.outcomes);
     await load(selectedKey ?? undefined);
   };
 
@@ -359,21 +359,27 @@ export function SkillsManager() {
           <div className="flex items-center gap-2">
             <button
               type="button"
+              disabled={readOnly}
               onClick={() => setShowCreateForm((current) => !current)}
-              className="rounded bg-brand-600 px-3 py-1.5 text-[12px] font-semibold text-text-on-brand hover:bg-brand-500"
+              className="h-8 cursor-pointer rounded-md bg-brand-600 px-3 text-[12px] font-semibold text-text-on-brand transition-colors duration-150 hover:bg-brand-500 disabled:cursor-not-allowed disabled:opacity-40"
             >
               + New skill
             </button>
             <button
               type="button"
-              disabled={busy}
+              disabled={busy || readOnly}
               onClick={() => void sync()}
-              className="rounded border border-surface-700 bg-surface-800 px-3 py-1.5 text-[12px] font-semibold text-text-secondary hover:bg-surface-700 disabled:opacity-40"
+              className="h-8 cursor-pointer rounded-md border border-surface-700 bg-surface-800 px-3 text-[12px] font-semibold text-text-secondary transition-colors duration-150 hover:bg-surface-700 disabled:cursor-not-allowed disabled:opacity-40"
             >
               Share with all agents
             </button>
           </div>
         </div>
+        {readOnly && (
+          <p className="mt-3 border-t border-surface-700/60 pt-3 text-[12px] text-text-dim">
+            This server is read-only, so skills cannot be created, edited, or shared here.
+          </p>
+        )}
         {showCreateForm && (
           <div className="mt-3 grid gap-2 border-t border-surface-700/60 pt-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_auto]">
             <input
@@ -392,9 +398,9 @@ export function SkillsManager() {
             />
             <button
               type="button"
-              disabled={busy || !newDirectory.trim()}
+              disabled={busy || readOnly || !newDirectory.trim()}
               onClick={() => void create()}
-              className="rounded bg-brand-600 px-4 py-2 text-[12px] font-semibold text-text-on-brand hover:bg-brand-500 disabled:opacity-40"
+              className="h-8 cursor-pointer rounded-md bg-brand-600 px-4 text-[12px] font-semibold text-text-on-brand transition-colors duration-150 hover:bg-brand-500 disabled:cursor-not-allowed disabled:opacity-40"
             >
               Create
             </button>
@@ -430,10 +436,10 @@ export function SkillsManager() {
                     {outcome.status === "conflict" && (
                       <button
                         type="button"
-                        disabled={busy}
+                        disabled={busy || readOnly}
                         onClick={() => void replaceConflict(outcome)}
                         aria-label={`Replace ${outcome.directory} in ${outcome.root}`}
-                        className="rounded border border-status-error/40 px-2 py-0.5 text-[11px] text-status-error hover:bg-status-error/10 disabled:opacity-40"
+                        className="h-8 cursor-pointer rounded-md border border-status-error/40 px-2 text-[11px] text-status-error transition-colors duration-150 hover:bg-status-error/10 disabled:cursor-not-allowed disabled:opacity-40"
                       >
                         Replace
                       </button>
@@ -525,11 +531,15 @@ export function SkillsManager() {
                       </span>
                     ))}
                   </div>
-                  <div className="flex items-center gap-1 rounded bg-surface-900 p-0.5">
+                  {/* Segmented toggle chips, not standalone action buttons: kept
+                      below the 32px button height so the pair reads as one
+                      compact control sitting at the tab-label baseline rather
+                      than a second row of full-size buttons. */}
+                  <div className="flex items-center gap-1 rounded-md bg-surface-900 p-0.5">
                     <button
                       type="button"
                       onClick={() => setViewMode("raw")}
-                      className={`rounded px-2 py-1 text-[11px] font-medium ${
+                      className={`cursor-pointer rounded-md px-2 py-1 text-[11px] font-medium transition-colors duration-150 ${
                         viewMode === "raw"
                           ? "bg-brand-600 text-text-on-brand"
                           : "text-text-secondary hover:text-text-primary"
@@ -540,7 +550,7 @@ export function SkillsManager() {
                     <button
                       type="button"
                       onClick={() => setViewMode("preview")}
-                      className={`rounded px-2 py-1 text-[11px] font-medium ${
+                      className={`cursor-pointer rounded-md px-2 py-1 text-[11px] font-medium transition-colors duration-150 ${
                         viewMode === "preview"
                           ? "bg-brand-600 text-text-on-brand"
                           : "text-text-secondary hover:text-text-primary"
@@ -560,7 +570,7 @@ export function SkillsManager() {
                   viewMode === "raw" ? (
                     <textarea
                       aria-label="SKILL.md content"
-                      readOnly={!selected.writable}
+                      readOnly={!selected.writable || readOnly}
                       value={draft}
                       onChange={(event) => setDraft(event.target.value)}
                       spellCheck={false}
@@ -582,9 +592,9 @@ export function SkillsManager() {
                 {selected.writable ? (
                   <button
                     type="button"
-                    disabled={busy}
+                    disabled={busy || readOnly}
                     onClick={() => void remove()}
-                    className="rounded border border-status-error/40 px-3 py-1.5 text-[12px] text-status-error hover:bg-status-error/10 disabled:opacity-40"
+                    className="h-8 cursor-pointer rounded-md border border-status-error/40 px-3 text-[12px] text-status-error transition-colors duration-150 hover:bg-status-error/10 disabled:cursor-not-allowed disabled:opacity-40"
                   >
                     Delete
                   </button>
@@ -601,26 +611,26 @@ export function SkillsManager() {
                       </span>
                       <button
                         type="button"
-                        disabled={busy || dirty}
+                        disabled={busy || dirty || readOnly}
                         title={dirty ? "Save or discard your changes before sharing" : undefined}
                         onClick={() => void shareSkill()}
-                        className="rounded border border-surface-700 bg-surface-800 px-3 py-1.5 text-[12px] text-text-secondary disabled:opacity-40"
+                        className="h-8 cursor-pointer rounded-md border border-surface-700 bg-surface-800 px-3 text-[12px] text-text-secondary transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-40"
                       >
                         Share this skill
                       </button>
                       <button
                         type="button"
-                        disabled={busy || !dirty}
+                        disabled={busy || !dirty || readOnly}
                         onClick={discard}
-                        className="rounded border border-surface-700 bg-surface-800 px-3 py-1.5 text-[12px] text-text-secondary disabled:opacity-40"
+                        className="h-8 cursor-pointer rounded-md border border-surface-700 bg-surface-800 px-3 text-[12px] text-text-secondary transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-40"
                       >
                         Discard
                       </button>
                       <button
                         type="button"
-                        disabled={busy || !dirty}
+                        disabled={busy || !dirty || readOnly}
                         onClick={() => void save()}
-                        className="rounded bg-brand-600 px-4 py-1.5 text-[12px] font-semibold text-text-on-brand hover:bg-brand-500 disabled:opacity-40"
+                        className="h-8 cursor-pointer rounded-md bg-brand-600 px-4 text-[12px] font-semibold text-text-on-brand transition-colors duration-150 hover:bg-brand-500 disabled:cursor-not-allowed disabled:opacity-40"
                       >
                         Save
                       </button>
@@ -628,9 +638,9 @@ export function SkillsManager() {
                   ) : (
                     <button
                       type="button"
-                      disabled={busy}
+                      disabled={busy || readOnly}
                       onClick={() => void adopt()}
-                      className="rounded bg-brand-600 px-3 py-1.5 text-[12px] font-semibold text-text-on-brand hover:bg-brand-500 disabled:opacity-40"
+                      className="h-8 cursor-pointer rounded-md bg-brand-600 px-3 text-[12px] font-semibold text-text-on-brand transition-colors duration-150 hover:bg-brand-500 disabled:cursor-not-allowed disabled:opacity-40"
                     >
                       Adopt into AoE
                     </button>

--- a/web/src/components/SkillsManager.tsx
+++ b/web/src/components/SkillsManager.tsx
@@ -1,0 +1,356 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  adoptSkill,
+  createSkill,
+  deleteSkill,
+  fetchSkill,
+  fetchSkills,
+  updateSkill,
+  type SkillDetail,
+  type SkillSummary,
+  type SkillsResponse,
+} from "../lib/api";
+
+function sourceId(skill: SkillSummary): string {
+  return skill.provenance.kind === "aoe-managed" ? "aoe-managed" : skill.provenance.root;
+}
+
+function skillKey(skill: SkillSummary): string {
+  return `${sourceId(skill)}:${skill.directory}`;
+}
+
+function SourceBadge({ skill }: { skill: SkillSummary }) {
+  const external = skill.provenance.kind === "external";
+  return (
+    <span
+      className={`rounded px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider ${
+        external ? "bg-accent-600/15 text-accent-400" : "bg-brand-600/15 text-brand-400"
+      }`}
+    >
+      {skill.provenance.kind === "external" ? skill.provenance.root : "managed"}
+    </span>
+  );
+}
+
+export function SkillsManager() {
+  const [data, setData] = useState<SkillsResponse | null>(null);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [detail, setDetail] = useState<SkillDetail | null>(null);
+  const [draft, setDraft] = useState("");
+  const [search, setSearch] = useState("");
+  const [root, setRoot] = useState("all");
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState(false);
+  const [newDirectory, setNewDirectory] = useState("");
+  const [newDescription, setNewDescription] = useState("");
+
+  const load = useCallback(async (preferredKey?: string) => {
+    const next = await fetchSkills();
+    if (!next) {
+      setLoadError(true);
+      return;
+    }
+    setLoadError(false);
+    setData(next);
+    if (next.skills.length === 0) {
+      setDetail(null);
+      setDraft("");
+    }
+    setSelectedKey((current) => {
+      const preferred = preferredKey ?? current;
+      if (preferred && next.skills.some((skill) => skillKey(skill) === preferred)) {
+        return preferred;
+      }
+      return next.skills[0] ? skillKey(next.skills[0]) : null;
+    });
+  }, []);
+
+  useEffect(() => {
+    const first = setTimeout(() => void load(), 0);
+    return () => clearTimeout(first);
+  }, [load]);
+
+  const selected = data?.skills.find((skill) => skillKey(skill) === selectedKey) ?? null;
+  const dirty = detail !== null && draft !== detail.content;
+
+  useEffect(() => {
+    if (!selected) {
+      return;
+    }
+    let cancelled = false;
+    const read = async () => {
+      const next = await fetchSkill(sourceId(selected), selected.directory);
+      if (!cancelled) {
+        setDetail(next);
+        setDraft(next?.content ?? "");
+        if (!next) setNotice("Could not read the selected skill.");
+      }
+    };
+    void read();
+    return () => {
+      cancelled = true;
+    };
+  }, [selected]);
+
+  useEffect(() => {
+    if (!dirty) return;
+    const warn = (event: BeforeUnloadEvent) => event.preventDefault();
+    window.addEventListener("beforeunload", warn);
+    return () => window.removeEventListener("beforeunload", warn);
+  }, [dirty]);
+
+  const select = (skill: SkillSummary) => {
+    if (dirty && !window.confirm("Discard unsaved changes to this skill?")) return;
+    setNotice(null);
+    setSelectedKey(skillKey(skill));
+  };
+
+  const create = async () => {
+    setBusy(true);
+    const result = await createSkill(newDirectory, newDescription || undefined);
+    setBusy(false);
+    if (!result.ok) {
+      setNotice(result.error ?? "Could not create skill.");
+      return;
+    }
+    const key = `aoe-managed:${newDirectory}`;
+    setNewDirectory("");
+    setNewDescription("");
+    setNotice("Managed skill created.");
+    await load(key);
+  };
+
+  const adopt = async () => {
+    if (!selected || selected.provenance.kind !== "external") return;
+    setBusy(true);
+    const result = await adoptSkill(selected.provenance.root, selected.directory);
+    setBusy(false);
+    if (!result.ok) {
+      setNotice(result.error ?? "Could not adopt skill.");
+      return;
+    }
+    setNotice("Skill adopted into AoE's managed store.");
+    await load(`aoe-managed:${result.directory ?? selected.directory}`);
+  };
+
+  const save = async () => {
+    if (!selected?.writable) return;
+    setBusy(true);
+    const result = await updateSkill(selected.directory, draft);
+    setBusy(false);
+    if (!result.ok) {
+      setNotice(result.error ?? "Could not save skill.");
+      return;
+    }
+    setDetail((current) => (current ? { ...current, content: draft } : current));
+    setNotice("Skill saved.");
+    await load(selectedKey ?? undefined);
+  };
+
+  const remove = async () => {
+    if (!selected?.writable || !window.confirm(`Delete managed skill "${selected.directory}"?`)) return;
+    setBusy(true);
+    const result = await deleteSkill(selected.directory);
+    setBusy(false);
+    if (!result.ok) {
+      setNotice(result.error ?? "Could not delete skill.");
+      return;
+    }
+    setDetail(null);
+    setNotice("Managed skill deleted.");
+    await load();
+  };
+
+  const normalized = search.trim().toLowerCase();
+  const visible =
+    data?.skills.filter(
+      (skill) =>
+        (root === "all" || sourceId(skill) === root) &&
+        (!normalized ||
+          skill.directory.toLowerCase().includes(normalized) ||
+          skill.name.toLowerCase().includes(normalized) ||
+          skill.description.toLowerCase().includes(normalized)),
+    ) ?? [];
+
+  if (loadError) {
+    return (
+      <div className="rounded-lg border border-status-error/30 bg-status-error/10 p-4 text-[13px] text-status-error">
+        Could not load skills.{" "}
+        <button onClick={() => void load()} className="underline">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-surface-700/60 bg-surface-850/70 p-4">
+        <div className="mb-3">
+          <h3 className="font-mono text-sm uppercase tracking-widest text-text-primary">Skills Library</h3>
+          <p className="mt-1 text-[12px] text-text-dim">
+            Browse skills installed for other agents. Adopt a skill before editing it so the original stays untouched.
+          </p>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_auto]">
+          <input
+            aria-label="New skill directory"
+            value={newDirectory}
+            onChange={(event) => setNewDirectory(event.target.value)}
+            placeholder="new-skill"
+            className="rounded border border-surface-700 bg-surface-900 px-3 py-2 font-mono text-[12px] text-text-primary outline-none focus:border-brand-500"
+          />
+          <input
+            aria-label="New skill description"
+            value={newDescription}
+            onChange={(event) => setNewDescription(event.target.value)}
+            placeholder="When should agents use it?"
+            className="rounded border border-surface-700 bg-surface-900 px-3 py-2 text-[12px] text-text-primary outline-none focus:border-brand-500"
+          />
+          <button
+            type="button"
+            disabled={busy || !newDirectory.trim()}
+            onClick={() => void create()}
+            className="rounded bg-brand-600 px-4 py-2 text-[12px] font-semibold text-white hover:bg-brand-500 disabled:opacity-40"
+          >
+            Create
+          </button>
+        </div>
+      </div>
+
+      {notice && (
+        <div
+          role="status"
+          className="rounded border border-surface-700 bg-surface-800 px-3 py-2 text-[12px] text-text-secondary"
+        >
+          {notice}
+        </div>
+      )}
+
+      <div className="grid min-h-[34rem] overflow-hidden rounded-lg border border-surface-700/60 bg-surface-900 lg:grid-cols-[20rem_minmax(0,1fr)]">
+        <aside className="border-b border-surface-700/60 bg-surface-850/45 lg:border-b-0 lg:border-r">
+          <div className="grid gap-2 border-b border-surface-700/60 p-3">
+            <input
+              aria-label="Search skills"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search skills"
+              className="rounded border border-surface-700 bg-surface-900 px-3 py-2 text-[12px] text-text-primary outline-none focus:border-brand-500"
+            />
+            <select
+              aria-label="Filter skills by source"
+              value={root}
+              onChange={(event) => setRoot(event.target.value)}
+              className="rounded border border-surface-700 bg-surface-900 px-3 py-2 font-mono text-[11px] text-text-secondary"
+            >
+              <option value="all">All sources</option>
+              <option value="aoe-managed">AoE managed</option>
+              {data?.roots.map((entry) => (
+                <option key={entry.id} value={entry.id}>
+                  {entry.label}
+                  {entry.legacy ? " (legacy)" : ""}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="max-h-[28rem] overflow-y-auto lg:max-h-[40rem]">
+            {visible.map((skill) => (
+              <button
+                type="button"
+                key={skillKey(skill)}
+                onClick={() => select(skill)}
+                className={`w-full border-b border-surface-700/40 px-3 py-3 text-left transition-colors ${
+                  skillKey(skill) === selectedKey
+                    ? "bg-brand-600/10 shadow-[inset_3px_0_0_var(--color-brand-500)]"
+                    : "hover:bg-surface-800"
+                }`}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate font-mono text-[12px] font-medium text-text-primary">
+                    {skill.directory}
+                  </span>
+                  <SourceBadge skill={skill} />
+                </div>
+                <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-text-dim">{skill.description}</p>
+              </button>
+            ))}
+            {data && visible.length === 0 && <p className="p-4 text-[12px] text-text-dim">No matching skills.</p>}
+          </div>
+        </aside>
+
+        <section className="min-w-0 p-4 sm:p-5">
+          {!selected && <p className="text-[13px] text-text-dim">Select a skill to inspect its instructions.</p>}
+          {selected && (
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <h4 className="font-mono text-lg font-semibold text-text-primary">{selected.name}</h4>
+                    <SourceBadge skill={selected} />
+                  </div>
+                  <p className="mt-1 text-[12px] text-text-secondary">{selected.description}</p>
+                  <p className="mt-2 font-mono text-[10px] text-text-muted">
+                    {sourceId(selected)} / {selected.directory}
+                  </p>
+                </div>
+                {selected.provenance.kind === "external" && (
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void adopt()}
+                    className="rounded bg-brand-600 px-3 py-1.5 text-[12px] font-semibold text-white hover:bg-brand-500 disabled:opacity-40"
+                  >
+                    Adopt into AoE
+                  </button>
+                )}
+              </div>
+
+              {detail ? (
+                <>
+                  <textarea
+                    aria-label="SKILL.md content"
+                    readOnly={!selected.writable}
+                    value={draft}
+                    onChange={(event) => setDraft(event.target.value)}
+                    spellCheck={false}
+                    className="min-h-[25rem] w-full resize-y rounded-md border border-surface-700 bg-surface-950 p-4 font-mono text-[12px] leading-5 text-text-primary outline-none focus:border-brand-500 read-only:text-text-secondary"
+                  />
+                  {selected.writable ? (
+                    <div className="flex items-center justify-between gap-3">
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => void remove()}
+                        className="rounded border border-status-error/40 px-3 py-1.5 text-[12px] text-status-error hover:bg-status-error/10 disabled:opacity-40"
+                      >
+                        Delete
+                      </button>
+                      <div className="flex items-center gap-3">
+                        {dirty && <span className="text-[11px] text-status-waiting">Unsaved changes</span>}
+                        <button
+                          type="button"
+                          disabled={busy || !dirty}
+                          onClick={() => void save()}
+                          className="rounded bg-brand-600 px-4 py-1.5 text-[12px] font-semibold text-white hover:bg-brand-500 disabled:opacity-40"
+                        >
+                          Save
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-[11px] text-text-dim">
+                      External skills are read-only. Adopt this package to make an editable AoE-managed copy.
+                    </p>
+                  )}
+                </>
+              ) : (
+                <p className="text-[13px] text-text-dim">Loading skill...</p>
+              )}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SkillsManager.tsx
+++ b/web/src/components/SkillsManager.tsx
@@ -109,7 +109,10 @@ function SkillGroup({
           >
             <div className="flex items-center justify-between gap-2">
               <span className="truncate text-[13px] font-medium text-text-primary">{skill.directory}</span>
-              <ProvenanceBadge label={labelForProvenance(skill.provenance, roots)} />
+              <ProvenanceBadge
+                label={labelForProvenance(skill.provenance, roots)}
+                tone={skill.provenance.kind === "aoe-managed" ? "primary" : "neutral"}
+              />
             </div>
             <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-text-dim">{skill.description}</p>
           </button>
@@ -501,7 +504,10 @@ export function SkillsManager() {
               <div className="sticky top-0 z-10 space-y-3 border-b border-surface-700/60 bg-surface-850/95 p-4">
                 <div className="flex items-center gap-2">
                   <h4 className="text-lg font-semibold text-text-bright">{selected.directory}</h4>
-                  <ProvenanceBadge label={labelForProvenance(selected.provenance, data?.roots ?? [])} />
+                  <ProvenanceBadge
+                    label={labelForProvenance(selected.provenance, data?.roots ?? [])}
+                    tone={selected.provenance.kind === "aoe-managed" ? "primary" : "neutral"}
+                  />
                 </div>
                 <p className="font-mono text-[11px]">
                   <span className="text-text-dim">{sourceId(selected)}</span>

--- a/web/src/components/SkillsManager.tsx
+++ b/web/src/components/SkillsManager.tsx
@@ -12,6 +12,8 @@ import {
   type SkillSyncOutcome,
   type SkillsResponse,
 } from "../lib/api";
+import { ProvenanceBadge } from "./ProvenanceBadge";
+import { labelForProvenance } from "../lib/skillProvenance";
 
 function sourceId(skill: SkillSummary): string {
   return skill.provenance.kind === "aoe-managed" ? "aoe-managed" : skill.provenance.root;
@@ -41,19 +43,6 @@ function summarizeSyncOutcomes(outcomes: SkillSyncOutcome[]): string {
   if (counts.conflict) parts.push(`${counts.conflict} conflict${counts.conflict === 1 ? "" : "s"}`);
   if (counts.error) parts.push(`${counts.error} error${counts.error === 1 ? "" : "s"}`);
   return parts.length ? parts.join(", ") : "Nothing to sync.";
-}
-
-function SourceBadge({ skill }: { skill: SkillSummary }) {
-  const external = skill.provenance.kind === "external";
-  return (
-    <span
-      className={`rounded px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider ${
-        external ? "bg-accent-600/15 text-accent-500" : "bg-brand-600/15 text-brand-400"
-      }`}
-    >
-      {skill.provenance.kind === "external" ? skill.provenance.root : "managed"}
-    </span>
-  );
 }
 
 export function SkillsManager() {
@@ -355,7 +344,7 @@ export function SkillsManager() {
                   <span className="truncate font-mono text-[12px] font-medium text-text-primary">
                     {skill.directory}
                   </span>
-                  <SourceBadge skill={skill} />
+                  <ProvenanceBadge label={labelForProvenance(skill.provenance, data?.roots ?? [])} />
                 </div>
                 <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-text-dim">{skill.description}</p>
               </button>
@@ -372,7 +361,7 @@ export function SkillsManager() {
                 <div>
                   <div className="flex items-center gap-2">
                     <h4 className="font-mono text-lg font-semibold text-text-primary">{selected.name}</h4>
-                    <SourceBadge skill={selected} />
+                    <ProvenanceBadge label={labelForProvenance(selected.provenance, data?.roots ?? [])} />
                   </div>
                   <p className="mt-1 text-[12px] text-text-secondary">{selected.description}</p>
                   <p className="mt-2 font-mono text-[10px] text-text-muted">

--- a/web/src/components/SkillsManager.tsx
+++ b/web/src/components/SkillsManager.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { TextMessagePartProvider } from "@assistant-ui/react";
 import {
   adoptSkill,
   createSkill,
@@ -8,12 +10,15 @@ import {
   syncSkills,
   updateSkill,
   type SkillDetail,
+  type SkillRoot,
   type SkillSummary,
   type SkillSyncOutcome,
   type SkillsResponse,
 } from "../lib/api";
 import { ProvenanceBadge } from "./ProvenanceBadge";
 import { labelForProvenance } from "../lib/skillProvenance";
+import { Markdown } from "./acp/Markdown";
+import { skillBody } from "../lib/skillBody";
 
 function sourceId(skill: SkillSummary): string {
   return skill.provenance.kind === "aoe-managed" ? "aoe-managed" : skill.provenance.root;
@@ -45,13 +50,71 @@ function summarizeSyncOutcomes(outcomes: SkillSyncOutcome[]): string {
   return parts.length ? parts.join(", ") : "Nothing to sync.";
 }
 
+/** One collapsible section of the sidebar list ("Managed" or "Available to
+ *  adopt"). Both groups render the same row shape; only the membership and
+ *  the section label differ, so the row markup lives here once. */
+function SkillGroup({
+  title,
+  skills,
+  roots,
+  selectedKey,
+  collapsed,
+  onToggle,
+  onSelect,
+}: {
+  title: string;
+  skills: SkillSummary[];
+  roots: SkillRoot[];
+  selectedKey: string | null;
+  collapsed: boolean;
+  onToggle: () => void;
+  onSelect: (skill: SkillSummary) => void;
+}) {
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={!collapsed}
+        className="flex w-full items-center justify-between px-3 py-2 font-mono text-[11px] uppercase tracking-wider text-text-dim hover:text-text-secondary"
+      >
+        <span>{title}</span>
+        {collapsed ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+      </button>
+      {!collapsed &&
+        skills.map((skill) => (
+          <button
+            type="button"
+            key={skillKey(skill)}
+            onClick={() => onSelect(skill)}
+            className={`block w-full border-b border-l-2 border-surface-800 px-3 py-2 text-left transition-colors ${
+              skillKey(skill) === selectedKey
+                ? "border-l-brand-500 bg-brand-600/10"
+                : "border-l-transparent hover:bg-surface-800"
+            }`}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate text-[13px] font-medium text-text-primary">{skill.directory}</span>
+              <ProvenanceBadge label={labelForProvenance(skill.provenance, roots)} />
+            </div>
+            <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-text-dim">{skill.description}</p>
+          </button>
+        ))}
+    </div>
+  );
+}
+
+/** The right pane's tab row. A single tab today (the raw/preview toggle lives
+ *  separately, since it applies within this tab); kept as a list so adding a
+ *  second tab (e.g. usage statistics) is a one-entry change. */
+const DETAIL_TABS = [{ id: "content", label: "SKILL.md" }] as const;
+
 export function SkillsManager() {
   const [data, setData] = useState<SkillsResponse | null>(null);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [detail, setDetail] = useState<SkillDetail | null>(null);
   const [draft, setDraft] = useState("");
   const [search, setSearch] = useState("");
-  const [root, setRoot] = useState("all");
   const [hideManagedExternal, setHideManagedExternal] = useState(true);
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
@@ -59,6 +122,10 @@ export function SkillsManager() {
   const [newDirectory, setNewDirectory] = useState("");
   const [newDescription, setNewDescription] = useState("");
   const [syncOutcomes, setSyncOutcomes] = useState<SkillSyncOutcome[] | null>(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [managedCollapsed, setManagedCollapsed] = useState(false);
+  const [adoptCollapsed, setAdoptCollapsed] = useState(false);
+  const [viewMode, setViewMode] = useState<"raw" | "preview">("raw");
 
   const load = useCallback(async (preferredKey?: string) => {
     const next = await fetchSkills();
@@ -132,6 +199,7 @@ export function SkillsManager() {
     const key = `aoe-managed:${newDirectory}`;
     setNewDirectory("");
     setNewDescription("");
+    setShowCreateForm(false);
     setNotice("Managed skill created.");
     await load(key);
   };
@@ -160,7 +228,6 @@ export function SkillsManager() {
       return;
     }
     setNotice("Skill adopted into AoE's managed store.");
-    setRoot("all");
     await load(`aoe-managed:${result.directory ?? selected.directory}`);
   };
 
@@ -178,6 +245,10 @@ export function SkillsManager() {
     await load(selectedKey ?? undefined);
   };
 
+  const discard = () => {
+    if (detail) setDraft(detail.content);
+  };
+
   const remove = async () => {
     if (!selected?.writable || !window.confirm(`Delete managed skill "${selected.directory}"?`)) return;
     setBusy(true);
@@ -193,18 +264,22 @@ export function SkillsManager() {
   };
 
   const normalized = search.trim().toLowerCase();
+  const matchesSearch = (skill: SkillSummary) =>
+    !normalized ||
+    skill.directory.toLowerCase().includes(normalized) ||
+    skill.name.toLowerCase().includes(normalized) ||
+    skill.description.toLowerCase().includes(normalized);
   const managedDirectories = new Set(
     data?.skills.filter((skill) => skill.provenance.kind === "aoe-managed").map((skill) => skill.directory) ?? [],
   );
-  const visible =
+  const managedSkills =
+    data?.skills.filter((skill) => skill.provenance.kind === "aoe-managed" && matchesSearch(skill)) ?? [];
+  const adoptableSkills =
     data?.skills.filter(
       (skill) =>
-        (root === "all" || sourceId(skill) === root) &&
-        (!hideManagedExternal || skill.provenance.kind === "aoe-managed" || !managedDirectories.has(skill.directory)) &&
-        (!normalized ||
-          skill.directory.toLowerCase().includes(normalized) ||
-          skill.name.toLowerCase().includes(normalized) ||
-          skill.description.toLowerCase().includes(normalized)),
+        skill.provenance.kind === "external" &&
+        matchesSearch(skill) &&
+        (!hideManagedExternal || !managedDirectories.has(skill.directory)),
     ) ?? [];
 
   if (loadError) {
@@ -221,46 +296,57 @@ export function SkillsManager() {
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-surface-700/60 bg-surface-850/70 p-4">
-        <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <h3 className="font-mono text-sm uppercase tracking-widest text-text-primary">Skills Library</h3>
             <p className="mt-1 text-[12px] text-text-dim">
               Browse skills installed for other agents. Adopt a skill before editing it so the original stays untouched.
             </p>
           </div>
-          <button
-            type="button"
-            disabled={busy}
-            onClick={() => void sync()}
-            className="rounded bg-brand-600 px-3 py-1.5 text-[12px] font-semibold text-white hover:bg-brand-500 disabled:opacity-40"
-          >
-            Share with all agents
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setShowCreateForm((current) => !current)}
+              className="rounded bg-brand-600 px-3 py-1.5 text-[12px] font-semibold text-text-on-brand hover:bg-brand-500"
+            >
+              + New skill
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void sync()}
+              className="rounded border border-surface-700 bg-surface-800 px-3 py-1.5 text-[12px] font-semibold text-text-secondary hover:bg-surface-700 disabled:opacity-40"
+            >
+              Share with all agents
+            </button>
+          </div>
         </div>
-        <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_auto]">
-          <input
-            aria-label="New skill directory"
-            value={newDirectory}
-            onChange={(event) => setNewDirectory(event.target.value)}
-            placeholder="new-skill"
-            className="rounded border border-surface-700 bg-surface-900 px-3 py-2 font-mono text-[12px] text-text-primary outline-none focus:border-brand-500"
-          />
-          <input
-            aria-label="New skill description"
-            value={newDescription}
-            onChange={(event) => setNewDescription(event.target.value)}
-            placeholder="When should agents use it?"
-            className="rounded border border-surface-700 bg-surface-900 px-3 py-2 text-[12px] text-text-primary outline-none focus:border-brand-500"
-          />
-          <button
-            type="button"
-            disabled={busy || !newDirectory.trim()}
-            onClick={() => void create()}
-            className="rounded bg-brand-600 px-4 py-2 text-[12px] font-semibold text-white hover:bg-brand-500 disabled:opacity-40"
-          >
-            Create
-          </button>
-        </div>
+        {showCreateForm && (
+          <div className="mt-3 grid gap-2 border-t border-surface-700/60 pt-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_auto]">
+            <input
+              aria-label="New skill directory"
+              value={newDirectory}
+              onChange={(event) => setNewDirectory(event.target.value)}
+              placeholder="new-skill"
+              className="rounded border border-surface-700 bg-surface-900 px-3 py-2 font-mono text-[12px] text-text-primary outline-none focus:border-brand-500"
+            />
+            <input
+              aria-label="New skill description"
+              value={newDescription}
+              onChange={(event) => setNewDescription(event.target.value)}
+              placeholder="When should agents use it?"
+              className="rounded border border-surface-700 bg-surface-900 px-3 py-2 text-[12px] text-text-primary outline-none focus:border-brand-500"
+            />
+            <button
+              type="button"
+              disabled={busy || !newDirectory.trim()}
+              onClick={() => void create()}
+              className="rounded bg-brand-600 px-4 py-2 text-[12px] font-semibold text-text-on-brand hover:bg-brand-500 disabled:opacity-40"
+            >
+              Create
+            </button>
+          </div>
+        )}
       </div>
 
       {notice && (
@@ -293,31 +379,21 @@ export function SkillsManager() {
         </div>
       )}
 
-      <div className="grid min-h-[34rem] overflow-hidden rounded-lg border border-surface-700/60 bg-surface-900 lg:grid-cols-[20rem_minmax(0,1fr)]">
-        <aside className="border-b border-surface-700/60 bg-surface-850/45 lg:border-b-0 lg:border-r">
-          <div className="grid gap-2 border-b border-surface-700/60 p-3">
+      {/* Explicit height: the settings content area (SettingsView) is itself
+          a scroll container with no fixed height, so a plain h-full/flex-1
+          pane here has nothing to measure against and collapses to its
+          content height instead of scrolling internally. Pinning a height
+          on the grid lets each pane scroll independently within it. */}
+      <div className="grid h-[calc(100vh-16rem)] min-h-[26rem] gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
+        <aside className="flex min-h-0 flex-col overflow-y-auto rounded-lg border border-surface-700/60 bg-surface-850/70">
+          <div className="sticky top-0 z-10 space-y-2 border-b border-surface-700/60 bg-surface-850/95 p-3">
             <input
               aria-label="Search skills"
               value={search}
               onChange={(event) => setSearch(event.target.value)}
               placeholder="Search skills"
-              className="rounded border border-surface-700 bg-surface-900 px-3 py-2 text-[12px] text-text-primary outline-none focus:border-brand-500"
+              className="w-full rounded border border-surface-700 bg-surface-900 px-3 py-2 text-[12px] text-text-primary outline-none focus:border-brand-500"
             />
-            <select
-              aria-label="Filter skills by source"
-              value={root}
-              onChange={(event) => setRoot(event.target.value)}
-              className="rounded border border-surface-700 bg-surface-900 px-3 py-2 font-mono text-[11px] text-text-secondary"
-            >
-              <option value="all">All sources</option>
-              <option value="aoe-managed">AoE managed</option>
-              {data?.roots.map((entry) => (
-                <option key={entry.id} value={entry.id}>
-                  {entry.label}
-                  {entry.legacy ? " (legacy)" : ""}
-                </option>
-              ))}
-            </select>
             <label className="flex items-center gap-2 text-[11px] text-text-secondary">
               <input
                 type="checkbox"
@@ -328,100 +404,162 @@ export function SkillsManager() {
               Hide external skills already managed
             </label>
           </div>
-          <div className="max-h-[28rem] overflow-y-auto lg:max-h-[40rem]">
-            {visible.map((skill) => (
-              <button
-                type="button"
-                key={skillKey(skill)}
-                onClick={() => select(skill)}
-                className={`w-full border-b border-surface-700/40 px-3 py-3 text-left transition-colors ${
-                  skillKey(skill) === selectedKey
-                    ? "bg-brand-600/10 shadow-[inset_3px_0_0_var(--color-brand-500)]"
-                    : "hover:bg-surface-800"
-                }`}
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <span className="truncate font-mono text-[12px] font-medium text-text-primary">
-                    {skill.directory}
-                  </span>
-                  <ProvenanceBadge label={labelForProvenance(skill.provenance, data?.roots ?? [])} />
-                </div>
-                <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-text-dim">{skill.description}</p>
-              </button>
-            ))}
-            {data && visible.length === 0 && <p className="p-4 text-[12px] text-text-dim">No matching skills.</p>}
-          </div>
+          <SkillGroup
+            title={`Managed (${managedSkills.length})`}
+            skills={managedSkills}
+            roots={data?.roots ?? []}
+            selectedKey={selectedKey}
+            collapsed={managedCollapsed}
+            onToggle={() => setManagedCollapsed((current) => !current)}
+            onSelect={select}
+          />
+          <SkillGroup
+            title={`Available to adopt (${adoptableSkills.length})`}
+            skills={adoptableSkills}
+            roots={data?.roots ?? []}
+            selectedKey={selectedKey}
+            collapsed={adoptCollapsed}
+            onToggle={() => setAdoptCollapsed((current) => !current)}
+            onSelect={select}
+          />
+          {data && managedSkills.length === 0 && adoptableSkills.length === 0 && (
+            <p className="p-4 text-[12px] text-text-dim">No matching skills.</p>
+          )}
         </aside>
 
-        <section className="min-w-0 p-4 sm:p-5">
-          {!selected && <p className="text-[13px] text-text-dim">Select a skill to inspect its instructions.</p>}
+        <section className="flex min-h-0 flex-col overflow-y-auto rounded-lg border border-surface-700/60 bg-surface-850/70">
+          {!selected && (
+            <div className="flex h-full items-center justify-center p-6">
+              <p className="text-[12px] text-text-dim">Select a skill to inspect its instructions.</p>
+            </div>
+          )}
           {selected && (
-            <div className="space-y-4">
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <div className="flex items-center gap-2">
-                    <h4 className="font-mono text-lg font-semibold text-text-primary">{selected.name}</h4>
-                    <ProvenanceBadge label={labelForProvenance(selected.provenance, data?.roots ?? [])} />
-                  </div>
-                  <p className="mt-1 text-[12px] text-text-secondary">{selected.description}</p>
-                  <p className="mt-2 font-mono text-[10px] text-text-muted">
-                    {sourceId(selected)} / {selected.directory}
-                  </p>
+            <>
+              <div className="sticky top-0 z-10 space-y-3 border-b border-surface-700/60 bg-surface-850/95 p-4">
+                <div className="flex items-center gap-2">
+                  <h4 className="text-lg font-semibold text-text-bright">{selected.directory}</h4>
+                  <ProvenanceBadge label={labelForProvenance(selected.provenance, data?.roots ?? [])} />
                 </div>
-                {selected.provenance.kind === "external" && (
-                  <button
-                    type="button"
-                    disabled={busy}
-                    onClick={() => void adopt()}
-                    className="rounded bg-brand-600 px-3 py-1.5 text-[12px] font-semibold text-white hover:bg-brand-500 disabled:opacity-40"
-                  >
-                    Adopt into AoE
-                  </button>
+                <p className="font-mono text-[11px]">
+                  <span className="text-text-dim">{sourceId(selected)}</span>
+                  <span className="text-text-muted"> / </span>
+                  <span className="text-brand-500">{selected.directory}</span>
+                </p>
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex gap-4">
+                    {DETAIL_TABS.map((tab) => (
+                      <span
+                        key={tab.id}
+                        className="border-b-2 border-brand-500 pb-1 font-mono text-[11px] uppercase tracking-wider text-brand-500"
+                      >
+                        {tab.label}
+                      </span>
+                    ))}
+                  </div>
+                  <div className="flex items-center gap-1 rounded bg-surface-900 p-0.5">
+                    <button
+                      type="button"
+                      onClick={() => setViewMode("raw")}
+                      className={`rounded px-2 py-1 text-[11px] font-medium ${
+                        viewMode === "raw"
+                          ? "bg-brand-600 text-text-on-brand"
+                          : "text-text-secondary hover:text-text-primary"
+                      }`}
+                    >
+                      Raw
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setViewMode("preview")}
+                      className={`rounded px-2 py-1 text-[11px] font-medium ${
+                        viewMode === "preview"
+                          ? "bg-brand-600 text-text-on-brand"
+                          : "text-text-secondary hover:text-text-primary"
+                      }`}
+                    >
+                      Preview
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              {/* min-h-0 lets the editor shrink inside the flex column so it
+                  grows to the bottom of the pane instead of sitting at a fixed
+                  height with dead space above the footer. */}
+              <div className="flex min-h-0 flex-1 flex-col p-4">
+                {detail ? (
+                  viewMode === "raw" ? (
+                    <textarea
+                      aria-label="SKILL.md content"
+                      readOnly={!selected.writable}
+                      value={draft}
+                      onChange={(event) => setDraft(event.target.value)}
+                      spellCheck={false}
+                      className="min-h-[16rem] w-full flex-1 resize-none rounded-md border border-surface-700 bg-surface-950 p-4 font-mono text-[12px] leading-5 text-text-primary outline-none focus:border-brand-500 read-only:text-text-secondary"
+                    />
+                  ) : (
+                    <div className="min-h-[16rem] flex-1 overflow-y-auto rounded-md border border-surface-700 bg-surface-950 p-4">
+                      <TextMessagePartProvider text={skillBody(draft)}>
+                        <Markdown text={skillBody(draft)} />
+                      </TextMessagePartProvider>
+                    </div>
+                  )
+                ) : (
+                  <p className="text-[13px] text-text-dim">Loading skill...</p>
                 )}
               </div>
 
-              {detail ? (
-                <>
-                  <textarea
-                    aria-label="SKILL.md content"
-                    readOnly={!selected.writable}
-                    value={draft}
-                    onChange={(event) => setDraft(event.target.value)}
-                    spellCheck={false}
-                    className="min-h-[25rem] w-full resize-y rounded-md border border-surface-700 bg-surface-950 p-4 font-mono text-[12px] leading-5 text-text-primary outline-none focus:border-brand-500 read-only:text-text-secondary"
-                  />
+              <div className="sticky bottom-0 z-10 flex items-center justify-between gap-3 border-t border-surface-700/60 bg-surface-850/95 p-3">
+                {selected.writable ? (
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void remove()}
+                    className="rounded border border-status-error/40 px-3 py-1.5 text-[12px] text-status-error hover:bg-status-error/10 disabled:opacity-40"
+                  >
+                    Delete
+                  </button>
+                ) : (
+                  <p className="text-[11px] text-text-dim">
+                    External skills are read-only. Adopt this package to make an editable AoE-managed copy.
+                  </p>
+                )}
+                <div className="flex items-center gap-3">
                   {selected.writable ? (
-                    <div className="flex items-center justify-between gap-3">
+                    <>
+                      <span className={`text-[11px] ${dirty ? "text-status-warning" : "text-status-running"}`}>
+                        {dirty ? "Unsaved changes" : "All changes saved"}
+                      </span>
                       <button
                         type="button"
-                        disabled={busy}
-                        onClick={() => void remove()}
-                        className="rounded border border-status-error/40 px-3 py-1.5 text-[12px] text-status-error hover:bg-status-error/10 disabled:opacity-40"
+                        disabled={busy || !dirty}
+                        onClick={discard}
+                        className="rounded border border-surface-700 bg-surface-800 px-3 py-1.5 text-[12px] text-text-secondary disabled:opacity-40"
                       >
-                        Delete
+                        Discard
                       </button>
-                      <div className="flex items-center gap-3">
-                        {dirty && <span className="text-[11px] text-status-waiting">Unsaved changes</span>}
-                        <button
-                          type="button"
-                          disabled={busy || !dirty}
-                          onClick={() => void save()}
-                          className="rounded bg-brand-600 px-4 py-1.5 text-[12px] font-semibold text-white hover:bg-brand-500 disabled:opacity-40"
-                        >
-                          Save
-                        </button>
-                      </div>
-                    </div>
+                      <button
+                        type="button"
+                        disabled={busy || !dirty}
+                        onClick={() => void save()}
+                        className="rounded bg-brand-600 px-4 py-1.5 text-[12px] font-semibold text-text-on-brand hover:bg-brand-500 disabled:opacity-40"
+                      >
+                        Save
+                      </button>
+                    </>
                   ) : (
-                    <p className="text-[11px] text-text-dim">
-                      External skills are read-only. Adopt this package to make an editable AoE-managed copy.
-                    </p>
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => void adopt()}
+                      className="rounded bg-brand-600 px-3 py-1.5 text-[12px] font-semibold text-text-on-brand hover:bg-brand-500 disabled:opacity-40"
+                    >
+                      Adopt into AoE
+                    </button>
                   )}
-                </>
-              ) : (
-                <p className="text-[13px] text-text-dim">Loading skill...</p>
-              )}
-            </div>
+                </div>
+              </div>
+            </>
           )}
         </section>
       </div>

--- a/web/src/components/SkillsManager.tsx
+++ b/web/src/components/SkillsManager.tsx
@@ -24,7 +24,7 @@ function SourceBadge({ skill }: { skill: SkillSummary }) {
   return (
     <span
       className={`rounded px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider ${
-        external ? "bg-accent-600/15 text-accent-400" : "bg-brand-600/15 text-brand-400"
+        external ? "bg-accent-600/15 text-accent-500" : "bg-brand-600/15 text-brand-400"
       }`}
     >
       {skill.provenance.kind === "external" ? skill.provenance.root : "managed"}

--- a/web/src/components/SkillsManager.tsx
+++ b/web/src/components/SkillsManager.tsx
@@ -5,9 +5,11 @@ import {
   deleteSkill,
   fetchSkill,
   fetchSkills,
+  syncSkills,
   updateSkill,
   type SkillDetail,
   type SkillSummary,
+  type SkillSyncOutcome,
   type SkillsResponse,
 } from "../lib/api";
 
@@ -17,6 +19,28 @@ function sourceId(skill: SkillSummary): string {
 
 function skillKey(skill: SkillSummary): string {
   return `${sourceId(skill)}:${skill.directory}`;
+}
+
+/** Compact counts line for a sync run, e.g. "3 shared, 1 unchanged, 1 conflict".
+ *  "shared" folds together "created" and "updated" since both put a skill into
+ *  an agent's directory; "unchanged" is omitted from the detail list below but
+ *  still counted here so the user sees the full picture. */
+function summarizeSyncOutcomes(outcomes: SkillSyncOutcome[]): string {
+  const counts = { shared: 0, removed: 0, unchanged: 0, conflict: 0, error: 0 };
+  for (const outcome of outcomes) {
+    if (outcome.status === "created" || outcome.status === "updated") counts.shared += 1;
+    else if (outcome.status === "removed") counts.removed += 1;
+    else if (outcome.status === "unchanged") counts.unchanged += 1;
+    else if (outcome.status === "conflict") counts.conflict += 1;
+    else if (outcome.status === "error") counts.error += 1;
+  }
+  const parts: string[] = [];
+  if (counts.shared) parts.push(`${counts.shared} shared`);
+  if (counts.removed) parts.push(`${counts.removed} removed`);
+  if (counts.unchanged) parts.push(`${counts.unchanged} unchanged`);
+  if (counts.conflict) parts.push(`${counts.conflict} conflict${counts.conflict === 1 ? "" : "s"}`);
+  if (counts.error) parts.push(`${counts.error} error${counts.error === 1 ? "" : "s"}`);
+  return parts.length ? parts.join(", ") : "Nothing to sync.";
 }
 
 function SourceBadge({ skill }: { skill: SkillSummary }) {
@@ -45,6 +69,7 @@ export function SkillsManager() {
   const [loadError, setLoadError] = useState(false);
   const [newDirectory, setNewDirectory] = useState("");
   const [newDescription, setNewDescription] = useState("");
+  const [syncOutcomes, setSyncOutcomes] = useState<SkillSyncOutcome[] | null>(null);
 
   const load = useCallback(async (preferredKey?: string) => {
     const next = await fetchSkills();
@@ -122,6 +147,20 @@ export function SkillsManager() {
     await load(key);
   };
 
+  const sync = async () => {
+    setBusy(true);
+    const result = await syncSkills();
+    setBusy(false);
+    if (!result.ok) {
+      setSyncOutcomes(null);
+      setNotice(result.error ?? "Could not sync skills.");
+      return;
+    }
+    setNotice(null);
+    setSyncOutcomes(result.outcomes);
+    await load(selectedKey ?? undefined);
+  };
+
   const adopt = async () => {
     if (!selected || selected.provenance.kind !== "external") return;
     setBusy(true);
@@ -193,11 +232,21 @@ export function SkillsManager() {
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-surface-700/60 bg-surface-850/70 p-4">
-        <div className="mb-3">
-          <h3 className="font-mono text-sm uppercase tracking-widest text-text-primary">Skills Library</h3>
-          <p className="mt-1 text-[12px] text-text-dim">
-            Browse skills installed for other agents. Adopt a skill before editing it so the original stays untouched.
-          </p>
+        <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 className="font-mono text-sm uppercase tracking-widest text-text-primary">Skills Library</h3>
+            <p className="mt-1 text-[12px] text-text-dim">
+              Browse skills installed for other agents. Adopt a skill before editing it so the original stays untouched.
+            </p>
+          </div>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void sync()}
+            className="rounded bg-brand-600 px-3 py-1.5 text-[12px] font-semibold text-white hover:bg-brand-500 disabled:opacity-40"
+          >
+            Share with all agents
+          </button>
         </div>
         <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_auto]">
           <input
@@ -231,6 +280,27 @@ export function SkillsManager() {
           className="rounded border border-surface-700 bg-surface-800 px-3 py-2 text-[12px] text-text-secondary"
         >
           {notice}
+        </div>
+      )}
+
+      {syncOutcomes && (
+        <div
+          role="status"
+          className="rounded border border-surface-700 bg-surface-800 px-3 py-2 text-[12px] text-text-secondary"
+        >
+          <p>{summarizeSyncOutcomes(syncOutcomes)}</p>
+          {syncOutcomes.some((outcome) => outcome.status === "conflict" || outcome.status === "error") && (
+            <ul className="mt-2 space-y-1 font-mono text-[11px] text-text-dim">
+              {syncOutcomes
+                .filter((outcome) => outcome.status === "conflict" || outcome.status === "error")
+                .map((outcome, index) => (
+                  <li key={`${outcome.root}:${outcome.directory}:${index}`}>
+                    {outcome.status} {outcome.root}/{outcome.directory}
+                    {outcome.message ? `: ${outcome.message}` : ""}
+                  </li>
+                ))}
+            </ul>
+          )}
         </div>
       )}
 

--- a/web/src/components/SkillsManager.tsx
+++ b/web/src/components/SkillsManager.tsx
@@ -173,13 +173,21 @@ export function SkillsManager({ readOnly = false }: { readOnly?: boolean } = {})
   const selected = data?.skills.find((skill) => skillKey(skill) === selectedKey) ?? null;
   const dirty = detail !== null && draft !== detail.content;
 
+  // Keyed on the selection's primitives, NOT the `selected` object: that object
+  // is a fresh `.find()` result on every render, so depending on it re-ran this
+  // effect after any `load()` and reset the draft out from under an unsaved
+  // edit. Sharing, replacing a conflict, and saving all keep the same skill
+  // selected, so with primitive deps they no longer touch the editor at all.
+  const selectedSource = selected ? sourceId(selected) : null;
+  const selectedDirectory = selected?.directory ?? null;
+
   useEffect(() => {
-    if (!selected) {
+    if (!selectedSource || !selectedDirectory) {
       return;
     }
     let cancelled = false;
     const read = async () => {
-      const next = await fetchSkill(sourceId(selected), selected.directory);
+      const next = await fetchSkill(selectedSource, selectedDirectory);
       if (!cancelled) {
         setDetail(next);
         setDraft(next?.content ?? "");
@@ -190,7 +198,7 @@ export function SkillsManager({ readOnly = false }: { readOnly?: boolean } = {})
     return () => {
       cancelled = true;
     };
-  }, [selected]);
+  }, [selectedSource, selectedDirectory]);
 
   useEffect(() => {
     if (!dirty) return;
@@ -199,13 +207,20 @@ export function SkillsManager({ readOnly = false }: { readOnly?: boolean } = {})
     return () => window.removeEventListener("beforeunload", warn);
   }, [dirty]);
 
+  /** Every path that moves the selection off an edited skill has to ask first,
+   *  because moving it is what discards the draft. */
+  const confirmDiscard = () => !dirty || window.confirm("Discard unsaved changes to this skill?");
+
   const select = (skill: SkillSummary) => {
-    if (dirty && !window.confirm("Discard unsaved changes to this skill?")) return;
+    if (!confirmDiscard()) return;
     setNotice(null);
     setSelectedKey(skillKey(skill));
   };
 
   const create = async () => {
+    // Creating jumps the selection to the new skill, so it discards a draft the
+    // same way clicking another row does.
+    if (!confirmDiscard()) return;
     setBusy(true);
     const result = await createSkill(newDirectory, newDescription || undefined);
     setBusy(false);
@@ -273,6 +288,8 @@ export function SkillsManager({ readOnly = false }: { readOnly?: boolean } = {})
 
   const adopt = async () => {
     if (!selected || selected.provenance.kind !== "external") return;
+    // Adopting selects the new managed copy, moving off whatever is being edited.
+    if (!confirmDiscard()) return;
     setBusy(true);
     const result = await adoptSkill(selected.provenance.root, selected.directory);
     setBusy(false);

--- a/web/src/components/SkillsManager.tsx
+++ b/web/src/components/SkillsManager.tsx
@@ -50,6 +50,20 @@ function summarizeSyncOutcomes(outcomes: SkillSyncOutcome[]): string {
   return parts.length ? parts.join(", ") : "Nothing to sync.";
 }
 
+/** Fold a follow-up sync's outcomes into the displayed list: rows sharing a
+ *  (root, directory) key are replaced in place so the rest of the panel
+ *  (other roots, other skills) does not disappear, and any outcome the
+ *  follow-up introduces that was not already shown is appended. */
+function mergeSyncOutcomes(current: SkillSyncOutcome[] | null, updates: SkillSyncOutcome[]): SkillSyncOutcome[] {
+  const key = (outcome: SkillSyncOutcome) => `${outcome.root}:${outcome.directory}`;
+  const updateMap = new Map(updates.map((outcome) => [key(outcome), outcome]));
+  const merged = (current ?? []).map((outcome) => updateMap.get(key(outcome)) ?? outcome);
+  for (const outcome of updates) {
+    if (!merged.some((existing) => key(existing) === key(outcome))) merged.push(outcome);
+  }
+  return merged;
+}
+
 /** One collapsible section of the sidebar list ("Managed" or "Available to
  *  adopt"). Both groups render the same row shape; only the membership and
  *  the section label differ, so the row markup lives here once. */
@@ -218,6 +232,42 @@ export function SkillsManager() {
     await load(selectedKey ?? undefined);
   };
 
+  /** Re-run sync for a single conflict, naming it in `replace` so the backend
+   *  overwrites it instead of leaving it alone. Merges the follow-up's
+   *  outcomes into the panel instead of replacing it wholesale, so the other
+   *  rows already shown do not vanish. */
+  const replaceConflict = async (outcome: SkillSyncOutcome) => {
+    setBusy(true);
+    const result = await syncSkills({ roots: [outcome.root], replace: [outcome.directory] });
+    setBusy(false);
+    if (!result.ok) {
+      setNotice(result.error ?? "Could not replace skill.");
+      return;
+    }
+    setNotice(null);
+    setSyncOutcomes((current) => mergeSyncOutcomes(current, result.outcomes));
+    await load(selectedKey ?? undefined);
+  };
+
+  /** Share only the selected skill, filtering the sync response down to its
+   *  directory so the outcome panel reports what happened to the one the
+   *  user is looking at, not the whole library. */
+  const shareSkill = async () => {
+    if (!selected) return;
+    const { directory } = selected;
+    setBusy(true);
+    const result = await syncSkills({});
+    setBusy(false);
+    if (!result.ok) {
+      setSyncOutcomes(null);
+      setNotice(result.error ?? "Could not share skill.");
+      return;
+    }
+    setNotice(null);
+    setSyncOutcomes(result.outcomes.filter((outcome) => outcome.directory === directory));
+    await load(selectedKey ?? undefined);
+  };
+
   const adopt = async () => {
     if (!selected || selected.provenance.kind !== "external") return;
     setBusy(true);
@@ -369,9 +419,22 @@ export function SkillsManager() {
               {syncOutcomes
                 .filter((outcome) => outcome.status === "conflict" || outcome.status === "error")
                 .map((outcome, index) => (
-                  <li key={`${outcome.root}:${outcome.directory}:${index}`}>
-                    {outcome.status} {outcome.root}/{outcome.directory}
-                    {outcome.message ? `: ${outcome.message}` : ""}
+                  <li key={`${outcome.root}:${outcome.directory}:${index}`} className="flex items-center gap-2">
+                    <span>
+                      {outcome.status} {outcome.root}/{outcome.directory}
+                      {outcome.message ? `: ${outcome.message}` : ""}
+                    </span>
+                    {outcome.status === "conflict" && (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => void replaceConflict(outcome)}
+                        aria-label={`Replace ${outcome.directory} in ${outcome.root}`}
+                        className="rounded border border-status-error/40 px-2 py-0.5 text-[11px] text-status-error hover:bg-status-error/10 disabled:opacity-40"
+                      >
+                        Replace
+                      </button>
+                    )}
                   </li>
                 ))}
             </ul>
@@ -530,6 +593,15 @@ export function SkillsManager() {
                       <span className={`text-[11px] ${dirty ? "text-status-warning" : "text-status-running"}`}>
                         {dirty ? "Unsaved changes" : "All changes saved"}
                       </span>
+                      <button
+                        type="button"
+                        disabled={busy || dirty}
+                        title={dirty ? "Save or discard your changes before sharing" : undefined}
+                        onClick={() => void shareSkill()}
+                        className="rounded border border-surface-700 bg-surface-800 px-3 py-1.5 text-[12px] text-text-secondary disabled:opacity-40"
+                      >
+                        Share this skill
+                      </button>
                       <button
                         type="button"
                         disabled={busy || !dirty}

--- a/web/src/components/__tests__/SettingsView.test.tsx
+++ b/web/src/components/__tests__/SettingsView.test.tsx
@@ -32,6 +32,7 @@ describe("buildSidebar", () => {
       { kind: "tab", id: "session", label: "Session" },
       { kind: "tab", id: "structured-view", label: "Structured view" },
       { kind: "tab", id: "mcp", label: "MCP servers" },
+      { kind: "tab", id: "skills", label: "Skills" },
       { kind: "divider", label: "Environment" },
       { kind: "tab", id: "sandbox", label: "Sandbox" },
       { kind: "tab", id: "worktree", label: "Worktree" },

--- a/web/src/components/__tests__/SkillsManager.test.tsx
+++ b/web/src/components/__tests__/SkillsManager.test.tsx
@@ -3,7 +3,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import type { SkillDetail, SkillMutationResult, SkillSummary, SkillsResponse } from "../../lib/api";
+import type { SkillDetail, SkillMutationResult, SkillSummary, SkillSyncResult, SkillsResponse } from "../../lib/api";
 
 const fetchSkills = vi.fn<[], Promise<SkillsResponse | null>>();
 const fetchSkill = vi.fn<[string, string], Promise<SkillDetail | null>>();
@@ -11,6 +11,7 @@ const createSkill = vi.fn<[string, string?], Promise<SkillMutationResult>>();
 const updateSkill = vi.fn<[string, string], Promise<SkillMutationResult>>();
 const deleteSkill = vi.fn<[string], Promise<SkillMutationResult>>();
 const adoptSkill = vi.fn<[string, string, string?], Promise<SkillMutationResult>>();
+const syncSkills = vi.fn<[string[]?], Promise<SkillSyncResult>>();
 
 vi.mock("../../lib/api", () => ({
   fetchSkills: () => fetchSkills(),
@@ -19,6 +20,7 @@ vi.mock("../../lib/api", () => ({
   updateSkill: (directory: string, content: string) => updateSkill(directory, content),
   deleteSkill: (directory: string) => deleteSkill(directory),
   adoptSkill: (source: string, directory: string, destination?: string) => adoptSkill(source, directory, destination),
+  syncSkills: (roots?: string[]) => syncSkills(roots),
 }));
 
 import { SkillsManager } from "../SkillsManager";
@@ -78,6 +80,7 @@ beforeEach(() => {
   updateSkill.mockReset();
   deleteSkill.mockReset();
   adoptSkill.mockReset();
+  syncSkills.mockReset();
   fetchSkills.mockResolvedValue(response());
   fetchSkill.mockImplementation(async (source, directory) =>
     detail(source === "aoe-managed" ? managed : { ...external, directory }),
@@ -86,6 +89,7 @@ beforeEach(() => {
   updateSkill.mockResolvedValue({ ok: true });
   deleteSkill.mockResolvedValue({ ok: true });
   adoptSkill.mockResolvedValue({ ok: true, directory: "review" });
+  syncSkills.mockResolvedValue({ ok: true, outcomes: [] });
 });
 
 describe("SkillsManager", () => {
@@ -149,5 +153,33 @@ describe("SkillsManager", () => {
     fireEvent.change(await screen.findByLabelText("New skill directory"), { target: { value: "mine" } });
     fireEvent.click(screen.getByText("Create"));
     expect(await screen.findByText("already exists")).toBeTruthy();
+  });
+
+  it("shares skills with all agents, showing conflicts but not unchanged outcomes", async () => {
+    syncSkills.mockResolvedValue({
+      ok: true,
+      outcomes: [
+        { root: "claude-user", directory: "review", status: "created", message: null },
+        { root: "codex-user", directory: "review", status: "unchanged", message: null },
+        { root: "claude-user", directory: "mine", status: "conflict", message: "user edited the propagated copy" },
+      ],
+    });
+    render(<SkillsManager />);
+
+    fireEvent.click(await screen.findByText("Share with all agents"));
+    await waitFor(() => expect(syncSkills).toHaveBeenCalledWith(undefined));
+    expect(await screen.findByText("1 shared, 1 unchanged, 1 conflict")).toBeTruthy();
+    expect(screen.getByText(/conflict claude-user\/mine: user edited the propagated copy/)).toBeTruthy();
+    expect(screen.queryByText(/codex-user\/review/)).toBeNull();
+    // load() re-runs after a successful sync.
+    await waitFor(() => expect(fetchSkills).toHaveBeenCalledTimes(2));
+  });
+
+  it("surfaces a failed sync request through the existing error notice", async () => {
+    syncSkills.mockResolvedValue({ ok: false, outcomes: [], error: "read only" });
+    render(<SkillsManager />);
+
+    fireEvent.click(await screen.findByText("Share with all agents"));
+    expect(await screen.findByText("read only")).toBeTruthy();
   });
 });

--- a/web/src/components/__tests__/SkillsManager.test.tsx
+++ b/web/src/components/__tests__/SkillsManager.test.tsx
@@ -288,6 +288,10 @@ describe("skillBody", () => {
       // worse than one that renders the raw text.
       ["unterminated fence", "---\nname: a\nbody\n", "---\nname: a\nbody\n"],
       ["no frontmatter", "# Just a heading\n", "# Just a heading\n"],
+      // `----` is not a closing fence; the file is malformed, so it is
+      // preserved rather than losing its first hyphen.
+      ["over-long fence", "---\nname: a\n----\nbody\n", "---\nname: a\n----\nbody\n"],
+      ["fence followed by text", "---\nname: a\n---text\n", "---\nname: a\n---text\n"],
       // A rule inside the body must not be mistaken for a fence close.
       ["hr in body", "---\nname: a\n---\nintro\n\n---\n\nmore\n", "intro\n\n---\n\nmore\n"],
     ];

--- a/web/src/components/__tests__/SkillsManager.test.tsx
+++ b/web/src/components/__tests__/SkillsManager.test.tsx
@@ -11,7 +11,10 @@ const createSkill = vi.fn<[string, string?], Promise<SkillMutationResult>>();
 const updateSkill = vi.fn<[string, string], Promise<SkillMutationResult>>();
 const deleteSkill = vi.fn<[string], Promise<SkillMutationResult>>();
 const adoptSkill = vi.fn<[string, string, string?], Promise<SkillMutationResult>>();
-const syncSkills = vi.fn<[{ roots?: string[]; replace?: string[] }?], Promise<SkillSyncResult>>();
+const syncSkills = vi.fn<
+  [{ roots?: string[]; replace?: string[]; directories?: string[] }?],
+  Promise<SkillSyncResult>
+>();
 
 vi.mock("../../lib/api", () => ({
   fetchSkills: () => fetchSkills(),
@@ -20,7 +23,7 @@ vi.mock("../../lib/api", () => ({
   updateSkill: (directory: string, content: string) => updateSkill(directory, content),
   deleteSkill: (directory: string) => deleteSkill(directory),
   adoptSkill: (source: string, directory: string, destination?: string) => adoptSkill(source, directory, destination),
-  syncSkills: (options?: { roots?: string[]; replace?: string[] }) => syncSkills(options),
+  syncSkills: (options?: { roots?: string[]; replace?: string[]; directories?: string[] }) => syncSkills(options),
 }));
 
 import { SkillsManager } from "../SkillsManager";
@@ -227,13 +230,10 @@ describe("SkillsManager", () => {
     expect(screen.queryByLabelText("Replace mine in claude-user")).toBeNull();
   });
 
-  it("shares only the selected skill, filtering outcomes to its directory", async () => {
+  it("shares only the selected skill, scoping the sync request to its directory", async () => {
     syncSkills.mockResolvedValue({
       ok: true,
-      outcomes: [
-        { root: "claude-user", directory: "mine", status: "updated", message: null },
-        { root: "claude-user", directory: "review", status: "unchanged", message: null },
-      ],
+      outcomes: [{ root: "claude-user", directory: "mine", status: "updated", message: null }],
     });
     render(<SkillsManager />);
 
@@ -241,9 +241,8 @@ describe("SkillsManager", () => {
     await screen.findByLabelText("SKILL.md content");
     fireEvent.click(screen.getByText("Share this skill"));
 
-    await waitFor(() => expect(syncSkills).toHaveBeenCalledWith({}));
+    await waitFor(() => expect(syncSkills).toHaveBeenCalledWith({ directories: ["mine"] }));
     expect(await screen.findByText("1 shared")).toBeTruthy();
-    expect(screen.queryByText(/review/, { selector: "li" })).toBeNull();
 
     // Sharing an unsaved edit would ship stale content, so the button
     // disables itself while the draft is dirty.
@@ -260,6 +259,30 @@ describe("SkillsManager", () => {
     expect(screen.queryByLabelText("SKILL.md content")).toBeNull();
     expect(await screen.findByText(/body/)).toBeTruthy();
 
+    fireEvent.click(screen.getByText("Raw"));
+    expect(await screen.findByLabelText("SKILL.md content")).toBeTruthy();
+  });
+
+  it("disables mutating controls in readOnly mode but leaves selection and Raw/Preview working", async () => {
+    render(<SkillsManager readOnly />);
+
+    await screen.findByLabelText("SKILL.md content");
+    expect(screen.getByText(/read-only, so skills cannot be/)).toBeTruthy();
+    expect((screen.getByText("+ New skill").closest("button") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByText("Share with all agents").closest("button") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByText("Delete").closest("button") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByText("Share this skill").closest("button") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByLabelText("SKILL.md content") as HTMLTextAreaElement).readOnly).toBe(true);
+
+    // Selection still works, and switching to an external (non-writable)
+    // skill shows a disabled "Adopt into AoE" instead of Save/Delete.
+    fireEvent.click(skillButton("review"));
+    expect(await screen.findByText("Adopt into AoE")).toBeTruthy();
+    expect((screen.getByText("Adopt into AoE").closest("button") as HTMLButtonElement).disabled).toBe(true);
+
+    // Raw/Preview toggling still works.
+    fireEvent.click(screen.getByText("Preview"));
+    expect(screen.queryByLabelText("SKILL.md content")).toBeNull();
     fireEvent.click(screen.getByText("Raw"));
     expect(await screen.findByLabelText("SKILL.md content")).toBeTruthy();
   });

--- a/web/src/components/__tests__/SkillsManager.test.tsx
+++ b/web/src/components/__tests__/SkillsManager.test.tsx
@@ -296,3 +296,18 @@ describe("skillBody", () => {
     }
   });
 });
+
+describe("SkillsManager provenance tint", () => {
+  it("brands AoE-managed rows and leaves external ones neutral", async () => {
+    render(<SkillsManager />);
+    await waitFor(() => expect(skillButton("mine")).toBeTruthy());
+
+    const toneFor = (directory: string) =>
+      skillButton(directory)?.querySelector("[data-tone]")?.getAttribute("data-tone");
+
+    // The whole point of the tint: AoE's own skills are pickable out of a
+    // mixed list without reading the label.
+    expect(toneFor("mine")).toBe("primary");
+    expect(toneFor("review")).toBe("neutral");
+  });
+});

--- a/web/src/components/__tests__/SkillsManager.test.tsx
+++ b/web/src/components/__tests__/SkillsManager.test.tsx
@@ -92,7 +92,7 @@ describe("SkillsManager", () => {
   it("filters source-qualified skills and adopts an external package", async () => {
     fetchSkills
       .mockResolvedValueOnce(response())
-      .mockResolvedValueOnce(response([{ ...external }, { ...managed, directory: "review" }]));
+      .mockResolvedValueOnce(response([{ ...external }, { ...managed, directory: "review", name: "Review" }]));
     render(<SkillsManager />);
 
     fireEvent.change(await screen.findByLabelText("Filter skills by source"), {
@@ -106,6 +106,10 @@ describe("SkillsManager", () => {
     fireEvent.click(screen.getByText("Adopt into AoE"));
     await waitFor(() => expect(adoptSkill).toHaveBeenCalledWith("claude-user", "review", undefined));
     expect(await screen.findByText("Skill adopted into AoE's managed store.")).toBeTruthy();
+
+    expect(screen.getAllByText("review", { selector: "button span" })).toHaveLength(1);
+    fireEvent.click(screen.getByLabelText("Hide external skills already managed"));
+    expect(screen.getAllByText("review", { selector: "button span" })).toHaveLength(2);
   });
 
   it("creates, edits, and deletes managed skills with dirty-state protection", async () => {

--- a/web/src/components/__tests__/SkillsManager.test.tsx
+++ b/web/src/components/__tests__/SkillsManager.test.tsx
@@ -24,6 +24,7 @@ vi.mock("../../lib/api", () => ({
 }));
 
 import { SkillsManager } from "../SkillsManager";
+import { skillBody } from "../../lib/skillBody";
 
 const managed: SkillSummary = {
   directory: "mine",
@@ -73,6 +74,10 @@ function skillButton(directory: string): HTMLButtonElement {
   return button;
 }
 
+function openCreateForm(): void {
+  fireEvent.click(screen.getByText("+ New skill"));
+}
+
 beforeEach(() => {
   fetchSkills.mockReset();
   fetchSkill.mockReset();
@@ -93,24 +98,21 @@ beforeEach(() => {
 });
 
 describe("SkillsManager", () => {
-  it("filters source-qualified skills and adopts an external package", async () => {
+  it("adopts an external package and hides/reveals its managed duplicate", async () => {
     fetchSkills
       .mockResolvedValueOnce(response())
       .mockResolvedValueOnce(response([{ ...external }, { ...managed, directory: "review", name: "Review" }]));
     render(<SkillsManager />);
 
-    fireEvent.change(await screen.findByLabelText("Filter skills by source"), {
-      target: { value: "claude-user" },
-    });
-    expect(skillButton("review")).toBeTruthy();
-    expect(screen.queryByText("mine", { selector: "button span" })).toBeNull();
-
+    await screen.findByText("Available to adopt (1)");
     fireEvent.click(skillButton("review"));
     expect(await screen.findByText(/External skills are read-only/)).toBeTruthy();
     fireEvent.click(screen.getByText("Adopt into AoE"));
     await waitFor(() => expect(adoptSkill).toHaveBeenCalledWith("claude-user", "review", undefined));
     expect(await screen.findByText("Skill adopted into AoE's managed store.")).toBeTruthy();
 
+    // The adopted copy is now managed; the original external listing is
+    // hidden by the "hide already managed" default.
     expect(screen.getAllByText("review", { selector: "button span" })).toHaveLength(1);
     fireEvent.click(screen.getByLabelText("Hide external skills already managed"));
     expect(screen.getAllByText("review", { selector: "button span" })).toHaveLength(2);
@@ -130,7 +132,9 @@ describe("SkillsManager", () => {
 
     fireEvent.click(screen.getByText("Save"));
     await waitFor(() => expect(updateSkill).toHaveBeenCalledWith("mine", "changed content"));
+    expect(await screen.findByText("All changes saved")).toBeTruthy();
 
+    openCreateForm();
     fireEvent.change(screen.getByLabelText("New skill directory"), { target: { value: "new-skill" } });
     fireEvent.change(screen.getByLabelText("New skill description"), { target: { value: "New instructions" } });
     fireEvent.click(screen.getByText("Create"));
@@ -139,6 +143,19 @@ describe("SkillsManager", () => {
     fireEvent.click(screen.getByText("Delete"));
     await waitFor(() => expect(deleteSkill).toHaveBeenCalledWith("mine"));
     confirm.mockRestore();
+  });
+
+  it("supports discarding an in-progress edit back to the loaded content", async () => {
+    render(<SkillsManager />);
+
+    const editor = (await screen.findByLabelText("SKILL.md content")) as HTMLTextAreaElement;
+    const original = editor.value;
+    fireEvent.change(editor, { target: { value: "scratch edit" } });
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Discard"));
+    expect((screen.getByLabelText("SKILL.md content") as HTMLTextAreaElement).value).toBe(original);
+    expect(screen.getByText("All changes saved")).toBeTruthy();
   });
 
   it("surfaces list and mutation failures", async () => {
@@ -150,7 +167,9 @@ describe("SkillsManager", () => {
     fetchSkills.mockResolvedValue(response());
     createSkill.mockResolvedValue({ ok: false, error: "already exists", status: 409 });
     render(<SkillsManager />);
-    fireEvent.change(await screen.findByLabelText("New skill directory"), { target: { value: "mine" } });
+    await screen.findByLabelText("SKILL.md content");
+    openCreateForm();
+    fireEvent.change(screen.getByLabelText("New skill directory"), { target: { value: "mine" } });
     fireEvent.click(screen.getByText("Create"));
     expect(await screen.findByText("already exists")).toBeTruthy();
   });
@@ -181,5 +200,50 @@ describe("SkillsManager", () => {
 
     fireEvent.click(await screen.findByText("Share with all agents"));
     expect(await screen.findByText("read only")).toBeTruthy();
+  });
+
+  it("switches to Preview and renders the draft as markdown instead of the raw textarea", async () => {
+    render(<SkillsManager />);
+
+    await screen.findByLabelText("SKILL.md content");
+    fireEvent.click(screen.getByText("Preview"));
+
+    expect(screen.queryByLabelText("SKILL.md content")).toBeNull();
+    expect(await screen.findByText(/body/)).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Raw"));
+    expect(await screen.findByLabelText("SKILL.md content")).toBeTruthy();
+  });
+
+  it("collapses a sidebar group to hide its rows without discarding the group", async () => {
+    render(<SkillsManager />);
+
+    await screen.findByText("Managed (1)");
+    expect(skillButton("mine")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Managed (1)"));
+    expect(screen.queryByText("mine", { selector: "button span" })).toBeNull();
+
+    fireEvent.click(screen.getByText("Managed (1)"));
+    expect(skillButton("mine")).toBeTruthy();
+  });
+});
+
+describe("skillBody", () => {
+  it("strips the frontmatter fence so the preview shows instructions, not YAML", () => {
+    const cases: Array<[string, string, string]> = [
+      ["plain fence", "---\nname: a\ndescription: b\n---\n# Title\n", "# Title\n"],
+      ["crlf fence", "---\r\nname: a\r\ndescription: b\r\n---\r\n# Title\n", "# Title\n"],
+      ["leading BOM", "\ufeff---\nname: a\ndescription: b\n---\nbody\n", "body\n"],
+      // No closing fence is malformed, but a preview that renders nothing is
+      // worse than one that renders the raw text.
+      ["unterminated fence", "---\nname: a\nbody\n", "---\nname: a\nbody\n"],
+      ["no frontmatter", "# Just a heading\n", "# Just a heading\n"],
+      // A rule inside the body must not be mistaken for a fence close.
+      ["hr in body", "---\nname: a\n---\nintro\n\n---\n\nmore\n", "intro\n\n---\n\nmore\n"],
+    ];
+    for (const [label, input, expected] of cases) {
+      expect(skillBody(input), label).toBe(expected);
+    }
   });
 });

--- a/web/src/components/__tests__/SkillsManager.test.tsx
+++ b/web/src/components/__tests__/SkillsManager.test.tsx
@@ -11,7 +11,7 @@ const createSkill = vi.fn<[string, string?], Promise<SkillMutationResult>>();
 const updateSkill = vi.fn<[string, string], Promise<SkillMutationResult>>();
 const deleteSkill = vi.fn<[string], Promise<SkillMutationResult>>();
 const adoptSkill = vi.fn<[string, string, string?], Promise<SkillMutationResult>>();
-const syncSkills = vi.fn<[string[]?], Promise<SkillSyncResult>>();
+const syncSkills = vi.fn<[{ roots?: string[]; replace?: string[] }?], Promise<SkillSyncResult>>();
 
 vi.mock("../../lib/api", () => ({
   fetchSkills: () => fetchSkills(),
@@ -20,7 +20,7 @@ vi.mock("../../lib/api", () => ({
   updateSkill: (directory: string, content: string) => updateSkill(directory, content),
   deleteSkill: (directory: string) => deleteSkill(directory),
   adoptSkill: (source: string, directory: string, destination?: string) => adoptSkill(source, directory, destination),
-  syncSkills: (roots?: string[]) => syncSkills(roots),
+  syncSkills: (options?: { roots?: string[]; replace?: string[] }) => syncSkills(options),
 }));
 
 import { SkillsManager } from "../SkillsManager";
@@ -200,6 +200,55 @@ describe("SkillsManager", () => {
 
     fireEvent.click(await screen.findByText("Share with all agents"));
     expect(await screen.findByText("read only")).toBeTruthy();
+  });
+
+  it("replaces a conflicting row on request, re-issuing sync scoped to that root and directory", async () => {
+    syncSkills
+      .mockResolvedValueOnce({
+        ok: true,
+        outcomes: [
+          { root: "claude-user", directory: "mine", status: "conflict", message: "user edited the propagated copy" },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        outcomes: [{ root: "claude-user", directory: "mine", status: "updated", message: "replaced on request" }],
+      });
+    render(<SkillsManager />);
+
+    fireEvent.click(await screen.findByText("Share with all agents"));
+    const replaceButton = await screen.findByLabelText("Replace mine in claude-user");
+    fireEvent.click(replaceButton);
+
+    await waitFor(() => expect(syncSkills).toHaveBeenLastCalledWith({ roots: ["claude-user"], replace: ["mine"] }));
+    // The row that was replaced no longer reports a conflict, so its Replace
+    // button and the conflict/error list disappear; the summary reflects it.
+    expect(await screen.findByText("1 shared")).toBeTruthy();
+    expect(screen.queryByLabelText("Replace mine in claude-user")).toBeNull();
+  });
+
+  it("shares only the selected skill, filtering outcomes to its directory", async () => {
+    syncSkills.mockResolvedValue({
+      ok: true,
+      outcomes: [
+        { root: "claude-user", directory: "mine", status: "updated", message: null },
+        { root: "claude-user", directory: "review", status: "unchanged", message: null },
+      ],
+    });
+    render(<SkillsManager />);
+
+    // "mine" (the managed skill) is selected by default.
+    await screen.findByLabelText("SKILL.md content");
+    fireEvent.click(screen.getByText("Share this skill"));
+
+    await waitFor(() => expect(syncSkills).toHaveBeenCalledWith({}));
+    expect(await screen.findByText("1 shared")).toBeTruthy();
+    expect(screen.queryByText(/review/, { selector: "li" })).toBeNull();
+
+    // Sharing an unsaved edit would ship stale content, so the button
+    // disables itself while the draft is dirty.
+    fireEvent.change(screen.getByLabelText("SKILL.md content"), { target: { value: "changed" } });
+    expect((screen.getByText("Share this skill").closest("button") as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("switches to Preview and renders the draft as markdown instead of the raw textarea", async () => {

--- a/web/src/components/__tests__/SkillsManager.test.tsx
+++ b/web/src/components/__tests__/SkillsManager.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import type { SkillDetail, SkillMutationResult, SkillSummary, SkillsResponse } from "../../lib/api";
+
+const fetchSkills = vi.fn<[], Promise<SkillsResponse | null>>();
+const fetchSkill = vi.fn<[string, string], Promise<SkillDetail | null>>();
+const createSkill = vi.fn<[string, string?], Promise<SkillMutationResult>>();
+const updateSkill = vi.fn<[string, string], Promise<SkillMutationResult>>();
+const deleteSkill = vi.fn<[string], Promise<SkillMutationResult>>();
+const adoptSkill = vi.fn<[string, string, string?], Promise<SkillMutationResult>>();
+
+vi.mock("../../lib/api", () => ({
+  fetchSkills: () => fetchSkills(),
+  fetchSkill: (source: string, directory: string) => fetchSkill(source, directory),
+  createSkill: (directory: string, description?: string) => createSkill(directory, description),
+  updateSkill: (directory: string, content: string) => updateSkill(directory, content),
+  deleteSkill: (directory: string) => deleteSkill(directory),
+  adoptSkill: (source: string, directory: string, destination?: string) => adoptSkill(source, directory, destination),
+}));
+
+import { SkillsManager } from "../SkillsManager";
+
+const managed: SkillSummary = {
+  directory: "mine",
+  name: "Mine",
+  description: "Managed instructions",
+  provenance: { kind: "aoe-managed" },
+  provenanceLabel: "aoe-managed",
+  writable: true,
+};
+
+const external: SkillSummary = {
+  directory: "review",
+  name: "Review",
+  description: "Review code carefully",
+  provenance: { kind: "external", root: "claude-user" },
+  provenanceLabel: "external:claude-user",
+  writable: false,
+};
+
+const response = (skills: SkillSummary[] = [managed, external]): SkillsResponse => ({
+  skills,
+  roots: [
+    {
+      id: "claude-user",
+      label: "Claude",
+      relativePath: ".claude/skills",
+      consumers: ["claude"],
+      legacy: false,
+    },
+  ],
+});
+
+function detail(skill: SkillSummary): SkillDetail {
+  return {
+    directory: skill.directory,
+    name: skill.name,
+    description: skill.description,
+    provenance: skill.provenance,
+    content: `---\nname: ${skill.directory}\ndescription: ${skill.description}\n---\n\nbody\n`,
+  };
+}
+
+function skillButton(directory: string): HTMLButtonElement {
+  const label = screen.getByText(directory, { selector: "button span" });
+  const button = label.closest("button");
+  if (!button) throw new Error(`missing skill button for ${directory}`);
+  return button;
+}
+
+beforeEach(() => {
+  fetchSkills.mockReset();
+  fetchSkill.mockReset();
+  createSkill.mockReset();
+  updateSkill.mockReset();
+  deleteSkill.mockReset();
+  adoptSkill.mockReset();
+  fetchSkills.mockResolvedValue(response());
+  fetchSkill.mockImplementation(async (source, directory) =>
+    detail(source === "aoe-managed" ? managed : { ...external, directory }),
+  );
+  createSkill.mockResolvedValue({ ok: true, directory: "new-skill" });
+  updateSkill.mockResolvedValue({ ok: true });
+  deleteSkill.mockResolvedValue({ ok: true });
+  adoptSkill.mockResolvedValue({ ok: true, directory: "review" });
+});
+
+describe("SkillsManager", () => {
+  it("filters source-qualified skills and adopts an external package", async () => {
+    fetchSkills
+      .mockResolvedValueOnce(response())
+      .mockResolvedValueOnce(response([{ ...external }, { ...managed, directory: "review" }]));
+    render(<SkillsManager />);
+
+    fireEvent.change(await screen.findByLabelText("Filter skills by source"), {
+      target: { value: "claude-user" },
+    });
+    expect(skillButton("review")).toBeTruthy();
+    expect(screen.queryByText("mine", { selector: "button span" })).toBeNull();
+
+    fireEvent.click(skillButton("review"));
+    expect(await screen.findByText(/External skills are read-only/)).toBeTruthy();
+    fireEvent.click(screen.getByText("Adopt into AoE"));
+    await waitFor(() => expect(adoptSkill).toHaveBeenCalledWith("claude-user", "review", undefined));
+    expect(await screen.findByText("Skill adopted into AoE's managed store.")).toBeTruthy();
+  });
+
+  it("creates, edits, and deletes managed skills with dirty-state protection", async () => {
+    const confirm = vi.spyOn(window, "confirm").mockReturnValueOnce(false).mockReturnValueOnce(true);
+    render(<SkillsManager />);
+
+    const editor = await screen.findByLabelText("SKILL.md content");
+    fireEvent.change(editor, { target: { value: "changed content" } });
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+
+    fireEvent.click(skillButton("review"));
+    expect(confirm).toHaveBeenCalledWith("Discard unsaved changes to this skill?");
+    expect((screen.getByLabelText("SKILL.md content") as HTMLTextAreaElement).value).toBe("changed content");
+
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => expect(updateSkill).toHaveBeenCalledWith("mine", "changed content"));
+
+    fireEvent.change(screen.getByLabelText("New skill directory"), { target: { value: "new-skill" } });
+    fireEvent.change(screen.getByLabelText("New skill description"), { target: { value: "New instructions" } });
+    fireEvent.click(screen.getByText("Create"));
+    await waitFor(() => expect(createSkill).toHaveBeenCalledWith("new-skill", "New instructions"));
+
+    fireEvent.click(screen.getByText("Delete"));
+    await waitFor(() => expect(deleteSkill).toHaveBeenCalledWith("mine"));
+    confirm.mockRestore();
+  });
+
+  it("surfaces list and mutation failures", async () => {
+    fetchSkills.mockResolvedValueOnce(null);
+    const { unmount } = render(<SkillsManager />);
+    expect(await screen.findByText("Could not load skills.")).toBeTruthy();
+    unmount();
+
+    fetchSkills.mockResolvedValue(response());
+    createSkill.mockResolvedValue({ ok: false, error: "already exists", status: 409 });
+    render(<SkillsManager />);
+    fireEvent.change(await screen.findByLabelText("New skill directory"), { target: { value: "mine" } });
+    fireEvent.click(screen.getByText("Create"));
+    expect(await screen.findByText("already exists")).toBeTruthy();
+  });
+});

--- a/web/src/components/__tests__/SkillsManager.test.tsx
+++ b/web/src/components/__tests__/SkillsManager.test.tsx
@@ -148,6 +148,51 @@ describe("SkillsManager", () => {
     confirm.mockRestore();
   });
 
+  // A sync refreshes the skill list, which used to hand the read effect a new
+  // `selected` object reference and silently reset the editor to the on-disk
+  // content. The selection has not changed, so the draft must survive.
+  it("keeps an unsaved edit across an action that reloads the skill list", async () => {
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(false);
+    // Fresh skill objects per call, as parsing a real JSON response gives. The
+    // bug was those new references re-firing the read effect, so the default
+    // mock (one shared response, reusing the same element objects) hides it.
+    fetchSkills.mockImplementation(async () => response([{ ...managed }, { ...external }]));
+    render(<SkillsManager />);
+
+    const editor = await screen.findByLabelText("SKILL.md content");
+    fireEvent.change(editor, { target: { value: "unsaved work" } });
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Share with all agents"));
+    await waitFor(() => expect(syncSkills).toHaveBeenCalled());
+    await waitFor(() => expect(fetchSkills).toHaveBeenCalledTimes(2));
+
+    expect((screen.getByLabelText("SKILL.md content") as HTMLTextAreaElement).value).toBe("unsaved work");
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+    // Sharing keeps the same skill selected, so it must not have prompted at all.
+    expect(confirm).not.toHaveBeenCalled();
+    confirm.mockRestore();
+  });
+
+  // Creating jumps the selection to the new skill, which does discard the
+  // draft, so unlike sharing it has to ask first.
+  it("asks before a create discards an unsaved edit", async () => {
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(<SkillsManager />);
+
+    const editor = await screen.findByLabelText("SKILL.md content");
+    fireEvent.change(editor, { target: { value: "unsaved work" } });
+
+    openCreateForm();
+    fireEvent.change(screen.getByLabelText("New skill directory"), { target: { value: "new-skill" } });
+    fireEvent.click(screen.getByText("Create"));
+
+    expect(confirm).toHaveBeenCalledWith("Discard unsaved changes to this skill?");
+    expect(createSkill).not.toHaveBeenCalled();
+    expect((screen.getByLabelText("SKILL.md content") as HTMLTextAreaElement).value).toBe("unsaved work");
+    confirm.mockRestore();
+  });
+
   it("supports discarding an in-progress edit back to the loaded content", async () => {
     render(<SkillsManager />);
 

--- a/web/src/components/acp/Composer.slashProvenance.test.tsx
+++ b/web/src/components/acp/Composer.slashProvenance.test.tsx
@@ -90,8 +90,12 @@ function Harness() {
 }
 
 beforeEach(() => {
-  if (!window.matchMedia) {
-    window.matchMedia = ((query: string) => ({
+  // jsdom has no matchMedia; a never-matching stub yields the desktop code
+  // path. Stubbed (not assigned directly) so it does not leak into later
+  // test files.
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
       matches: false,
       media: query,
       onchange: null,
@@ -100,8 +104,8 @@ beforeEach(() => {
       addEventListener: () => {},
       removeEventListener: () => {},
       dispatchEvent: () => false,
-    })) as typeof window.matchMedia;
-  }
+    })),
+  );
   // "aoe-review" is a skill (single source "Claude"); "help" is not indexed
   // at all, so it must render with no badge.
   skillIndexRef.current = buildSkillIndex({
@@ -123,6 +127,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
 });
 
 function getComposer(): HTMLTextAreaElement {

--- a/web/src/components/acp/Composer.slashProvenance.test.tsx
+++ b/web/src/components/acp/Composer.slashProvenance.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+//
+// RTL mount of the real <Composer>, driving the `/` slash-command popover to
+// verify the provenance badge (#3052): a command backed by a skill renders
+// its source pill inline with the label, and a plain non-skill command (or
+// one with no resolvable skill) renders no badge at all. The live Playwright
+// suite (tests/live/acp-stories/composer-slash-pick-no-arg.spec.ts) drives
+// the same popover against a real backend; this jsdom mount is what lifts
+// the badge-rendering branch in the merged coverage report.
+
+import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { AssistantRuntimeProvider, useExternalStoreRuntime, type ThreadMessageLike } from "@assistant-ui/react";
+import { afterEach, beforeEach } from "vitest";
+
+import { Composer } from "./Composer";
+import { buildSkillIndex, type SkillIndex } from "../../lib/skillProvenance";
+import type { AvailableCommand } from "../../lib/acpTypes";
+
+vi.mock("./useFilesIndex", () => ({
+  useFilesIndex: () => ({ files: [] }),
+  // The trigger popover's own query-detection drives which items are
+  // offered; the identity filter keeps this test independent of fuzzyFilter's
+  // ranking behavior.
+  fuzzyFilter: <T,>(items: T[]) => items,
+}));
+vi.mock("./SessionConfigControls", () => ({ SessionConfigControls: () => null }));
+vi.mock("./SwitchAgentModal", () => ({ SwitchAgentModal: () => null }));
+vi.mock("../../hooks/useMobileKeyboard", () => ({ useMobileKeyboard: () => ({ keyboardOpen: false }) }));
+vi.mock("../../hooks/useFocusTerminalTarget", () => ({ useFocusTerminalTarget: () => {} }));
+vi.mock("../../lib/agentProfileContext", () => ({
+  useAgentProfile: () => ({ clearAliases: [], capabilities: { legacyModeFallback: false } }),
+}));
+vi.mock("../../lib/acpDrafts", () => ({
+  getDraft: () => "",
+  setDraft: () => {},
+  clearDraft: () => {},
+  clearDraftAttachments: () => {},
+}));
+vi.mock("./useDictationBurstGuard", () => ({
+  useDictationBurstGuard: () => ({
+    observeInputType: () => {},
+    shouldSuppressUpstream: () => false,
+    flushOnBlur: () => {},
+  }),
+}));
+
+const { skillIndexRef } = vi.hoisted(() => ({
+  skillIndexRef: { current: { labelsByKey: new Map<string, Set<string>>() } as SkillIndex },
+}));
+vi.mock("../../hooks/useSkillIndex", () => ({
+  useSkillIndex: () => skillIndexRef.current,
+}));
+
+const COMMANDS: AvailableCommand[] = [
+  { name: "aoe-review", description: "Run the review skill", accepts_input: false },
+  { name: "help", description: "Show help", accepts_input: false },
+];
+
+function Harness() {
+  const runtime = useExternalStoreRuntime<ThreadMessageLike>({
+    messages: [],
+    isRunning: false,
+    convertMessage: (m) => m,
+    onNew: async () => {},
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Composer
+        sessionId="s-slash-provenance"
+        currentAgent={"claude" as never}
+        availableModes={[] as never}
+        currentModeId={null as never}
+        legacyMode={null as never}
+        configOptions={[] as never}
+        pendingConfigOption={null as never}
+        setConfigOption={() => {}}
+        sessionUsage={null as never}
+        availableCommands={COMMANDS}
+        connected={true}
+        turnActive={false}
+        queuedCount={0}
+        enqueuePrompt={() => {}}
+        promptCapabilities={null}
+        pendingAttachments={[]}
+        setPendingAttachments={() => {}}
+      />
+    </AssistantRuntimeProvider>
+  );
+}
+
+beforeEach(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+  }
+  // "aoe-review" is a skill (single source "Claude"); "help" is not indexed
+  // at all, so it must render with no badge.
+  skillIndexRef.current = buildSkillIndex({
+    roots: [
+      { id: "claude-user", label: "Claude", relativePath: ".claude/skills", consumers: ["claude"], legacy: false },
+    ],
+    skills: [
+      {
+        directory: "aoe-review",
+        name: "aoe-review",
+        description: "",
+        provenance: { kind: "external", root: "claude-user" },
+        provenanceLabel: "external:claude-user",
+        writable: false,
+      },
+    ],
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function getComposer(): HTMLTextAreaElement {
+  return screen.getByRole("textbox") as HTMLTextAreaElement;
+}
+
+describe("<Composer> slash popover provenance badge (#3052)", () => {
+  it("badges a skill-backed command and leaves a plain command unbadged", async () => {
+    render(<Harness />);
+    const ta = getComposer();
+    fireEvent.change(ta, { target: { value: "/" } });
+
+    const options = await waitFor(() => {
+      const opts = screen.getAllByRole("option");
+      expect(opts.length).toBeGreaterThan(0);
+      return opts;
+    });
+
+    const reviewOption = options.find((o) => o.textContent?.includes("/aoe-review"));
+    const helpOption = options.find((o) => o.textContent?.includes("/help"));
+    expect(reviewOption).toBeDefined();
+    expect(helpOption).toBeDefined();
+    expect(reviewOption!.textContent).toContain("Claude");
+    expect(helpOption!.textContent).not.toContain("Claude");
+  });
+});

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -23,7 +23,7 @@ import { SessionConfigControls } from "./SessionConfigControls";
 import { Tooltip } from "../Tooltip";
 import { ProvenanceBadge } from "../ProvenanceBadge";
 import { useSkillIndex } from "../../hooks/useSkillIndex";
-import { badgeLabel, resolveSkillSource, type SkillIndex } from "../../lib/skillProvenance";
+import { badgeLabel, badgeTone, resolveSkillSource, type SkillIndex } from "../../lib/skillProvenance";
 import { SwitchAgentModal } from "./SwitchAgentModal";
 import {
   clearPendingSwitchAgent,
@@ -1263,7 +1263,7 @@ function PopoverItems({ trigger, skillIndex }: { trigger: string; skillIndex?: S
                 <span className="min-w-0 flex-1">
                   <span className="flex items-center gap-1.5">
                     <span className="block truncate font-medium text-text-primary">{item.label}</span>
-                    {source && <ProvenanceBadge label={badgeLabel(source)} />}
+                    {source && <ProvenanceBadge label={badgeLabel(source)} tone={badgeTone(source)} />}
                   </span>
                   {item.description && (
                     <span className="block truncate text-[11px] text-text-dim">{item.description}</span>

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -21,6 +21,9 @@ import { AtSign, ChevronUp, Paperclip, Pencil, Slash, Square, X } from "lucide-r
 import { useFilesIndex, fuzzyFilter } from "./useFilesIndex";
 import { SessionConfigControls } from "./SessionConfigControls";
 import { Tooltip } from "../Tooltip";
+import { ProvenanceBadge } from "../ProvenanceBadge";
+import { useSkillIndex } from "../../hooks/useSkillIndex";
+import { badgeLabel, resolveSkillSource, type SkillIndex } from "../../lib/skillProvenance";
 import { SwitchAgentModal } from "./SwitchAgentModal";
 import {
   clearPendingSwitchAgent,
@@ -495,6 +498,13 @@ export function Composer({
     [slashItems],
   );
 
+  // Provenance lookup for the `/` picker's badges (#3052): resolves a
+  // command name (which the composer indexes by the agent's advertised
+  // frontmatter name) to the skill's source, so a skill-backed slash
+  // command reads the same "AoE" / agent-root label as the skills manager
+  // and the SkillToolCard.
+  const skillIndex = useSkillIndex();
+
   const composerRuntime = useComposerRuntime();
 
   // ArrowUp/ArrowDown queue recall (shell-history style). recallRef holds
@@ -895,7 +905,7 @@ export function Composer({
                 onExecute={(item) => insertSlashCommand(composerRuntime, item)}
                 removeOnExecute
               />
-              <PopoverItems trigger="/" />
+              <PopoverItems trigger="/" skillIndex={skillIndex} />
             </ComposerPrimitive.Unstable_TriggerPopover>
 
             {/* Input area — tall by default, grows up to 200px */}
@@ -1226,34 +1236,42 @@ export function Composer({
 }
 
 /** Popover items list — same render shape for @ and / since both
- *  have a single category and we surface a flat list. */
-function PopoverItems({ trigger }: { trigger: string }) {
+ *  have a single category and we surface a flat list. `skillIndex` is only
+ *  passed for the `/` picker (#3052): when a command name resolves to a
+ *  known skill, its provenance badge renders inline with the label. */
+function PopoverItems({ trigger, skillIndex }: { trigger: string; skillIndex?: SkillIndex }) {
   return (
     <ComposerPrimitive.Unstable_TriggerPopoverItems className="max-h-64 overflow-y-auto">
       {(items) =>
         items.length === 0 ? (
           <div className="px-3 py-2 text-xs italic text-text-dim">No matches</div>
         ) : (
-          items.map((item, i) => (
-            <ComposerPrimitive.Unstable_TriggerPopoverItem
-              key={item.id}
-              item={item}
-              index={i}
-              className={[
-                "flex w-full items-start gap-2 px-3 py-2 text-left text-xs",
-                "hover:bg-surface-800/60",
-                "data-[highlighted=true]:bg-surface-800",
-              ].join(" ")}
-            >
-              <span className="font-mono text-text-dim">{trigger}</span>
-              <span className="min-w-0 flex-1">
-                <span className="block truncate font-medium text-text-primary">{item.label}</span>
-                {item.description && (
-                  <span className="block truncate text-[11px] text-text-dim">{item.description}</span>
-                )}
-              </span>
-            </ComposerPrimitive.Unstable_TriggerPopoverItem>
-          ))
+          items.map((item, i) => {
+            const source = skillIndex ? resolveSkillSource(skillIndex, item.id) : null;
+            return (
+              <ComposerPrimitive.Unstable_TriggerPopoverItem
+                key={item.id}
+                item={item}
+                index={i}
+                className={[
+                  "flex w-full items-start gap-2 px-3 py-2 text-left text-xs",
+                  "hover:bg-surface-800/60",
+                  "data-[highlighted=true]:bg-surface-800",
+                ].join(" ")}
+              >
+                <span className="font-mono text-text-dim">{trigger}</span>
+                <span className="min-w-0 flex-1">
+                  <span className="flex items-center gap-1.5">
+                    <span className="block truncate font-medium text-text-primary">{item.label}</span>
+                    {source && <ProvenanceBadge label={badgeLabel(source)} />}
+                  </span>
+                  {item.description && (
+                    <span className="block truncate text-[11px] text-text-dim">{item.description}</span>
+                  )}
+                </span>
+              </ComposerPrimitive.Unstable_TriggerPopoverItem>
+            );
+          })
         )
       }
     </ComposerPrimitive.Unstable_TriggerPopoverItems>

--- a/web/src/components/acp/ToolCards.tsx
+++ b/web/src/components/acp/ToolCards.tsx
@@ -66,6 +66,9 @@ import { useBackgroundAgentFor, useOpenBackgroundAgentsPane } from "./background
 import { relativeDisplayPath } from "../../lib/fileRef";
 import { useToolDisplayMode, type ToolDensity } from "./ToolDisplayMode";
 import type { AgentProfile, CardKind } from "../../lib/agentProfiles";
+import { ProvenanceBadge } from "../ProvenanceBadge";
+import { useSkillIndex } from "../../hooks/useSkillIndex";
+import { badgeLabel, resolveSkillSource } from "../../lib/skillProvenance";
 
 interface Props {
   tool: ToolCall;
@@ -1365,6 +1368,12 @@ function SkillToolCard({ tool, result, skillName }: SkillProps) {
   const args = useMemo(() => parseJsonObject(tool.args_preview), [tool.args_preview]);
   const output = result?.text ?? "";
 
+  // Provenance badge (#3052): resolves the same skill index the composer's
+  // `/` picker and the skills manager use, so a skill's source badge reads
+  // identically at call time, pick time, and in the manager.
+  const skillIndex = useSkillIndex();
+  const skillSource = useMemo(() => resolveSkillSource(skillIndex, skillName), [skillIndex, skillName]);
+
   // Pretty-printed input minus the bookkeeping _aoe_title field so the
   // user sees the actual skill arguments, not the adapter's title echo.
   const inputJson = useMemo<string>(() => {
@@ -1385,7 +1394,12 @@ function SkillToolCard({ tool, result, skillName }: SkillProps) {
       icon={<Sparkles className="h-3.5 w-3.5" />}
       label="skill"
       primary={skillName}
-      meta={sessionId && <PluginToolCardBadges sessionId={sessionId} kind="skill" target={skillName} />}
+      meta={
+        <>
+          {skillSource && <ProvenanceBadge label={badgeLabel(skillSource)} />}
+          {sessionId && <PluginToolCardBadges sessionId={sessionId} kind="skill" target={skillName} />}
+        </>
+      }
       expanded={open}
       onToggle={status === "err" || hasBody ? () => setOpen((v) => !v) : undefined}
       startedAt={tool.started_at}

--- a/web/src/components/acp/ToolCards.tsx
+++ b/web/src/components/acp/ToolCards.tsx
@@ -68,7 +68,7 @@ import { useToolDisplayMode, type ToolDensity } from "./ToolDisplayMode";
 import type { AgentProfile, CardKind } from "../../lib/agentProfiles";
 import { ProvenanceBadge } from "../ProvenanceBadge";
 import { useSkillIndex } from "../../hooks/useSkillIndex";
-import { badgeLabel, resolveSkillSource } from "../../lib/skillProvenance";
+import { badgeLabel, badgeTone, resolveSkillSource } from "../../lib/skillProvenance";
 
 interface Props {
   tool: ToolCall;
@@ -1396,7 +1396,7 @@ function SkillToolCard({ tool, result, skillName }: SkillProps) {
       primary={skillName}
       meta={
         <>
-          {skillSource && <ProvenanceBadge label={badgeLabel(skillSource)} />}
+          {skillSource && <ProvenanceBadge label={badgeLabel(skillSource)} tone={badgeTone(skillSource)} />}
           {sessionId && <PluginToolCardBadges sessionId={sessionId} kind="skill" target={skillName} />}
         </>
       }

--- a/web/src/components/acp/__tests__/ToolCards.test.tsx
+++ b/web/src/components/acp/__tests__/ToolCards.test.tsx
@@ -25,6 +25,7 @@ import { AgentProfileProvider } from "../../../lib/agentProfileContext";
 import { AcpSessionContext } from "../../../lib/acpSessionContext";
 import type { ActivityRow, BackgroundAgent, ToolCall, ToolOutputBlock } from "../../../lib/acpTypes";
 import type { PluginUiEntry } from "../../../lib/api";
+import { buildSkillIndex, type SkillIndex } from "../../../lib/skillProvenance";
 
 // The tool-card-badge renderer reads the plugin ui snapshot from context; mock
 // it so the badge tests drive a fixed set of entries. Defaults to empty, so
@@ -33,6 +34,21 @@ const { pluginEntriesRef } = vi.hoisted(() => ({ pluginEntriesRef: { current: []
 vi.mock("../../../lib/pluginUiContext", () => ({
   usePluginUiEntries: () => pluginEntriesRef.current,
 }));
+
+// SkillToolCard resolves the skill index synchronously through this hook
+// (#3052); mock it so tests control the index directly instead of racing a
+// real fetch. Defaults to empty, so every other card test renders unchanged
+// (no provenance badge).
+const { skillIndexRef } = vi.hoisted(() => ({
+  skillIndexRef: { current: { labelsByKey: new Map<string, Set<string>>() } as SkillIndex },
+}));
+vi.mock("../../../hooks/useSkillIndex", () => ({
+  useSkillIndex: () => skillIndexRef.current,
+}));
+
+afterEach(() => {
+  skillIndexRef.current = { labelsByKey: new Map() };
+});
 
 function toolWith(overrides: Partial<ToolCall> = {}): ToolCall {
   return {
@@ -634,6 +650,31 @@ describe("SkillToolCard (claude profile)", () => {
     expect(container.textContent).toContain("input");
     // bookkeeping title field is stripped from the rendered input
     expect(container.textContent).not.toContain("_aoe_title");
+  });
+
+  it("renders the resolved skill's provenance badge alongside the plugin badges (#3052)", () => {
+    skillIndexRef.current = buildSkillIndex({
+      roots: [
+        { id: "claude-user", label: "Claude", relativePath: ".claude/skills", consumers: ["claude"], legacy: false },
+      ],
+      skills: [
+        {
+          directory: "investigate",
+          name: "investigate",
+          description: "",
+          provenance: { kind: "external", root: "claude-user" },
+          provenanceLabel: "external:claude-user",
+          writable: false,
+        },
+      ],
+    });
+    const tool = toolWith({
+      kind: "other",
+      name: "Skill",
+      args_preview: JSON.stringify({ skill: "investigate", _aoe_title: "Skill" }),
+    });
+    const { container } = renderClaude(<ToolCard tool={tool} result={completeRow({ text: "ran" })} />);
+    expect(container.textContent).toContain("Claude");
   });
 });
 

--- a/web/src/hooks/useSkillIndex.ts
+++ b/web/src/hooks/useSkillIndex.ts
@@ -21,6 +21,12 @@ function getSkillIndexOnce(): Promise<SkillIndex> {
       // Built once, not per mounted card; a long transcript can hold many.
       return buildSkillIndex(res);
     });
+    // Every consumer awaits this one shared promise, so letting it reject would
+    // turn a single bad response into an unhandled rejection per mounted card.
+    skillsPromise = skillsPromise.catch(() => {
+      skillsPromise = null;
+      return EMPTY_INDEX;
+    });
   }
   return skillsPromise;
 }

--- a/web/src/hooks/useSkillIndex.ts
+++ b/web/src/hooks/useSkillIndex.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { fetchSkills, type SkillsResponse } from "../lib/api";
+import { buildSkillIndex, type SkillIndex } from "../lib/skillProvenance";
+
+/** Module-level cache of the in-flight/completed `/api/skills` fetch, so
+ *  every mounted slash-command popover and skill tool card shares one
+ *  request per page load instead of each refetching independently. */
+let skillsPromise: Promise<SkillIndex> | null = null;
+
+const EMPTY_INDEX = buildSkillIndex(null);
+
+function getSkillIndexOnce(): Promise<SkillIndex> {
+  if (!skillsPromise) {
+    skillsPromise = fetchSkills().then((res: SkillsResponse | null) => {
+      // Do not cache a failure: badges are cosmetic, and one bad response at
+      // page load should not disable them for the rest of the session.
+      if (!res) {
+        skillsPromise = null;
+        return EMPTY_INDEX;
+      }
+      // Built once, not per mounted card; a long transcript can hold many.
+      return buildSkillIndex(res);
+    });
+  }
+  return skillsPromise;
+}
+
+/** Lookup from a slash-command/skill name to its provenance badge. Fetches
+ *  `/api/skills` at most once per page load; returns the empty index until
+ *  that fetch resolves. */
+export function useSkillIndex(): SkillIndex {
+  const [index, setIndex] = useState<SkillIndex>(EMPTY_INDEX);
+  useEffect(() => {
+    let cancelled = false;
+    void getSkillIndexOnce().then((next) => {
+      if (cancelled) return;
+      setIndex(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return index;
+}
+
+/** Test-only seam: drop the cached skills fetch so each test starts cold. */
+export function __resetSkillIndexCacheForTests(): void {
+  skillsPromise = null;
+}

--- a/web/src/lib/api.skills.test.ts
+++ b/web/src/lib/api.skills.test.ts
@@ -92,18 +92,32 @@ describe("skills API", () => {
     });
   });
 
-  it("posts the right body for syncSkills and preserves an error message on failure", async () => {
-    const cases: { roots: string[] | undefined; expectedBody: Record<string, unknown> }[] = [
-      { roots: undefined, expectedBody: {} },
-      { roots: ["claude-user", "aoe-managed"], expectedBody: { roots: ["claude-user", "aoe-managed"] } },
+  it("posts the right body for syncSkills across every options shape and preserves an error message on failure", async () => {
+    const cases: {
+      label: string;
+      options: { roots?: string[]; replace?: string[] } | undefined;
+      expectedBody: Record<string, unknown>;
+    }[] = [
+      { label: "no options", options: undefined, expectedBody: {} },
+      {
+        label: "roots only",
+        options: { roots: ["claude-user", "aoe-managed"] },
+        expectedBody: { roots: ["claude-user", "aoe-managed"] },
+      },
+      { label: "replace only", options: { replace: ["aoe-review"] }, expectedBody: { replace: ["aoe-review"] } },
+      {
+        label: "roots and replace",
+        options: { roots: ["claude-user"], replace: ["aoe-review"] },
+        expectedBody: { roots: ["claude-user"], replace: ["aoe-review"] },
+      },
     ];
-    for (const { roots, expectedBody } of cases) {
+    for (const { label, options, expectedBody } of cases) {
       fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true, outcomes: [] }));
-      await syncSkills(roots);
+      await syncSkills(options);
       const lastCall = fetchSpy.mock.calls[fetchSpy.mock.calls.length - 1];
-      expect(lastCall[0]).toBe("/api/skills/sync");
-      expect(lastCall[1]?.method).toBe("POST");
-      expect(JSON.parse(lastCall[1]?.body as string)).toEqual(expectedBody);
+      expect(lastCall[0], label).toBe("/api/skills/sync");
+      expect(lastCall[1]?.method, label).toBe("POST");
+      expect(JSON.parse(lastCall[1]?.body as string), label).toEqual(expectedBody);
     }
 
     fetchSpy.mockResolvedValueOnce(jsonResponse({ message: "read only" }, 403));

--- a/web/src/lib/api.skills.test.ts
+++ b/web/src/lib/api.skills.test.ts
@@ -1,6 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { adoptSkill, createSkill, deleteSkill, fetchSkill, fetchSkills, updateSkill, type SkillsResponse } from "./api";
+import {
+  adoptSkill,
+  createSkill,
+  deleteSkill,
+  fetchSkill,
+  fetchSkills,
+  syncSkills,
+  updateSkill,
+  type SkillsResponse,
+} from "./api";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -80,6 +89,29 @@ describe("skills API", () => {
     expect(await deleteSkill("mine")).toEqual({
       ok: false,
       error: "Network error: offline",
+    });
+  });
+
+  it("posts the right body for syncSkills and preserves an error message on failure", async () => {
+    const cases: { roots: string[] | undefined; expectedBody: Record<string, unknown> }[] = [
+      { roots: undefined, expectedBody: {} },
+      { roots: ["claude-user", "aoe-managed"], expectedBody: { roots: ["claude-user", "aoe-managed"] } },
+    ];
+    for (const { roots, expectedBody } of cases) {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true, outcomes: [] }));
+      await syncSkills(roots);
+      const lastCall = fetchSpy.mock.calls[fetchSpy.mock.calls.length - 1];
+      expect(lastCall[0]).toBe("/api/skills/sync");
+      expect(lastCall[1]?.method).toBe("POST");
+      expect(JSON.parse(lastCall[1]?.body as string)).toEqual(expectedBody);
+    }
+
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ message: "read only" }, 403));
+    expect(await syncSkills()).toEqual({
+      ok: false,
+      outcomes: [],
+      error: "read only",
+      status: 403,
     });
   });
 });

--- a/web/src/lib/api.skills.test.ts
+++ b/web/src/lib/api.skills.test.ts
@@ -95,7 +95,7 @@ describe("skills API", () => {
   it("posts the right body for syncSkills across every options shape and preserves an error message on failure", async () => {
     const cases: {
       label: string;
-      options: { roots?: string[]; replace?: string[] } | undefined;
+      options: { roots?: string[]; replace?: string[]; directories?: string[] } | undefined;
       expectedBody: Record<string, unknown>;
     }[] = [
       { label: "no options", options: undefined, expectedBody: {} },
@@ -109,6 +109,11 @@ describe("skills API", () => {
         label: "roots and replace",
         options: { roots: ["claude-user"], replace: ["aoe-review"] },
         expectedBody: { roots: ["claude-user"], replace: ["aoe-review"] },
+      },
+      {
+        label: "directories only",
+        options: { directories: ["aoe-review"] },
+        expectedBody: { directories: ["aoe-review"] },
       },
     ];
     for (const { label, options, expectedBody } of cases) {

--- a/web/src/lib/api.skills.test.ts
+++ b/web/src/lib/api.skills.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { adoptSkill, createSkill, deleteSkill, fetchSkill, fetchSkills, updateSkill, type SkillsResponse } from "./api";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const fetchSpy = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("skills API", () => {
+  it("reads source-qualified skills and sends each managed mutation contract", async () => {
+    const list: SkillsResponse = { skills: [], roots: [] };
+    fetchSpy.mockResolvedValueOnce(jsonResponse(list));
+    expect(await fetchSkills()).toEqual(list);
+    expect(fetchSpy.mock.calls[0]).toEqual(["/api/skills", undefined]);
+
+    const detail = {
+      directory: "review",
+      name: "review",
+      description: "Review code",
+      provenance: { kind: "external" as const, root: "claude-user" },
+      content: "---\nname: review\ndescription: Review code\n---\n",
+    };
+    fetchSpy.mockResolvedValueOnce(jsonResponse(detail));
+    expect(await fetchSkill("claude user", "review/a")).toEqual(detail);
+    expect(fetchSpy.mock.calls[1]).toEqual(["/api/skills/claude%20user/review%2Fa", undefined]);
+
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true, directory: "mine" }, 201));
+    expect(await createSkill("mine", "Mine")).toMatchObject({ ok: true, directory: "mine" });
+    expect(fetchSpy.mock.calls[2]?.[0]).toBe("/api/skills");
+    expect(JSON.parse(fetchSpy.mock.calls[2]?.[1]?.body as string)).toEqual({
+      directory: "mine",
+      description: "Mine",
+    });
+
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    expect(await updateSkill("mine", "content")).toMatchObject({ ok: true });
+    expect(fetchSpy.mock.calls[3]?.[1]?.method).toBe("PUT");
+    expect(JSON.parse(fetchSpy.mock.calls[3]?.[1]?.body as string)).toEqual({ content: "content" });
+
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true, directory: "adopted" }, 201));
+    expect(await adoptSkill("claude-user", "review", "adopted")).toMatchObject({
+      ok: true,
+      directory: "adopted",
+    });
+    expect(fetchSpy.mock.calls[4]?.[0]).toBe("/api/skills/claude-user/review/adopt");
+    expect(JSON.parse(fetchSpy.mock.calls[4]?.[1]?.body as string)).toEqual({ destination: "adopted" });
+
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    expect(await deleteSkill("mine")).toMatchObject({ ok: true });
+    expect(fetchSpy.mock.calls[5]?.[1]?.method).toBe("DELETE");
+  });
+
+  it("returns null for failed reads and preserves mutation error messages", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 500 }));
+    expect(await fetchSkills()).toBeNull();
+    fetchSpy.mockRejectedValueOnce(new Error("offline"));
+    expect(await fetchSkill("aoe-managed", "mine")).toBeNull();
+
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ message: "already exists" }, 409));
+    expect(await createSkill("mine")).toEqual({
+      ok: false,
+      error: "already exists",
+      status: 409,
+    });
+    fetchSpy.mockRejectedValueOnce(new Error("offline"));
+    expect(await deleteSkill("mine")).toEqual({
+      ok: false,
+      error: "Network error: offline",
+    });
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2703,15 +2703,21 @@ export interface SkillSyncResult {
  *  cases come back as a `conflict` outcome instead. `replace` names skills
  *  the user has explicitly asked AoE to take over, so a conflict for that
  *  directory is overwritten instead of left alone; omitting it (or passing an
- *  empty array) overwrites nothing. Distinct shape from {@link skillMutation}
- *  (outcomes array, not a single directory), so this is a sibling rather than
- *  a reuse. */
-export async function syncSkills(options?: { roots?: string[]; replace?: string[] }): Promise<SkillSyncResult> {
+ *  empty array) overwrites nothing. `directories`, when non-empty, reconciles
+ *  only those skills and skips orphan removal for everything else, so a
+ *  single-skill share cannot touch unrelated skills. Distinct shape from
+ *  {@link skillMutation} (outcomes array, not a single directory), so this is
+ *  a sibling rather than a reuse. */
+export async function syncSkills(options?: {
+  roots?: string[];
+  replace?: string[];
+  directories?: string[];
+}): Promise<SkillSyncResult> {
   try {
     const response = await fetch("/api/skills/sync", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ roots: options?.roots, replace: options?.replace }),
+      body: JSON.stringify({ roots: options?.roots, replace: options?.replace, directories: options?.directories }),
     });
     const data = (await response.json().catch(() => ({}))) as {
       outcomes?: SkillSyncOutcome[];

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2582,3 +2582,97 @@ export async function dropMcpServer(name: string, agent: string): Promise<boolea
   const res = await postMcp(`/api/mcp/servers/${encodeURIComponent(name)}/drop`, { agent });
   return !!res && res.ok;
 }
+
+// --- Skills (#3050) ---
+
+export type SkillProvenance = { kind: "aoe-managed" } | { kind: "external"; root: string };
+
+export interface SkillSummary {
+  directory: string;
+  name: string;
+  description: string;
+  provenance: SkillProvenance;
+  provenanceLabel: string;
+  writable: boolean;
+}
+
+export interface SkillDetail {
+  directory: string;
+  name: string;
+  description: string;
+  provenance: SkillProvenance;
+  content: string;
+}
+
+export interface SkillRoot {
+  id: string;
+  label: string;
+  relativePath: string;
+  consumers: string[];
+  legacy: boolean;
+}
+
+export interface SkillsResponse {
+  skills: SkillSummary[];
+  roots: SkillRoot[];
+}
+
+export interface SkillMutationResult {
+  ok: boolean;
+  directory?: string;
+  error?: string;
+  status?: number;
+}
+
+export function fetchSkills(): Promise<SkillsResponse | null> {
+  return fetchJson<SkillsResponse>("/api/skills");
+}
+
+export function fetchSkill(source: string, directory: string): Promise<SkillDetail | null> {
+  return fetchJson<SkillDetail>(`/api/skills/${encodeURIComponent(source)}/${encodeURIComponent(directory)}`);
+}
+
+async function skillMutation(url: string, method: string, body?: unknown): Promise<SkillMutationResult> {
+  try {
+    const response = await fetch(url, {
+      method,
+      headers: body === undefined ? undefined : { "Content-Type": "application/json" },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const data = (await response.json().catch(() => ({}))) as {
+      directory?: string | null;
+      message?: string;
+    };
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: data.message ?? `Server error (${response.status})`,
+        status: response.status,
+      };
+    }
+    return { ok: true, directory: data.directory ?? undefined, status: response.status };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Network error: ${error instanceof Error ? error.message : "connection failed"}`,
+    };
+  }
+}
+
+export function createSkill(directory: string, description?: string): Promise<SkillMutationResult> {
+  return skillMutation("/api/skills", "POST", { directory, description });
+}
+
+export function updateSkill(directory: string, content: string): Promise<SkillMutationResult> {
+  return skillMutation(`/api/skills/${encodeURIComponent(directory)}`, "PUT", { content });
+}
+
+export function deleteSkill(directory: string): Promise<SkillMutationResult> {
+  return skillMutation(`/api/skills/${encodeURIComponent(directory)}`, "DELETE");
+}
+
+export function adoptSkill(source: string, directory: string, destination?: string): Promise<SkillMutationResult> {
+  return skillMutation(`/api/skills/${encodeURIComponent(source)}/${encodeURIComponent(directory)}/adopt`, "POST", {
+    destination,
+  });
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2700,15 +2700,18 @@ export interface SkillSyncResult {
  *  (`POST /api/skills/sync`). Omitting `roots` (or passing an empty array)
  *  syncs every root. Never overwrites or deletes anything AoE did not itself
  *  deploy and that is not still byte-identical to what AoE deployed; such
- *  cases come back as a `conflict` outcome instead. Distinct shape from
- *  {@link skillMutation} (outcomes array, not a single directory), so this is
- *  a sibling rather than a reuse. */
-export async function syncSkills(roots?: string[]): Promise<SkillSyncResult> {
+ *  cases come back as a `conflict` outcome instead. `replace` names skills
+ *  the user has explicitly asked AoE to take over, so a conflict for that
+ *  directory is overwritten instead of left alone; omitting it (or passing an
+ *  empty array) overwrites nothing. Distinct shape from {@link skillMutation}
+ *  (outcomes array, not a single directory), so this is a sibling rather than
+ *  a reuse. */
+export async function syncSkills(options?: { roots?: string[]; replace?: string[] }): Promise<SkillSyncResult> {
   try {
     const response = await fetch("/api/skills/sync", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ roots }),
+      body: JSON.stringify({ roots: options?.roots, replace: options?.replace }),
     });
     const data = (await response.json().catch(() => ({}))) as {
       outcomes?: SkillSyncOutcome[];

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2676,3 +2676,58 @@ export function adoptSkill(source: string, directory: string, destination?: stri
     destination,
   });
 }
+
+export type SkillSyncStatus = "created" | "updated" | "unchanged" | "removed" | "conflict" | "error";
+
+/** One skill's sync outcome for one agent root. `message` is populated for
+ *  `conflict` (the user's own skill, or an edited propagated copy, was left
+ *  alone) and `error`. */
+export interface SkillSyncOutcome {
+  root: string;
+  directory: string;
+  status: SkillSyncStatus;
+  message: string | null;
+}
+
+export interface SkillSyncResult {
+  ok: boolean;
+  outcomes: SkillSyncOutcome[];
+  error?: string;
+  status?: number;
+}
+
+/** Copy AoE-managed skills into each agent's own skills directory
+ *  (`POST /api/skills/sync`). Omitting `roots` (or passing an empty array)
+ *  syncs every root. Never overwrites or deletes anything AoE did not itself
+ *  deploy and that is not still byte-identical to what AoE deployed; such
+ *  cases come back as a `conflict` outcome instead. Distinct shape from
+ *  {@link skillMutation} (outcomes array, not a single directory), so this is
+ *  a sibling rather than a reuse. */
+export async function syncSkills(roots?: string[]): Promise<SkillSyncResult> {
+  try {
+    const response = await fetch("/api/skills/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ roots }),
+    });
+    const data = (await response.json().catch(() => ({}))) as {
+      outcomes?: SkillSyncOutcome[];
+      message?: string;
+    };
+    if (!response.ok) {
+      return {
+        ok: false,
+        outcomes: [],
+        error: data.message ?? `Server error (${response.status})`,
+        status: response.status,
+      };
+    }
+    return { ok: true, outcomes: data.outcomes ?? [], status: response.status };
+  } catch (error) {
+    return {
+      ok: false,
+      outcomes: [],
+      error: `Network error: ${error instanceof Error ? error.message : "connection failed"}`,
+    };
+  }
+}

--- a/web/src/lib/skillBody.ts
+++ b/web/src/lib/skillBody.ts
@@ -11,6 +11,9 @@
  */
 export function skillBody(content: string): string {
   const withoutBom = content.replace(/^\uFEFF/, "");
-  const match = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/.exec(withoutBom);
+  // The closing marker must be followed by a newline or end of input.
+  // A bare `\r?\n?` also matched the first three hyphens of `----`, so a
+  // malformed file lost a character instead of being left alone.
+  const match = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/.exec(withoutBom);
   return match ? withoutBom.slice(match[0].length) : withoutBom;
 }

--- a/web/src/lib/skillBody.ts
+++ b/web/src/lib/skillBody.ts
@@ -1,0 +1,16 @@
+/** Drop a SKILL.md's leading YAML frontmatter fence, leaving the instructions.
+ *
+ *  Rendered as markdown, frontmatter turns into a horizontal rule followed by a
+ *  paragraph reading "name: ... description: ...", which is noise: both fields
+ *  already appear in the detail header. Falls back to the whole text when there
+ *  is no closing fence, so a malformed file still previews as something rather
+ *  than as nothing.
+ *
+ *  Lives outside the component file so the preview can import it without
+ *  tripping the fast-refresh rule against non-component exports.
+ */
+export function skillBody(content: string): string {
+  const withoutBom = content.replace(/^\uFEFF/, "");
+  const match = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/.exec(withoutBom);
+  return match ? withoutBom.slice(match[0].length) : withoutBom;
+}

--- a/web/src/lib/skillProvenance.test.ts
+++ b/web/src/lib/skillProvenance.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import type { SkillProvenance, SkillRoot, SkillsResponse } from "./api";
+import { buildSkillIndex, labelForProvenance, resolveSkillSource } from "./skillProvenance";
+
+const roots: SkillRoot[] = [
+  { id: "claude-user", label: "Claude", relativePath: ".claude/skills", consumers: ["claude"], legacy: false },
+  { id: "gemini-user", label: "Gemini", relativePath: ".gemini/skills", consumers: ["gemini"], legacy: false },
+];
+
+const response: SkillsResponse = {
+  roots,
+  skills: [
+    // Directory and frontmatter name match.
+    {
+      directory: "aoe-review",
+      name: "aoe-review",
+      description: "",
+      provenance: { kind: "aoe-managed" },
+      provenanceLabel: "aoe-managed",
+      writable: true,
+    },
+    // Frontmatter name diverges from directory (AoE deliberately allows this).
+    {
+      directory: "review-dir",
+      name: "diverge-name",
+      description: "",
+      provenance: { kind: "external", root: "claude-user" },
+      provenanceLabel: "external:claude-user",
+      writable: false,
+    },
+    // External root id absent from `roots`.
+    {
+      directory: "orphan-dir",
+      name: "orphan-dir",
+      description: "",
+      provenance: { kind: "external", root: "mystery-root" },
+      provenanceLabel: "external:mystery-root",
+      writable: false,
+    },
+    // Two distinct skills whose keys collide under "shared", from different
+    // roots: an agent name lookup for "shared" must read as ambiguous.
+    {
+      directory: "shared",
+      name: "shared-a",
+      description: "",
+      provenance: { kind: "external", root: "claude-user" },
+      provenanceLabel: "external:claude-user",
+      writable: false,
+    },
+    {
+      directory: "shared-b",
+      name: "shared",
+      description: "",
+      provenance: { kind: "external", root: "gemini-user" },
+      provenanceLabel: "external:gemini-user",
+      writable: false,
+    },
+    // Two distinct skills whose keys collide under "dupkey" but share the
+    // same label: must NOT read as ambiguous (one source, reached twice).
+    {
+      directory: "dupkey",
+      name: "dupkey-full",
+      description: "",
+      provenance: { kind: "aoe-managed" },
+      provenanceLabel: "aoe-managed",
+      writable: true,
+    },
+    {
+      directory: "dupkey-alt",
+      name: "dupkey",
+      description: "",
+      provenance: { kind: "aoe-managed" },
+      provenanceLabel: "aoe-managed",
+      writable: true,
+    },
+  ],
+};
+
+const index = buildSkillIndex(response);
+
+describe("resolveSkillSource", () => {
+  it("resolves a command name to its provenance across single/ambiguous/unknown cases", () => {
+    const cases: [string, ReturnType<typeof resolveSkillSource>][] = [
+      // Single source, matched by directory (directory === name here).
+      ["aoe-review", { kind: "single", label: "AoE" }],
+      // Single source, matched by directory key.
+      ["review-dir", { kind: "single", label: "Claude" }],
+      // Single source, matched by the diverging frontmatter name key.
+      ["diverge-name", { kind: "single", label: "Claude" }],
+      // Ambiguous: two distinct skills/roots collide on "shared".
+      ["shared", { kind: "multiple" }],
+      // Same label reached via two different skills/keys is ONE source.
+      ["dupkey", { kind: "single", label: "AoE" }],
+      // Unknown command name: no badge.
+      ["does-not-exist", null],
+    ];
+    for (const [name, expected] of cases) {
+      expect(resolveSkillSource(index, name), name).toEqual(expected);
+    }
+  });
+
+  it("resolves everything to null against the empty index for a null response", () => {
+    const empty = buildSkillIndex(null);
+    expect(resolveSkillSource(empty, "aoe-review")).toBeNull();
+  });
+});
+
+describe("labelForProvenance", () => {
+  it("maps aoe-managed to 'AoE', a known root to its label, and an unknown root to the raw id", () => {
+    const cases: [SkillProvenance, string][] = [
+      [{ kind: "aoe-managed" }, "AoE"],
+      [{ kind: "external", root: "claude-user" }, "Claude"],
+      [{ kind: "external", root: "mystery-root" }, "mystery-root"],
+    ];
+    for (const [provenance, expected] of cases) {
+      expect(labelForProvenance(provenance, roots), JSON.stringify(provenance)).toBe(expected);
+    }
+  });
+});

--- a/web/src/lib/skillProvenance.test.ts
+++ b/web/src/lib/skillProvenance.test.ts
@@ -104,6 +104,26 @@ describe("resolveSkillSource", () => {
     const empty = buildSkillIndex(null);
     expect(resolveSkillSource(empty, "aoe-review")).toBeNull();
   });
+
+  // `fetchJson` casts any 200 body to SkillsResponse without validating it, so
+  // a surprising payload reaches buildSkillIndex as-is. It must degrade to an
+  // empty index: these badges are cosmetic and must not throw into the surface
+  // rendering them.
+  it("degrades to an empty index for a malformed response", () => {
+    const cases = [
+      ["skills missing", {}],
+      ["skills not an array", { skills: null, roots }],
+      ["roots missing", { skills: response.skills }],
+      ["roots not an array", { skills: response.skills, roots: "nope" }],
+    ] as const;
+    for (const [label, body] of cases) {
+      const built = buildSkillIndex(body as unknown as SkillsResponse);
+      // A usable skills array still indexes; only the roots lookup degrades,
+      // falling labels back to the raw root id.
+      const expected = Array.isArray((body as { skills?: unknown }).skills) ? "aoe-review" : null;
+      expect(resolveSkillSource(built, "aoe-review")?.label ?? null, label).toEqual(expected === null ? null : "AoE");
+    }
+  });
 });
 
 describe("labelForProvenance", () => {

--- a/web/src/lib/skillProvenance.test.ts
+++ b/web/src/lib/skillProvenance.test.ts
@@ -110,18 +110,22 @@ describe("resolveSkillSource", () => {
   // empty index: these badges are cosmetic and must not throw into the surface
   // rendering them.
   it("degrades to an empty index for a malformed response", () => {
-    const cases = [
-      ["skills missing", {}],
-      ["skills not an array", { skills: null, roots }],
-      ["roots missing", { skills: response.skills }],
-      ["roots not an array", { skills: response.skills, roots: "nope" }],
-    ] as const;
-    for (const [label, body] of cases) {
-      const built = buildSkillIndex(body as unknown as SkillsResponse);
+    // The label "aoe-review" resolves to once the response has degraded, or
+    // null when nothing could be indexed at all.
+    const cases: Array<[string, unknown, string | null]> = [
+      ["skills missing", {}, null],
+      ["skills not an array", { skills: null, roots }, null],
       // A usable skills array still indexes; only the roots lookup degrades,
-      // falling labels back to the raw root id.
-      const expected = Array.isArray((body as { skills?: unknown }).skills) ? "aoe-review" : null;
-      expect(resolveSkillSource(built, "aoe-review")?.label ?? null, label).toEqual(expected === null ? null : "AoE");
+      // falling labels back to the raw root id (unused by an aoe-managed one).
+      ["roots missing", { skills: response.skills }, "AoE"],
+      ["roots not an array", { skills: response.skills, roots: "nope" }, "AoE"],
+      // A single bad member is skipped, not fatal to its neighbours.
+      ["null member", { skills: [null, ...response.skills], roots }, "AoE"],
+      ["member without provenance", { skills: [{ directory: "x", name: "x" }, ...response.skills], roots }, "AoE"],
+    ];
+    for (const [label, body, expected] of cases) {
+      const built = buildSkillIndex(body as SkillsResponse);
+      expect(resolveSkillSource(built, "aoe-review")?.label ?? null, label).toEqual(expected);
     }
   });
 });

--- a/web/src/lib/skillProvenance.test.ts
+++ b/web/src/lib/skillProvenance.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { SkillProvenance, SkillRoot, SkillsResponse } from "./api";
-import { buildSkillIndex, labelForProvenance, resolveSkillSource } from "./skillProvenance";
+import { badgeTone, buildSkillIndex, labelForProvenance, resolveSkillSource } from "./skillProvenance";
 
 const roots: SkillRoot[] = [
   { id: "claude-user", label: "Claude", relativePath: ".claude/skills", consumers: ["claude"], legacy: false },
@@ -83,15 +83,15 @@ describe("resolveSkillSource", () => {
   it("resolves a command name to its provenance across single/ambiguous/unknown cases", () => {
     const cases: [string, ReturnType<typeof resolveSkillSource>][] = [
       // Single source, matched by directory (directory === name here).
-      ["aoe-review", { kind: "single", label: "AoE" }],
+      ["aoe-review", { kind: "single", label: "AoE", managed: true }],
       // Single source, matched by directory key.
-      ["review-dir", { kind: "single", label: "Claude" }],
+      ["review-dir", { kind: "single", label: "Claude", managed: false }],
       // Single source, matched by the diverging frontmatter name key.
-      ["diverge-name", { kind: "single", label: "Claude" }],
+      ["diverge-name", { kind: "single", label: "Claude", managed: false }],
       // Ambiguous: two distinct skills/roots collide on "shared".
       ["shared", { kind: "multiple" }],
       // Same label reached via two different skills/keys is ONE source.
-      ["dupkey", { kind: "single", label: "AoE" }],
+      ["dupkey", { kind: "single", label: "AoE", managed: true }],
       // Unknown command name: no badge.
       ["does-not-exist", null],
     ];
@@ -115,6 +115,25 @@ describe("labelForProvenance", () => {
     ];
     for (const [provenance, expected] of cases) {
       expect(labelForProvenance(provenance, roots), JSON.stringify(provenance)).toBe(expected);
+    }
+  });
+});
+
+describe("badgeTone", () => {
+  it("brands only an unambiguously AoE-managed source", () => {
+    const cases: Array<[string, "neutral" | "primary"]> = [
+      // AoE's own store is the thing the tint is for.
+      ["aoe-review", "primary"],
+      // A host root is not ours, so it stays neutral and the branded one pops.
+      ["review-dir", "neutral"],
+      // Ambiguous: we cannot say the AoE copy is what the agent will load, so
+      // claiming it in colour would be a guess presented as a fact.
+      ["shared", "neutral"],
+    ];
+    for (const [name, expected] of cases) {
+      const source = resolveSkillSource(index, name);
+      expect(source, name).not.toBeNull();
+      expect(badgeTone(source!), name).toBe(expected);
     }
   });
 });

--- a/web/src/lib/skillProvenance.ts
+++ b/web/src/lib/skillProvenance.ts
@@ -1,0 +1,67 @@
+// Skill provenance resolution shared by the skills manager, the composer's
+// `/` slash-command picker, and the skill tool-call card (#3052). Pure, no
+// React, so it can be unit-tested and reused by a plain hook.
+
+import type { SkillProvenance, SkillRoot, SkillsResponse } from "./api";
+
+/** What a resolved command/skill name should render as a badge: a single
+ *  known source, or "multiple" when the same name is backed by more than one
+ *  distinct source (the caller renders a generic "multiple sources" label). */
+export type SkillSource = { kind: "single"; label: string } | { kind: "multiple" };
+
+/** The human-facing label for a skill's provenance. AoE-managed skills get a
+ *  fixed short label; an external skill's label is its root's declared
+ *  label, falling back to the raw root id when the root is unknown so a
+ *  badge is never silently dropped. */
+export function labelForProvenance(provenance: SkillProvenance, roots: SkillRoot[]): string {
+  if (provenance.kind === "aoe-managed") return "AoE";
+  return roots.find((root) => root.id === provenance.root)?.label ?? provenance.root;
+}
+
+/** The badge text for a resolved source. Lives here, not at each call site,
+ *  because every surface showing this badge has to read identically; two
+ *  inline ternaries would be two places for the ambiguous wording to drift. */
+export function badgeLabel(source: SkillSource): string {
+  return source.kind === "single" ? source.label : "multiple sources";
+}
+
+export interface SkillIndex {
+  /** Directory or frontmatter-name key -> distinct provenance labels backing
+   *  it. AoE deliberately allows a skill's directory and frontmatter name to
+   *  diverge, and agents advertise the frontmatter name in slash commands and
+   *  tool calls, so every skill is indexed under both. */
+  labelsByKey: Map<string, Set<string>>;
+}
+
+const EMPTY_INDEX: SkillIndex = { labelsByKey: new Map() };
+
+/** Build a lookup from skill directory/name to the set of distinct
+ *  provenance labels backing it. A null/absent response yields an empty
+ *  index, so every lookup resolves to null rather than throwing. */
+export function buildSkillIndex(res: SkillsResponse | null): SkillIndex {
+  if (!res) return EMPTY_INDEX;
+  const labelsByKey = new Map<string, Set<string>>();
+  for (const skill of res.skills) {
+    const label = labelForProvenance(skill.provenance, res.roots);
+    for (const key of [skill.directory, skill.name]) {
+      if (!key) continue;
+      const labels = labelsByKey.get(key) ?? new Set<string>();
+      labels.add(label);
+      labelsByKey.set(key, labels);
+    }
+  }
+  return { labelsByKey };
+}
+
+/** Resolve a slash-command or skill tool-call name to its provenance badge.
+ *  Null means the name is not a known skill (every non-skill slash command,
+ *  or an unrecognised skill name), so the caller renders no badge at all.
+ *  Reaching the same label through both the directory key and the name key
+ *  is one source, not two; only distinct labels count as ambiguous. */
+export function resolveSkillSource(index: SkillIndex, commandName: string): SkillSource | null {
+  const labels = index.labelsByKey.get(commandName);
+  if (!labels || labels.size === 0) return null;
+  if (labels.size > 1) return { kind: "multiple" };
+  const [label] = labels;
+  return { kind: "single", label: label! };
+}

--- a/web/src/lib/skillProvenance.ts
+++ b/web/src/lib/skillProvenance.ts
@@ -49,13 +49,17 @@ export interface SkillIndex {
 const EMPTY_INDEX: SkillIndex = { labelsByKey: new Map() };
 
 /** Build a lookup from skill directory/name to the set of distinct
- *  provenance labels backing it. A null/absent response yields an empty
- *  index, so every lookup resolves to null rather than throwing. */
+ *  provenance labels backing it. A null, absent, or malformed response yields
+ *  an empty index, so every lookup resolves to null rather than throwing.
+ *  The shape is checked rather than trusted because `fetchJson` casts an
+ *  arbitrary 200 body to this type without validating it, and these badges are
+ *  cosmetic: a surprising payload must not take out the surface rendering it. */
 export function buildSkillIndex(res: SkillsResponse | null): SkillIndex {
-  if (!res) return EMPTY_INDEX;
+  if (!res || !Array.isArray(res.skills)) return EMPTY_INDEX;
+  const roots = Array.isArray(res.roots) ? res.roots : [];
   const labelsByKey = new Map<string, Set<string>>();
   for (const skill of res.skills) {
-    const label = labelForProvenance(skill.provenance, res.roots);
+    const label = labelForProvenance(skill.provenance, roots);
     for (const key of [skill.directory, skill.name]) {
       if (!key) continue;
       const labels = labelsByKey.get(key) ?? new Set<string>();

--- a/web/src/lib/skillProvenance.ts
+++ b/web/src/lib/skillProvenance.ts
@@ -59,6 +59,9 @@ export function buildSkillIndex(res: SkillsResponse | null): SkillIndex {
   const roots = Array.isArray(res.roots) ? res.roots : [];
   const labelsByKey = new Map<string, Set<string>>();
   for (const skill of res.skills) {
+    // Skipped, not fatal: one malformed member must not cost every other skill
+    // in the response its badge.
+    if (!skill?.provenance) continue;
     const label = labelForProvenance(skill.provenance, roots);
     for (const key of [skill.directory, skill.name]) {
       if (!key) continue;

--- a/web/src/lib/skillProvenance.ts
+++ b/web/src/lib/skillProvenance.ts
@@ -7,14 +7,19 @@ import type { SkillProvenance, SkillRoot, SkillsResponse } from "./api";
 /** What a resolved command/skill name should render as a badge: a single
  *  known source, or "multiple" when the same name is backed by more than one
  *  distinct source (the caller renders a generic "multiple sources" label). */
-export type SkillSource = { kind: "single"; label: string } | { kind: "multiple" };
+export type SkillSource = { kind: "single"; label: string; managed: boolean } | { kind: "multiple" };
+
+/** The label AoE's own store renders as. Exported so a surface can ask whether
+ *  a resolved source is the managed one without string-matching at the call
+ *  site, and so renaming it is a one-line change. */
+export const AOE_MANAGED_LABEL = "AoE";
 
 /** The human-facing label for a skill's provenance. AoE-managed skills get a
  *  fixed short label; an external skill's label is its root's declared
  *  label, falling back to the raw root id when the root is unknown so a
  *  badge is never silently dropped. */
 export function labelForProvenance(provenance: SkillProvenance, roots: SkillRoot[]): string {
-  if (provenance.kind === "aoe-managed") return "AoE";
+  if (provenance.kind === "aoe-managed") return AOE_MANAGED_LABEL;
   return roots.find((root) => root.id === provenance.root)?.label ?? provenance.root;
 }
 
@@ -23,6 +28,14 @@ export function labelForProvenance(provenance: SkillProvenance, roots: SkillRoot
  *  inline ternaries would be two places for the ambiguous wording to drift. */
 export function badgeLabel(source: SkillSource): string {
   return source.kind === "single" ? source.label : "multiple sources";
+}
+
+/** The badge tint for a resolved source. Only an unambiguously AoE-managed
+ *  skill is branded: when a name resolves to several sources we cannot say the
+ *  AoE one is what the agent will load, so claiming it in colour would be a
+ *  guess dressed as a fact. */
+export function badgeTone(source: SkillSource): "neutral" | "primary" {
+  return source.kind === "single" && source.managed ? "primary" : "neutral";
 }
 
 export interface SkillIndex {
@@ -63,5 +76,5 @@ export function resolveSkillSource(index: SkillIndex, commandName: string): Skil
   if (!labels || labels.size === 0) return null;
   if (labels.size > 1) return { kind: "multiple" };
   const [label] = labels;
-  return { kind: "single", label: label! };
+  return { kind: "single", label: label!, managed: label === AOE_MANAGED_LABEL };
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1925,6 +1925,17 @@
       "components": ["web/src/components/acp/Composer.tsx", "web/src/components/acp/recallNav.ts"]
     },
     {
+      "id": "acp.composer-slash-skill-provenance",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/acp/Composer.slashProvenance.test.tsx", "src/lib/skillProvenance.test.ts"],
+      "components": [
+        "web/src/components/acp/Composer.tsx",
+        "web/src/lib/skillProvenance.ts",
+        "web/src/components/ProvenanceBadge.tsx"
+      ]
+    },
+    {
       "id": "acp.composer-usage-tooltip",
       "kind": "vitest",
       "risk": "low",
@@ -2199,8 +2210,8 @@
       "id": "acp.tool-cards",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/components/acp/ToolCards.render.test.tsx"],
-      "components": ["web/src/components/acp/ToolCards.tsx"]
+      "specs": ["src/components/acp/ToolCards.render.test.tsx", "src/components/acp/__tests__/ToolCards.test.tsx"],
+      "components": ["web/src/components/acp/ToolCards.tsx", "web/src/components/ProvenanceBadge.tsx"]
     },
     {
       "id": "acp.reused-tool-message-ids",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -53,6 +53,20 @@
       "components": ["web/src/components/McpServers.tsx"]
     },
     {
+      "id": "settings.skills-management",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": ["tests/live/skills-management.spec.ts"],
+      "components": ["web/src/components/SkillsManager.tsx"]
+    },
+    {
+      "id": "settings.skills-management.handlers",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/components/__tests__/SkillsManager.test.tsx", "src/lib/api.skills.test.ts"],
+      "components": ["web/src/components/SkillsManager.tsx"]
+    },
+    {
       "id": "dashboard.golden-path",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/read-only-mode.spec.ts
+++ b/web/tests/live/read-only-mode.spec.ts
@@ -62,6 +62,16 @@ test("POST /api/sessions with malformed body still returns 403", async ({ serveR
   }
 });
 
+test("skills mutations reject malformed bodies before parsing in read-only mode", async ({ serveReadOnly }) => {
+  const res = await fetch(`${serveReadOnly.baseUrl}/api/skills`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "not even json",
+  });
+  expect(res.status).toBe(403);
+  expect(await res.json()).toMatchObject({ error: "read_only" });
+});
+
 test("dashboard suppresses mutation UI in read-only", async ({ serveReadOnly, page }) => {
   // Wait for /api/about to land before driving keyboard shortcuts. The
   // "n" shortcut handler reads `serverAbout?.read_only`; if /api/about

--- a/web/tests/live/skills-management.spec.ts
+++ b/web/tests/live/skills-management.spec.ts
@@ -23,7 +23,9 @@ test("skills panel adopts, edits, creates, and deletes skills", async ({ page },
     await page.goto(`${serve.baseUrl}/settings/skills`);
 
     await expect(page.getByRole("heading", { name: "Skills Library" })).toBeVisible();
-    await page.getByRole("button", { name: /review/i }).click();
+    // Anchored: the detail pane's "Preview" toggle also contains "review", so
+    // an unanchored match is ambiguous and trips strict mode.
+    await page.getByRole("button", { name: /^review/i }).click();
     await expect(page.getByText("claude-user").first()).toBeVisible();
     await expect(page.getByLabel("SKILL.md content")).toHaveAttribute("readonly", "");
 

--- a/web/tests/live/skills-management.spec.ts
+++ b/web/tests/live/skills-management.spec.ts
@@ -1,0 +1,58 @@
+// Live: the skills settings panel (#3050) discovers a real external skill,
+// adopts it without changing the source, and persists managed edits/deletion.
+
+import { test, expect } from "@playwright/test";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnAoeServe } from "../helpers/aoeServe";
+
+test("skills panel adopts, edits, creates, and deletes skills", async ({ page }, testInfo) => {
+  const original = "---\nname: Review\ndescription: Review code carefully\n---\n\nOriginal body\n";
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home }) => {
+      const skill = join(home, ".claude", "skills", "review");
+      mkdirSync(skill, { recursive: true });
+      writeFileSync(join(skill, "SKILL.md"), original);
+    },
+  });
+
+  try {
+    await page.goto(`${serve.baseUrl}/settings/skills`);
+
+    await expect(page.getByRole("heading", { name: "Skills Library" })).toBeVisible();
+    await page.getByRole("button", { name: /review/i }).click();
+    await expect(page.getByText("claude-user").first()).toBeVisible();
+    await expect(page.getByLabel("SKILL.md content")).toHaveAttribute("readonly", "");
+
+    await page.getByRole("button", { name: "Adopt into AoE" }).click();
+    await expect(page.getByRole("status")).toContainText("adopted");
+    await expect(page.getByLabel("SKILL.md content")).not.toHaveAttribute("readonly");
+    expect(readFileSync(join(serve.home, ".claude", "skills", "review", "SKILL.md"), "utf8")).toBe(original);
+
+    const edited = "---\nname: Review\ndescription: Updated review\n---\n\nEdited body\n";
+    await page.getByLabel("SKILL.md content").fill(edited);
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByRole("status")).toContainText("saved");
+
+    const persisted = await page.request.get(`${serve.baseUrl}/api/skills/aoe-managed/review`);
+    expect(persisted.ok()).toBe(true);
+    expect((await persisted.json()).content).toBe(edited);
+
+    await page.getByLabel("New skill directory").fill("new-skill");
+    await page.getByLabel("New skill description").fill("Use for new work");
+    await page.getByRole("button", { name: "Create" }).click();
+    await expect(page.getByRole("status")).toContainText("created");
+    await expect(page.getByLabel("SKILL.md content")).toHaveValue(/name: new-skill/);
+
+    page.once("dialog", (dialog) => void dialog.accept());
+    await page.getByRole("button", { name: "Delete" }).click();
+    await expect(page.getByRole("status")).toContainText("deleted");
+    const removed = await page.request.get(`${serve.baseUrl}/api/skills/aoe-managed/new-skill`);
+    expect(removed.status()).toBe(404);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/skills-management.spec.ts
+++ b/web/tests/live/skills-management.spec.ts
@@ -41,6 +41,7 @@ test("skills panel adopts, edits, creates, and deletes skills", async ({ page },
     expect(persisted.ok()).toBe(true);
     expect((await persisted.json()).content).toBe(edited);
 
+    await page.getByRole("button", { name: "+ New skill" }).click();
     await page.getByLabel("New skill directory").fill("new-skill");
     await page.getByLabel("New skill description").fill("Use for new work");
     await page.getByRole("button", { name: "Create" }).click();


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Skills management moves into core, closing the #3044 epic. Core already had the model (`src/session/skills_model.rs`), reachable only through the plugin RPC layer being removed. This wires every core surface onto it and makes an AoE-authored skill actually usable by every agent.

**#3050, management surfaces.** REST (`src/server/api/skills.rs`), CLI (`aoe skill list/view/add/edit/adopt/remove`), and a dashboard manager under Settings, all on the read-only-layer plus adopt model: host skills are read-only, and editing one requires adopting it into AoE's store first. Mutations sit behind the existing read-only / CityHall / elevation gate.

**#3053, cross-agent propagation.** Skills reach an agent only as files on disk, so there is no protocol to forward them over; the copy is the mechanism. A propagated copy now carries an `.aoe-managed.json` marker naming its root, its skill, and the package digest at deploy time, and that marker is the only thing authorizing AoE to later replace or delete that directory, and only while the copy still matches the recorded digest.

That digest is what makes propagation safe to reverse. Without it, "AoE wrote this" and "AoE may delete this" are the same claim, and a user who edits a propagated skill loses that work the next time the source changes. With it, a hand-written skill and an edited propagated copy are both preserved and reported as conflicts rather than overwritten or removed. Discovery skips copies carrying a valid marker, so a shared skill is listed once as its managed original rather than once per root.

Propagation at session launch is opt-in and off by default. Letting AoE create, replace, and remove directories inside a user's real `~/.claude/skills` is a different privilege from editing AoE's own store, so an upgrade must not start doing it unasked. When enabled, launching a session reconciles into the one root that agent is the primary consumer of; keying on a primary agent rather than on every root an agent can read matters for opencode, which reads three roots and would otherwise get three copies of everything. Sandboxed sessions reconcile into the sandbox skills dir on every launch instead of riding `copy_dirs`, which only runs on a container's first launch and so would never deliver a skill authored afterwards.

**Taking a skill over.** Refusing to overwrite anything AoE did not write is what keeps a hand-written skill safe, but it also meant a skill already present in an agent's directory could never be managed from AoE: adopt it, edit it, sync, and you get a conflict forever while the edits never reach the agent. Naming a skill is now the way past that, via `aoe skill sync --replace <dir>`, a `replace` list on the REST body, and a Replace button on each conflict row. Once taken over the copy is AoE-owned, so later syncs keep it current unasked. Automatic propagation passes an empty replace set and always will.

Replacing renames the existing entry aside before installing, so replacing a symlink moves the link rather than writing through it. That also makes AoE safe to run beside a symlink-based manager such as [skillshare](https://github.com/runkids/skillshare): an untouched symlinked skill is something AoE did not deploy, so it reads as a conflict and is left alone rather than followed or clobbered. There is a test pinning that.

**#3052, provenance badges.** ACP advertises a slash command's name and description and nothing else, so provenance is resolved client-side against the skills index rather than pretending the agent supplied it. The `/` picker and the skill tool card now carry the same pill the manager does, lifted out of the MCP panel rather than reimplemented. A name backed by two distinct sources reads "multiple sources" instead of guessing.

**Dashboard redesign.** The skills manager is a two-pane workspace: a header card, a searchable sidebar grouping skills into Managed and Available to adopt, and a detail pane with the editor, a Raw/Preview toggle, and its actions pinned to the footer. Preview strips the YAML frontmatter first, since markdown otherwise renders it as a rule plus a paragraph of "name: ... description: ..." directly under a header already showing both.

Settings content was capped at `max-w-2xl`, which is what made the page look cramped on a wide window. Skills renders full width for its two panes; other tabs get a larger cap rather than no cap, so form labels and controls do not end up separated by half an ultrawide monitor. Every colour is a theme token, verified by repainting the panel under a light theme.

**#3051, TUI panel.** A skills panel on the command palette, modelled on the existing plugin manager, enforcing the same read-only and adopt rule. Editing is an inline text area rather than an `$EDITOR` shell-out, which would need raw mode toggled on `App` and a result threaded back up through `HomeView`.

Closes #3050
Closes #3051
Closes #3052
Closes #3053

### Breaking changes

- `skills_model::propagate_skill` is removed. Propagation is a root-level reconcile now, so a single skill is no longer an addressable unit.
- The `skills.propagate` plugin RPC takes `{ agent }` instead of `{ directory, agent }` and returns per-skill `outcomes`. The plugin API is being removed by the epic's cleanup child, so this was not worth a compatibility shim.

### Known gaps, deliberate

- Codex reads `~/.agents/skills`, which is outside its `.codex` sandbox mount, so it gets host propagation but no sandbox propagation.
- The design's "Statistics" tab is not built. Skill invocations are only recoverable from the ACP transcript store, and permanent delete plus trash expiry hard-delete those rows (`EventStore::delete_session` -> `events::delete_topic`), so a count derived from it would silently shrink over time. A trustworthy count needs its own durable counter that survives session deletion, which is a feature in its own right rather than a tab in this PR.
- The sandbox `copy_dirs` first-run gate is untouched; re-copying whole config trees on every launch is #2258's problem, and managed skills route around it via their own reconcile.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] `aoe skill add demo --description "hello"`, then `aoe skill list`, and confirm `demo` appears as `aoe-managed`.
- [ ] `aoe skill sync`, then confirm `demo` now exists under `~/.claude/skills/`, `~/.gemini/skills/`, `~/.agents/skills/`, and `~/.config/opencode/skills/`, each containing an `.aoe-managed.json`.
- [ ] Run `aoe skill list` again and confirm `demo` is still listed exactly once, as `aoe-managed`, not once per root.
- [ ] Hand-write `~/.gemini/skills/mine/SKILL.md` with valid frontmatter, run `aoe skill sync`, and confirm it is reported as a conflict and its contents are unchanged.
- [ ] Edit the propagated `~/.claude/skills/demo/SKILL.md` by hand, then `aoe skill edit demo` to change the managed source, then `aoe skill sync`, and confirm your hand edit survives and is reported as a conflict.
- [ ] `aoe skill remove demo`, then `aoe skill sync`, and confirm the untouched propagated copies are withdrawn while the edited one from the previous step stays.
- [ ] With a skill of the same name in both AoE and `~/.claude/skills`, run `aoe skill sync` and confirm it reports a conflict and leaves your file alone; then `aoe skill sync --replace <dir>` and confirm your copy is replaced and a later plain sync reports it unchanged.
- [ ] Symlink a skill directory into `~/.claude/skills` from elsewhere, run `aoe skill sync`, and confirm the symlink and its target are untouched.
- [ ] In the dashboard, trigger a sync that conflicts and confirm each conflict row offers Replace, and that using it resolves only that row.
- [ ] Select a managed skill and use "Share this skill", confirming it reports outcomes for that skill only.
- [ ] Open the TUI, press Ctrl-K, type "skills", Enter. Confirm the panel lists skills with a source column.
- [ ] In the panel, press `e` on a host row and confirm it refuses and tells you to adopt first; press `a`, then `e` on the new AoE row and confirm the editor opens and Ctrl-S saves.
- [ ] In the panel, press `x` on an AoE row and confirm the delete goes behind a `y` confirmation.
- [ ] In the dashboard, open Settings, Skills, and confirm the source badges read `AoE` / `Claude` / `Gemini` rather than raw root ids, and that "Share with all agents" reports its outcome counts.
- [ ] In a Claude structured-view session, type `/` and confirm a skill-backed command shows a source pill while non-skill commands show none.
- [ ] Invoke a skill in that session and confirm its tool card shows the same pill as the picker did.
- [ ] Open Settings, Skills on a wide window and confirm the page uses the full width, with the sidebar and detail pane scrolling independently and the editor reaching the footer with no dead gap.
- [ ] In the sidebar, collapse and expand the Managed and Available to adopt groups, and confirm search filters across directory, name, and description.
- [ ] Select a managed skill, switch to Preview, and confirm the markdown body renders without the YAML frontmatter showing as a paragraph.
- [ ] Select an external skill and confirm the editor is read-only and offers Adopt into AoE instead of Save.
- [ ] Switch to a light theme (Settings, Theme, catppuccin-latte) and confirm the skills panel repaints legibly rather than staying dark.
- [ ] With `skills.auto_propagate` off (the default), launch a session and confirm nothing was written into any agent skills dir. Turn it on in Settings, launch again, and confirm the managed skills appear in that agent's dir.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording <!-- screenshots not attached yet; the redesign was verified live against a light and a dark theme -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

`web/tests/live/skills-management.spec.ts` drives discover, adopt, edit, create, delete against a real `aoe serve`. `web/tests/live/read-only-mode.spec.ts` covers the pre-body-parse mutation rejection. Matrix entries: `settings.skills-management`, `settings.skills-management.handlers`, and the new `acp.composer-slash-skill-provenance`, with `acp.tool-cards` extended.

Vitest covers the badge resolver as a table (single source, ambiguous, unknown name, frontmatter name diverging from directory, and the same-label-via-both-keys case that must not read as ambiguous), the sync request payloads, and the manager's sync result rendering.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

`tests/e2e/skills_tui.rs` covers the panel arc through tmux: palette open, source label, edit refused on a host row, adopt, delete behind confirmation. `tests/e2e/cli.rs::test_cli_skill_management_flow` was extended rather than duplicated, and now also covers sync landing in every root, the copies not being double-counted, and withdrawal after the managed source is deleted.

Propagation safety is covered by Rust unit tests on the ownership matrix: absent, clean-owned, drifted-owned, foreign, unmarked, symlinked, and root-mismatched marker; orphan removal only when clean; adopt stripping the marker; the digest excluding the marker; and one root per primary agent. The opt-in gate is tested directly, which is why the sandbox reconcile takes the flag as an argument instead of reading global config in a leaf function.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with the propagation design pressure-tested through a two-model debate before any code was written. That debate is what moved the opt-in from default-on to default-off and added the content digest, so it is load-bearing rather than decoration. I made the design calls, reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added skill management across the REST API, CLI, web dashboard, and TUI.
- Users can list, view, create, edit, delete, and adopt skills.
- Host skills remain read-only until users adopt them.
- Added opt-in skill propagation with ownership markers, digests, conflict detection, safe cleanup, and duplicate prevention.
- Added provenance badges to the dashboard, slash-command picker, and skill tool cards.
- Added a two-pane dashboard workspace and an inline TUI manager.
- Updated skill discovery for multiple agent sources.
- Updated plugin reconciliation to process all managed skills for an agent and report per-skill results.
- Added mutation safeguards for read-only and CityHall modes.
- Added API, CLI, TUI, live, integration, and unit test coverage.
- Added documentation for the REST API, CLI commands, discovery roots, and propagation behavior.

## Benefits

- Users can manage skills from their preferred interface.
- Adoption protects host files from accidental changes.
- Propagation avoids overwriting user changes.
- Provenance labels make skill sources clear.
- Detailed synchronization results improve troubleshooting.

## Known gaps

- Codex sandbox propagation is not implemented.
- The dashboard statistics tab is not implemented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->