### PR TITLE
feat(acp): opt-in compaction reminder with a configurable context threshold

### DIFF
--- a/docs/development/internals/structured-view.md
+++ b/docs/development/internals/structured-view.md
@@ -107,6 +107,8 @@ max_concurrent_workers = 100
 replay_events = 0                 # 0 = unlimited; caps per-session rows and the web client buffer (#1111)
 node_path = ""
 show_tool_durations = true
+compaction_reminder = false       # opt-in /compact nudge past the threshold (#3253)
+compaction_reminder_percent = 75  # 1..99; independent of the meter's fixed 90% warn colour
 silent_orphan_grace_secs = 120    # 0 disables (#1240)
 auto_stop_idle_secs = 3600        # 0 disables; next prompt respawns the worker
 rate_limit_auto_resume = false

--- a/src/acp/client/http.rs
+++ b/src/acp/client/http.rs
@@ -463,6 +463,31 @@ impl HttpClient {
             .ok_or_else(|| HttpError::SessionNotFound(session_id.to_string()))
     }
 
+    /// Context-window percentage at which the daemon wants the structured
+    /// view to show its compaction reminder, or `None` when the reminder is
+    /// off. Read from the daemon rather than local config on purpose: the
+    /// native view can attach to a remote daemon over `AOE_DAEMON_URL`,
+    /// where this host's `config.toml` describes a different install, and
+    /// the daemon already resolves the active profile's value for the web
+    /// dashboard. See #3253.
+    pub async fn compaction_reminder(&self) -> Result<Option<u8>, HttpError> {
+        /// The two `/api/about` fields the view needs. `ServerAbout` lives
+        /// behind the `serve` feature, so a TUI-only build cannot name it.
+        #[derive(serde::Deserialize)]
+        struct ReminderAbout {
+            acp_compaction_reminder: bool,
+            acp_compaction_reminder_percent: u8,
+        }
+        let url = format!("{}/api/about", self.endpoint.base_url);
+        let res = self.auth(self.http.get(&url)).send().await?;
+        let res = check_status(res, "<about>").await?;
+        let about = res.json::<ReminderAbout>().await?;
+        Ok(about
+            .acp_compaction_reminder
+            .then_some(about.acp_compaction_reminder_percent)
+            .filter(|pct| (1..=99).contains(pct)))
+    }
+
     /// Lightweight reachability probe used by `require_daemon` (when
     /// `AOE_DAEMON_URL` is set, we fail loud before falling into raw
     /// reqwest transport errors) and `aoe serve --status` (renders

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -1372,6 +1372,14 @@ pub struct ServerAbout {
     /// honours the user's chosen ceiling instead of clipping at a
     /// hard-coded constant. See #1111.
     pub acp_replay_events: u32,
+    /// Resolved value of `acp.compaction_reminder` from the active
+    /// profile. Gates the structured view's compaction reminder; off by
+    /// default. See #3253.
+    pub acp_compaction_reminder: bool,
+    /// Resolved value of `acp.compaction_reminder_percent` from the
+    /// active profile. Context-window percentage at which the reminder
+    /// appears.
+    pub acp_compaction_reminder_percent: u8,
     /// `"debug"` when built with `debug_assertions`, `"release"`
     /// otherwise. The web UI renders a "DEV" badge in the topbar
     /// when this is `"debug"` so users can tell concurrently-running
@@ -1397,6 +1405,8 @@ pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> 
     let acp_cfg = crate::session::profile_config::resolve_config_or_warn(&state.profile).acp;
     let acp_show_tool_durations = acp_cfg.show_tool_durations;
     let acp_replay_events = acp_cfg.replay_events;
+    let acp_compaction_reminder = acp_cfg.compaction_reminder;
+    let acp_compaction_reminder_percent = acp_cfg.compaction_reminder_percent;
     let snapshot = state
         .sleep_inhibit_snapshot
         .load(std::sync::atomic::Ordering::Relaxed);
@@ -1416,6 +1426,8 @@ pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> 
         profile: state.profile.clone(),
         acp_show_tool_durations,
         acp_replay_events,
+        acp_compaction_reminder,
+        acp_compaction_reminder_percent,
         build_flavor: if cfg!(debug_assertions) {
             "debug"
         } else {

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -427,6 +427,27 @@ pub struct AcpConfig {
     #[serde(default = "default_true")]
     #[setting(label = "Show tool-call durations", widget = "toggle")]
     pub show_tool_durations: bool,
+    /// Show a dismissable reminder in the structured view once the agent's
+    /// context window passes `compaction_reminder_percent`, suggesting
+    /// `/compact`. Off by default: the composer's usage chip already
+    /// reports the percentage passively, and a banner is an interruption
+    /// only some users want. Agents that do not advertise a `compact`
+    /// command never show it. See #3253.
+    #[serde(default)]
+    #[setting(label = "Compaction reminder", widget = "toggle")]
+    pub compaction_reminder: bool,
+    /// Context-window percentage at which the compaction reminder appears.
+    /// Independent of the usage meter's own warn colour, which stays at a
+    /// fixed 90%: that is passive severity, this is when to interrupt.
+    #[serde(default = "default_compaction_reminder_percent")]
+    #[setting(
+        label = "Compaction reminder threshold (%)",
+        widget = "number",
+        min = 1,
+        max = 99,
+        validate = "range:1:99"
+    )]
+    pub compaction_reminder_percent: u8,
     /// Silent-orphan watchdog: vendor-agnostic correctness grace. When
     /// a prompt is in flight, `tool_calls_in_flight` is empty, at least
     /// one progress notification has arrived, and no further progress
@@ -532,6 +553,10 @@ fn default_acp_auto_stop_idle_secs() -> u32 {
     3600
 }
 
+fn default_compaction_reminder_percent() -> u8 {
+    75
+}
+
 fn default_silent_orphan_grace_secs() -> u32 {
     120
 }
@@ -545,6 +570,8 @@ impl Default for AcpConfig {
             replay_events: default_replay_events(),
             node_path: String::new(),
             show_tool_durations: true,
+            compaction_reminder: false,
+            compaction_reminder_percent: default_compaction_reminder_percent(),
             silent_orphan_grace_secs: default_silent_orphan_grace_secs(),
             auto_stop_idle_secs: default_acp_auto_stop_idle_secs(),
             rate_limit_auto_resume: false,

--- a/src/tui/structured_view/embedded.rs
+++ b/src/tui/structured_view/embedded.rs
@@ -29,7 +29,6 @@ use super::{
     PluginPoll, ViewSetup,
 };
 use crate::acp::client::{DaemonEndpoint, WsError, WsMessage};
-use crate::acp::session_paths::SessionViewInfo;
 use crate::tui::styles::Theme;
 
 /// One event surfaced by [`EmbeddedView::next_event`], applied by
@@ -39,14 +38,14 @@ pub enum EmbeddedEvent {
     /// A WebSocket message, or `None` when the ws channel closed.
     Ws(Option<Result<WsMessage, WsError>>),
     Plugin(PluginPoll),
-    SessionInfo(Result<SessionViewInfo, String>),
+    SessionInfo(super::ViewSideInfo),
 }
 
 pub struct EmbeddedView {
     state: StructuredViewState,
     toast_deadline: Option<Instant>,
     plugin_rx: tokio::sync::mpsc::Receiver<PluginPoll>,
-    session_info_rx: tokio::sync::mpsc::Receiver<Result<SessionViewInfo, String>>,
+    session_info_rx: tokio::sync::mpsc::Receiver<super::ViewSideInfo>,
     /// Preview vs. interactive. A view is mounted (streaming, rendered
     /// in the preview pane) as soon as its session is selected, but the
     /// keyboard only routes to it once activated (Enter), the same
@@ -135,7 +134,7 @@ impl EmbeddedView {
                 }
             } => EmbeddedEvent::Ws(msg),
             Some(poll) = self.plugin_rx.recv() => EmbeddedEvent::Plugin(poll),
-            Some(result) = self.session_info_rx.recv() => EmbeddedEvent::SessionInfo(result),
+            Some(side) = self.session_info_rx.recv() => EmbeddedEvent::SessionInfo(side),
         }
     }
 
