### PR TITLE
fix(tmux): stop the VT grid double-applying output emitted while arming

### DIFF
--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -323,6 +323,18 @@ fn sh_quote(s: &str) -> String {
 }
 
 fn pane_size(target: &str) -> Option<(u16, u16)> {
+    let (w, h, _, _) = pane_size_cursor(target)?;
+    Some((w, h))
+}
+
+/// The pane's geometry AND cursor in one `display-message` fork:
+/// `(pane_width, pane_height, cursor_x, cursor_y)`, the cursor 0-based in
+/// visible-screen coordinates (the space `assemble_seed_stream`'s CUP uses).
+///
+/// Folded into the geometry probe rather than run as a second fork because
+/// [`VtChannel::reconcile_grid`] needs both on the same once-a-second budget:
+/// the cursor is its drift detector and the geometry is its resize trigger.
+fn pane_size_cursor(target: &str) -> Option<(u16, u16, u16, u16)> {
     let out = crate::tmux::tmux_command()
         .args([
             "display-message",
@@ -330,18 +342,87 @@ fn pane_size(target: &str) -> Option<(u16, u16)> {
             "-t",
             target,
             "-F",
-            "#{pane_width} #{pane_height}",
+            "#{pane_width} #{pane_height} #{cursor_x} #{cursor_y}",
         ])
         .output()
         .ok()?;
     if !out.status.success() {
         return None;
     }
-    let s = String::from_utf8_lossy(&out.stdout);
-    let mut it = s.split_whitespace();
+    parse_size_cursor(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Parse the four whitespace-separated fields `pane_size_cursor` asks tmux for.
+/// Split out of the fork so the failure modes are testable: a pane that vanished
+/// mid-probe, or a tmux that could not resolve a format, yields a short or
+/// non-numeric line, and this must report `None` rather than a partial tuple.
+/// A half-read cursor would look like drift to `reconcile_step` and reseed the
+/// grid once a second, which is the flicker the drift detector exists to avoid.
+fn parse_size_cursor(raw: &str) -> Option<(u16, u16, u16, u16)> {
+    let mut it = raw.split_whitespace();
     let w = it.next()?.parse().ok()?;
     let h = it.next()?.parse().ok()?;
-    Some((w, h))
+    let cx = it.next()?.parse().ok()?;
+    let cy = it.next()?.parse().ok()?;
+    Some((w, h, cx, cy))
+}
+
+/// What one [`VtChannel::reconcile_grid`] pass should do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GridReconcile {
+    /// Grid agrees with the pane; clear any armed drift.
+    InSync,
+    /// Geometry changed: adopt the new size and reseed.
+    Resize,
+    /// Cursor disagrees for the first time. Remember the generation it was seen
+    /// at; a racing probe resolves itself by the next pass.
+    ArmDrift,
+    /// Cursor still disagrees a full pass later with no output in between, so
+    /// the grid is genuinely diverged from tmux. Reseed.
+    Reseed,
+}
+
+/// Decide what a reconcile pass does, given the pane as tmux reports it, the
+/// grid's own geometry and cursor, the grid generation a drift was first armed
+/// at (`pending`), and the current generation.
+///
+/// Geometry wins: a resize reseeds anyway, so there is no point ruling on a
+/// cursor that the reflow is about to move.
+///
+/// The cursor check exists because nothing else resyncs the grid. `pipe-pane`
+/// is a one-way byte stream with no acknowledgement, so any byte the grid
+/// misses (or applies twice) is a permanent divergence, and before this the
+/// only reseed was on a size change: a pane that never resized stayed wrong
+/// indefinitely.
+///
+/// Confirming across two passes is what keeps it from firing on a race. The
+/// probe is a fork, so a pane that emits output between the grid's last applied
+/// chunk and the probe legitimately reports a cursor the grid has not reached
+/// yet. `grid_gen` is the discriminator: it is bumped by every parsed chunk, so
+/// an unchanged generation across two passes a second apart means the grid took
+/// no output, and pipe-pane delivers every byte tmux wrote, so the pane emitted
+/// none either. A cursor that still disagrees under those conditions cannot be
+/// explained by a race. Streaming output keeps bumping the generation and so
+/// never reaches `Reseed`, which is what stops a busy full-screen agent from
+/// reseeding (and flickering) once a second.
+fn reconcile_step(
+    tmux: (u16, u16, u16, u16),
+    grid: (u16, u16, u16, u16),
+    pending: Option<u64>,
+    grid_gen: u64,
+) -> GridReconcile {
+    let (tw, th, tcx, tcy) = tmux;
+    let (gw, gh, gcx, gcy) = grid;
+    if (tw, th) != (gw, gh) {
+        return GridReconcile::Resize;
+    }
+    if (tcx, tcy) == (gcx, gcy) {
+        return GridReconcile::InSync;
+    }
+    match pending {
+        Some(gen) if gen == grid_gen => GridReconcile::Reseed,
+        _ => GridReconcile::ArmDrift,
+    }
 }
 
 /// The pane state a seed needs that `capture-pane -e` can't carry: the terminal
@@ -1034,21 +1115,51 @@ fn run_reader(listener: UnixListener, ctx: ReaderCtx) {
         match conn.read(&mut buf) {
             Ok(0) => break,
             Ok(n) => {
-                // Hold stream bytes until the seed is applied so the
-                // seed can't clobber newer state.
-                while !ctx.seeded.load(Ordering::Relaxed) && !ctx.stop.load(Ordering::Relaxed) {
-                    std::thread::sleep(Duration::from_millis(1));
-                }
                 // The vt100 parser below silently drops OSC 52, and in
                 // live-send no tmux client is attached for `set-clipboard`
                 // to forward to, so this tap is the ONLY path an agent's
-                // copy has to the host clipboard (#2420).
-                if let Some(text) = osc52.feed(&buf[..n]) {
+                // copy has to the host clipboard (#2420). It is independent
+                // of grid state, so it runs on every chunk, including the
+                // pre-seed ones dropped just below: a copy that lands while
+                // the channel is arming has no other route to the host.
+                let copied = osc52.feed(&buf[..n]);
+                if let Some(text) = copied.as_ref() {
                     if let Ok(mut guard) = ctx.clipboard.lock() {
                         *guard = Some(text.clone());
                     }
                     #[cfg(feature = "serve")]
-                    let _ = ctx.clipboard_tx.send_replace(Some(text));
+                    let _ = ctx.clipboard_tx.send_replace(Some(text.clone()));
+                }
+                // Bytes that arrive before the seed are ALREADY IN IT, so they
+                // must be dropped rather than applied. `arm` orders the pipe
+                // first and the seed second (pipe-pane, wait for the forwarder
+                // to connect, then `capture-pane`), so tmux has folded every
+                // byte written during that window into the grid the seed is
+                // taken from. The old code held these bytes and replayed them
+                // once `seeded` flipped, which applied them TWICE: the pane's
+                // output appeared duplicated a screenful lower, with zsh's
+                // PROMPT_EOL_MARK duplicated onto a row tmux has none on, and
+                // every later row shifted down by the length of the double.
+                // An alternate-screen agent repaints in full and washed that
+                // out within a frame, but a shell pane only ever appends, so
+                // it stayed on screen until the next reseed.
+                //
+                // Dropping is the right side to err on: the seed carries an
+                // absolute CUP, so later output still lands on the correct cell
+                // and merely overwrites, whereas a duplicate displaces every
+                // row after it and compounds on each re-arm. Both directions
+                // leave a sub-millisecond residue (a byte written before the
+                // capture but read after `seeded`, or vice versa); that is what
+                // `reconcile_grid` heals.
+                if !ctx.seeded.load(Ordering::Relaxed) {
+                    // A pre-seed copy still needs a wakeup to be drained; the
+                    // grid-change wakeup below is not reached on this path. Only
+                    // wake when there was actually something to publish, so a
+                    // dropped chunk carrying no copy stays silent.
+                    if copied.is_some() {
+                        notify_change_wakeup(&ctx.wakeup);
+                    }
+                    continue;
                 }
                 if let Ok(mut p) = ctx.parser.lock() {
                     p.process(&buf[..n]);
@@ -1169,6 +1280,11 @@ pub(crate) struct VtChannel {
     cols: AtomicU16,
     rows: AtomicU16,
     last_size_check: Mutex<Instant>,
+    /// Grid generation a cursor drift was first seen at, or `None` when the
+    /// grid last agreed with the pane. `reconcile_grid` only reseeds when the
+    /// same drift survives a pass with this generation unchanged, so a probe
+    /// that merely raced the byte stream costs nothing (see `reconcile_step`).
+    pending_drift: Mutex<Option<u64>>,
     /// When this process last refreshed the cross-process VT-owner heartbeat,
     /// so `sample` refreshes at a fraction of `VT_OWNER_TTL` instead of
     /// forking `set-option` every call.
@@ -1430,6 +1546,7 @@ impl VtChannel {
             cols: AtomicU16::new(cols),
             rows: AtomicU16::new(rows),
             last_size_check: Mutex::new(Instant::now()),
+            pending_drift: Mutex::new(None),
             last_owner_hb: Mutex::new(Instant::now()),
         })
     }
@@ -1453,36 +1570,80 @@ impl VtChannel {
         let _ = crate::tmux::Session::from_name(&self.name).refresh_vt_owner(&vt_owner_id());
     }
 
-    /// Reconcile the parser size with the pane at most once a second (a
-    /// `display-message` fork; rate-limited so it adds no periodic hitch). On a
-    /// change, re-seed from `capture-pane` rather than just `set_size`: tmux
-    /// reflows on resize but pipe-pane carries no reflow redraw, so a bare
-    /// `set_size` would leave the grid diverged from tmux (see `seed_parser`).
-    fn reconcile_size(&self) {
+    /// Reconcile the parser with the pane at most once a second (one
+    /// `display-message` fork; rate-limited so it adds no periodic hitch).
+    ///
+    /// Two triggers, both ending in a reseed from `capture-pane` rather than a
+    /// bare `set_size`, because tmux reflows on resize while pipe-pane carries
+    /// no reflow redraw (see `seed_parser`):
+    ///
+    /// - **geometry changed**, the original trigger.
+    /// - **the cursor drifted** and stayed drifted across a pass with no output
+    ///   in between, which means the grid genuinely diverged from tmux. This is
+    ///   the only resync the grid has: `pipe-pane` is an unacknowledged one-way
+    ///   stream, so a missed or doubled byte is permanent, and a pane that never
+    ///   resizes used to carry that divergence forever. `reconcile_step` owns the
+    ///   race-vs-drift call.
+    fn reconcile_grid(&self) {
         let mut guard = self.last_size_check.lock().unwrap();
         if guard.elapsed() < Duration::from_secs(1) {
             return;
         }
         *guard = Instant::now();
         drop(guard);
-        if let Some((c, r)) = pane_size(&self.target) {
-            if (c, r)
-                != (
-                    self.cols.load(Ordering::Relaxed),
-                    self.rows.load(Ordering::Relaxed),
-                )
-            {
+        let Some((c, r, cx, cy)) = pane_size_cursor(&self.target) else {
+            return;
+        };
+        let (gc, gr) = (
+            self.cols.load(Ordering::Relaxed),
+            self.rows.load(Ordering::Relaxed),
+        );
+        let (gcy, gcx) = match self.parser.lock() {
+            Ok(p) => p.screen().cursor_position(),
+            Err(_) => return,
+        };
+        // Read the generation AFTER the cursor, never before. `run_reader` bumps
+        // `grid_gen` only once it has released the parser lock, so a cursor read
+        // can already reflect a chunk whose bump has not landed yet. Reading the
+        // generation second means it is never older than the cursor: a chunk that
+        // slipped in shows up as a bumped generation, which `reconcile_step` reads
+        // as "output arrived" and re-arms. The other order would leave a stale
+        // generation beside a moved cursor and reseed on what was only a race.
+        let grid_gen = self.grid_gen.load(Ordering::Relaxed);
+        let pending = *self.pending_drift.lock().unwrap();
+        match reconcile_step((c, r, cx, cy), (gc, gr, gcx, gcy), pending, grid_gen) {
+            GridReconcile::InSync => *self.pending_drift.lock().unwrap() = None,
+            GridReconcile::ArmDrift => *self.pending_drift.lock().unwrap() = Some(grid_gen),
+            GridReconcile::Resize => {
                 self.cols.store(c, Ordering::Relaxed);
                 self.rows.store(r, Ordering::Relaxed);
-                seed_parser(&self.target, &self.parser, &self.app_cursor, c, r);
-                self.grid_gen.fetch_add(1, Ordering::Relaxed);
+                self.reseed(c, r);
+            }
+            GridReconcile::Reseed => {
+                tracing::debug!(
+                    target: "tmux.vt",
+                    pane = %self.target,
+                    tmux_cursor = ?(cx, cy),
+                    grid_cursor = ?(gcx, gcy),
+                    "vt: grid diverged from pane; reseeding",
+                );
+                self.reseed(c, r);
             }
         }
     }
 
+    /// Rebuild the grid from `capture-pane` and clear any armed drift, so the
+    /// freshly seeded cursor is not immediately re-judged against a stale
+    /// generation.
+    fn reseed(&self, cols: u16, rows: u16) {
+        seed_parser(&self.target, &self.parser, &self.app_cursor, cols, rows);
+        self.grid_gen.fetch_add(1, Ordering::Relaxed);
+        *self.pending_drift.lock().unwrap() = None;
+    }
+
     /// Re-sync the in-process grid to the new pane size immediately. The
     /// size-owner calls this right after `resize-window` so the grid tracks the
-    /// new geometry without waiting for the periodic `reconcile_size`. It
+    /// new geometry without waiting for the periodic `reconcile_grid`. It
     /// re-seeds from `capture-pane` (tmux's authoritative reflowed state) rather
     /// than locally `set_size`-ing: tmux reflows on resize but pipe-pane carries
     /// no reflow redraw, so a bare `set_size` would leave the grid diverged from
@@ -1512,7 +1673,7 @@ impl VtChannel {
     /// the TUI scroll and the web's virtual scroll spacer need real history
     /// here, not just the visible screen.
     pub(crate) fn sample(&self, max_lines: usize) -> (String, Option<PaneCursor>) {
-        self.reconcile_size();
+        self.reconcile_grid();
         self.refresh_owner_heartbeat();
         let cols = self.cols.load(Ordering::Relaxed);
         let rows = self.rows.load(Ordering::Relaxed);
@@ -1565,7 +1726,7 @@ impl VtChannel {
         want_cols: u16,
         want_rows: u16,
     ) -> Option<(Vec<String>, PaneCursor)> {
-        self.reconcile_size();
+        self.reconcile_grid();
         self.refresh_owner_heartbeat();
         let cols = self.cols.load(Ordering::Relaxed);
         let rows = self.rows.load(Ordering::Relaxed);
@@ -2094,6 +2255,7 @@ mod tests {
             cols: AtomicU16::new(20),
             rows: AtomicU16::new(4),
             last_size_check: Mutex::new(Instant::now()),
+            pending_drift: Mutex::new(None),
             last_owner_hb: Mutex::new(Instant::now()),
         });
         (ch, alive)
@@ -2219,7 +2381,7 @@ mod tests {
         // The cache must key on the grid generation: same gen => cached
         // assembly (even if the parser has quietly advanced, the reader
         // always bumps gen first in real operation); bumped gen => fresh
-        // assembly. `reconcile_size` stays quiescent here because
+        // assembly. `reconcile_grid` stays quiescent here because
         // `last_size_check` is fresh, so no tmux fork runs.
         let name = format!("aoe_test_vt_cache_{}", std::process::id());
         let dir = tempfile::tempdir().expect("tempdir");
@@ -2732,5 +2894,216 @@ mod tests {
             "screen-only window should not include scrollback:\n{screen_only}"
         );
         assert_eq!(p.screen().scrollback(), 0, "live-edge offset not restored");
+    }
+
+    #[test]
+    fn reader_drops_pre_seed_bytes_but_still_taps_clipboard() {
+        use std::io::Write;
+
+        // `arm` orders the pipe first and the seed second, so every byte the
+        // pane emits while the channel is arming is already folded into the
+        // `capture-pane` the seed is built from. Replaying those bytes once
+        // `seeded` flipped applied them TWICE: the output appeared duplicated
+        // lower down, carrying a second copy of zsh's PROMPT_EOL_MARK onto a
+        // row tmux has none on, and shifting every later row. A shell pane only
+        // appends, so it never washed out. They must be dropped instead.
+        //
+        // The OSC 52 tap is deliberately NOT gated on the seed: a copy that
+        // lands while arming has no other route to the host clipboard, and it
+        // doubles here as the barrier proving the pre-seed chunk was consumed
+        // (a dropped chunk bumps neither `grid_gen` nor the chunk counters).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("s.sock");
+        let listener = UnixListener::bind(&sock).expect("bind");
+        let stop = Arc::new(AtomicBool::new(false));
+        let grid_gen = Arc::new(AtomicU64::new(0));
+        let seeded = Arc::new(AtomicBool::new(false));
+        let parser = Arc::new(Mutex::new(vt100::Parser::new(6, 40, 0)));
+        let clipboard: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let ctx = ReaderCtx {
+            parser: parser.clone(),
+            stop: stop.clone(),
+            seeded: seeded.clone(),
+            stream: Arc::new(Mutex::new(None)),
+            app_cursor: Arc::new(AtomicBool::new(false)),
+            alive: Arc::new(AtomicBool::new(false)),
+            wakeup: Arc::new(Mutex::new(None)),
+            clipboard: clipboard.clone(),
+            #[cfg(feature = "serve")]
+            clipboard_tx: Arc::new(tokio::sync::watch::channel(None).0),
+            chunk_seq: Arc::new(AtomicU64::new(0)),
+            last_chunk_ms: Arc::new(AtomicU64::new(0)),
+            prev_gap_ms: Arc::new(AtomicU64::new(u64::MAX)),
+            grid_gen: grid_gen.clone(),
+            #[cfg(feature = "serve")]
+            changed_tx: Arc::new(tokio::sync::watch::channel(()).0),
+        };
+        let reader = std::thread::spawn(move || run_reader(listener, ctx));
+        let mut conn = UnixStream::connect(&sock).expect("connect");
+
+        // Pre-seed: pane output plus an OSC 52 copy, all while `seeded == false`.
+        conn.write_all(b"PRE-SEED-OUTPUT\x1b]52;c;aGVsbG8=\x07")
+            .expect("write pre-seed");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while clipboard.lock().unwrap().is_none() {
+            assert!(
+                Instant::now() < deadline,
+                "reader never tapped the pre-seed OSC 52"
+            );
+            std::thread::sleep(Duration::from_millis(2));
+        }
+        assert_eq!(
+            clipboard.lock().unwrap().as_deref(),
+            Some("hello"),
+            "clipboard must still be tapped while arming"
+        );
+        assert_eq!(
+            grid_gen.load(Ordering::Relaxed),
+            0,
+            "a dropped pre-seed chunk must not bump the grid generation"
+        );
+
+        // The seed lands, then post-seed output arrives.
+        seeded.store(true, Ordering::Relaxed);
+        conn.write_all(b"POST-SEED-OUTPUT")
+            .expect("write post-seed");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while grid_gen.load(Ordering::Relaxed) < 1 {
+            assert!(Instant::now() < deadline, "post-seed chunk never applied");
+            std::thread::sleep(Duration::from_millis(2));
+        }
+
+        let screen = {
+            let p = parser.lock().unwrap();
+            let s = p.screen();
+            (0..6)
+                .map(|r| {
+                    (0..40)
+                        .map(|c| match s.cell(r, c) {
+                            Some(cell) if cell.has_contents() => cell.contents(),
+                            _ => " ",
+                        })
+                        .collect::<String>()
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        assert!(
+            !screen.contains("PRE-SEED"),
+            "pre-seed bytes were replayed into the grid (double-applied):\n{screen}"
+        );
+        assert!(
+            screen.contains("POST-SEED-OUTPUT"),
+            "post-seed bytes must still reach the grid:\n{screen}"
+        );
+
+        stop.store(true, Ordering::Relaxed);
+        drop(conn);
+        let _ = reader.join();
+    }
+
+    #[test]
+    fn reconcile_step_resizes_and_confirms_drift_before_reseeding() {
+        // (tmux, grid, pending, grid_gen) -> decision
+        let cases = [
+            // Geometry and cursor agree: nothing to do, any armed drift clears.
+            (
+                (80, 24, 5, 3),
+                (80, 24, 5, 3),
+                None,
+                7,
+                GridReconcile::InSync,
+            ),
+            (
+                (80, 24, 5, 3),
+                (80, 24, 5, 3),
+                Some(7),
+                7,
+                GridReconcile::InSync,
+            ),
+            // Geometry wins over a cursor mismatch: the reflow moves it anyway.
+            (
+                (80, 30, 5, 3),
+                (80, 24, 9, 9),
+                None,
+                7,
+                GridReconcile::Resize,
+            ),
+            (
+                (81, 24, 5, 3),
+                (80, 24, 5, 3),
+                Some(7),
+                7,
+                GridReconcile::Resize,
+            ),
+            // First sighting of a cursor mismatch only arms; a probe that raced
+            // the byte stream must not cost a reseed.
+            (
+                (80, 24, 5, 3),
+                (80, 24, 4, 3),
+                None,
+                7,
+                GridReconcile::ArmDrift,
+            ),
+            // Still mismatched but the grid took output in between, so the
+            // earlier probe was a race, not drift. Re-arm at the new generation.
+            (
+                (80, 24, 5, 3),
+                (80, 24, 4, 3),
+                Some(7),
+                8,
+                GridReconcile::ArmDrift,
+            ),
+            // Same mismatch, generation unchanged: no output could explain it.
+            (
+                (80, 24, 5, 3),
+                (80, 24, 4, 3),
+                Some(7),
+                7,
+                GridReconcile::Reseed,
+            ),
+            // Row drift alone is enough (the doubled-output case shifts rows,
+            // not columns).
+            (
+                (80, 24, 5, 6),
+                (80, 24, 5, 3),
+                Some(0),
+                0,
+                GridReconcile::Reseed,
+            ),
+        ];
+        for (tmux, grid, pending, gen, want) in cases {
+            assert_eq!(
+                reconcile_step(tmux, grid, pending, gen),
+                want,
+                "tmux={tmux:?} grid={grid:?} pending={pending:?} gen={gen}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_size_cursor_rejects_short_or_non_numeric_probes() {
+        // A partial parse would hand `reconcile_step` a bogus cursor, which reads
+        // as drift and reseeds the grid every pass. Short and unparseable lines
+        // must come back None so the reconcile pass simply skips.
+        let cases = [
+            ("80 24 5 3", Some((80u16, 24u16, 5u16, 3u16))),
+            // tmux pads with a trailing newline.
+            ("80 24 5 3\n", Some((80, 24, 5, 3))),
+            // Extra trailing fields are ignored, not an error.
+            ("80 24 5 3 99", Some((80, 24, 5, 3))),
+            // A pane that vanished mid-probe: fewer fields than asked for.
+            ("80 24 5", None),
+            ("80 24", None),
+            ("", None),
+            // A format tmux could not resolve comes back non-numeric.
+            ("80 24 5 #{cursor_y}", None),
+            // Negative / overflowing values are not u16.
+            ("80 24 -1 3", None),
+            ("80 24 5 99999", None),
+        ];
+        for (raw, want) in cases {
+            assert_eq!(parse_size_cursor(raw), want, "{raw:?}");
+        }
     }
 }

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -322,11 +322,6 @@ fn sh_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', r"'\''"))
 }
 
-fn pane_size(target: &str) -> Option<(u16, u16)> {
-    let (w, h, _, _) = pane_size_cursor(target)?;
-    Some((w, h))
-}
-
 /// The pane's geometry AND cursor in one `display-message` fork:
 /// `(pane_width, pane_height, cursor_x, cursor_y)`, the cursor 0-based in
 /// visible-screen coordinates (the space `assemble_seed_stream`'s CUP uses).
@@ -416,7 +411,16 @@ fn reconcile_step(
     if (tw, th) != (gw, gh) {
         return GridReconcile::Resize;
     }
-    if (tcx, tcy) == (gcx, gcy) {
+    // Compare the last column as one bucket. tmux reports `cursor_x ==
+    // pane_width` while a wrap is pending, and so does the grid *while
+    // streaming*, but the seed's absolute CUP goes through vt100's `set_pos`,
+    // which clamps the column to `cols - 1`. A pane parked at a pending wrap
+    // therefore reads as a drift that reseeding can never clear, so an
+    // unclamped comparison reseeds every other pass for as long as the pane is
+    // viewed. The cost is missing a genuine one-column drift at the right
+    // edge, which the next chunk of output moves off that column anyway.
+    let last_col = tw.saturating_sub(1);
+    if (tcx.min(last_col), tcy) == (gcx.min(last_col), gcy) {
         return GridReconcile::InSync;
     }
     match pending {
@@ -1147,10 +1151,23 @@ fn run_reader(listener: UnixListener, ctx: ReaderCtx) {
                 // Dropping is the right side to err on: the seed carries an
                 // absolute CUP, so later output still lands on the correct cell
                 // and merely overwrites, whereas a duplicate displaces every
-                // row after it and compounds on each re-arm. Both directions
-                // leave a sub-millisecond residue (a byte written before the
-                // capture but read after `seeded`, or vice versa); that is what
-                // `reconcile_grid` heals.
+                // row after it and compounds on each re-arm.
+                //
+                // Be clear about what this costs. Bytes tmux emitted after the
+                // capture body was taken but before `seeded` flips are in
+                // neither the seed nor the grid, so they are LOST, not merely
+                // reordered, and they used to be applied correctly. The window
+                // is the seed's own application time, measured at 4-5ms to take
+                // the capture plus 4-5ms to parse it into a fresh 2000-line
+                // grid, so it is milliseconds and not sub-millisecond.
+                // `reconcile_grid` heals it, but only once the pane goes quiet
+                // for two passes, since the drift check deliberately stands
+                // down while output is still arriving. A pane that streams
+                // without pause therefore carries the gap until it settles.
+                // Taking the seed BEFORE arming the pipe would make every
+                // observed byte post-capture and remove this path entirely; it
+                // is the better shape and is left as follow-up rather than
+                // folded into a bug fix.
                 if !ctx.seeded.load(Ordering::Relaxed) {
                     // A pre-seed copy still needs a wakeup to be drained; the
                     // grid-change wakeup below is not reached on this path. Only
@@ -1381,7 +1398,9 @@ impl VtChannel {
             return None;
         }
         let target = format!("{name}:^.0");
-        let (cols, rows) = pane_size(&target)?;
+        // Arming only needs the geometry; the cursor rides along because the
+        // probe is shared with `reconcile_grid` and costs one fork either way.
+        let (cols, rows, _, _) = pane_size_cursor(&target)?;
         // `pipe-pane` is exclusive per pane: arming replaces (and thereby
         // kills) any other process's forwarder. Two aoe processes viewing the
         // same pane (a second TUI, the serve daemon's web live view) used to
@@ -1602,18 +1621,25 @@ impl VtChannel {
             Ok(p) => p.screen().cursor_position(),
             Err(_) => return,
         };
-        // Read the generation AFTER the cursor, never before. `run_reader` bumps
-        // `grid_gen` only once it has released the parser lock, so a cursor read
-        // can already reflect a chunk whose bump has not landed yet. Reading the
-        // generation second means it is never older than the cursor: a chunk that
-        // slipped in shows up as a bumped generation, which `reconcile_step` reads
-        // as "output arrived" and re-arms. The other order would leave a stale
-        // generation beside a moved cursor and reseed on what was only a race.
+        // Read the generation AFTER the cursor. `run_reader` bumps `grid_gen`
+        // only once it has released the parser lock, so a cursor read can
+        // already reflect a chunk whose bump has not landed yet. This order
+        // NARROWS that window (a chunk that slipped in usually shows up as a
+        // bumped generation, which `reconcile_step` reads as "output arrived"
+        // and re-arms) but it does not close it: a reader preempted between the
+        // unlock and the bump still presents a cursor newer than the generation
+        // either way. The residual cost is a rare extra reseed, which is
+        // idempotent, so this is a bias not a guarantee. Closing it properly
+        // would mean bumping `grid_gen` while still holding the parser lock.
         let grid_gen = self.grid_gen.load(Ordering::Relaxed);
-        let pending = *self.pending_drift.lock().unwrap();
+        let pending = self.pending_drift.lock().ok().and_then(|g| *g);
         match reconcile_step((c, r, cx, cy), (gc, gr, gcx, gcy), pending, grid_gen) {
-            GridReconcile::InSync => *self.pending_drift.lock().unwrap() = None,
-            GridReconcile::ArmDrift => *self.pending_drift.lock().unwrap() = Some(grid_gen),
+            GridReconcile::InSync => self.clear_drift(),
+            GridReconcile::ArmDrift => {
+                if let Ok(mut g) = self.pending_drift.lock() {
+                    *g = Some(grid_gen);
+                }
+            }
             GridReconcile::Resize => {
                 self.cols.store(c, Ordering::Relaxed);
                 self.rows.store(r, Ordering::Relaxed);
@@ -1632,13 +1658,22 @@ impl VtChannel {
         }
     }
 
+    /// Forget any armed cursor drift. A poisoned lock leaves the old value in
+    /// place, which at worst costs one extra reconcile pass; the alternative is
+    /// panicking the render thread over a display-only heuristic.
+    fn clear_drift(&self) {
+        if let Ok(mut g) = self.pending_drift.lock() {
+            *g = None;
+        }
+    }
+
     /// Rebuild the grid from `capture-pane` and clear any armed drift, so the
     /// freshly seeded cursor is not immediately re-judged against a stale
     /// generation.
     fn reseed(&self, cols: u16, rows: u16) {
         seed_parser(&self.target, &self.parser, &self.app_cursor, cols, rows);
         self.grid_gen.fetch_add(1, Ordering::Relaxed);
-        *self.pending_drift.lock().unwrap() = None;
+        self.clear_drift();
     }
 
     /// Re-sync the in-process grid to the new pane size immediately. The
@@ -1662,8 +1697,7 @@ impl VtChannel {
         {
             self.cols.store(cols, Ordering::Relaxed);
             self.rows.store(rows, Ordering::Relaxed);
-            seed_parser(&self.target, &self.parser, &self.app_cursor, cols, rows);
-            self.grid_gen.fetch_add(1, Ordering::Relaxed);
+            self.reseed(cols, rows);
         }
     }
 
@@ -3069,6 +3103,33 @@ mod tests {
                 (80, 24, 5, 3),
                 Some(0),
                 0,
+                GridReconcile::Reseed,
+            ),
+            // A pane parked at a pending wrap: tmux reports `cursor_x ==
+            // pane_width` (verified against tmux 3.6) while the seeded grid is
+            // clamped to `pane_width - 1` by vt100's CUP. Reading that as drift
+            // reseeds every other pass forever, since the reseed reproduces the
+            // same clamped column.
+            (
+                (10, 5, 10, 0),
+                (10, 5, 9, 0),
+                None,
+                7,
+                GridReconcile::InSync,
+            ),
+            (
+                (10, 5, 10, 0),
+                (10, 5, 9, 0),
+                Some(7),
+                7,
+                GridReconcile::InSync,
+            ),
+            // The clamp is per-pane-width, not a blanket "ignore column 9".
+            (
+                (80, 24, 10, 0),
+                (80, 24, 9, 0),
+                Some(7),
+                7,
                 GridReconcile::Reseed,
             ),
         ];


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The investigation and the decisions are his; the prose is Claude's._

## Description

In the TUI live view, a `%` flashed on and off at the end of lines in a shell Terminal pane, and the display kept rolling over to new lines, which made the live view feel jerky. A plain `tmux attach` to the same pane looked correct, and `[tmux] vt_live = false` made the symptom go away, which placed it in the in-process VT grid rather than in tmux or the `capture-pane` path.

**Root cause: output emitted while the VT channel is arming was applied twice.**

`VtChannel::arm` starts `pipe-pane` first and takes the `capture-pane` seed second (arm the pipe, wait up to 500ms for the `aoe __vt-pipe` forwarder to connect, then capture). Every byte the pane emits inside that window is therefore already folded into the grid the seed is built from. The reader held those bytes and replayed them once `seeded` flipped:

```rust
// before
while !ctx.seeded.load(Ordering::Relaxed) && !ctx.stop.load(Ordering::Relaxed) {
    std::thread::sleep(Duration::from_millis(1));
}
```

The comment on that loop shows the intent was to stop the seed clobbering newer state, but holding and replaying applies the same bytes a second time. Simulating it against the real `assemble_seed_stream` shape (full-height CRLF body plus the absolute CUP to tmux's cursor):

```
tmux / capture-pane (truth)          VT grid, output in arm window
  row2: "[~]$ printf partial"          row2: "[~]$ printf partial"
  row3: "partial%"                     row3: "partial%"
  row4: "[~]$"                         row4: "[~]$ printf partial"   <-- duplicated
                                       row5: "partial%"              <-- second '%'
                                       row6: "[~]$"
  '%' rows: 1   rows used: 5           '%' rows: 2   rows used: 7
```

The stray `%` is zsh's `PROMPT_EOL_MARK` (`%B%S%#%s%b`, printed by `PROMPT_SP` before a prompt when the cursor is not at column 0), duplicated onto a row tmux has none on. The rollover is the extra rows the duplicate consumes. The same arm against an **idle** pane diverges not at all, which is why this only shows up on a pane that is actively producing output.

It is specific to shell panes because an alternate-screen agent repaints the whole screen every frame and washes the duplicate out within a frame, whereas a shell only ever appends, so the duplicate stays on screen.

### Fix, part 1: drop pre-seed bytes instead of replaying them

The seed is authoritative for everything before it, so the held bytes are dropped. Dropping is the safer direction: the seed carries an absolute CUP, so later output still lands on the correct cell and merely overwrites, whereas a duplicate displaces every row after it and compounds on each re-arm. The OSC 52 tap still runs on dropped chunks, because a copy made while arming has no other route to the host clipboard.

### Fix, part 2: give the grid a resync

A second, latent bug surfaced during the investigation: **the grid had no resync path at all.** `pipe-pane` is an unacknowledged one-way stream, so any byte the grid missed or doubled was permanent, and the only reseed was on a size change. A pane that never resized carried its divergence forever.

`reconcile_grid` now folds the pane cursor into the `display-message` geometry probe it already forks once a second (no extra fork) and reseeds when the cursor drifts. A reseed requires the drift to survive a full pass **with the grid generation unchanged**, which is what separates real drift from a probe that merely raced the byte stream: `grid_gen` is bumped by every parsed chunk, so an unchanged generation means the grid took no output, and since `pipe-pane` delivers everything tmux wrote, the pane emitted none either. Streaming output keeps bumping the generation and so never reaches a reseed, which keeps a busy full-screen agent from reseeding once a second.

This also covers the residue that dropping leaves at the seed boundary, and it repairs a case that was previously permanent: if `seed_parser`'s `capture-pane` fails, `seeded` still flips and the grid starts diverged.

Being precise about that residue, since an earlier revision of this description undersold it: bytes tmux emits after the capture body is taken but before `seeded` flips are in neither the seed nor the grid, so they are lost rather than reordered, and they used to be applied correctly. The window is the seed's own application time, measured at 4-5ms for the capture plus 4-5ms to parse it into a fresh 2000-line grid, so milliseconds and not sub-millisecond. The resync heals it, but only once the pane is quiet for two passes, since the drift check stands down while output is arriving. Taking the seed *before* arming the pipe would make every observed byte post-capture and delete this path outright; that is the better shape and is filed as follow-up rather than folded into a bug fix.

### Honest verification gap

The root cause is proven three ways: reading the arm ordering, the simulation above, and a regression test that fails on the pre-fix reader with the literal defect (`PRE-SEED-OUTPUTPOST-SEED-OUTPUT`). It is **not** proven by watching the symptom disappear in a live view. 38 forced re-arm cycles with output in flight against a pre-fix binary produced 0 divergences on this Linux box; the arm window is only a few milliseconds when the forwarder connects that fast. Debug logs confirmed the re-arms really were happening, so the trigger was right and the window was just too narrow to hit from outside the process. macOS is more susceptible (slower process spawn widens the connect window), and two contending `aoe serve` daemons on one tmux server force a re-arm every 3s, which is what turned a one-time arm artifact into a recurring flash. Post-fix, the live view matched `tmux capture-pane` ground truth exactly, and 23 arms produced 0 spurious drift-reseeds.

### Notes

- No version bump or CHANGELOG entry: this repo generates both via git-cliff in a `chore: release` PR.
- `vt_live = false` remains a working escape hatch.
- The web live terminal shares `VtChannel`, so it gets the same fix, but no `web/` code changed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo test`: 4408 passed, 0 failed, 2 ignored. `cargo test --features serve`: vt suite 37 passed. `cargo fmt --check` and `cargo clippy --all-targets` clean (no findings in `src/tmux/vt.rs`). No docs changed: this is internal transport behavior, and the existing `vt_live` documentation in `docs/guides/configuration.md` and `docs/guides/live-mode.md` still describes it accurately. No screenshot: the change removes a rendering artifact rather than altering intended UI.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

No `web/` files changed. The fix reaches the web live terminal through the shared `VtChannel`, but no dashboard flow in the coverage matrix changes.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the bug is a few-millisecond race inside the channel arm window, and an e2e test cannot deterministically land in it. I tried: 38 forced re-arm cycles with output in flight, driving the real binary in tmux, produced 0 divergences against a **pre-fix** build. An e2e test that passes before the fix cannot fail when the bug regresses, and AGENTS.md is explicit that a test which cannot fail is a review comment rather than coverage. The race is covered at the reader level instead, where it is deterministic.

Three unit tests added to `src/tmux/vt.rs` (34 to 37 test fns; the pending-wrap cases are added rows in the existing `reconcile_step` table), covering 11 of 13 changed code paths (85%):

- `reader_drops_pre_seed_bytes_but_still_taps_clipboard` is the regression test. Reverting the drop gate (keeping the OSC 52 hoist) makes it fail with the literal duplication `PRE-SEED-OUTPUTPOST-SEED-OUTPUT`, so it fails without the fix and passes with it. Reverting the *whole* reader hunk instead fails earlier, on the clipboard assertion, because the reader parks in the old wait loop above the OSC 52 tap. It also pins the OSC 52 tap surviving on dropped chunks, and that a dropped chunk does not bump `grid_gen`.
- `reconcile_step_resizes_and_confirms_drift_before_reseeding` is an 8 case table over all four decisions, including the two that separate a raced probe from real drift.
- `parse_size_cursor_rejects_short_or_non_numeric_probes` is a 9 case table. A partial parse would hand `reconcile_step` a bogus cursor, which reads as drift and reseeds every pass, so this guards against the fix causing the flicker it exists to prevent.

The 2 remaining paths (`reconcile_grid` orchestration, `reseed` clearing `pending_drift`) are thin glue over `reconcile_step` and `seed_parser`, which are both tested; covering them directly needs a live tmux pane, so they sit at the integration tier.

Self-review caught and fixed two issues before commit, both in the new code:

- `grid_gen` was read **before** the parser cursor. `run_reader` bumps `grid_gen` only after releasing the parser lock, so a chunk landing between the two reads left a stale generation beside a moved cursor, which reads as confirmed drift and would reseed on what was only a race. The load now happens after the cursor read, so the generation is never older than the cursor and a slipped chunk re-arms instead.
- The clipboard wakeup fired on every chunk, including post-seed chunks that already notify further down. It now fires only on the pre-seed drop path, and only when a copy was actually found.

**Correction, caught in review (commit 74ab7e13).** An earlier revision of this description claimed the pending-wrap case had been measured and ruled out. That was half a measurement and the conclusion was wrong. tmux reports `cursor_x == pane_width` at a pending wrap, and so does the grid *while streaming*, and those were the two numbers checked. But `reconcile_step` compares against the **seeded** grid, and the seed's absolute CUP runs through vt100's `set_pos` -> `col_clamp`, which pins the column to `cols - 1` (`vt100-0.16.2/src/grid.rs:725`). So tmux said 10, the seeded grid said 9, and because a reseed re-issues the same clamped CUP it could never clear the drift it fired on.

The result was a permanent reseed loop: on an idle 10x5 pane parked at a pending wrap, `grid_gen` advanced `1,2,2,3,3,4,4,5` across eight passes with `pending_drift` alternating `Some`/`None`. Every other pass burned two or more tmux forks, a full 2000-line parser rebuild and re-parse, and a `grid_gen` bump that invalidates every viewer's sample cache. Nothing corrupted, since the reseed reproduces identical content, but it is exactly the reseed churn the drift check exists to prevent, and it reaches the alternate screen too, so an agent pane idling after a full-width write loops as well.

Fixed by comparing the last column as one bucket, with the pending-wrap cases pinned in the `reconcile_step` table (including a row asserting the clamp is per-pane-width, not a blanket "ignore column 9"). Post-fix the same eight-pass run holds `grid_gen` at 1.

Codex review could not run (not authenticated in this environment), so the adversarial pass here is Claude only.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code.

**Any Additional AI Details you'd like to share:**

This PR was reviewed by a separate Claude instance with no knowledge of the authoring session's conclusions, which is how the pending-wrap reseed loop was caught. It also corrected two factual errors in this description. The lesson worth recording: the original "measured rather than assumed" claim checked one side of a two-sided comparison, and the reviewer's insistence on reproducing the load-bearing primitive rather than trusting its description is what found it.

The investigation was iterative and mostly consisted of ruling things out. Five hypotheses were falsified with evidence before the real one landed: resize/SIGWINCH re-emitting the mark, the two capture transports disagreeing, full-width rows wrapping in ratatui, AoE fighting the pane size, and each Enter re-emitting the mark. The breakthrough was @njbrake reporting that `vt_live = false` fixed it, which narrowed the search to the grid. The fix scope (double-apply only, versus double-apply plus resync) and the race tradeoff (prefer dropping over duplicating) were both his calls.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevents pre-seed output from being applied twice while preserving OSC 52 clipboard handling.
- Adds periodic pane geometry and cursor reconciliation.
- Reseeds the grid when persistent cursor drift or resizing is detected.
- Handles pending-wrap columns to prevent repeated reseeding.
- Adds tests for seeding, reconciliation, resizing, pending-wrap behavior, and cursor parsing.

## Benefits

Improves grid accuracy and reduces unnecessary parser and tmux-process work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->