### PR TITLE
feat(plugin-api): grow the pane block vocabulary (api_version 12)

### DIFF
--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -43,5 +43,8 @@ pub use manifest::{
 /// `dynamic_select`); 10 when the `settings-page` full-page slot and the
 /// `tool-card-badge` slot were added; 11 when `acp.capabilities.probe` let a
 /// plugin trigger a handshake-only catalog probe and the capability response
-/// grew a `thinking` (thought-level) list.
-pub const API_VERSION: u32 = 11;
+/// grew a `thinking` (thought-level) list; 12 when the pane block vocabulary
+/// gained the `callout`, `bar`, and `columns` kinds, clickable/badged `row`s,
+/// header-summary and scrollable `section`s, `disabled`/`variant` actions, and
+/// the pane-level `footer`.
+pub const API_VERSION: u32 = 12;

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -805,29 +805,49 @@ These slots carry more than a single value, so one entry (one declared
   dashboard renders the pill in the card header; the TUI ignores this slot.
 - `pane` also accepts `blocks: Block[]`, an ordered list of typed
   blocks. The web renderer knows these kinds: `heading { text }`,
-  `row { label, value?, sublabel?, icon?, tone?, color?, href? }`,
+  `row { label?, value?, prefix?, sublabel?, icon?, avatar?, tone?, value_tone?, color?, href?, tooltip?, mono?, selected?, badges?, method?, params? }`,
   `note { text, tone? }`, `divider {}`,
-  `section { title?, children: Block[], collapsible?, collapsed? }` (nested
+  `section { title?, children: Block[], value?, value_tone?, badges?, icon?, tone?, boxed?, scroll?, collapsible?, collapsed? }` (nested
   blocks; `collapsible` wraps the section in a native `<details>` the user can
   fold, and `collapsed` starts it folded, default open),
+  `callout { title?, detail?, icon?, tone?, color?, actions? }` (a tone-bordered
+  verdict card with its own full-width buttons: the one thing the pane is saying,
+  where a `section` is a list),
+  `bar { segments: [{ value, tone?, color?, label? }], caption? }` (a proportional
+  stacked bar; non-positive segments are dropped and an empty bar renders nothing),
+  `columns { children: Block[] }` (children side by side in equal fractions; a lone
+  child spans the full width, so eliding a card collapses the row rather than
+  leaving a gap),
   `comment { author, body, path?, line?, resolved?, href? }` (a read-only PR
   review comment: author, optional file:line, a wrapped body excerpt, and an
   unresolved/resolved marker), and
-  `action { label, method, icon? }` (a button that forwards `method` to the
-  plugin's worker, see below). A block's optional `color` is a validated hex
-  literal (`#rgb`/`#rrggbb`, normalized; no CSS names, `rgb()`, `var()`, or
-  `url()`, so it can never carry arbitrary CSS) that tints the block's
-  icon/value where a semantic `tone` cannot name the hue, e.g. a merged PR's
-  purple. The simple `{ title, body }` form still works
+  `action { label, method?, href?, disabled?, variant?, tone?, tooltip?, icon? }`
+  (a button that forwards `method` to the plugin's worker, see below; with `href`
+  and no `method` it is a link-out instead, and `disabled` renders it inert and
+  non-navigating, which is how a blocked state reads). A block's optional `color`
+  is a validated hex literal (`#rgb`/`#rrggbb`, normalized; no CSS names,
+  `rgb()`, `var()`, or `url()`, so it can never carry arbitrary CSS) that tints
+  the block's icon/value where a semantic `tone` cannot name the hue, e.g. a
+  merged PR's purple. The simple `{ title, body }` form still works
   when `blocks` is absent. A `pane`
   also takes an optional `default_location` (`right` | `bottom`) choosing the
-  dock it first opens in; the user can move it between docks afterward, and an
+  dock it first opens in; the user can move it between docks afterward, an
   optional `icon` (any lucide icon name, kebab-case) for its activity-bar
-  button, falling back to a generic plugin icon. The host renders each `pane` as
-  a dockable tool-window (activity-bar toggle, move, close) alongside the
-  built-in diff and terminal panes. Each pane's body scrolls, and a long
-  `comment` body is clamped with a "more"/"less" toggle, so a full PR comment
+  button, falling back to a generic plugin icon, and an optional
+  `footer { text?, value?, icon?, tone? }` (api_version 12) rendered outside the
+  scroll area so a status line stays put while the blocks scroll. The host renders
+  each `pane` as a dockable tool-window (activity-bar toggle, move, close)
+  alongside the built-in diff and terminal panes. Each pane's body scrolls, and a
+  long `comment` body is clamped with a "more"/"less" toggle, so a full PR comment
   list stays browsable.
+
+  A `row` lays out at most two lines: `prefix` (mono, tone-tinted) and `label`
+  lead the first with `value` pinned right, then `sublabel` leads the second with
+  `badges` (compact `{ text?, icon?, tone?, tooltip? }` signals, not pills) pinned
+  right. `value_tone` colors the trailing token independently of the row, for the
+  common shape of a status glyph beside a neutral scalar such as a timestamp.
+  `scroll` on a section caps its body height with a fixed class rather than a
+  plugin-supplied length: a worker must not be able to size host chrome.
 
   A pane entry gets a larger payload budget than the other slots: its normalized
   JSON may be up to 64KB, against 8KB for every other slot (`status-bar`,
@@ -853,14 +873,19 @@ change: an older host simply renders what it understands and drops the rest.
 This is deliberate, the GitHub plugin's pane keeps growing (PR state today,
 review/CI/timelines later) and must not require lockstep host releases.
 
-**Pane actions (host to worker).** An `action` block is a button. When clicked,
-the dashboard POSTs `/api/plugins/{id}/action { method, params? }`; the host
-writes that JSON-RPC method to the worker's stdin as a notification (no id, so
-no reply) via `PluginHost::notify_worker`. The worker runs the method (e.g.
-`github.refresh`) and re-pushes its UI state, which the next `ui-state` poll
-renders. The plugin names the `method` in its own block, and the worker is the
-trust boundary: it acts only on methods it implements and ignores the rest (the
-honest-plugin model). The endpoint is gated on read-write mode only, not on
+**Pane actions (host to worker).** An `action` block is a button, and so is a
+`row` carrying a `method`. When clicked, the dashboard POSTs
+`/api/plugins/{id}/action { method, params? }`; the host writes that JSON-RPC
+method to the worker's stdin as a notification (no id, so no reply) via
+`PluginHost::notify_worker`. The worker runs the method (e.g. `github.refresh`)
+and re-pushes its UI state, which the next `ui-state` poll renders. `params` is
+the block's own `params` object forwarded verbatim, which is what lets one method
+serve a whole list (`github.select_pr { pr }` on every row of a PR selector); the
+host merges the authoritative `session_id` in server-side, so a plugin cannot
+spoof which session it is acting on. Since the object round-trips values the
+plugin itself authored, there is nothing to sanitize on the way out. The plugin
+names the `method` in its own block, and the worker is the trust boundary: it acts
+only on methods it implements and ignores the rest (the honest-plugin model). The endpoint is gated on read-write mode only, not on
 passphrase elevation: a pane action mutates no host-managed state (config,
 registry, grants, lockfile) and grants no new host capability, so it does not
 warrant the step-up the way enable/disable does (the worker's own behavior may

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -19,10 +19,10 @@ A manifest carries two independent version axes.
 
 | Key | Meaning |
 |---|---|
-| `api_version` | The manifest *schema* version. The current schema is `11`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
+| `api_version` | The manifest *schema* version. The current schema is `12`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
 | `aoe_version` | A semver requirement on the *host app* version, e.g. `">=1.11.0, <2.0.0"`. The host refuses to install, and skips loading, a plugin whose requirement excludes the running version. Optional; requires `api_version >= 4`. |
 
-Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added identity icons, `8` added the `composer-action` UI slot, `9` added session-driving worker RPCs (see [Session-driving RPCs](#session-driving-rpcs)), plugin-private storage, and the `dynamic_select` / `object_list` / `cron` settings widgets, `10` added the `tool-card-badge` UI slot, `11` added the `acp.capabilities.probe` RPC + capability, a `thinking` (thought-level) list on the capability response, the `dynamic_multi_select` object-list field widget, and an optional `project_path` (empty = scratch session), `extra_project_paths`, and a `sandbox` flag on `sessions.create`, plus a `multiline` attribute for `string` settings fields.
+Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added identity icons, `8` added the `composer-action` UI slot, `9` added session-driving worker RPCs (see [Session-driving RPCs](#session-driving-rpcs)), plugin-private storage, and the `dynamic_select` / `object_list` / `cron` settings widgets, `10` added the `tool-card-badge` UI slot, `11` added the `acp.capabilities.probe` RPC + capability, a `thinking` (thought-level) list on the capability response, the `dynamic_multi_select` object-list field widget, and an optional `project_path` (empty = scratch session), `extra_project_paths`, and a `sandbox` flag on `sessions.create`, plus a `multiline` attribute for `string` settings fields, `12` grew the pane block vocabulary (see [Pane payload](#pane-payload)): the `callout`, `bar` and `columns` kinds, clickable `row`s carrying `params`, header summaries and scrollable bodies on `section`, `disabled` / `variant` / `href` on `action`, and a pane-level `footer`.
 
 ## Top-level fields
 
@@ -356,10 +356,124 @@ id = "my_pane"
 | `row-badge` | per-session | A badge on the session row. |
 | `row-column` | per-session | A text column on the session row. |
 | `detail-badge` | per-session | A badge in the session detail view. |
-| `pane` | per-session | A dockable tool-window pane (requires `api_version >= 3`). |
+| `pane` | per-session | A dockable tool-window pane (requires `api_version >= 3`). See [Pane payload](#pane-payload). |
+| `settings-page` | global | A full page under Settings, using the same block vocabulary as `pane` (requires `api_version >= 10`). |
 | `composer-action` | per-session | A button beside the ACP composer controls (requires `api_version >= 8`). |
 | `tool-card-badge` | per-session | A pill on a transcript MCP or skill tool-call card, matched by target (requires `api_version >= 10`). |
 | `notification` | n/a | A transient notification pushed via `ui.notify`; gated by the `notifications` capability, not a slot declaration. |
+
+### Pane payload
+
+A `pane` entry renders a dockable tool-window. The worker pushes it with
+`ui.state.set`:
+
+```json
+{
+  "title": "GitHub",
+  "default_location": "right",
+  "icon": "git-branch",
+  "blocks": [{ "kind": "heading", "text": "GitHub" }],
+  "footer": { "text": "refreshed 12:07", "value": "blocked", "tone": "danger", "icon": "refresh-cw" }
+}
+```
+
+| Key | Type | Notes |
+|---|---|---|
+| `title` | string | Shown on the dock tab. |
+| `body` | string | The simple form: plain text, used only when `blocks` is absent. |
+| `blocks` | array | The block list (below). Takes precedence over `body`. |
+| `default_location` | string | `right` or `bottom`. The dock it first opens in; the user can move it after. |
+| `icon` | string | Lucide name for the activity-bar / dock-tab icon. A manifest `icon_asset` outranks it. |
+| `footer` | table | A status line pinned below the scrolling block list: `text` left, tone-colored `value` right, plus an optional `icon`. Requires `api_version >= 12`. |
+
+The whole payload is capped at 64 KiB. Everything else on the entry is validated
+strictly, but `blocks` is stored as opaque JSON: **each surface renders the kinds
+it knows and silently drops the rest.** That is the forward-compatibility
+contract, and it cuts both ways. A new kind needs no host change, and an older
+host will render nothing for it, so a pane whose layout depends on a newer kind
+should say so with `api_version` (and `aoe_version`) rather than degrade silently.
+
+The `settings-page` slot takes the same block vocabulary, minus
+`default_location` and `footer` (a full page is not docked, so neither has
+anything to attach to).
+
+#### Block kinds
+
+| `kind` | Required | Optional |
+|---|---|---|
+| `heading` | `text` | |
+| `note` | `text` | `tone` |
+| `divider` | | |
+| `row` | one of `label` / `value` / `prefix` / `icon` / `avatar` | `sublabel`, `tone`, `value_tone`, `color`, `href`, `tooltip`, `mono`, `selected`, `badges`, `method`, `params` |
+| `section` | | `title`, `children`, `value`, `value_tone`, `badges`, `icon`, `tone`, `boxed`, `scroll`, `collapsible`, `collapsed` |
+| `callout` | one of `title` / `detail` | `icon`, `tone`, `color`, `actions` |
+| `bar` | `segments` | `caption` |
+| `columns` | `children` | |
+| `action` | `label`, plus one of `method` / `href` / `disabled` | `icon`, `tone`, `tooltip`, `variant` |
+| `comment` | one of `author` / `body` | `path`, `line`, `resolved`, `href` |
+
+`tone` is one of `neutral` / `info` / `success` / `warn` / `danger`. `color` is a
+validated `#rgb` / `#rrggbb` literal for a hue no tone names (a merged PR's
+purple); anything else is ignored.
+
+**`row`** lays out at most two lines: `prefix` (mono, tone-tinted) and `label`
+lead the first with `value` pinned right, and `sublabel` leads the second with
+`badges` pinned right. `value_tone` colors the trailing token independently of the
+row, for a status glyph beside a neutral scalar such as a timestamp. `mono`
+monospaces the row's own text. Each entry in `badges` is `{ text?, icon?, tone?,
+tooltip? }` and renders as a compact glyph or token, not a pill.
+
+A `method` makes the row body a button that fires that worker method; an `href`
+alongside it becomes a separate trailing open-externally link, so a selectable row
+can still link out. With `href` alone the whole row is the link. `selected` marks
+the row as the pane's current subject.
+
+**`section`** groups `children`. The header takes a right-pinned `value` summary
+or a run of `badges` (count pills). `boxed` draws it as a bordered card, `scroll`
+caps the body height so a long list scrolls inside the section instead of pushing
+the rest of the pane away, and `collapsible` folds it via a native `<details>`
+(`collapsed` sets the initial state).
+
+**`callout`** is a tone-bordered verdict card: a glyph, a `title`, a `detail`
+paragraph, and its own `actions` laid out full width. Use it for the one thing the
+pane is telling the user; use a `section` for a list.
+
+**`bar`** is a proportional stacked bar over `segments`, each
+`{ value, tone?, color?, label? }`. Segments without a positive numeric `value` are
+dropped, and a bar left with nothing renders nothing. `caption` sits beneath it.
+
+**`columns`** lays its `children` side by side in equal fractions. A single child
+spans the full width, so eliding one card collapses the row cleanly rather than
+leaving a gap.
+
+**`action`** forwards `method` to the worker (see [Pane actions](#pane-actions)).
+With `href` and no `method` it is a link-out button instead, for something the host
+cannot do itself. `disabled` renders it inert, which is how a blocked state reads
+without pretending to be clickable; a disabled action never navigates either.
+`variant: "primary"` gives the brand-filled treatment.
+
+#### Pane actions
+
+Clicking an `action` block, or a `row` carrying a `method`, POSTs to
+`/api/plugins/{id}/action` with `{ method, params, session_id }`. `params` is the
+block's own `params` object, forwarded verbatim, so one method can serve every row
+in a list:
+
+```json
+{ "kind": "row", "label": "warn when daemon is stale", "prefix": "#3231",
+  "method": "github.select_pr", "params": { "pr": "o/r#3231" } }
+```
+
+The host merges in the authoritative `session_id` (a plugin cannot spoof it) and
+delivers the call to the worker as a **fire-and-forget JSON-RPC notification**:
+there is no reply and no return value. The worker does its work and re-pushes its
+UI state; the clicked control spins until the plugin's UI revision moves, with a
+15s timeout fallback. Actions are read-write-mode only and are not passphrase
+gated, so treat every method as reachable by anyone who can use the dashboard.
+
+The native TUI renders panes read-only for now: it draws the text of every kind
+above (dropping icons, hrefs and tooltips, and stacking `columns`) but cannot fire
+an action, so `action` blocks appear as inert `[action] <label>` labels.
 
 ### Composer action payload
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -41,7 +41,7 @@ capabilities = ["runtime.worker"]
 | `id` | string | yes | Plugin id (see [Plugin id](#plugin-id)). Namespaces config, events, and action names. |
 | `name` | string | yes | Human-readable display name. |
 | `version` | string | yes | Semantic version of the plugin. |
-| `api_version` | integer | yes | Manifest schema version, `1` to `11`. |
+| `api_version` | integer | yes | Manifest schema version, `1` to `12`. |
 | `description` | string | no | Shown in plugin listings. Defaults to empty. |
 | `aoe_version` | string | no | Host-app semver requirement. Requires `api_version >= 4`. |
 | `capabilities` | array of string | no | Runtime grants the worker needs (see [Capabilities](#capabilities)). Static contributions need none. |

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -255,6 +255,26 @@ pub enum PaneLocation {
     Bottom,
 }
 
+/// A pane's pinned status line, rendered below the scrolling block list so it
+/// stays visible while the body scrolls. `text` reads on the left, `value` on
+/// the right; both are optional, and a footer with neither renders nothing.
+/// Unlike the blocks this is a typed envelope field, since the surfaces need to
+/// know it is chrome rather than content in order to pin it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PaneFooter {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    value: Option<String>,
+    /// Lucide icon name, resolved web-side against its allowlist.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    icon: Option<String>,
+    /// Tones `value`, which is the status half of the line.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tone: Option<Tone>,
+}
+
 /// `pane` payload (the dockable tool-window slot). Either the simple
 /// `{ title, body }` form or an ordered `blocks` list, plus an optional
 /// `default_location` picking the dock it first opens in (defaults to the
@@ -279,6 +299,8 @@ struct PanePayload {
     /// generic icon); kept only so `deny_unknown_fields` accepts it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     icon: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    footer: Option<PaneFooter>,
 }
 
 /// `settings-page` payload (the routed full-page slot). Mirrors `PanePayload`'s
@@ -1494,6 +1516,53 @@ mod tests {
             &json!({"title": "T", "body": "B"}),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn pane_footer_round_trips_and_rejects_unknown_fields() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        // The footer is a typed envelope field (unlike the opaque blocks), so the
+        // surfaces can tell pinned chrome from scrolling content.
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::Pane,
+            "gh",
+            Some("s1"),
+            &json!({"blocks": [{"kind": "heading", "text": "GitHub"}],
+                    "footer": {"text": "refreshed 12:07", "value": "blocked", "tone": "danger", "icon": "refresh-cw"}}),
+        )
+        .unwrap();
+        let snap = s.snapshot();
+        assert_eq!(snap.entries[0].payload["footer"]["value"], json!("blocked"));
+        assert_eq!(snap.entries[0].payload["footer"]["tone"], json!("danger"));
+        // A typo in the footer is a hard error rather than a silently ignored
+        // field, which is the point of typing it instead of leaving it opaque.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::Pane,
+                "gh",
+                Some("s1"),
+                &json!({"footer": {"txt": "oops"}})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+        // `settings-page` has no footer: a full page is not docked, so a pinned
+        // status line would have nothing to pin against.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::SettingsPage,
+                "page",
+                None,
+                &json!({"footer": {"text": "x"}})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
     }
 
     #[test]

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -845,6 +845,39 @@ fn check_scope(slot: UiSlot, session_id: Option<&str>) -> Result<(), UiError> {
 /// Validate `raw` against the slot's typed payload and return the normalized
 /// JSON (re-serialized from the parsed struct, so unknown fields are rejected
 /// and the stored shape is canonical).
+/// How deeply a pane's `blocks` may nest through the recursive kinds
+/// (`section.children`, `columns.children`). Generous against any real pane: the
+/// GitHub plugin's deepest chain is a `section` holding a `section` holding rows,
+/// so three. The cap exists because the size limit alone is not one: a 64 KiB
+/// payload still fits a chain around 1,800 links long, and the surfaces recurse
+/// per level, so an accidental cycle in a plugin's block builder would blow the
+/// web renderer's stack. The host is the right place to draw that line, not the
+/// renderer, so every surface inherits the same bound.
+const MAX_BLOCK_DEPTH: usize = 16;
+
+/// Reject a `blocks` list that nests past [`MAX_BLOCK_DEPTH`]. Only arrays under
+/// the `children` key count as a level, matching what the renderers actually
+/// recurse through; any other nested JSON a block carries is inert data.
+fn check_block_depth(blocks: Option<&[Value]>) -> Result<(), String> {
+    fn depth_ok(blocks: &[Value], remaining: usize) -> bool {
+        if remaining == 0 {
+            return blocks.is_empty();
+        }
+        blocks
+            .iter()
+            .all(|b| match b.get("children").and_then(Value::as_array) {
+                Some(children) => depth_ok(children, remaining - 1),
+                None => true,
+            })
+    }
+    match blocks {
+        Some(blocks) if !depth_ok(blocks, MAX_BLOCK_DEPTH) => {
+            Err(format!("pane blocks nest deeper than {MAX_BLOCK_DEPTH}"))
+        }
+        _ => Ok(()),
+    }
+}
+
 fn validate_payload(slot: UiSlot, raw: &Value) -> Result<Value, String> {
     fn normalize<T: serde::de::DeserializeOwned + Serialize>(raw: &Value) -> Result<Value, String> {
         let parsed: T = serde_json::from_value(raw.clone()).map_err(|e| e.to_string())?;
@@ -857,8 +890,18 @@ fn validate_payload(slot: UiSlot, raw: &Value) -> Result<Value, String> {
         UiSlot::SortKey => normalize::<SortKeyPayload>(raw),
         UiSlot::FilterFacet => normalize::<FilterFacetPayload>(raw),
         UiSlot::Card => normalize::<CardPayload>(raw),
-        UiSlot::Pane => normalize::<PanePayload>(raw),
-        UiSlot::SettingsPage => normalize::<SettingsPagePayload>(raw),
+        UiSlot::Pane => {
+            let parsed: PanePayload =
+                serde_json::from_value(raw.clone()).map_err(|e| e.to_string())?;
+            check_block_depth(parsed.blocks.as_deref())?;
+            serde_json::to_value(parsed).map_err(|e| e.to_string())
+        }
+        UiSlot::SettingsPage => {
+            let parsed: SettingsPagePayload =
+                serde_json::from_value(raw.clone()).map_err(|e| e.to_string())?;
+            check_block_depth(parsed.blocks.as_deref())?;
+            serde_json::to_value(parsed).map_err(|e| e.to_string())
+        }
         UiSlot::ComposerAction => {
             let parsed: ComposerActionPayload =
                 serde_json::from_value(raw.clone()).map_err(|e| e.to_string())?;
@@ -1514,6 +1557,72 @@ mod tests {
             "gh",
             Some("s1"),
             &json!({"title": "T", "body": "B"}),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn pane_rejects_blocks_nested_past_the_depth_cap() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        // `children` chains are what the renderers recurse through, so they are
+        // what the cap counts. The size limit is not a depth limit: a 64KB payload
+        // fits a chain thousands of links long, and every surface recurses per
+        // level, so the host draws the line once for all of them.
+        let chain = |depth: usize| {
+            let mut block = json!({"kind": "row", "label": "leaf"});
+            for _ in 0..depth {
+                block = json!({"kind": "section", "children": [block]});
+            }
+            json!({"blocks": [block]})
+        };
+        // At the cap it stores; one level past it is a hard error, not a silent
+        // truncation, so a plugin author sees the mistake.
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::Pane,
+            "gh",
+            Some("s1"),
+            &chain(MAX_BLOCK_DEPTH - 1),
+        )
+        .unwrap();
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::Pane,
+                "gh",
+                Some("s1"),
+                &chain(MAX_BLOCK_DEPTH + 1)
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+        // The same bound covers `settings-page`, which shares the vocabulary.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::SettingsPage,
+                "page",
+                None,
+                &chain(MAX_BLOCK_DEPTH + 1)
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+        // Deep JSON that is not a `children` array is inert data the renderers
+        // never walk, so it must not trip the cap.
+        let mut inert = json!("leaf");
+        for _ in 0..64 {
+            inert = json!({"nested": inert});
+        }
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::Pane,
+            "gh",
+            Some("s1"),
+            &json!({"blocks": [{"kind": "some-future-kind", "payload": inert}]}),
         )
         .unwrap();
     }

--- a/src/tui/plugin_ui.rs
+++ b/src/tui/plugin_ui.rs
@@ -372,10 +372,10 @@ fn bar_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'static>> 
 }
 
 /// Lay the segments out over [`BAR_WIDTH`] cells. Every positive segment gets at
-/// least one cell so a tiny slice is still visible, and the widest segment
-/// absorbs the rounding slack so the run is exactly `BAR_WIDTH` wide (or as wide
-/// as the one-cell minimums force it to be, when there are more segments than
-/// cells).
+/// least one cell so a tiny slice is still visible, and the rounding slack is
+/// taken off the widest segments so the run is exactly `BAR_WIDTH` wide. With
+/// more segments than cells the one-cell floor wins and the run is `segments.len()`
+/// wide instead, which is the only case where it exceeds `BAR_WIDTH`.
 fn bar_spans(segments: &[(f64, Option<Tone>)], indent: usize, theme: &Theme) -> Vec<Span<'static>> {
     let total: f64 = segments.iter().map(|(v, _)| v).sum();
     let mut cells: Vec<usize> = segments
@@ -383,18 +383,34 @@ fn bar_spans(segments: &[(f64, Option<Tone>)], indent: usize, theme: &Theme) -> 
         .map(|(v, _)| ((v / total) * BAR_WIDTH as f64).round().max(1.0) as usize)
         .collect();
     let sum: usize = cells.iter().sum();
-    // Widest segment by cell count, so the correction lands where it is least
-    // visible and can never push a segment below its one-cell floor.
-    let widest = cells
-        .iter()
-        .enumerate()
-        .max_by_key(|(_, c)| **c)
-        .map(|(i, _)| i)
-        .unwrap_or(0);
+    // Widest segment by cell count, so a correction lands where it is least
+    // visible.
+    let widest = |cells: &[usize]| {
+        cells
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, c)| **c)
+            .map(|(i, _)| i)
+            .unwrap_or(0)
+    };
     if sum > BAR_WIDTH {
-        cells[widest] = cells[widest].saturating_sub(sum - BAR_WIDTH).max(1);
+        // Shed one cell at a time from whichever segment is currently widest:
+        // taking the whole overshoot off a single segment cannot converge once the
+        // one-cell floor bites (13 equal segments round to 2 cells each, 26 total,
+        // and one segment can only give back 1). Stops when the floor leaves
+        // nothing to take, which is exactly the more-segments-than-cells case.
+        let mut over = sum - BAR_WIDTH;
+        while over > 0 {
+            let i = widest(&cells);
+            if cells[i] <= 1 {
+                break;
+            }
+            cells[i] -= 1;
+            over -= 1;
+        }
     } else if sum < BAR_WIDTH {
-        cells[widest] += BAR_WIDTH - sum;
+        let i = widest(&cells);
+        cells[i] += BAR_WIDTH - sum;
     }
     let mut spans = indent_span(indent);
     for (cell_count, (_, tone)) in cells.iter().zip(segments) {
@@ -1014,8 +1030,18 @@ mod tests {
     #[test]
     fn pane_bar_cells_always_total_the_fixed_width() {
         // Rounding must never leave the run short or long, and a segment too
-        // small to earn a cell still gets one so it stays visible.
-        let cases: [&[f64]; 4] = [&[1.0], &[1.0, 1.0, 1.0], &[999.0, 1.0], &[7.0, 11.0, 13.0]];
+        // small to earn a cell still gets one so it stays visible. 13 equal
+        // segments is the case that needs the repair to iterate: each rounds up to
+        // 2 cells (26 total) and no single segment can give back more than 1.
+        let equal_13 = [1.0; 13];
+        let cases: [&[f64]; 6] = [
+            &[1.0],
+            &[1.0, 1.0, 1.0],
+            &[999.0, 1.0],
+            &[7.0, 11.0, 13.0],
+            &equal_13,
+            &[5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
+        ];
         for values in cases {
             let segments: Vec<(f64, Option<Tone>)> = values.iter().map(|v| (*v, None)).collect();
             let spans = bar_spans(&segments, 0, &Theme::default());
@@ -1023,6 +1049,13 @@ mod tests {
             assert_eq!(width, BAR_WIDTH, "{values:?}");
             assert_eq!(spans.len(), values.len(), "{values:?}");
         }
+        // More segments than cells: the one-cell floor wins, so the run is as wide
+        // as the segment count. The only shape allowed to exceed BAR_WIDTH.
+        let crowded: Vec<(f64, Option<Tone>)> = (0..BAR_WIDTH + 6).map(|_| (1.0, None)).collect();
+        let spans = bar_spans(&crowded, 0, &Theme::default());
+        let width: usize = spans.iter().map(|s| s.content.chars().count()).sum();
+        assert_eq!(width, crowded.len());
+        assert!(spans.iter().all(|s| s.content.chars().count() == 1));
     }
 
     #[test]

--- a/src/tui/plugin_ui.rs
+++ b/src/tui/plugin_ui.rs
@@ -163,14 +163,20 @@ pub fn pane_lines(snapshot: &UiSnapshot, session_id: &str, theme: &Theme) -> Vec
 /// carries the attribution, falling back to the `plugin_id` the way the web's
 /// `paneTitle` does (`web/src/lib/pluginPanes.ts`).
 fn pane_entry_lines(entry: &UiEntry, theme: &Theme) -> Vec<Line<'static>> {
+    // The footer belongs to the entry, not to the `blocks` form: a payload can
+    // pair it with the simple `{ title, body }` shape, and a block list that all
+    // drops out still has a status line worth showing. Computed once, up front, so
+    // both paths below append it and neither can forget.
+    let footer = footer_lines(&entry.payload, theme);
     if let Some(blocks) = entry.payload.get("blocks").and_then(Value::as_array) {
         let body: Vec<Line<'static>> = blocks
             .iter()
             .flat_map(|b| block_lines(b, 0, theme))
             .collect();
-        // No renderable block means no heading either: an empty or malformed
-        // payload must not leave a bare plugin name on screen.
-        if body.is_empty() {
+        // Nothing renderable at all means no heading either: an empty or malformed
+        // payload must not leave a bare plugin name on screen. A footer counts as
+        // content, so it keeps the entry (and its heading) alive on its own.
+        if body.is_empty() && footer.is_empty() {
             return body;
         }
         let heading = block_str(&entry.payload, "title").unwrap_or(entry.plugin_id.as_str());
@@ -184,7 +190,7 @@ fn pane_entry_lines(entry: &UiEntry, theme: &Theme) -> Vec<Line<'static>> {
         out.extend(body);
         // The web pins the footer below the scroll area; the TUI has no separate
         // viewport per entry, so it trails the blocks.
-        out.extend(footer_lines(&entry.payload, theme));
+        out.extend(footer);
         return out;
     }
     let mut out: Vec<Line<'static>> = Vec::new();
@@ -206,6 +212,7 @@ fn pane_entry_lines(entry: &UiEntry, theme: &Theme) -> Vec<Line<'static>> {
             ));
         }
     }
+    out.extend(footer);
     out
 }
 
@@ -834,6 +841,30 @@ mod tests {
         let snap = pane_snapshot(pane_entry(json!({"title": "Checks", "body": "all\ngood"})));
         let lines = pane_lines(&snap, "s1", &Theme::default());
         assert_eq!(texts(&lines), vec!["Checks", "all", "good"]);
+    }
+
+    #[test]
+    fn pane_footer_renders_without_blocks_and_carries_an_all_dropped_entry() {
+        // The footer belongs to the entry, so the simple title/body form gets it
+        // too rather than only the `blocks` form.
+        let simple = pane_snapshot(pane_entry(json!({
+            "title": "GitHub", "body": "no PRs",
+            "footer": {"text": "refreshed 12:07", "value": "ready"}
+        })));
+        assert_eq!(
+            texts(&pane_lines(&simple, "s1", &Theme::default())),
+            vec!["GitHub", "no PRs", "refreshed 12:07 ready"]
+        );
+        // And a block list that all drops out still has a status line worth
+        // showing, so the footer keeps the entry (and its heading) alive.
+        let dropped = pane_snapshot(pane_entry(json!({
+            "title": "GitHub", "blocks": [{"kind": "row"}],
+            "footer": {"text": "refreshed 12:07"}
+        })));
+        assert_eq!(
+            texts(&pane_lines(&dropped, "s1", &Theme::default())),
+            vec!["GitHub", "refreshed 12:07"]
+        );
     }
 
     #[test]

--- a/src/tui/plugin_ui.rs
+++ b/src/tui/plugin_ui.rs
@@ -182,6 +182,9 @@ fn pane_entry_lines(entry: &UiEntry, theme: &Theme) -> Vec<Line<'static>> {
                 .add_modifier(Modifier::BOLD),
         )];
         out.extend(body);
+        // The web pins the footer below the scroll area; the TUI has no separate
+        // viewport per entry, so it trails the blocks.
+        out.extend(footer_lines(&entry.payload, theme));
         return out;
     }
     let mut out: Vec<Line<'static>> = Vec::new();
@@ -204,6 +207,35 @@ fn pane_entry_lines(entry: &UiEntry, theme: &Theme) -> Vec<Line<'static>> {
         }
     }
     out
+}
+
+/// A pane's `footer` status line: `text` then the tone-colored `value`. Drops the
+/// icon. Yields nothing when the footer is absent, malformed, or carries neither
+/// half, so a bare separator never appears.
+fn footer_lines(payload: &Value, theme: &Theme) -> Vec<Line<'static>> {
+    let Some(footer) = payload.get("footer") else {
+        return vec![];
+    };
+    let text = block_str(footer, "text");
+    let value = block_str(footer, "value");
+    if text.is_none() && value.is_none() {
+        return vec![];
+    }
+    let mut spans = Vec::new();
+    if let Some(t) = text {
+        spans.push(Span::styled(
+            t.to_string(),
+            Style::default().fg(theme.dimmed),
+        ));
+    }
+    if let Some(v) = value {
+        push_sep(&mut spans, 0);
+        spans.push(Span::styled(
+            v.to_string(),
+            tone_style(block_tone(footer), theme),
+        ));
+    }
+    vec![Line::from(spans)]
 }
 
 /// Render one block to lines, indented by `indent` spaces. `section` recurses
@@ -247,24 +279,158 @@ fn block_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'static>
         Some("row") => row_lines(block, indent, theme),
         Some("comment") => comment_lines(block, indent, theme),
         Some("section") => section_lines(block, indent, theme),
+        Some("callout") => callout_lines(block, indent, theme),
+        Some("bar") => bar_lines(block, indent, theme),
+        // The terminal has no side-by-side layout, so a `columns` block degrades
+        // to its children stacked at the same indent, in order.
+        Some("columns") => match block.get("children").and_then(Value::as_array) {
+            Some(children) => children
+                .iter()
+                .flat_map(|c| block_lines(c, indent, theme))
+                .collect(),
+            None => vec![],
+        },
         _ => vec![],
     }
 }
 
-/// `row`: `label value sublabel` on one line, the value tone-colored. Drops
-/// icon / href / color (no terminal surface). Renders nothing without a label or
-/// a value: the web guard is `!label && !value && !iconComp`, and the icon leg
-/// can never carry a row here, so a sublabel-only row is dropped just as it is
-/// on the web.
+/// `callout`: the pane's headline verdict. A toned title line, the detail
+/// wrapped beneath it, then each of its actions as an inert `[action]` label
+/// (same read-only treatment as a top-level `action`). Renders nothing without a
+/// title or detail, matching the web guard.
+fn callout_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'static>> {
+    let title = block_str(block, "title");
+    let detail = block_str(block, "detail");
+    if title.is_none() && detail.is_none() {
+        return vec![];
+    }
+    let mut out: Vec<Line<'static>> = Vec::new();
+    if let Some(t) = title {
+        out.push(indented_line(
+            indent,
+            t.to_string(),
+            tone_style(block_tone(block), theme).add_modifier(Modifier::BOLD),
+        ));
+    }
+    if let Some(d) = detail {
+        for l in d.lines() {
+            out.push(indented_line(
+                indent,
+                l.to_string(),
+                Style::default().fg(theme.text),
+            ));
+        }
+    }
+    if let Some(actions) = block.get("actions").and_then(Value::as_array) {
+        for a in actions {
+            out.extend(block_lines(a, indent, theme));
+        }
+    }
+    out
+}
+
+/// Cells in a `bar` block's text rendering. Fixed for the same reason
+/// [`DIVIDER_WIDTH`] is: the bar is a proportion, not a measurement, so it does
+/// not need the live panel width threaded down to read correctly.
+const BAR_WIDTH: usize = 24;
+
+/// `bar`: the proportional stacked bar as a run of block glyphs per segment,
+/// each tone-colored, followed by the caption. Segments without a positive
+/// numeric `value` are dropped; a bar with nothing left renders nothing.
+fn bar_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'static>> {
+    let segments: Vec<(f64, Option<Tone>)> = block
+        .get("segments")
+        .and_then(Value::as_array)
+        .map(|segs| {
+            segs.iter()
+                .filter_map(|s| {
+                    let v = s.get("value").and_then(Value::as_f64)?;
+                    (v > 0.0 && v.is_finite()).then(|| (v, block_tone(s)))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    if segments.is_empty() {
+        return vec![];
+    }
+    let mut out = vec![Line::from(bar_spans(&segments, indent, theme))];
+    if let Some(caption) = block_str(block, "caption") {
+        out.push(indented_line(
+            indent,
+            caption.to_string(),
+            Style::default().fg(theme.dimmed),
+        ));
+    }
+    out
+}
+
+/// Lay the segments out over [`BAR_WIDTH`] cells. Every positive segment gets at
+/// least one cell so a tiny slice is still visible, and the widest segment
+/// absorbs the rounding slack so the run is exactly `BAR_WIDTH` wide (or as wide
+/// as the one-cell minimums force it to be, when there are more segments than
+/// cells).
+fn bar_spans(segments: &[(f64, Option<Tone>)], indent: usize, theme: &Theme) -> Vec<Span<'static>> {
+    let total: f64 = segments.iter().map(|(v, _)| v).sum();
+    let mut cells: Vec<usize> = segments
+        .iter()
+        .map(|(v, _)| ((v / total) * BAR_WIDTH as f64).round().max(1.0) as usize)
+        .collect();
+    let sum: usize = cells.iter().sum();
+    // Widest segment by cell count, so the correction lands where it is least
+    // visible and can never push a segment below its one-cell floor.
+    let widest = cells
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, c)| **c)
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+    if sum > BAR_WIDTH {
+        cells[widest] = cells[widest].saturating_sub(sum - BAR_WIDTH).max(1);
+    } else if sum < BAR_WIDTH {
+        cells[widest] += BAR_WIDTH - sum;
+    }
+    let mut spans = indent_span(indent);
+    for (cell_count, (_, tone)) in cells.iter().zip(segments) {
+        spans.push(Span::styled(
+            "█".repeat(*cell_count),
+            tone_style(*tone, theme),
+        ));
+    }
+    spans
+}
+
+/// Marks a `selected` row, which the web draws as a brand-accent ring. The
+/// terminal has no border to tint, so the state has to live in the text.
+const SELECTED_MARKER: &str = "▸ ";
+
+/// `row`: `prefix label value sublabel badges` on one line, the prefix and value
+/// tone-colored and the badges appended as a trailing status strip. Drops
+/// icon / avatar / href / tooltip / color (no terminal surface), and a `method`
+/// row renders as text rather than a control, the same read-only treatment
+/// `action` gets. Renders nothing without a label, value or prefix: the web guard
+/// also admits an icon-or-avatar-only row, and neither leg can carry a row here.
 fn row_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'static>> {
     let label = block_str(block, "label");
     let value = block_str(block, "value");
+    let prefix = block_str(block, "prefix");
     let sublabel = block_str(block, "sublabel");
-    if label.is_none() && value.is_none() {
+    let badges = row_badges(block);
+    if label.is_none() && value.is_none() && prefix.is_none() {
         return vec![];
     }
+    let tone = tone_style(block_tone(block), theme);
     let mut spans = indent_span(indent);
+    if block.get("selected").and_then(Value::as_bool) == Some(true) {
+        spans.push(Span::styled(
+            SELECTED_MARKER.to_string(),
+            Style::default().fg(theme.title),
+        ));
+    }
+    if let Some(p) = prefix {
+        spans.push(Span::styled(p.to_string(), tone));
+    }
     if let Some(l) = label {
+        push_sep(&mut spans, indent);
         spans.push(Span::styled(
             l.to_string(),
             Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
@@ -272,9 +438,14 @@ fn row_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'static>> 
     }
     if let Some(v) = value {
         push_sep(&mut spans, indent);
+        // `value_tone` decouples the trailing token from the row's tone (a status
+        // glyph beside a neutral timestamp), falling back to the row's tone.
         spans.push(Span::styled(
             v.to_string(),
-            tone_style(block_tone(block), theme),
+            match value_tone(block) {
+                Some(t) => tone_style(Some(t), theme),
+                None => tone,
+            },
         ));
     }
     if let Some(s) = sublabel {
@@ -284,7 +455,27 @@ fn row_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'static>> 
             Style::default().fg(theme.dimmed),
         ));
     }
+    for (text, badge_tone) in badges {
+        push_sep(&mut spans, indent);
+        spans.push(Span::styled(text, tone_style(badge_tone, theme)));
+    }
     vec![Line::from(spans)]
+}
+
+/// A row's or section's `badges` as `(text, tone)` pairs. An item's `text` is
+/// what a terminal can show, so an icon-only badge (the web's glyph-only signal)
+/// contributes nothing rather than an empty span.
+fn row_badges(block: &Value) -> Vec<(String, Option<Tone>)> {
+    block
+        .get("badges")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|b| Some((block_str(b, "text")?.to_string(), block_tone(b))))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// `comment`: a read-only PR review comment. A header line (author, optional
@@ -342,14 +533,30 @@ fn comment_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'stati
 /// to reveal it.
 fn section_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'static>> {
     let mut out: Vec<Line<'static>> = Vec::new();
+    let value = block_str(block, "value");
+    let badges = row_badges(block);
     if let Some(title) = block_str(block, "title") {
         // `tone_style` already maps no-tone (and an explicit neutral) to dimmed,
         // which is the web's untoned title color.
-        out.push(indented_line(
-            indent,
+        let mut spans = indent_span(indent);
+        spans.push(Span::styled(
             title.to_uppercase(),
             tone_style(block_tone(block), theme).add_modifier(Modifier::BOLD),
         ));
+        // The web pins the header summary right; the terminal appends it, which
+        // keeps the association without needing the panel width.
+        if let Some(v) = value {
+            spans.push(Span::raw("  "));
+            spans.push(Span::styled(
+                v.to_string(),
+                tone_style(value_tone(block), theme),
+            ));
+        }
+        for (text, badge_tone) in badges {
+            spans.push(Span::raw("  "));
+            spans.push(Span::styled(text, tone_style(badge_tone, theme)));
+        }
+        out.push(Line::from(spans));
     }
     if let Some(children) = block.get("children").and_then(Value::as_array) {
         for c in children {
@@ -363,6 +570,13 @@ fn section_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'stati
 fn block_tone(block: &Value) -> Option<Tone> {
     block
         .get("tone")
+        .and_then(|v| serde_json::from_value::<Tone>(v.clone()).ok())
+}
+
+/// The separate tone for a `row`/`section`'s trailing `value`, if it carries one.
+fn value_tone(block: &Value) -> Option<Tone> {
+    block
+        .get("value_tone")
         .and_then(|v| serde_json::from_value::<Tone>(v.clone()).ok())
 }
 
@@ -721,10 +935,93 @@ mod tests {
             {"kind": "heading"},
             {"kind": "row"},
             {"kind": "comment"},
+            {"kind": "callout"},
+            {"kind": "bar", "segments": [{"value": 0}, {"tone": "info"}]},
+            {"kind": "columns", "children": []},
             {"kind": "note", "text": "  "}
         ]})));
         let lines = pane_lines(&snap, "s1", &Theme::default());
         assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn pane_renders_the_api_12_block_kinds() {
+        let snap = pane_snapshot(pane_entry(json!({"blocks": [
+            {"kind": "callout", "tone": "danger", "icon": "circle-x",
+             "title": "2 required checks failing", "detail": "Blocked until Clippy passes.",
+             "actions": [{"kind": "action", "label": "Merge blocked", "method": "gh.merge", "disabled": true}]},
+            {"kind": "bar", "caption": "18 files", "segments": [
+                {"value": 750, "tone": "success"}, {"value": 250, "tone": "danger"}
+            ]},
+            // No side-by-side layout in a terminal: the children stack in order
+            // at the columns block's own indent.
+            {"kind": "columns", "children": [
+                {"kind": "row", "label": "DIFF", "value": "+842 -317"},
+                {"kind": "row", "prefix": "#3180", "label": "Stale daemon"}
+            ]}
+        ]})));
+        let lines = pane_lines(&snap, "s1", &Theme::default());
+        // The bar's two tone-colored spans join into one full-width run of cells.
+        let bar = "█".repeat(BAR_WIDTH);
+        assert_eq!(
+            texts(&lines),
+            vec![
+                "p",
+                "2 required checks failing",
+                "Blocked until Clippy passes.",
+                // A callout's actions get the same inert treatment as a
+                // top-level `action`; the TUI cannot fire either yet.
+                "[action] Merge blocked",
+                &bar,
+                "18 files",
+                "DIFF +842 -317",
+                "#3180 Stale daemon",
+            ]
+        );
+    }
+
+    #[test]
+    fn pane_bar_cells_always_total_the_fixed_width() {
+        // Rounding must never leave the run short or long, and a segment too
+        // small to earn a cell still gets one so it stays visible.
+        let cases: [&[f64]; 4] = [&[1.0], &[1.0, 1.0, 1.0], &[999.0, 1.0], &[7.0, 11.0, 13.0]];
+        for values in cases {
+            let segments: Vec<(f64, Option<Tone>)> = values.iter().map(|v| (*v, None)).collect();
+            let spans = bar_spans(&segments, 0, &Theme::default());
+            let width: usize = spans.iter().map(|s| s.content.chars().count()).sum();
+            assert_eq!(width, BAR_WIDTH, "{values:?}");
+            assert_eq!(spans.len(), values.len(), "{values:?}");
+        }
+    }
+
+    #[test]
+    fn pane_row_and_section_render_the_api_12_fields() {
+        let snap = pane_snapshot(pane_entry(json!({
+            "blocks": [
+                {"kind": "section", "title": "checks", "value": "1 of 2 approved", "value_tone": "warn",
+                 "badges": [{"text": "2 failing", "tone": "danger"}, {"icon": "check", "tone": "success"}],
+                 "children": [
+                    {"kind": "row", "prefix": "#3231", "label": "warn when daemon is stale",
+                     "sublabel": "japanese", "selected": true, "method": "gh.select_pr",
+                     "badges": [{"text": "ci", "tone": "danger"}, {"icon": "circle-x", "tone": "danger"}]}
+                 ]}
+            ],
+            "footer": {"text": "refreshed 12:07", "value": "blocked", "tone": "danger", "icon": "refresh-cw"}
+        })));
+        let lines = pane_lines(&snap, "s1", &Theme::default());
+        assert_eq!(
+            texts(&lines),
+            vec![
+                "p",
+                // The header summary trails the title rather than pinning right;
+                // an icon-only badge has no text a terminal can show.
+                "CHECKS  1 of 2 approved  2 failing",
+                // `selected` becomes a leading marker (there is no ring to tint),
+                // and a `method` row is text, not a control.
+                "  ▸ #3231 warn when daemon is stale japanese ci",
+                "refreshed 12:07 blocked",
+            ]
+        );
     }
 
     #[test]

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -7,7 +7,7 @@
 // filter (the sidebar owns those; see SidebarSortPicker / WorkspaceSidebar, #2401).
 
 import { createElement, useEffect, useId, useRef, useState } from "react";
-import { ChevronRight } from "lucide-react";
+import { ArrowUpRight, ChevronRight } from "lucide-react";
 
 import { invokePluginAction } from "../../lib/api";
 import {
@@ -56,6 +56,15 @@ function str(obj: Record<string, unknown>, key: string): string | undefined {
 function objectList(payload: Record<string, unknown>, key: string): Record<string, unknown>[] | undefined {
   const v = payload[key];
   return Array.isArray(v) ? v.filter(isObject) : undefined;
+}
+
+/** A block's `params`: the argument object forwarded verbatim with its action so
+ *  the worker knows which subject was acted on (which PR a row selects, which
+ *  group a button folds). It round-trips values the plugin itself authored, so
+ *  there is nothing to sanitize; the host still merges in the authoritative
+ *  `session_id` server-side, which a plugin cannot spoof from here. */
+function actionParams(block: Record<string, unknown>): Record<string, unknown> | undefined {
+  return isObject(block.params) ? block.params : undefined;
 }
 
 /** One pill: an optional tone-tinted icon plus optional text, wrapped in a
@@ -388,52 +397,189 @@ function PluginComposerActionButton({
   );
 }
 
-/** A clickable-when-href detail row: tone-tinted icon, primary label, secondary
- *  value, muted sublabel. */
-function BlockRow({ block }: { block: Record<string, unknown> }) {
+/** A row's initials bubble, from an `avatar` string (a reviewer's initials, an
+ *  org's short tag). Clipped to 3 characters so a plugin cannot stretch the row
+ *  by pushing a long string through it. */
+function RowAvatar({ initials }: { initials: string }) {
+  return (
+    <span
+      className="flex size-5 shrink-0 items-center justify-center rounded-full bg-surface-700 font-mono text-[9px] text-text-secondary"
+      aria-hidden
+    >
+      {initials.slice(0, 3)}
+    </span>
+  );
+}
+
+/** A detail row. Two lines at most: `prefix` + `label` lead the first with
+ *  `value` pinned right, and `sublabel` leads the second with `badges` pinned
+ *  right. Interactivity is layered: a `method` makes the row body a button that
+ *  fires that worker method, and an `href` alongside it becomes a separate
+ *  trailing open-externally affordance (so a selectable row can still link out).
+ *  With `href` alone the whole row is the link, as before. */
+function BlockRow({
+  block,
+  pluginId,
+  sessionId,
+}: {
+  block: Record<string, unknown>;
+  pluginId: string;
+  sessionId?: string;
+}) {
   const label = str(block, "label");
   const value = str(block, "value");
+  const prefix = str(block, "prefix");
   const sublabel = str(block, "sublabel");
+  const avatar = str(block, "avatar");
   const iconComp = lucideIcon(str(block, "icon"));
   const tone = validTone(block.tone);
-  // A validated hex `color` overrides the tone color for the icon and value
-  // (e.g. a merged PR's purple, which no semantic tone names).
+  const valueTone = validTone(block.value_tone);
+  // A validated hex `color` overrides the tone color for the icon, prefix and
+  // value (e.g. a merged PR's purple, which no semantic tone names).
   const accent = accentStyle(block.color);
   const safe = safeHref(str(block, "href"));
-  if (!label && !value && !iconComp) return null;
-  // Name the link from its text so an icon-only row is not announced unlabeled.
-  const ariaLabel = [label, value, sublabel].filter(Boolean).join(" · ") || undefined;
+  const method = str(block, "method");
+  const selected = block.selected === true;
+  const tooltip = str(block, "tooltip");
+  // `mono` monospaces the row's own text (numbers, refs, durations). The prefix
+  // and badges are always mono: they exist for exactly that kind of token.
+  const mono = block.mono === true ? "font-mono" : "";
+  const badges = objectList(block, "badges") ?? [];
+  const { busy, run } = usePaneActionRunner(pluginId, sessionId);
+  if (!label && !value && !prefix && !iconComp && !avatar) return null;
+  // Name the link/button from its text so an icon-only row is not announced
+  // unlabeled.
+  const ariaLabel = [prefix, label, value, sublabel].filter(Boolean).join(" · ") || undefined;
+  const secondLine = sublabel || badges.length > 0;
   const inner = (
-    <span className="flex min-w-0 items-center gap-2">
-      {iconComp &&
-        createElement(iconComp, {
-          className: `size-4 shrink-0 ${accent ? "" : toneTextClass(tone)}`,
-          style: accent,
-          "aria-hidden": true,
-        })}
-      <span className="min-w-0 truncate">
-        {label && <span className="font-medium text-text-primary">{label}</span>}
+    <span className="flex min-w-0 flex-col gap-0.5">
+      <span className="flex min-w-0 items-center gap-2">
+        {avatar ? (
+          <RowAvatar initials={avatar} />
+        ) : (
+          iconComp &&
+          createElement(iconComp, {
+            className: `size-4 shrink-0 ${accent ? "" : toneTextClass(tone)}`,
+            style: accent,
+            "aria-hidden": true,
+          })
+        )}
+        {prefix && (
+          <span className={`shrink-0 font-mono ${accent ? "" : toneTextClass(tone)}`} style={accent}>
+            {prefix}
+          </span>
+        )}
+        {label && (
+          <span className={`min-w-0 truncate ${mono} ${selected ? "text-text-bright" : "text-text-primary"}`}>
+            {label}
+          </span>
+        )}
         {value && (
-          <span className="ml-1.5 text-text-secondary" style={accent}>
+          // `value_tone` decouples the trailing token from the row's tone, for the
+          // common shape of a status-colored glyph beside a neutral scalar (a
+          // timestamp, a duration) that is not itself a status.
+          <span
+            className={`ml-auto shrink-0 font-mono text-[11px] ${accent && !valueTone ? "" : toneTextClass(valueTone ?? tone)}`}
+            style={valueTone ? undefined : accent}
+          >
             {value}
           </span>
         )}
-        {sublabel && <span className="ml-1.5 text-[11px] text-text-dim">{sublabel}</span>}
       </span>
+      {secondLine && (
+        <span className="flex min-w-0 items-center gap-2">
+          {sublabel && <span className={`min-w-0 truncate font-mono text-[10px] text-text-dim`}>{sublabel}</span>}
+          {badges.length > 0 && (
+            <span className="ml-auto flex shrink-0 items-center gap-1.5">
+              {badges.map((b, i) => (
+                <RowSignal key={i} badge={b} />
+              ))}
+            </span>
+          )}
+        </span>
+      )}
     </span>
   );
+
+  // A selected row reads as the pane's current subject, so it gets the brand
+  // accent ring rather than a tone (tones are already spoken for by status).
+  const shell = selected
+    ? "rounded border border-brand-500/40 bg-brand-500/10"
+    : method
+      ? "rounded border border-surface-700/60"
+      : "";
+
+  if (method) {
+    return (
+      <div className={`flex items-stretch text-xs ${shell}`} data-testid="plugin-row-selectable">
+        <button
+          type="button"
+          onClick={() => run(method, actionParams(block))}
+          disabled={busy}
+          aria-busy={busy || undefined}
+          aria-pressed={selected}
+          title={tooltip || undefined}
+          aria-label={ariaLabel}
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 px-1.5 py-1 text-left hover:bg-surface-700/40 disabled:cursor-default"
+        >
+          {busy && <Spinner className="size-3 shrink-0" />}
+          {inner}
+        </button>
+        {safe && (
+          <a
+            className="flex w-7 shrink-0 items-center justify-center border-l border-surface-700/50 text-text-dim hover:bg-surface-700/40 hover:text-brand-500"
+            href={safe}
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Open externally"
+            aria-label={ariaLabel ? `Open ${ariaLabel} externally` : "Open externally"}
+          >
+            <ArrowUpRight className="size-3.5" aria-hidden />
+          </a>
+        )}
+      </div>
+    );
+  }
+
   return safe ? (
     <a
       className="block rounded px-1 py-0.5 text-xs hover:bg-surface-700/40"
       href={safe}
       target="_blank"
       rel="noopener noreferrer"
+      title={tooltip || undefined}
       aria-label={ariaLabel}
     >
       {inner}
     </a>
   ) : (
-    <div className="px-1 py-0.5 text-xs">{inner}</div>
+    <div className="px-1 py-0.5 text-xs" title={tooltip || undefined}>
+      {inner}
+    </div>
+  );
+}
+
+/** One compact signal on a row's second line: a tone-tinted glyph or short
+ *  token with a tooltip (CI state, review state, conflict state). Distinct from
+ *  `BadgeChip` in that it carries no pill background, so a run of them reads as
+ *  a status strip rather than competing with the row's own text. */
+function RowSignal({ badge }: { badge: Record<string, unknown> }) {
+  const text = str(badge, "text");
+  const iconComp = lucideIcon(str(badge, "icon"));
+  const tone = validTone(badge.tone);
+  const accent = accentStyle(badge.color);
+  const tooltip = str(badge, "tooltip");
+  if (!text && !iconComp) return null;
+  return (
+    <span
+      className={`inline-flex items-center gap-0.5 font-mono text-[10px] ${accent ? "" : toneTextClass(tone)}`}
+      style={accent}
+      title={tooltip || text || undefined}
+      aria-label={text ? undefined : tooltip || undefined}
+    >
+      {iconComp && createElement(iconComp, { className: "size-3 shrink-0", "aria-hidden": true })}
+      {text}
+    </span>
   );
 }
 
@@ -453,31 +599,20 @@ function Spinner({ className }: { className: string }) {
 // method, mid-refresh crash) can never leave the button spinning forever.
 const ACTION_TIMEOUT_MS = 15000;
 
-/** An `action` pane block: a button that forwards a worker method (named by the
- *  plugin) to that plugin's worker. The worker runs the method and re-pushes its
- *  UI state, which a later poll renders. The button spins from the click until
- *  the plugin's UI revision moves off the baseline the action POST returned (the
- *  worker's re-pushed state has landed), not merely until the POST is accepted,
- *  with a hard timeout fallback so it can never hang. A failed POST clears the
- *  spinner at once. An icon is optional. */
-function BlockAction({
-  block,
-  pluginId,
-  sessionId,
-}: {
-  block: Record<string, unknown>;
-  pluginId: string;
-  sessionId?: string;
-}) {
-  const label = str(block, "label");
-  const method = str(block, "method");
-  const iconComp = lucideIcon(str(block, "icon"));
+/** The click -> POST -> wait-for-fresh-state lifecycle every interactive pane
+ *  element shares (`action` blocks, `callout` buttons, `method`-bearing rows).
+ *  The worker runs the method and re-pushes its UI state, which a later poll
+ *  renders; `busy` stays true from the click until the plugin's UI revision
+ *  moves off the baseline the action POST returned (the worker's re-pushed state
+ *  has landed), not merely until the POST is accepted, with a hard timeout
+ *  fallback so it can never hang. A failed POST clears it at once. */
+function usePaneActionRunner(pluginId: string, sessionId?: string) {
   const revision = usePluginUiRevision(pluginId, sessionId);
   const poke = usePluginUiPoke();
   // `posting`: the POST is in flight. `waitBaseline`: the revision the host had
-  // when it accepted the action; the button keeps spinning until the polled
-  // revision moves off it (the worker's re-pushed state landed) or the timeout
-  // fires. Stored as state so a polled revision change re-renders the button.
+  // when it accepted the action; the caller keeps spinning until the polled
+  // revision moves off it or the timeout fires. Stored as state so a polled
+  // revision change re-renders.
   const [posting, setPosting] = useState(false);
   const [waitBaseline, setWaitBaseline] = useState<number | null>(null);
   // Guards a same-tick double-fire of the POST, before `posting` commits and
@@ -500,13 +635,12 @@ function BlockAction({
     [],
   );
 
-  if (!label || !method) return null;
-  const onClick = async () => {
+  const run = async (method: string, params: Record<string, unknown> = {}) => {
     if (postingRef.current || busy) return;
     postingRef.current = true;
     setPosting(true);
     try {
-      const accepted = await invokePluginAction(pluginId, method, sessionId);
+      const accepted = await invokePluginAction(pluginId, method, sessionId, params);
       if (!accepted) return; // 403/404/network: nothing re-pushes, stop spinning
       poke();
       // No baseline (older daemon): can't track completion, so degrade to
@@ -524,23 +658,203 @@ function BlockAction({
       setPosting(false);
     }
   };
+
+  return { busy, run };
+}
+
+/** An `action` pane block: a button that forwards a worker method (named by the
+ *  plugin) to that plugin's worker, or, with `href` and no `method`, a link-out
+ *  button for a state the host cannot perform itself. `disabled` renders it
+ *  inert, which is how a blocked state reads (a merge gate, an unavailable
+ *  operation) without pretending to be clickable. `variant: "primary"` gives the
+ *  brand-filled treatment for a callout's main affordance. An icon is optional.
+ *  `stretch` fills the width, which is how callout buttons lay out. */
+function BlockAction({
+  block,
+  pluginId,
+  sessionId,
+  stretch = false,
+}: {
+  block: Record<string, unknown>;
+  pluginId: string;
+  sessionId?: string;
+  stretch?: boolean;
+}) {
+  const label = str(block, "label");
+  const method = str(block, "method");
+  const iconComp = lucideIcon(str(block, "icon"));
+  const disabled = block.disabled === true;
+  const primary = str(block, "variant") === "primary";
+  const tooltip = str(block, "tooltip");
+  const safe = safeHref(str(block, "href"));
+  const { busy, run } = usePaneActionRunner(pluginId, sessionId);
+
+  // A label is the minimum; beyond that the button needs something to do, or an
+  // explicit `disabled` saying it deliberately does nothing.
+  if (!label || (!method && !safe && !disabled)) return null;
+
+  const layout = stretch ? "w-full justify-center" : "self-start";
+  const skin = primary
+    ? "bg-brand-500 text-text-on-brand hover:bg-brand-400 font-semibold"
+    : "bg-surface-700/50 text-text-secondary hover:text-text-primary hover:bg-surface-700";
+  const className = `${layout} inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs cursor-pointer ${skin} disabled:opacity-50 disabled:cursor-default transition-colors`;
+  const leading = busy ? (
+    <Spinner className="size-3.5" />
+  ) : (
+    iconComp && createElement(iconComp, { className: "size-3.5", "aria-hidden": true })
+  );
+
+  // A disabled action never navigates either: rendering the href as a live link
+  // would let a blocked state be clicked through anyway.
+  if (safe && !method && !disabled) {
+    return (
+      <a
+        href={safe}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={tooltip || undefined}
+        data-testid="plugin-pane-action"
+        className={className}
+      >
+        {leading}
+        {label}
+        <ArrowUpRight className="size-3" aria-hidden />
+      </a>
+    );
+  }
+
   return (
     <button
       type="button"
-      onClick={onClick}
-      disabled={busy}
+      onClick={method ? () => run(method, actionParams(block)) : undefined}
+      disabled={busy || disabled || !method}
       aria-busy={busy || undefined}
+      title={tooltip || undefined}
       data-testid="plugin-pane-action"
-      className="self-start inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs cursor-pointer bg-surface-700/50 text-text-secondary hover:text-text-primary hover:bg-surface-700 disabled:opacity-50 disabled:cursor-default transition-colors"
+      className={className}
     >
-      {busy ? (
-        <Spinner className="size-3.5" />
-      ) : (
-        iconComp && createElement(iconComp, { className: "size-3.5", "aria-hidden": true })
-      )}
+      {leading}
       {label}
     </button>
   );
+}
+
+/** A `callout` pane block: the pane's headline verdict. A tone-bordered card
+ *  carrying a glyph, a title, an optional detail paragraph, and its own action
+ *  buttons laid out full width. This is the shape a "can I merge / is this
+ *  blocked" summary wants, which a `section` (a titled list) cannot express. */
+function BlockCallout({
+  block,
+  pluginId,
+  sessionId,
+}: {
+  block: Record<string, unknown>;
+  pluginId: string;
+  sessionId?: string;
+}) {
+  const title = str(block, "title");
+  const detail = str(block, "detail");
+  const tone = validTone(block.tone);
+  const accent = accentStyle(block.color);
+  const iconComp = lucideIcon(str(block, "icon"));
+  const actions = objectList(block, "actions") ?? [];
+  if (!title && !detail) return null;
+  const toneText = accent ? "" : toneTextClass(tone);
+  return (
+    <div
+      className={`flex flex-col gap-2 rounded-md border p-2.5 ${calloutBorder(tone)} bg-surface-800/60`}
+      data-testid="plugin-pane-callout"
+    >
+      <div className="flex items-start gap-2">
+        {iconComp &&
+          createElement(iconComp, {
+            className: `mt-0.5 size-4 shrink-0 ${toneText}`,
+            style: accent,
+            "aria-hidden": true,
+          })}
+        <div className="flex min-w-0 flex-col gap-0.5">
+          {title && (
+            <div className={`text-xs font-semibold ${toneText}`} style={accent}>
+              {title}
+            </div>
+          )}
+          {detail && <div className="text-[11px] leading-snug text-text-secondary">{detail}</div>}
+        </div>
+      </div>
+      {actions.map((a, i) => (
+        <BlockAction key={i} block={a} pluginId={pluginId} sessionId={sessionId} stretch />
+      ))}
+    </div>
+  );
+}
+
+/** Tone-matched border for a callout. Kept separate from `toneClasses` because
+ *  that returns a fill + text pair for pills; a callout needs only the edge. */
+function calloutBorder(tone: PluginUiTone | undefined): string {
+  switch (tone) {
+    case "info":
+      return "border-status-unread/35";
+    case "success":
+      return "border-status-running/35";
+    case "warn":
+      return "border-status-waiting/35";
+    case "danger":
+      return "border-status-error/35";
+    default:
+      return "border-surface-700/60";
+  }
+}
+
+/** A `bar` pane block: one proportional stacked bar over a list of weighted
+ *  segments, for a ratio a number pair alone does not convey (added vs removed
+ *  lines, passing vs failing counts). Segments with a non-positive or absent
+ *  `value` are dropped; a bar left with nothing renders nothing. */
+function BlockBar({ block }: { block: Record<string, unknown> }) {
+  const segments = (objectList(block, "segments") ?? [])
+    .map((s) => ({
+      value: typeof s.value === "number" && Number.isFinite(s.value) ? s.value : 0,
+      tone: validTone(s.tone),
+      color: accentStyle(s.color),
+      label: str(s, "label"),
+    }))
+    .filter((s) => s.value > 0);
+  const caption = str(block, "caption");
+  const total = segments.reduce((sum, s) => sum + s.value, 0);
+  if (total <= 0) return null;
+  return (
+    <div className="flex flex-col gap-1" data-testid="plugin-pane-bar">
+      <div className="flex h-1 gap-px overflow-hidden rounded-full">
+        {segments.map((s, i) => (
+          <span
+            key={i}
+            // The width is the whole point of the block, and it is a computed
+            // percentage rather than a plugin string, so it cannot carry CSS.
+            style={{ width: `${(s.value / total) * 100}%`, ...(s.color ? { backgroundColor: s.color.color } : {}) }}
+            className={s.color ? "" : barFill(s.tone)}
+            title={s.label || undefined}
+          />
+        ))}
+      </div>
+      {caption && <span className="text-[10px] text-text-dim">{caption}</span>}
+    </div>
+  );
+}
+
+/** Solid fill per tone for a bar segment (the pill classes are translucent,
+ *  which reads as washed out at a 4px bar height). */
+function barFill(tone: PluginUiTone | undefined): string {
+  switch (tone) {
+    case "info":
+      return "bg-status-unread";
+    case "success":
+      return "bg-status-running";
+    case "warn":
+      return "bg-status-waiting";
+    case "danger":
+      return "bg-status-error";
+    default:
+      return "bg-status-idle";
+  }
 }
 
 /** A read-only PR review comment: author, optional file:line, a wrapped body,
@@ -633,7 +947,7 @@ function DetailBlock({
       return text ? <div className="font-semibold text-sm text-text-primary">{text}</div> : null;
     }
     case "row":
-      return <BlockRow block={block} />;
+      return <BlockRow block={block} pluginId={pluginId} sessionId={sessionId} />;
     case "comment":
       return <BlockComment block={block} />;
     case "note": {
@@ -644,47 +958,124 @@ function DetailBlock({
       return <hr className="border-surface-700/60" />;
     case "action":
       return <BlockAction block={block} pluginId={pluginId} sessionId={sessionId} />;
-    case "section": {
-      const title = str(block, "title");
-      const children = Array.isArray(block.children) ? block.children.filter(isObject) : [];
-      const body = children.map((c, i) => <DetailBlock key={i} block={c} pluginId={pluginId} sessionId={sessionId} />);
-      // An optional tone-tinted icon on the title gives an at-a-glance status
-      // even when the section is folded (e.g. a green check vs a red x).
-      const tone = validTone(block.tone);
-      const iconComp = lucideIcon(str(block, "icon"));
-      const titleColor = iconComp || tone ? toneTextClass(tone) : "text-text-dim";
-      const titleClass = `text-[11px] font-semibold uppercase tracking-wide ${titleColor}`;
-      const titleInner = (
-        <>
-          {iconComp && createElement(iconComp, { className: "size-3 shrink-0", "aria-hidden": true })}
-          {title}
-        </>
-      );
-      // A `collapsible` section folds via a native <details>: keyboard-accessible
-      // and stateless, no JS toggle to track. `collapsed` sets the initial state;
-      // it stays open by default so existing panes look unchanged.
-      if (block.collapsible === true) {
-        return (
-          <details className="group flex flex-col gap-1" open={block.collapsed !== true}>
-            <summary className={`flex cursor-pointer list-none items-center gap-1 select-none ${titleClass}`}>
-              <ChevronRight className="size-3 shrink-0 transition-transform group-open:rotate-90" aria-hidden />
-              {titleInner}
-            </summary>
-            <div className="flex flex-col gap-1">{body}</div>
-          </details>
-        );
-      }
-      return (
-        <section className="flex flex-col gap-1">
-          {title && <div className={`flex items-center gap-1 ${titleClass}`}>{titleInner}</div>}
-          {body}
-        </section>
-      );
-    }
+    case "callout":
+      return <BlockCallout block={block} pluginId={pluginId} sessionId={sessionId} />;
+    case "bar":
+      return <BlockBar block={block} />;
+    case "columns":
+      return <BlockColumns block={block} pluginId={pluginId} sessionId={sessionId} />;
+    case "section":
+      return <BlockSection block={block} pluginId={pluginId} sessionId={sessionId} />;
     default:
       // Unknown kind: ignored, not rendered, never throws.
       return null;
   }
+}
+
+/** A `columns` pane block: its children laid out side by side in equal
+ *  fractions, so two compact summaries share a row instead of stacking. A single
+ *  child spans the full width, which is what makes an elided sibling (an empty
+ *  linked-issues card, say) collapse cleanly rather than leaving a gap. Nesting
+ *  is one level in practice; children are dispatched through the normal
+ *  vocabulary, so a column is usually a `section`. */
+function BlockColumns({
+  block,
+  pluginId,
+  sessionId,
+}: {
+  block: Record<string, unknown>;
+  pluginId: string;
+  sessionId?: string;
+}) {
+  const children = Array.isArray(block.children) ? block.children.filter(isObject) : [];
+  if (children.length === 0) return null;
+  return (
+    <div
+      className={`grid gap-1.5 ${children.length > 1 ? "grid-cols-2" : "grid-cols-1"}`}
+      data-testid="plugin-pane-columns"
+    >
+      {children.map((c, i) => (
+        <DetailBlock key={i} block={c} pluginId={pluginId} sessionId={sessionId} />
+      ))}
+    </div>
+  );
+}
+
+/** A `section` pane block: a titled group of child blocks. The header carries an
+ *  optional tone-tinted icon plus, pinned right, either a `value` summary string
+ *  or a run of `badges` (count pills). `boxed` draws it as a bordered card and
+ *  `scroll` caps the body height so a long list scrolls inside the section
+ *  instead of pushing the rest of the pane away; `collapsible` folds it. */
+function BlockSection({
+  block,
+  pluginId,
+  sessionId,
+}: {
+  block: Record<string, unknown>;
+  pluginId: string;
+  sessionId?: string;
+}) {
+  const title = str(block, "title");
+  const children = Array.isArray(block.children) ? block.children.filter(isObject) : [];
+  const body = children.map((c, i) => <DetailBlock key={i} block={c} pluginId={pluginId} sessionId={sessionId} />);
+  // An optional tone-tinted icon on the title gives an at-a-glance status
+  // even when the section is folded (e.g. a green check vs a red x).
+  const tone = validTone(block.tone);
+  const iconComp = lucideIcon(str(block, "icon"));
+  const value = str(block, "value");
+  const valueTone = validTone(block.value_tone);
+  const badges = objectList(block, "badges") ?? [];
+  const boxed = block.boxed === true;
+  const scroll = block.scroll === true;
+  const titleColor = iconComp || tone ? toneTextClass(tone) : "text-text-dim";
+  const titleClass = `text-[11px] font-semibold uppercase tracking-wide ${titleColor}`;
+  const summary = (value || badges.length > 0) && (
+    <span className="ml-auto flex shrink-0 items-center gap-1.5">
+      {value && <span className={`font-mono text-[10px] normal-case ${toneTextClass(valueTone)}`}>{value}</span>}
+      {badges.map((b, i) => (
+        <BadgeChip
+          key={i}
+          text={str(b, "text") || undefined}
+          icon={str(b, "icon") || undefined}
+          tone={validTone(b.tone)}
+          tooltip={str(b, "tooltip") || undefined}
+          slot="pane"
+          pluginId={pluginId}
+        />
+      ))}
+    </span>
+  );
+  const titleInner = (
+    <>
+      {iconComp && createElement(iconComp, { className: "size-3 shrink-0", "aria-hidden": true })}
+      {title}
+      {summary}
+    </>
+  );
+  // A capped body scrolls in place. The cap is a fixed class rather than a
+  // plugin-supplied length: a worker must not be able to size host chrome.
+  const bodyClass = `flex flex-col gap-1 ${scroll ? "max-h-64 overflow-y-auto" : ""}`;
+  const shell = boxed ? "rounded-md border border-surface-700/60 bg-surface-800/40 p-2" : "";
+  // A `collapsible` section folds via a native <details>: keyboard-accessible
+  // and stateless, no JS toggle to track. `collapsed` sets the initial state;
+  // it stays open by default so existing panes look unchanged.
+  if (block.collapsible === true) {
+    return (
+      <details className={`group flex flex-col gap-1 ${shell}`} open={block.collapsed !== true}>
+        <summary className={`flex cursor-pointer list-none items-center gap-1 select-none ${titleClass}`}>
+          <ChevronRight className="size-3 shrink-0 transition-transform group-open:rotate-90" aria-hidden />
+          {titleInner}
+        </summary>
+        <div className={bodyClass}>{body}</div>
+      </details>
+    );
+  }
+  return (
+    <section className={`flex flex-col gap-1 ${shell}`}>
+      {(title || summary) && <div className={`flex items-center gap-1 ${titleClass}`}>{titleInner}</div>}
+      <div className={bodyClass}>{body}</div>
+    </section>
+  );
 }
 
 /** pane: the body of one dockable plugin pane. An entry is either a `blocks`
@@ -695,32 +1086,57 @@ export function PluginPaneBody({ entry }: { entry: PluginUiEntry }) {
   const blocks = objectList(entry.payload, "blocks");
   const title = payloadStr(entry, "title");
   const body = payloadStr(entry, "body");
+  const footer = isObject(entry.payload.footer) ? entry.payload.footer : undefined;
   // A background poll only flips this once it outlasts the indicator delay, so
   // this surfaces a slow auto-refresh without strobing on every 3s cadence.
   const refreshing = usePluginUiRefreshing();
   return (
-    <div className="flex-1 min-h-0 overflow-auto p-3" data-testid="plugin-pane-body" data-plugin-id={entry.plugin_id}>
-      {refreshing && (
-        <div
-          className="sticky top-0 z-10 mb-1.5 flex items-center justify-end gap-1 text-[10px] text-text-dim"
-          data-testid="plugin-pane-refreshing"
-        >
-          <Spinner className="size-3" />
-          Refreshing…
-        </div>
-      )}
-      {blocks ? (
-        <div className="flex flex-col gap-1.5">
-          {blocks.map((b, i) => (
-            <DetailBlock key={i} block={b} pluginId={entry.plugin_id} sessionId={entry.session_id} />
-          ))}
-        </div>
-      ) : (
-        <>
-          {title && <div className="font-semibold text-sm text-text-primary">{title}</div>}
-          {body && <div className="mt-1 text-xs text-text-secondary whitespace-pre-wrap">{body}</div>}
-        </>
-      )}
+    <div className="flex flex-1 min-h-0 flex-col" data-testid="plugin-pane-body" data-plugin-id={entry.plugin_id}>
+      <div className="min-h-0 flex-1 overflow-auto p-3">
+        {refreshing && (
+          <div
+            className="sticky top-0 z-10 mb-1.5 flex items-center justify-end gap-1 text-[10px] text-text-dim"
+            data-testid="plugin-pane-refreshing"
+          >
+            <Spinner className="size-3" />
+            Refreshing…
+          </div>
+        )}
+        {blocks ? (
+          <div className="flex flex-col gap-1.5">
+            {blocks.map((b, i) => (
+              <DetailBlock key={i} block={b} pluginId={entry.plugin_id} sessionId={entry.session_id} />
+            ))}
+          </div>
+        ) : (
+          <>
+            {title && <div className="font-semibold text-sm text-text-primary">{title}</div>}
+            {body && <div className="mt-1 text-xs text-text-secondary whitespace-pre-wrap">{body}</div>}
+          </>
+        )}
+      </div>
+      {footer && <PluginPaneFooter footer={footer} />}
+    </div>
+  );
+}
+
+/** The pane's pinned status line. Sits outside the scroll area so it stays put
+ *  while the blocks scroll: `text` on the left, tone-colored `value` on the
+ *  right. A footer with neither renders nothing rather than an empty bar. */
+function PluginPaneFooter({ footer }: { footer: Record<string, unknown> }) {
+  const text = str(footer, "text");
+  const value = str(footer, "value");
+  const iconComp = lucideIcon(str(footer, "icon"));
+  const tone = validTone(footer.tone);
+  if (!text && !value) return null;
+  return (
+    <div
+      className="flex shrink-0 items-center gap-1.5 border-t border-surface-700/60 px-3 py-1.5 font-mono text-[10px] text-text-dim"
+      data-testid="plugin-pane-footer"
+    >
+      {iconComp && createElement(iconComp, { className: "size-3 shrink-0", "aria-hidden": true })}
+      {text && <span className="min-w-0 truncate">{text}</span>}
+      {value && <span className={`ml-auto shrink-0 ${toneTextClass(tone)}`}>{value}</span>}
     </div>
   );
 }

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -128,7 +128,9 @@ describe("plugin slot renderers", () => {
     const btn = screen.getByTestId("plugin-pane-action");
     expect(btn.textContent).toContain("Refresh");
     fireEvent.click(btn);
-    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("acme.kit", "github.refresh", "s1"));
+    // A block with no `params` still forwards an empty object, which is what the
+    // API sends on the wire either way.
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("acme.kit", "github.refresh", "s1", {}));
   });
 
   it("composer action button forwards a composer snapshot to the worker", async () => {
@@ -676,5 +678,242 @@ describe("tool-card-badge renderer", () => {
     render(<PluginToolCardBadges sessionId="s1" kind="mcp" target="github" />);
     expect(screen.getByText("mine")).toBeTruthy();
     expect(screen.queryByText("other")).toBeNull();
+  });
+});
+
+// The block kinds and fields added in api_version 12: callout, bar, columns, the
+// pane footer, and the interactive/summary additions to row, section and action.
+describe("pane block vocabulary (api 12)", () => {
+  beforeEach(() => {
+    entriesRef.current = [];
+    refreshingRef.current = false;
+    revisionRef.current = 0;
+    pokeMock.mockClear();
+    invokeMock.mockReset();
+    invokeMock.mockImplementation(async () => ({ baselineRevision: 0 }));
+  });
+
+  function pane(payload: Record<string, unknown>): PluginUiEntry {
+    return { plugin_id: "acme.kit", slot: "pane", id: "gh", session_id: "s1", payload };
+  }
+
+  it("a callout renders its verdict and stretches its actions; a disabled action never posts", () => {
+    render(
+      <PluginPaneBody
+        entry={pane({
+          blocks: [
+            {
+              kind: "callout",
+              tone: "danger",
+              icon: "circle-x",
+              title: "2 required checks failing",
+              detail: "Merging is blocked until Clippy passes.",
+              actions: [{ kind: "action", label: "Merge blocked", method: "gh.merge", disabled: true }],
+            },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByTestId("plugin-pane-callout")).toBeTruthy();
+    expect(screen.getByText("2 required checks failing")).toBeTruthy();
+    expect(screen.getByText("Merging is blocked until Clippy passes.")).toBeTruthy();
+    const button = screen.getByTestId("plugin-pane-action") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    fireEvent.click(button);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("a callout with neither title nor detail renders nothing", () => {
+    const { container } = render(<PluginPaneBody entry={pane({ blocks: [{ kind: "callout", tone: "danger" }] })} />);
+    expect(container.querySelector("[data-testid='plugin-pane-callout']")).toBeNull();
+  });
+
+  it("an action with an href and no method links out instead of posting", () => {
+    render(
+      <PluginPaneBody
+        entry={pane({
+          blocks: [
+            { kind: "action", label: "Squash and merge", href: "https://github.com/o/r/pull/1", variant: "primary" },
+          ],
+        })}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /Squash and merge/ });
+    expect(link.getAttribute("href")).toBe("https://github.com/o/r/pull/1");
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("a bar sizes segments proportionally and drops non-positive values", () => {
+    const { container } = render(
+      <PluginPaneBody
+        entry={pane({
+          blocks: [
+            {
+              kind: "bar",
+              caption: "18 files",
+              segments: [
+                { value: 750, tone: "success" },
+                { value: 250, tone: "danger" },
+                { value: 0, tone: "warn" },
+                { tone: "info" },
+              ],
+            },
+          ],
+        })}
+      />,
+    );
+    // Scoped to the track, so the caption span below it is not counted.
+    const spans = Array.from(container.querySelectorAll("[data-testid='plugin-pane-bar'] > div > span"));
+    // Only the two positive segments survive, at 75% / 25% of the total.
+    expect(spans.map((s) => (s as HTMLElement).style.width)).toEqual(["75%", "25%"]);
+    expect(screen.getByText("18 files")).toBeTruthy();
+  });
+
+  it("a bar with no positive segment renders nothing", () => {
+    const { container } = render(
+      <PluginPaneBody entry={pane({ blocks: [{ kind: "bar", segments: [{ value: 0 }] }] })} />,
+    );
+    expect(container.querySelector("[data-testid='plugin-pane-bar']")).toBeNull();
+  });
+
+  it("columns lay children side by side, and a lone child spans the full width", () => {
+    const two = render(
+      <PluginPaneBody
+        entry={pane({
+          blocks: [
+            {
+              kind: "columns",
+              children: [
+                { kind: "section", title: "DIFF", children: [{ kind: "row", value: "+842 -317" }] },
+                {
+                  kind: "section",
+                  title: "LINKED",
+                  children: [{ kind: "row", prefix: "#3180", label: "Stale daemon" }],
+                },
+              ],
+            },
+          ],
+        })}
+      />,
+    );
+    expect(two.getByTestId("plugin-pane-columns").className).toContain("grid-cols-2");
+    expect(screen.getByText("Stale daemon")).toBeTruthy();
+    two.unmount();
+
+    const one = render(
+      <PluginPaneBody
+        entry={pane({ blocks: [{ kind: "columns", children: [{ kind: "section", title: "DIFF" }] }] })}
+      />,
+    );
+    expect(one.getByTestId("plugin-pane-columns").className).toContain("grid-cols-1");
+  });
+
+  it("columns with no children render nothing", () => {
+    const { container } = render(<PluginPaneBody entry={pane({ blocks: [{ kind: "columns", children: [] }] })} />);
+    expect(container.querySelector("[data-testid='plugin-pane-columns']")).toBeNull();
+  });
+
+  it("a row with a method posts it, marks selection, and keeps its href as a separate link", async () => {
+    render(
+      <PluginPaneBody
+        entry={pane({
+          blocks: [
+            {
+              kind: "row",
+              prefix: "#3231",
+              label: "fix(update): warn when daemon is stale",
+              sublabel: "japanese · njbrake",
+              method: "gh.select_pr",
+              params: { repo: "o/r", number: 3231 },
+              selected: true,
+              href: "https://github.com/o/r/pull/3231",
+              badges: [{ icon: "circle-x", tone: "danger", tooltip: "CI failing" }],
+            },
+          ],
+        })}
+      />,
+    );
+    // The body is the selectable control; the href is a sibling link, so the
+    // row can be picked without navigating away.
+    const button = screen.getByRole("button", { name: /fix\(update\)/ });
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+    const link = screen.getByRole("link", { name: /Open .* externally/ });
+    expect(link.getAttribute("href")).toBe("https://github.com/o/r/pull/3231");
+    // The glyph-only badge is named from its tooltip so it is not silent.
+    expect(screen.getByLabelText("CI failing")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    // `params` names the subject, so one method can serve every row.
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("acme.kit", "gh.select_pr", "s1", { repo: "o/r", number: 3231 }),
+    );
+  });
+
+  it("a row with only a prefix still renders, and the value pins right of the label", () => {
+    render(
+      <PluginPaneBody
+        entry={pane({
+          blocks: [
+            { kind: "row", prefix: "◉", tone: "success" },
+            { kind: "row", label: "Nate Brake", value: "approved", avatar: "NB" },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText("◉")).toBeTruthy();
+    expect(screen.getByText("NB")).toBeTruthy();
+    expect(screen.getByText("approved").className).toContain("ml-auto");
+  });
+
+  it("a section header pins a value summary and badge pills", () => {
+    render(
+      <PluginPaneBody
+        entry={pane({
+          blocks: [
+            {
+              kind: "section",
+              title: "CHECKS",
+              value: "1 of 2 approved",
+              value_tone: "warn",
+              boxed: true,
+              scroll: true,
+              badges: [
+                { text: "2 failing", tone: "danger" },
+                { text: "17 passing", tone: "success" },
+              ],
+              children: [{ kind: "row", label: "Clippy" }],
+            },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText("1 of 2 approved")).toBeTruthy();
+    expect(screen.getByText("2 failing")).toBeTruthy();
+    expect(screen.getByText("17 passing")).toBeTruthy();
+    expect(screen.getByText("Clippy")).toBeTruthy();
+  });
+
+  it("the pane footer renders outside the scroll area, and an empty one renders nothing", () => {
+    const withFooter = render(
+      <PluginPaneBody
+        entry={pane({
+          blocks: [{ kind: "heading", text: "GitHub" }],
+          footer: { text: "refreshed 12:07", value: "blocked", tone: "danger", icon: "refresh-cw" },
+        })}
+      />,
+    );
+    const footer = withFooter.getByTestId("plugin-pane-footer");
+    expect(footer.textContent).toContain("refreshed 12:07");
+    expect(footer.textContent).toContain("blocked");
+    // Pinned: a sibling of the scrolling block list, never inside it.
+    expect(footer.closest(".overflow-auto")).toBeNull();
+    withFooter.unmount();
+
+    const empty = render(
+      <PluginPaneBody entry={pane({ blocks: [{ kind: "heading", text: "GitHub" }], footer: {} })} />,
+    );
+    expect(empty.container.querySelector("[data-testid='plugin-pane-footer']")).toBeNull();
   });
 });

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -3404,6 +3404,14 @@
       "components": ["web/src/components/plugin/PluginSlots.tsx", "web/src/components/acp/ToolCards.tsx"]
     },
     {
+      "id": "plugins.pane-blocks",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/plugin/__tests__/PluginSlots.test.tsx"],
+      "components": ["web/src/components/plugin/PluginSlots.tsx"],
+      "notes": "The api_version 12 pane block vocabulary: callout, bar and columns, plus the interactive row (clicking a row fires its `method` with the block's `params`, e.g. github.select_pr) and the pinned pane footer."
+    },
+    {
       "id": "plugins.composer-actions",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
## Description

A plugin pane could express a titled list of rows and little else. A pane that
wants to lead with a verdict, show a ratio, pair two summaries side by side, or
let the user pick which subject it details had no way to say so, so
`plugin-github`'s pane was a flat wall of rows across every repo in the session.

This grows the pane block vocabulary to `api_version` 12. Three new kinds:

- **`callout`** — a tone-bordered verdict card with its own full-width actions,
  for the one thing a pane is saying. A `section` is for lists; this is not.
- **`bar`** — a proportional stacked bar over weighted segments, for a ratio a
  number pair alone does not convey. Non-positive segments drop out and an empty
  bar renders nothing.
- **`columns`** — children side by side in equal fractions. A lone child spans
  the full width, so eliding one card collapses the row rather than leaving a gap.

And the existing kinds grow:

- **`row`** — `prefix`, `badges`, `avatar`, `mono`, `selected`, `value_tone`,
  `tooltip`, plus `method`/`params` making the row body a button.
- **`section`** — a right-pinned `value` summary or `badges` count pills in the
  header, `boxed`, and `scroll` to cap the body so a long list scrolls in place
  instead of pushing the rest of the pane away.
- **`action`** — `disabled` (inert *and* non-navigating, which is how a blocked
  state reads without pretending to be clickable), `variant: "primary"`, `href`
  for a link-out, `tone`, `tooltip`.
- **`PanePayload`** — a typed `footer { text?, value?, icon?, tone? }` pinned
  below the scroll area.

### `params` is the load-bearing bit

`invokePluginAction` already accepted a `params` object; nothing exposed it to a
block. Surfacing it lets **one method serve a whole list** (`github.select_pr
{ pr }` on every row of a selector) instead of encoding the subject in the method
name. The host still merges the authoritative `session_id` server-side, so a
plugin cannot spoof which session it acted on, and the object only round-trips
values the plugin itself authored, so there is nothing new to sanitize.

### Notes for reviewers

- **`row` relayout is a visual change for existing panes.** `value` now pins
  right and `sublabel` stacks onto a second line. Both read better for the rows
  that exist today (the GitHub plugin's `Last refreshed | 14:32`), but it is a
  change, not an addition.
- The click/POST/wait-for-fresh-state lifecycle moved into
  `usePaneActionRunner`, so rows, callout buttons and standalone actions share
  one spinner and revision baseline rather than three copies of it.
- `scroll` caps the body with a fixed class, not a plugin-supplied length: a
  worker must not be able to size host chrome. Same reasoning as `validColor`.
- New block kinds need no host type change (blocks are opaque `Vec<Value>`), but
  `footer` does, since `PanePayload` is `deny_unknown_fields`.
- Because an older host silently drops unknown kinds, a plugin whose layout
  *depends* on these should gate on `api_version`/`aoe_version` rather than
  degrade quietly. Called out in the docs.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

`cargo fmt --check`, `cargo clippy --features serve --all-targets`, and
`cargo test --features serve` (6258 passed) are clean; `npm run format:check`,
`npm run lint`, `npx tsc -b` and Vitest (69 plugin-slot tests) are clean.

Docs: `docs/plugin-api.md` gained a **Pane payload** section (the author-facing
reference had no pane-payload coverage at all before this, only the slot table),
and `docs/development/internals/plugin-system.md` grew the block list and the
pane-actions `params` semantics.

**Screenshots:** verification was done by generating a real pane payload from
`plugin-github` and rendering it through the dashboard in Playwright, comparing
against the design. I could not attach the PNGs from the CLI; they are at
`/tmp/final.png` (collapsed) and `/tmp/shot-expanded.png` (passing group open) on
the authoring machine and want dragging into this description. That render is
also what caught the one bug found in review-of-self: activity timestamps
inherited the row tone where the design keeps them dim, which is why
`value_tone` exists.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: every new kind and field is covered by Vitest in
  `PluginSlots.test.tsx` (12 new cases, including the row action round-trip with
  `params`, the disabled-action no-POST path, bar proportions, and the pinned
  footer), and `PluginSlots.tsx` is already mapped in `coverage-matrix.json`
  under `app-shell.pane-docking` and `settings.plugin-settings-page`; the
  validator passes unchanged. A mocked Playwright spec costs ~200x a Vitest test
  and would assert nothing these do not, since none of this needs a real browser.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the TUI change is pure snapshot-to-lines rendering,
  covered by unit tests in `src/tui/plugin_ui.rs` (the api-12 kinds, the new
  row/section fields, the footer, and a check that bar cells always total
  `BAR_WIDTH`). An e2e adds ~2s to a strictly serial suite forever to exercise
  the same pure function.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any Additional AI Details you'd like to share:**

Written by an agent from a design mockup, then verified against that mockup by
rendering a real generated payload in Playwright rather than by eyeballing the
diff. The scope decisions (read-only merge affordance, TUI parity, deriving the
merge verdict instead of selecting `mergeStateStatus`) were the human's calls.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the plugin pane API from version 11 to 12.
- Added `callout`, `bar`, and `columns` blocks.
- Expanded rows, sections, and actions with richer display, styling, interaction, and navigation options.
- Added parameter support for pane actions and typed pane footers.
- Centralized action handling with `usePaneActionRunner`.
- Updated web and TUI rendering for the new blocks, interactive rows, links, badges, selection states, scrolling, and pinned footers.
- Expanded documentation and test coverage for the API and rendering behavior.

## Benefits

- Provides richer and more flexible plugin pane layouts.
- Improves interactive actions and navigation.
- Keeps action behavior consistent across pane surfaces.
- Gives users clearer status information through summaries, badges, tones, and footers.
- Strengthens confidence through broad Rust, TypeScript, UI, and rendering test coverage.

## Potential follow-up

- Continue reviewing complex pane layouts and action flows as more plugins adopt API version 12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->