### PR TITLE
fix(session): quote a shell-active --model value in extra_args at launch

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -2650,6 +2650,113 @@ pub fn get_telemetry_settings() -> TelemetryConfig {
     Config::load_or_warn().telemetry
 }
 
+/// Wrap a value so the launching shell passes it through literally.
+///
+/// Only quotes when the value contains something a shell would interpret, so
+/// ordinary model ids keep their current, unquoted command line.
+fn shell_quote_value(value: &str) -> String {
+    const SAFE: &str = "-_./:=@,+";
+    let plain = !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || SAFE.contains(c));
+    if plain {
+        return value.to_string();
+    }
+    // Already quoted by whoever wrote it: re-quoting would nest, and the agent
+    // would receive a model id with literal quote characters in it.
+    if value.len() >= 2 && value.starts_with('\'') && value.ends_with('\'') {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', r"'\''"))
+}
+
+/// Quote a shell-active `--model` / `-m` VALUE inside a free-form extra-args
+/// string, leaving every other token exactly as the user wrote it.
+///
+/// `extra_args` is spliced into the launch command verbatim, so a model id
+/// carrying shell metacharacters aborts the whole line before the agent
+/// starts. A context-window suffix does exactly that: `--model claude-x[1m]`
+/// dies under zsh with `no matches found: claude-x[1m]`, status 1, and the
+/// pane is dead at launch with nothing to show for it.
+///
+/// Quoting only the model value keeps the rest of `extra_args` usable as the
+/// caller's own argv, where shell syntax may well be intended.
+pub fn quote_model_value_in_args(args: &str) -> String {
+    let toks: Vec<&str> = args.split_whitespace().collect();
+    let mut out: Vec<String> = Vec::with_capacity(toks.len());
+    let mut i = 0;
+    while i < toks.len() {
+        let tok = toks[i];
+        if let Some((lhs, value)) = tok.split_once('=') {
+            if (lhs == "--model" || lhs == "-m") && !value.is_empty() {
+                out.push(format!("{lhs}={}", shell_quote_value(value)));
+                i += 1;
+                continue;
+            }
+        }
+        if (tok == "--model" || tok == "-m") && i + 1 < toks.len() {
+            out.push(tok.to_string());
+            out.push(shell_quote_value(toks[i + 1]));
+            i += 2;
+            continue;
+        }
+        out.push(tok.to_string());
+        i += 1;
+    }
+    out.join(" ")
+}
+
+#[cfg(test)]
+mod model_value_quoting_tests {
+    use super::*;
+
+    #[test]
+    fn a_context_window_suffix_is_quoted() {
+        assert_eq!(
+            quote_model_value_in_args("--model claude-x[1m]"),
+            "--model 'claude-x[1m]'"
+        );
+        assert_eq!(
+            quote_model_value_in_args("--model=claude-x[1m]"),
+            "--model='claude-x[1m]'"
+        );
+        assert_eq!(
+            quote_model_value_in_args("-m claude-x[1m]"),
+            "-m 'claude-x[1m]'"
+        );
+    }
+
+    #[test]
+    fn an_ordinary_model_id_is_left_alone() {
+        // Quoting everything would change every existing command line.
+        for args in ["--model claude-opus-4-8", "-m gpt-5", "--model=sonnet"] {
+            assert_eq!(quote_model_value_in_args(args), args);
+        }
+    }
+
+    #[test]
+    fn other_arguments_are_never_rewritten() {
+        let args = "--verbose --model claude-x[1m] --flag value";
+        let got = quote_model_value_in_args(args);
+        assert!(got.contains("--verbose"));
+        assert!(got.contains("--flag value"));
+        assert!(got.contains("'claude-x[1m]'"));
+    }
+
+    #[test]
+    fn an_already_quoted_value_is_not_nested() {
+        let args = "--model 'claude-x[1m]'";
+        assert_eq!(quote_model_value_in_args(args), args);
+    }
+
+    #[test]
+    fn a_dangling_flag_is_harmless() {
+        assert_eq!(quote_model_value_in_args("--model"), "--model");
+        assert_eq!(quote_model_value_in_args(""), "");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -2664,8 +2664,13 @@ fn shell_quote_value(value: &str) -> String {
         return value.to_string();
     }
     // Already quoted by whoever wrote it: re-quoting would nest, and the agent
-    // would receive a model id with literal quote characters in it.
-    if value.len() >= 2 && value.starts_with('\'') && value.ends_with('\'') {
+    // would receive a model id with literal quote characters in it. Both
+    // quote styles are shell-valid ways to protect a value, so either wrapper
+    // is left alone.
+    let already_quoted = value.len() >= 2
+        && ((value.starts_with('\'') && value.ends_with('\''))
+            || (value.starts_with('"') && value.ends_with('"')));
+    if already_quoted {
         return value.to_string();
     }
     format!("'{}'", value.replace('\'', r"'\''"))
@@ -2681,30 +2686,44 @@ fn shell_quote_value(value: &str) -> String {
 /// pane is dead at launch with nothing to show for it.
 ///
 /// Quoting only the model value keeps the rest of `extra_args` usable as the
-/// caller's own argv, where shell syntax may well be intended.
+/// caller's own argv, where shell syntax may well be intended. Untouched
+/// regions (including their original whitespace) are copied byte-for-byte
+/// rather than round-tripped through a tokenize/rejoin, which would collapse
+/// runs of whitespace elsewhere in the string.
 pub fn quote_model_value_in_args(args: &str) -> String {
-    let toks: Vec<&str> = args.split_whitespace().collect();
-    let mut out: Vec<String> = Vec::with_capacity(toks.len());
-    let mut i = 0;
-    while i < toks.len() {
-        let tok = toks[i];
-        if let Some((lhs, value)) = tok.split_once('=') {
+    let mut out = String::with_capacity(args.len());
+    let mut rest = args;
+    let mut expect_model_value = false;
+    loop {
+        let ws_len = rest.len() - rest.trim_start().len();
+        out.push_str(&rest[..ws_len]);
+        rest = &rest[ws_len..];
+        if rest.is_empty() {
+            break;
+        }
+        let tok_len = rest.find(char::is_whitespace).unwrap_or(rest.len());
+        let tok = &rest[..tok_len];
+        let assigned_model_value = tok.split_once('=').and_then(|(lhs, value)| {
             if (lhs == "--model" || lhs == "-m") && !value.is_empty() {
-                out.push(format!("{lhs}={}", shell_quote_value(value)));
-                i += 1;
-                continue;
+                Some((lhs, value))
+            } else {
+                None
             }
+        });
+        if expect_model_value {
+            out.push_str(&shell_quote_value(tok));
+            expect_model_value = false;
+        } else if let Some((lhs, value)) = assigned_model_value {
+            out.push_str(lhs);
+            out.push('=');
+            out.push_str(&shell_quote_value(value));
+        } else {
+            out.push_str(tok);
+            expect_model_value = tok == "--model" || tok == "-m";
         }
-        if (tok == "--model" || tok == "-m") && i + 1 < toks.len() {
-            out.push(tok.to_string());
-            out.push(shell_quote_value(toks[i + 1]));
-            i += 2;
-            continue;
-        }
-        out.push(tok.to_string());
-        i += 1;
+        rest = &rest[tok_len..];
     }
-    out.join(" ")
+    out
 }
 
 #[cfg(test)]
@@ -2739,9 +2758,22 @@ mod model_value_quoting_tests {
     fn other_arguments_are_never_rewritten() {
         let args = "--verbose --model claude-x[1m] --flag value";
         let got = quote_model_value_in_args(args);
-        assert!(got.contains("--verbose"));
-        assert!(got.contains("--flag value"));
-        assert!(got.contains("'claude-x[1m]'"));
+        assert_eq!(got, "--verbose --model 'claude-x[1m]' --flag value");
+    }
+
+    #[test]
+    fn unrelated_whitespace_and_quoting_survive_byte_for_byte() {
+        // A tokenize/join round trip would collapse the double space here and
+        // re-wrap an already double-quoted model value, changing what the
+        // agent receives even though neither token needed rewriting.
+        let cases = [
+            ("--prompt \"hello  world\"", "--prompt \"hello  world\""),
+            ("--model \"gpt-5\"", "--model \"gpt-5\""),
+            ("--flag1   --flag2", "--flag1   --flag2"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(quote_model_value_in_args(input), expected, "{input:?}");
+        }
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3180,6 +3180,16 @@ impl Instance {
             let launch_cmd = self.get_launch_command();
             let base_cmd = if self.extra_args.is_empty() {
                 launch_cmd
+            } else if self.command.is_empty() {
+                // Default agent binary: quote a shell-active --model/-m value
+                // the same way the host launch path does (build_host_command).
+                // A custom command override is the user's own argv, so it is
+                // left untouched, matching that path's scoping.
+                format!(
+                    "{} {}",
+                    launch_cmd,
+                    super::config::quote_model_value_in_args(&self.extra_args)
+                )
             } else {
                 format!("{} {}", launch_cmd, self.extra_args)
             };

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3486,7 +3486,14 @@ impl Instance {
                 Some(a) => {
                     let mut cmd = a.launch_base_command();
                     if !self.extra_args.is_empty() {
-                        cmd = format!("{} {}", cmd, self.extra_args);
+                        // A model id carrying shell metacharacters (a
+                        // context-window suffix such as `[1m]`) would abort the
+                        // launch line before the agent starts.
+                        cmd = format!(
+                            "{} {}",
+                            cmd,
+                            super::config::quote_model_value_in_args(&self.extra_args)
+                        );
                     }
                     if self.is_yolo_mode() {
                         if let Some(ref yolo) = a.yolo {


### PR DESCRIPTION
## What

A model id carrying shell metacharacters aborts the launch line before the agent starts. `extra_args` is spliced into the launch command verbatim, so a context-window suffix does exactly that:

```
aoe add --tool claude      # session extra_args: --model claude-x[1m]
aoe session start <id>
zsh:1: no matches found: claude-x[1m]
```

The pane exits 1 at launch. zsh reads `[1m]` as a character-class glob, matches no file, and aborts the whole line; bash with `failglob` behaves the same way. Nothing in the output points at the model id, so it presents as "the session just dies".

## Why this shape

Only the `--model` / `-m` **value** is quoted, in both the spaced and joined forms. The rest of `extra_args` is the caller's own argv, where shell syntax may well be intended, so it is left untouched. An ordinary model id is not quoted at all, so existing command lines keep their current shape, and an already-quoted value is not re-quoted (that would nest and hand the agent a model id containing literal quotes).

## How it was tested

`cargo test --lib` green (4402 passed). Five unit tests cover both flag forms, the untouched ordinary case, other arguments preserved, no nesting, and a dangling flag.

Also verified end to end against a real pane: with the fix the pane launches and the agent receives the value intact; without it the pane is dead at launch with the glob error above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds shell-safe quoting for model values in `extra_args` during default host and sandboxed launches.
- Supports spaced and joined `--model` and `-m` forms.
- Preserves unrelated arguments, whitespace, ordinary model IDs, and existing quotes.
- Adds regression tests for model quoting and edge cases.
- Prevents shell expansion from interrupting session launches while preserving custom command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->