### PR TITLE
chore(plugins): pin the featured hash for GitHub plugin 2.0.0

### DIFF
--- a/plugins/featured.toml
+++ b/plugins/featured.toml
@@ -32,7 +32,13 @@ source = "gh:agent-of-empires/plugin-github"
 # namespace gate skips it). Dropping the pin downgrades it to community so the
 # reserved-namespace install gate blocks it outright. Fixed in 1.2.0, which
 # builds under `.aoe-build/`.
-versions = {"0.1.0" = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c28276df435ced940fc", "1.0.0" = "sha256:b2f293d77244b03ddd98deb4426e96a09184a9454e2424bdd00a8e9d93ff4388", "1.2.0" = "sha256:e5fe509a3e7d39030350d7ee7efcd94623e9ec8ce7707a121804ec95212aba8a", "1.3.0" = "sha256:112fc40480a0dff2abacaa38062f619653a8153ac61bfeab9f14721090ee8e28", "1.4.0" = "sha256:f2d231e8d0877a8092c75efaa06016359be8da30c2c4a9ffe88ee7c7f3dfac18", "1.5.0" = "sha256:c61ae57dd94baf895869279a0ebe63a4bf478c3356a26077a6f269ee16eb5685", "1.6.0" = "sha256:353e30d21a5ceee9c7522cec0ab49f2e66a234c6f6a318a40ec24bd9436de903", "1.6.1" = "sha256:b3067c0483b4fc12d32d5084809190216fe53a1c1e471dabfe8748bf37592511", "1.7.0" = "sha256:98e8c88e133de38df499433ec0a8dc0b1831066a4fc4d37a3bf275dcc6f21606", "1.7.1" = "sha256:7a843bbb4c9ef37d5a367b2305aff62902c7d7111fd25e2c80058c7de255aaca", "1.7.2" = "sha256:dc15857292f26768b17a60689ac24c88486e1c8c3260df625fd6de7a6b8b7ba6", "1.8.0" = "sha256:5f8d13ed463beb1127b4fa207804b6f91b80a94fedcf6e07f3e9e08cbf2fec09"}
+#
+# 2.0.0 is the first release whose manifest declares `api_version = 12`, and its
+# `aoe_version` floor is `>=1.14.0`. It therefore stays unloadable until the aoe
+# release that carries api_version 12 ships; the load-time host_compat check
+# skips it on 1.13.x rather than failing startup. Pinning it here is what lets it
+# claim the reserved namespace once that release lands.
+versions = {"0.1.0" = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c28276df435ced940fc", "1.0.0" = "sha256:b2f293d77244b03ddd98deb4426e96a09184a9454e2424bdd00a8e9d93ff4388", "1.2.0" = "sha256:e5fe509a3e7d39030350d7ee7efcd94623e9ec8ce7707a121804ec95212aba8a", "1.3.0" = "sha256:112fc40480a0dff2abacaa38062f619653a8153ac61bfeab9f14721090ee8e28", "1.4.0" = "sha256:f2d231e8d0877a8092c75efaa06016359be8da30c2c4a9ffe88ee7c7f3dfac18", "1.5.0" = "sha256:c61ae57dd94baf895869279a0ebe63a4bf478c3356a26077a6f269ee16eb5685", "1.6.0" = "sha256:353e30d21a5ceee9c7522cec0ab49f2e66a234c6f6a318a40ec24bd9436de903", "1.6.1" = "sha256:b3067c0483b4fc12d32d5084809190216fe53a1c1e471dabfe8748bf37592511", "1.7.0" = "sha256:98e8c88e133de38df499433ec0a8dc0b1831066a4fc4d37a3bf275dcc6f21606", "1.7.1" = "sha256:7a843bbb4c9ef37d5a367b2305aff62902c7d7111fd25e2c80058c7de255aaca", "1.7.2" = "sha256:dc15857292f26768b17a60689ac24c88486e1c8c3260df625fd6de7a6b8b7ba6", "1.8.0" = "sha256:5f8d13ed463beb1127b4fa207804b6f91b80a94fedcf6e07f3e9e08cbf2fec09", "2.0.0" = "sha256:f5343edc97e1a7f0892064abc07645f7f4d96b6badbd508be3b5ede53b2ac4e7"}
 
 [plugins."agent-of-empires.cron"]
 source = "gh:agent-of-empires/plugin-cron"


### PR DESCRIPTION
## Description

Adds the featured-index pin for [plugin-github 2.0.0](https://github.com/agent-of-empires/plugin-github/pull/87), the first release built on the `api_version = 12` pane block vocabulary from #3244.

`agent-of-empires.github` is a reserved namespace, so a release is installable only while the featured index vouches for its exact source tree (`reject_reserved_or_builtin` at install, and its load-time twin in `registry::validation_for`). Without this pin, plugin-github 2.0.0 resolves as featured-unverified and the install gate refuses it outright.

The pin does not make 2.0.0 loadable on its own. Its manifest declares `aoe_version = ">=1.14.0, <2.0.0"`, so `host_compat` skips it on 1.13.x with a load error rather than failing startup. **It becomes installable only once the aoe release that carries api_version 12 ships, and that release must be a minor bump** (`open-release-pr.yml` defaults to patch, which would cut 1.13.3 and leave the floor unmet).

### How the hash was produced

```
git archive v2.0.0 | tar -x -C "$tmp"
aoe plugin hash "$tmp"
```

`git archive` is used rather than a working checkout so the tree holds exactly the tracked files, with no venv, no `.aoe-build/`, and no stray artifacts. The procedure was validated by reproducing the already-shipped 1.8.0 pin (`sha256:5f8d13ed…`) byte for byte before being used for this one.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

A pin is data, and the code that consumes it is already covered by `plugin::featured`'s tests plus the install/load gates in `plugin::install` and `plugin::registry`. A test asserting this specific hash string would restate the declaration and fail only when someone deliberately edited both, which `AGENTS.md` calls out as a test not worth adding.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Hash computed locally and cross-checked against the shipped 1.8.0 pin to validate the procedure.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added the featured-index hash for `agent-of-empires.github` plugin version `2.0.0`.
- Documented its `api_version = 12` requirement and `aoe_version >=1.14.0` compatibility floor.
- Preserved safe loading behavior on older AoE versions.

## Benefits

- Enables installation validation for plugin version `2.0.0`.
- Prevents loading on unsupported AoE versions.
- Introduces no user-facing or CLI/TUI behavior changes.

## Potential follow-up

- Enable the plugin after the AoE release that supports API version 12 becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->