@@ -167,15 +166,7 @@ impl EmbeddedView {
                 self.state.ingest_plugin_ui(poll.snapshot);
                 drain_plugin_toast(&mut self.state, &mut self.toast_deadline);
             }
-            EmbeddedEvent::SessionInfo(result) => match result {
-                Ok(info) => super::apply_session_info(&mut self.state, info),
-                Err(e) => {
-                    tracing::warn!(
-                        target: "acp.tui",
-                        "session info fetch failed; rendering fallback header and raw paths: {e}"
-                    );
-                }
-            },
+            EmbeddedEvent::SessionInfo(side) => super::apply_side_info(&mut self.state, side),
         }
     }
 

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -240,8 +240,17 @@ struct ViewSetup {
     state: StructuredViewState,
     startup_toast: Option<String>,
     plugin_rx: tokio::sync::mpsc::Receiver<PluginPoll>,
-    session_info_rx:
-        tokio::sync::mpsc::Receiver<Result<crate::acp::session_paths::SessionViewInfo, String>>,
+    session_info_rx: tokio::sync::mpsc::Receiver<ViewSideInfo>,
+}
+
+/// One-shot daemon reads the view wants at open but must not block on:
+/// the session header / path roots, and the resolved compaction-reminder
+/// threshold. Batched onto one channel because they share a task and both
+/// land before the first user interaction. A failed fetch degrades to the
+/// fallback header or a disabled reminder, never to a startup error.
+pub(crate) struct ViewSideInfo {
+    session: Result<crate::acp::session_paths::SessionViewInfo, String>,
+    compaction_reminder: Option<u8>,
 }
 
 /// Hydrate the transcript via /replay, open the WebSocket, and spawn
@@ -273,11 +282,23 @@ async fn setup_view(endpoint: DaemonEndpoint, session_id: &str) -> Result<ViewSe
         let http = state.http.clone();
         let session_id = state.session_id.clone();
         tokio::spawn(async move {
-            let result = http
+            let session = http
                 .session_view_info(&session_id)
                 .await
                 .map_err(|e| e.to_string());
-            let _ = session_info_tx.send(result).await;
+            let compaction_reminder = match http.compaction_reminder().await {
+                Ok(pct) => pct,
+                Err(e) => {
+                    tracing::warn!(target: "acp.tui", "compaction-reminder config fetch failed; reminder stays off: {e}");
+                    None
+                }
+            };
+            let _ = session_info_tx
+                .send(ViewSideInfo {
+                    session,
+                    compaction_reminder,
+                })
+                .await;
         });
     }
 
@@ -446,13 +467,8 @@ pub async fn run_for_endpoint(
                 drain_plugin_toast(&mut state, &mut toast_deadline);
                 redraw(terminal, theme, &mut state)?;
             }
-            Some(result) = session_info_rx.recv() => {
-                match result {
-                    Ok(info) => apply_session_info(&mut state, info),
-                    Err(e) => {
-                        tracing::warn!(target: "acp.tui", "session info fetch failed; rendering fallback header and raw paths: {e}");
-                    }
-                }
+            Some(side) = session_info_rx.recv() => {
+                apply_side_info(&mut state, side);
                 redraw(terminal, theme, &mut state)?;
             }
             _ = redraw_ticker.tick() => {
@@ -478,6 +494,18 @@ fn apply_session_info(
     state.transcript.session_title = Some(info.title.clone());
     state.transcript.agent_name = Some(info.agent_label());
     state.path_roots = Some(info.paths);
+}
+
+/// Fold the one-shot side-channel payload into the view. Shared by the
+/// full-screen loop and the embedded preview.
+pub(crate) fn apply_side_info(state: &mut StructuredViewState, side: ViewSideInfo) {
+    state.compaction_reminder_percent = side.compaction_reminder;
+    match side.session {
+        Ok(info) => apply_session_info(state, info),
+        Err(e) => {
+            tracing::warn!(target: "acp.tui", "session info fetch failed; rendering fallback header and raw paths: {e}");
+        }
+    }
 }
 
 /// Apply one WebSocket message to the view state: reduce a frame (with

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -655,6 +655,13 @@ impl AcpTranscript {
                 // rather than a context-reset warning, and the primer
                 // banner stays untouched. See #1109.
                 self.compacting = false;
+                // Drop the pre-compaction usage snapshot: the model's
+                // context is now a summary, so the latched "160k/200k"
+                // describes a window that no longer exists. The web
+                // reducer nulls it at the same boundary; without this the
+                // meter and the compaction reminder both read stale until
+                // the next UsageUpdated lands. See #3253.
+                self.usage = None;
                 self.flush_pending_chunk();
                 self.rows.push(ActivityRow::Note {
                     kind: NoteKind::Info,
@@ -1502,6 +1509,11 @@ mod tests {
             },
         ));
         assert_eq!(t.usage.as_ref().map(|u| u.used), Some(5_000));
+        // A compaction rewrites the model's context, so the snapshot it
+        // replaced no longer describes anything. Matching the web reducer
+        // keeps the meter and the compaction reminder from reading stale.
+        t.apply(&frame(3, Event::ConversationCompacted));
+        assert!(t.usage.is_none());
     }
 
     #[test]

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -991,6 +991,12 @@ fn render_status(
             Style::default().fg(theme.error),
         ));
     }
+    if compaction_reminder_due(state) {
+        spans.push(Span::styled(
+            " context filling; /compact ",
+            Style::default().fg(theme.error),
+        ));
+    }
     if state.scroll_offset != u16::MAX {
         spans.push(Span::styled(
             " · G latest ",
@@ -1077,6 +1083,27 @@ fn usage_percent(usage: &SessionUsage) -> u64 {
         return 0;
     }
     (((usage.used as f64 / usage.size as f64) * 100.0).round() as u64).min(100)
+}
+
+/// Whether the status line should nudge the user toward `/compact`: the
+/// daemon has the reminder on, a usage snapshot has arrived, and it is at
+/// or past the configured percentage. Suppressed while a compaction is
+/// already running, since the nudge would be telling the user to do the
+/// thing they are waiting on. Unlike the web banner this is advisory: it
+/// has no dismiss key and clears itself when the next snapshot lands
+/// under the threshold. See #3253.
+fn compaction_reminder_due(state: &StructuredViewState) -> bool {
+    let Some(threshold) = state.compaction_reminder_percent else {
+        return false;
+    };
+    if state.transcript.compacting {
+        return false;
+    }
+    state
+        .transcript
+        .usage
+        .as_ref()
+        .is_some_and(|usage| usage.size > 0 && usage_percent(usage) >= u64::from(threshold))
 }
 
 /// `12.3k/200k (6%) · $0.42`-style usage summary, matching the web
@@ -2759,6 +2786,60 @@ mod tests {
         });
         let dump = render_dump(&state, 80, 24);
         assert!(dump.contains("12k/200k (6%)"), "usage meter missing");
+    }
+
+    #[test]
+    fn compaction_reminder_gating() {
+        // (threshold, used, size, compacting, expected)
+        let cases = [
+            // Off by default: no threshold configured, never nudge.
+            (None, 190_000, 200_000, false, false),
+            // At and past the threshold both fire; equality counts.
+            (Some(75), 150_000, 200_000, false, true),
+            (Some(75), 190_000, 200_000, false, true),
+            // One point under stays quiet.
+            (Some(75), 148_000, 200_000, false, false),
+            // Suppressed mid-compaction: the nudge would name the running job.
+            (Some(75), 190_000, 200_000, true, false),
+            // A zero-size window means the agent has not reported a real
+            // window yet, so there is no percentage to compare.
+            (Some(75), 0, 0, false, false),
+            // Over-full windows are past any legal threshold.
+            (Some(99), 210_000, 200_000, false, true),
+        ];
+        for (threshold, used, size, compacting, expected) in cases {
+            let mut state = test_state();
+            state.compaction_reminder_percent = threshold;
+            state.transcript.compacting = compacting;
+            state.transcript.usage = Some(SessionUsage {
+                used,
+                size,
+                cost: None,
+            });
+            assert_eq!(
+                compaction_reminder_due(&state),
+                expected,
+                "threshold={threshold:?} used={used} size={size} compacting={compacting}"
+            );
+        }
+
+        // No snapshot at all: enabled but nothing to measure.
+        let mut state = test_state();
+        state.compaction_reminder_percent = Some(75);
+        assert!(!compaction_reminder_due(&state));
+    }
+
+    #[test]
+    fn status_line_renders_compaction_reminder() {
+        let mut state = test_state();
+        state.compaction_reminder_percent = Some(75);
+        state.transcript.usage = Some(SessionUsage {
+            used: 160_000,
+            size: 200_000,
+            cost: None,
+        });
+        let dump = render_dump(&state, 100, 24);
+        assert!(dump.contains("/compact"), "reminder missing: {dump}");
     }
 
     #[test]

--- a/src/tui/structured_view/state.rs
+++ b/src/tui/structured_view/state.rs
@@ -119,6 +119,12 @@ pub struct StructuredViewState {
     /// before moving. Interior-mutable so the render (which borrows the
     /// state immutably) can record it. See `apply_scroll`.
     pub last_scroll_max: std::cell::Cell<u16>,
+    /// Context-window percentage at which the status line nudges the user
+    /// to run `/compact`, or `None` when the daemon has the reminder off
+    /// (the default) or its config fetch failed. Read from the daemon's
+    /// `/api/about`, not local config, so a view attached to a remote
+    /// daemon honours that daemon's setting. See #3253.
+    pub compaction_reminder_percent: Option<u8>,
 }
 
 /// One open choice-picker: a titled option list plus what accepting the
@@ -285,6 +291,7 @@ impl StructuredViewState {
             choice: None,
             auto_presented_elicitation: None,
             last_scroll_max: std::cell::Cell::new(0),
+            compaction_reminder_percent: None,
         }
     }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1848,8 +1848,15 @@ function AppContent({
     () => ({
       showToolDurations: serverAbout?.acp_show_tool_durations ?? true,
       replayEvents: serverAbout?.acp_replay_events ?? 0,
+      compactionReminder: serverAbout?.acp_compaction_reminder ?? false,
+      compactionReminderPercent: serverAbout?.acp_compaction_reminder_percent ?? 75,
     }),
-    [serverAbout?.acp_show_tool_durations, serverAbout?.acp_replay_events],
+    [
+      serverAbout?.acp_show_tool_durations,
+      serverAbout?.acp_replay_events,
+      serverAbout?.acp_compaction_reminder,
+      serverAbout?.acp_compaction_reminder_percent,
+    ],
   );
 
   const tourScope: TourScope =

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -100,6 +100,7 @@ export interface AcpContext {
   lastActivityRef: ReturnType<typeof useAcpSession>["lastActivityRef"];
   dismissError: () => void;
   dismissPrimer: () => void;
+  dismissCompactionReminder: () => void;
   removeQueuedPrompt: (id: string) => void;
   editQueuedPrompt: (id: string, text: string) => void;
   clearQueue: () => void;
@@ -272,6 +273,7 @@ export function AcpRuntime({
         lastActivityRef: acp.lastActivityRef,
         dismissError: acp.dismissError,
         dismissPrimer: acp.dismissPrimer,
+        dismissCompactionReminder: acp.dismissCompactionReminder,
         removeQueuedPrompt: acp.removeQueuedPrompt,
         editQueuedPrompt: acp.editQueuedPrompt,
         clearQueue: acp.clearQueue,

--- a/web/src/components/acp/CompactionReminderBanner.test.tsx
+++ b/web/src/components/acp/CompactionReminderBanner.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+//
+// User stories (#3253):
+//   - With the reminder off (the default), context usage passing any
+//     threshold changes nothing.
+//   - With it on and the threshold at 80, a snapshot at or past 80% of the
+//     window shows a dismissable banner above the composer offering
+//     /compact.
+//
+// The gate itself is `isCompactionReminderDue`, exercised here as a table so
+// each condition has a case without a test function per row. The rendered
+// assertions cover the parts a pure gate cannot: the action sends /compact
+// rather than prefilling, and dismiss reports back to the reducer.
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { CompactionReminderBanner } from "./CompactionReminderBanner";
+import { AcpPrefsProvider, type AcpPrefs } from "../../lib/acpPrefs";
+import { isCompactionReminderDue, type AcpState, type SessionUsage } from "../../lib/acpTypes";
+
+const COMPACT_COMMAND = { name: "compact", description: "compact the conversation", accepts_input: false };
+
+type GateState = Pick<AcpState, "sessionUsage" | "compacting" | "compactionReminderDismissed" | "availableCommands">;
+
+function usage(used: number, size: number): SessionUsage {
+  return { used, size, cost: null };
+}
+
+function gateState(over: Partial<GateState> = {}): GateState {
+  return {
+    sessionUsage: usage(160_000, 200_000),
+    compacting: false,
+    compactionReminderDismissed: null,
+    availableCommands: [COMPACT_COMMAND],
+    ...over,
+  };
+}
+
+function prefs(over: Partial<AcpPrefs> = {}): AcpPrefs {
+  return {
+    showToolDurations: true,
+    replayEvents: 0,
+    compactionReminder: true,
+    compactionReminderPercent: 80,
+    ...over,
+  };
+}
+
+function renderBanner(state: GateState, p: AcpPrefs, onCompact = vi.fn(), onDismiss = vi.fn()) {
+  render(
+    <AcpPrefsProvider value={p}>
+      <CompactionReminderBanner state={state} onCompact={onCompact} onDismiss={onDismiss} />
+    </AcpPrefsProvider>,
+  );
+  return { onCompact, onDismiss };
+}
+
+describe("isCompactionReminderDue", () => {
+  it("gates on every condition", () => {
+    const cases: [string, GateState, AcpPrefs, boolean][] = [
+      // Off by default: no banner however full the window is.
+      ["disabled", gateState({ sessionUsage: usage(199_000, 200_000) }), prefs({ compactionReminder: false }), false],
+      // Equality counts, so a threshold of exactly 80% fires at 80%.
+      ["at threshold", gateState({ sessionUsage: usage(160_000, 200_000) }), prefs(), true],
+      ["past threshold", gateState({ sessionUsage: usage(190_000, 200_000) }), prefs(), true],
+      ["below threshold", gateState({ sessionUsage: usage(150_000, 200_000) }), prefs(), false],
+      // Some agents report used > size transiently; that is past any
+      // legal threshold, not a rendering glitch to swallow.
+      ["over-full window", gateState({ sessionUsage: usage(210_000, 200_000) }), prefs(), true],
+      // No window reported yet means there is no percentage to compare.
+      ["zero size", gateState({ sessionUsage: usage(0, 0) }), prefs(), false],
+      ["no snapshot", gateState({ sessionUsage: null }), prefs(), false],
+      // Telling the user to compact while a compaction runs names the job
+      // they are already waiting on.
+      ["compacting", gateState({ compacting: true }), prefs(), false],
+      ["dismissed", gateState({ compactionReminderDismissed: usage(160_000, 200_000) }), prefs(), false],
+      // Suggesting a command the agent never advertised is noise.
+      ["no compact command", gateState({ availableCommands: [] }), prefs(), false],
+    ];
+    for (const [label, state, p, expected] of cases) {
+      expect(isCompactionReminderDue(state, p), label).toBe(expected);
+    }
+  });
+});
+
+describe("CompactionReminderBanner", () => {
+  it("renders nothing while the reminder is off", () => {
+    renderBanner(gateState(), prefs({ compactionReminder: false }));
+    expect(screen.queryByTestId("compaction-reminder")).toBeNull();
+  });
+
+  it("reports the current percentage once the threshold is crossed", () => {
+    renderBanner(gateState({ sessionUsage: usage(170_000, 200_000) }), prefs());
+    expect(screen.getByTestId("compaction-reminder").textContent).toContain("85%");
+  });
+
+  it("sends /compact rather than prefilling, and dismisses on the close control", () => {
+    const { onCompact, onDismiss } = renderBanner(gateState(), prefs());
+    screen.getByRole("button", { name: "Compact now" }).click();
+    expect(onCompact).toHaveBeenCalledTimes(1);
+    expect(onDismiss).not.toHaveBeenCalled();
+    screen.getByRole("button", { name: "Dismiss compaction reminder" }).click();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/acp/CompactionReminderBanner.tsx
+++ b/web/src/components/acp/CompactionReminderBanner.tsx
@@ -1,0 +1,68 @@
+import { isCompactionReminderDue, type AcpState } from "../../lib/acpTypes";
+import { useAcpPrefs } from "../../lib/acpPrefs";
+
+/**
+ * Banner shown above the structured view composer once the agent's context
+ * window passes the configured percentage, offering to run `/compact`. Opt
+ * in through `[acp] compaction_reminder`; off by default. See #3253.
+ *
+ * Unlike the composer's usage chip this renders at every viewport, since
+ * mobile is where the chip is hidden (`hidden sm:inline-flex`) and so where
+ * a filling window is otherwise invisible.
+ *
+ * "Compact now" sends the command instead of prefilling the composer:
+ * prefill goes through `composerRuntime.setText`, which would silently
+ * destroy a draft the user had typed. Losing typed work is worse than a
+ * labelled button doing what it says, and compaction leaves the transcript
+ * and the event log untouched.
+ *
+ * Dismiss state lives on the reducer (`dismissCompactionReminder`) rather
+ * than component `useState`, so dismissing once survives a session switch,
+ * and re-arms on the next context boundary.
+ */
+interface Props {
+  state: Pick<AcpState, "sessionUsage" | "compacting" | "compactionReminderDismissed" | "availableCommands">;
+  onCompact: () => void;
+  onDismiss: () => void;
+}
+
+export function CompactionReminderBanner({ state, onCompact, onDismiss }: Props) {
+  const prefs = useAcpPrefs();
+  if (!isCompactionReminderDue(state, prefs)) return null;
+  const usage = state.sessionUsage;
+  if (!usage) return null;
+  const pct = Math.round((usage.used / usage.size) * 100);
+
+  return (
+    <div
+      role="status"
+      data-testid="compaction-reminder"
+      className="bg-amber-900/30 border-y border-amber-700/40 px-4 py-2 flex items-center gap-3 text-xs font-mono text-amber-200"
+    >
+      <span className="shrink-0 text-amber-400" aria-hidden="true">
+        ⚠
+      </span>
+      <span className="flex-1 leading-snug">
+        Context window {pct}% full.{" "}
+        <span className="text-amber-100/70">
+          Compacting replaces the earlier turns in the model&apos;s context with a summary.
+        </span>
+      </span>
+      <button
+        type="button"
+        onClick={onCompact}
+        className="shrink-0 px-2 py-1 rounded bg-amber-800/40 hover:bg-amber-700/50 border border-amber-700/60 text-amber-100 cursor-pointer transition-colors"
+      >
+        Compact now
+      </button>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss compaction reminder"
+        className="shrink-0 px-1 text-amber-300/70 hover:text-amber-100 cursor-pointer"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -27,6 +27,7 @@ import { ToolDensityToggle, ToolDisplayModeProvider, useToolDensityPref } from "
 import { AcpRuntime, SUBAGENT_TASK_NAME, TODO_GROUP_NAME, TOOL_GROUP_NAME, type AcpContext } from "./AcpRuntime";
 import { Composer } from "./Composer";
 import { ConfigOptionSwitchFailedNotice } from "./SessionConfigControls";
+import { CompactionReminderBanner } from "./CompactionReminderBanner";
 import { ContextPrimerBanner } from "./ContextPrimerBanner";
 import { SwitchAgentModal } from "./SwitchAgentModal";
 import { Markdown } from "./Markdown";
@@ -265,6 +266,7 @@ function AcpChrome({
   lastActivityRef,
   dismissError,
   dismissPrimer,
+  dismissCompactionReminder,
   removeQueuedPrompt,
   editQueuedPrompt,
   clearQueue,
@@ -695,6 +697,12 @@ function AcpChrome({
                   })
                 }
                 onDismiss={dismissPrimer}
+              />
+
+              <CompactionReminderBanner
+                state={state}
+                onCompact={() => sendPrompt("/compact")}
+                onDismiss={dismissCompactionReminder}
               />
 
               <Composer

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -74,6 +74,7 @@ export type Action =
   | { kind: "edit_queued_prompt"; id: string; text: string }
   | { kind: "clear_queue" }
   | { kind: "dismiss_primer" }
+  | { kind: "dismiss_compaction_reminder" }
   | { kind: "dismiss_rejected_prompt"; id: string }
   | { kind: "dismiss_mode_switch_failed" }
   | { kind: "set_pending_config_option"; configId: string; value: string }
@@ -707,6 +708,12 @@ export function reducer(state: AcpState, action: Action): AcpState {
     // with a new `resetSeq`, which the banner reads as a fresh
     // incident and shows again. See #1110.
     return { ...state, contextPrimerAvailable: null };
+  }
+  if (action.kind === "dismiss_compaction_reminder") {
+    // Latch the snapshot the user dismissed at. The `UsageUpdated` arm
+    // re-arms on the first snapshot after any context boundary, so this
+    // stays set only for the life of the current context. See #3253.
+    return { ...state, compactionReminderDismissed: state.sessionUsage };
   }
   if (action.kind === "dismiss_rejected_prompt") {
     return {
@@ -1880,6 +1887,10 @@ export function useAcpSession(
     dispatch({ kind: "dismiss_primer" });
   }, []);
 
+  const dismissCompactionReminder = useCallback(() => {
+    dispatch({ kind: "dismiss_compaction_reminder" });
+  }, []);
+
   const dismissRejectedPrompt = useCallback((id: string) => {
     dispatch({ kind: "dismiss_rejected_prompt", id });
   }, []);
@@ -2067,6 +2078,7 @@ export function useAcpSession(
     lastActivityRef,
     dismissError,
     dismissPrimer,
+    dismissCompactionReminder,
     removeQueuedPrompt,
     editQueuedPrompt,
     clearQueue,

--- a/web/src/lib/acpPrefs.tsx
+++ b/web/src/lib/acpPrefs.tsx
@@ -27,11 +27,21 @@ export interface AcpPrefs {
    *  rendered transcript matches the user's chosen retention).
    *  0 means unlimited. See #1111. */
   replayEvents: number;
+  /** Resolved `acp.compaction_reminder` from the active profile. Gates
+   *  the compaction reminder banner above the composer. Off by default:
+   *  the usage chip already reports the percentage passively, and a
+   *  banner is an interruption only some users want. See #3253. */
+  compactionReminder: boolean;
+  /** Resolved `acp.compaction_reminder_percent` from the active profile.
+   *  Context-window percentage at which that banner appears. */
+  compactionReminderPercent: number;
 }
 
 const DEFAULT_PREFS: AcpPrefs = {
   showToolDurations: true,
   replayEvents: 0,
+  compactionReminder: false,
+  compactionReminderPercent: 75,
 };
 
 const AcpPrefsContext = createContext<AcpPrefs>(DEFAULT_PREFS);

--- a/web/src/lib/acpTypes.test.ts
+++ b/web/src/lib/acpTypes.test.ts
@@ -2379,6 +2379,69 @@ describe("normaliseTurnCounters (#1170 persisted-state backfill)", () => {
   });
 });
 
+describe("compaction reminder dismissal", () => {
+  const usageFrame = (seq: number, used: number, size = 200_000): AcpFrame => ({
+    session_id: "s-1",
+    seq,
+    event: { UsageUpdated: { usage: { used, size } } },
+  });
+
+  it("survives usage climbing further, and re-arms after a context boundary", async () => {
+    const { acpHookReducer } = await import("../hooks/useAcpSession");
+    let state = applyEvent(emptyAcpState(), usageFrame(1, 160_000));
+
+    state = acpHookReducer(state, { kind: "dismiss_compaction_reminder" });
+    expect(state.compactionReminderDismissed?.used).toBe(160_000);
+
+    // Still dismissed as the window keeps filling: dismiss means dismiss,
+    // not snooze until the next percentage point.
+    state = applyEvent(state, usageFrame(2, 180_000));
+    expect(state.compactionReminderDismissed?.used).toBe(160_000);
+
+    // Compaction nulls the snapshot, so the next one is a fresh window and
+    // re-arms the reminder.
+    state = applyEvent(state, { session_id: "s-1", seq: 3, event: "ConversationCompacted" });
+    expect(state.sessionUsage).toBeNull();
+    state = applyEvent(state, usageFrame(4, 20_000));
+    expect(state.compactionReminderDismissed).toBeNull();
+
+    // The regression this shape exists for: re-arming has to latch at the
+    // boundary. Deriving "used dropped below the dismissed value" at render
+    // time re-suppresses the reminder the moment usage climbs back past it.
+    state = acpHookReducer(state, { kind: "dismiss_compaction_reminder" });
+    state = applyEvent(state, usageFrame(5, 30_000));
+    expect(state.compactionReminderDismissed?.used).toBe(20_000);
+    state = applyEvent(state, { session_id: "s-1", seq: 6, event: "SessionCleared" });
+    state = applyEvent(state, usageFrame(7, 40_000));
+    expect(state.compactionReminderDismissed).toBeNull();
+  });
+
+  it("re-arms on every boundary that nulls the usage snapshot", async () => {
+    const { acpHookReducer } = await import("../hooks/useAcpSession");
+    const boundaries: AcpFrame["event"][] = [
+      "ConversationCompacted",
+      "SessionCleared",
+      { SessionContextReset: { reason: "session/load failed: bad id" } },
+      { AgentSwitched: { from: "claude", to: "codex", reason: "rate_limit" } },
+    ];
+    for (const event of boundaries) {
+      let state = applyEvent(emptyAcpState(), usageFrame(1, 160_000));
+      state = acpHookReducer(state, { kind: "dismiss_compaction_reminder" });
+      state = applyEvent(state, { session_id: "s-1", seq: 2, event });
+      state = applyEvent(state, usageFrame(3, 170_000));
+      expect(state.compactionReminderDismissed, JSON.stringify(event)).toBeNull();
+    }
+  });
+
+  it("backfills the dismissal on entries persisted before it existed", () => {
+    const persisted = { ...emptyAcpState() } as AcpState & {
+      compactionReminderDismissed?: AcpState["compactionReminderDismissed"];
+    };
+    delete persisted.compactionReminderDismissed;
+    expect(normaliseTurnCounters(persisted).compactionReminderDismissed).toBeNull();
+  });
+});
+
 describe("acpHookReducer / dismiss_primer", () => {
   // Banner dismiss used to live in component-local useState and
   // re-armed itself on every session switch. Moved into the reducer so

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -648,6 +648,21 @@ export interface AcpState {
    *  the full event-store replay, since boundary events are applied in
    *  seq order. See #1354. */
   usageBaseline: { cost: number } | null;
+  /** Usage snapshot captured when the user dismissed the compaction
+   *  reminder, or null while the reminder is armed. Lives on reducer
+   *  state rather than component state so one dismissal survives a
+   *  session switch and a reload, the same reason `contextPrimerAvailable`
+   *  does (#1110).
+   *
+   *  Re-armed in the `UsageUpdated` arm whenever the previous snapshot was
+   *  null, which every context boundary already guarantees: compact,
+   *  clear, `SessionContextReset`, `AgentSwitched`, and a model change all
+   *  null `sessionUsage`. Latching there rather than deriving "used went
+   *  down" at render time is deliberate: the drop is visible only on the
+   *  first post-boundary snapshot, so a derived check would re-suppress
+   *  the reminder as soon as usage climbed back past the dismissed value.
+   *  See #3253. */
+  compactionReminderDismissed: SessionUsage | null;
   /** Most recent assistant message chunks accumulated as a single
    *  text body. Cleared each time a new prompt is sent. */
   assistantMessage: string;
@@ -1045,6 +1060,7 @@ export function emptyAcpState(): AcpState {
     rateLimit: null,
     sessionUsage: null,
     usageBaseline: null,
+    compactionReminderDismissed: null,
     assistantMessage: "",
     activity: [],
     lastSeq: 0,
@@ -1535,6 +1551,13 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     // which resets the latch to the next raw value. Drop once upstream
     // stops emitting the downgraded mid-turn guess.
     const size = Math.max(incoming.size, next.sessionUsage?.size ?? 0);
+    // Re-arm the compaction reminder on the first snapshot after a context
+    // boundary. Every boundary nulls sessionUsage (see the latch comment
+    // above), so a null previous snapshot IS the boundary signal and this
+    // needs no per-boundary bookkeeping in those five arms. See #3253.
+    if (next.compactionReminderDismissed && next.sessionUsage === null) {
+      next.compactionReminderDismissed = null;
+    }
     if (next.usageBaseline && incoming.cost) {
       const rebasedAmount = Math.max(0, incoming.cost.amount - next.usageBaseline.cost);
       const rebasedCost = {
@@ -2414,6 +2437,30 @@ export function isTurnActive(state: Pick<AcpState, "pendingUserPromptSeq" | "las
   return state.pendingUserPromptSeq > state.lastStoppedSeq;
 }
 
+/** Whether the structured view should show the compaction reminder.
+ *  Single source of truth for the gate so the banner and its tests
+ *  cannot drift.
+ *
+ *  Capability gates the whole reminder, not just its button: telling a
+ *  user to run a command their agent never advertised is noise. A
+ *  zero-size window means the agent has not reported a real window yet,
+ *  so there is no percentage to compare; `used > size` (which some agents
+ *  report transiently) is past any legal threshold and counts. See #3253.
+ */
+export function isCompactionReminderDue(
+  state: Pick<AcpState, "sessionUsage" | "compacting" | "compactionReminderDismissed" | "availableCommands">,
+  prefs: { compactionReminder: boolean; compactionReminderPercent: number },
+): boolean {
+  if (!prefs.compactionReminder) return false;
+  if (state.compacting || state.compactionReminderDismissed) return false;
+  const usage = state.sessionUsage;
+  if (!usage || !Number.isFinite(usage.used) || !Number.isFinite(usage.size) || usage.size <= 0) {
+    return false;
+  }
+  if (!state.availableCommands.some((c) => c.name === "compact")) return false;
+  return (usage.used / usage.size) * 100 >= prefs.compactionReminderPercent;
+}
+
 /** Normalise a partial AcpState so the turn counters are populated.
  *  Used by the localStorage loader after the #1170 schema change: pre-
  *  schema persisted entries have no counters, so we backfill from the
@@ -2431,6 +2478,7 @@ export function normaliseTurnCounters(
     configOptions?: ConfigOptionDescriptor[];
     configOptionSwitchFailed?: ConfigOptionSwitchFailure | null;
     pendingConfigOption?: { configId: string; value: string } | null;
+    compactionReminderDismissed?: SessionUsage | null;
   },
 ): AcpState {
   const pendingUserPromptSeq =
@@ -2457,6 +2505,11 @@ export function normaliseTurnCounters(
   const configOptions = Array.isArray(state.configOptions) ? state.configOptions : [];
   const configOptionSwitchFailed = state.configOptionSwitchFailed === undefined ? null : state.configOptionSwitchFailed;
   const pendingConfigOption = state.pendingConfigOption === undefined ? null : state.pendingConfigOption;
+  // Pre-#3253 persisted entries lack the compaction-reminder dismissal;
+  // backfill to null so a warm hydrate starts armed rather than reading
+  // `undefined` as "not dismissed" by luck.
+  const compactionReminderDismissed =
+    state.compactionReminderDismissed === undefined ? null : state.compactionReminderDismissed;
   // Pre-#2236 persisted entries lack oldestSeq; backfill to 0 (nothing
   // older loaded) so the recent-first `before=<oldestSeq>` paging contract
   // never sees undefined on a warm hydrate.
@@ -2474,6 +2527,7 @@ export function normaliseTurnCounters(
     configOptions,
     configOptionSwitchFailed,
     pendingConfigOption,
+    compactionReminderDismissed,
     pendingUserPromptSeq,
     lastStoppedSeq,
     turnActive: isTurnActive({ pendingUserPromptSeq, lastStoppedSeq }),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1226,6 +1226,12 @@ export interface ServerAbout {
    *  so the rendered transcript matches the user's chosen ceiling
    *  instead of clipping at a hard-coded frontend constant. See #1111. */
   acp_replay_events: number;
+  /** Resolved `acp.compaction_reminder` from the active profile's
+   *  config; gates the structured view's compaction reminder (#3253). */
+  acp_compaction_reminder: boolean;
+  /** Resolved `acp.compaction_reminder_percent` from the active
+   *  profile's config. */
+  acp_compaction_reminder_percent: number;
   build_flavor: "debug" | "release"; // `"debug"` => debug_assertions; drives topbar DEV badge. See #1055.
   /** Content-hashed entry bundle name (`index-<hash>.js`) of the
    *  embedded dashboard build. Compared against this page's own entry

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2270,6 +2270,13 @@
       "components": ["web/src/lib/agentProfiles.ts"]
     },
     {
+      "id": "acp.compaction-reminder-banner",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/acp/CompactionReminderBanner.test.tsx"],
+      "components": ["web/src/components/acp/CompactionReminderBanner.tsx"]
+    },
+    {
       "id": "acp.context-primer-banner",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Nothing in AoE tells you to compact. The context window fills, the composer's usage chip quietly turns amber then red, and the first real signal is a degraded turn or an agent that starts forgetting the conversation. On mobile there is no signal at all: the chip is `hidden sm:inline-flex`, so it does not render below the `sm` breakpoint. The agent does not rescue you either, since `claude-agent-acp` implements `/compact` as a manual command with no auto-compaction path.

This adds an opt-in reminder. Two fields on `AcpConfig`, `compaction_reminder` (off by default) and `compaction_reminder_percent` (default 75), and the reminder appears on both structured-view surfaces once the agent reports usage at or past the threshold.

On the web it is a dismissable banner above the composer, rendered at every viewport, with a "Compact now" button. Dismissal is a usage snapshot on the reducer rather than component state, so one dismiss survives a session switch and a reload, the same reason `contextPrimerAvailable` moved there in #1110. It re-arms in the `UsageUpdated` arm whenever the previous snapshot was null, which every context boundary already guarantees: compact, clear, `SessionContextReset`, `AgentSwitched`, and a model change all null `sessionUsage`. That is the whole re-arm mechanism, so there is no per-boundary bookkeeping to keep in sync as new boundaries appear. Latching at the boundary rather than deriving "used went down" at render time is deliberate: the drop is visible only on the first post-boundary snapshot, so a derived check re-suppresses the reminder as soon as usage climbs back past the dismissed value. There is a regression test for exactly that.

"Compact now" sends the command rather than prefilling the composer. Prefill would go through `composerRuntime.setText`, which replaces the textarea contents unconditionally and would silently destroy a typed draft. Losing typed work is worse than a labelled button doing what it says, and compaction leaves the transcript and the event log untouched.

On the TUI it is a status-line span next to the existing `context lost` and `broadcast lagged` notices. Two deliberate limits there, both worth a reviewer's opinion. It reads its threshold from the daemon's `/api/about` rather than local config, because the native view can attach to a remote daemon over `AOE_DAEMON_URL` where this host's `config.toml` describes a different install; it rides the one-shot side channel that already fetches the session header, so opening the view adds no blocking request. And it is advisory, not dismissable: no keybinding, and it clears itself once a snapshot lands under the threshold, matching its non-dismissable neighbours. The web surface is where the dismiss affordance lives.

The usage meter's own warn colour stays at a fixed 90% on both surfaces. That is passive severity; this setting is when to interrupt, and folding them together would turn every user's meter red at 75% including users who never enable the reminder.

One adjacent fix rides along: the TUI reducer now drops the latched usage snapshot when a compaction lands, matching the web reducer. Without it both the meter and the new reminder keep reporting a window that no longer exists until the next `UsageUpdated` arrives.

Closes #3253

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Default config, no changes: open a structured-view session, run a long conversation past 75% context. No banner appears on the web, no reminder in the TUI, and the usage chip behaves exactly as before.
- [ ] Turn "Compaction reminder" on in Settings (web panel or TUI settings screen, both derive from the same schema declaration) and set the threshold to a low number such as 10, so it triggers quickly.
- [ ] Send prompts until the composer chip passes the threshold: a banner appears above the composer reporting the percentage, with "Compact now" and a dismiss control.
- [ ] Shrink the browser to a phone viewport: the usage chip disappears (expected, unchanged) but the banner stays visible.
- [ ] Click the dismiss control, switch to another session, switch back: the banner stays dismissed.
- [ ] Click "Compact now" instead: `/compact` is sent, the banner clears while compaction runs, and it does not reappear on the fresh smaller window.
- [ ] After that compaction, send prompts until usage passes the threshold again: the banner returns, confirming a dismiss does not silence the session forever.
- [ ] Point a session at an agent that does not advertise `/compact`: no banner, regardless of how full the window is.
- [ ] Attach the native TUI view (`aoe acp attach <session>`) to a session past the threshold: the status line shows `context filling; /compact` next to the usage meter, and it clears once the next snapshot lands under the threshold.
- [ ] Set the threshold to `0` or `100` in the settings UI: the input rejects it (valid range is 1 to 99).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Covered with Vitest rather than Playwright, and the matrix entry (`acp.compaction-reminder-banner`) records it as such. Per `AGENTS.md` a mocked Playwright test costs roughly 200x a Vitest test and is warranted only when the assertion needs a real browser. Nothing here does: the gate is pure logic over reducer state and prefs, and the two DOM assertions (button sends, dismiss reports) are plain clicks. `CompactionReminderBanner.test.tsx` covers the gating table (disabled, at, past and below threshold, `used > size`, zero size, no snapshot, compacting, dismissed, no `compact` command) plus the rendered percentage and both controls. `acpTypes.test.ts` covers the dismissal lifecycle: it survives usage climbing, re-arms on each of the four boundary events, backfills on entries persisted before the field existed, and specifically pins the climb-back-past-the-dismissed-value case that a render-time derivation gets wrong.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Strictly speaking this does change TUI rendering, so the honest answer is a skip rather than N/A: the new span is covered by unit tests in `render.rs` (a gating table plus a full status-line render assertion) and the reducer change by a unit test in `reducer.rs`. An e2e test would need a live daemon reporting a context window past a threshold, which costs 10 to 28 seconds on the serial e2e critical path to assert one status-line string that the render test already asserts from the same state.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, the `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**

Investigation, plan and implementation drafted by Claude under my direction. The dismissal design went through a two-round debate with two other models before implementation, which is what caught the render-time derivation bug and killed the magic-number heuristic that preceded it; I made the calls on the send-versus-prefill question, the TUI advisory scope, and leaving the meter's 90% warn colour alone.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added an opt-in compaction reminder for ACP views.
- Added configurable reminder thresholds with a default of 75%.
- Added a dismissible web banner with a direct `/compact` action.
- Added a TUI status-line reminder.
- Preserved dismissal state across sessions and re-armed reminders after context changes or compaction.
- Added daemon configuration support and expanded test coverage.

## Benefits

Users receive a visible reminder before context usage becomes critical, including on small screens. The reminder avoids replacing composer drafts and remains inactive by default.

## Potential follow-up

Consider reviewing reminder wording and accessibility behavior after user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->