### PR TITLE
fix(telemetry): exclude trashed sessions from the session census

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -23,6 +23,9 @@ kinds:
   - session counts by status (running / idle / errored), and how many use a
     sandbox, the structured view, or yolo mode,
   - peak concurrent sessions, and counts of pinned / snoozed / archived,
+  - how many sessions are sitting in the trash. Trashed sessions are counted
+    only here and are excluded from every other session count above, so the
+    totals describe live sessions,
   - a per-substrate census (`local` / `worktree` / `workspace` / `sandbox` /
     `scratch`),
   - per-agent and per-model-family counts (e.g. `{claude: 3, codex: 1}`),

--- a/src/telemetry/aggregate.rs
+++ b/src/telemetry/aggregate.rs
@@ -42,9 +42,20 @@ pub struct UsageAggregator {
 
 impl UsageAggregator {
     /// Fold one sample of the live session list into the running window.
+    ///
+    /// Trashed sessions are excluded, matching the point-in-time census
+    /// (#3258). The exclusion is by observation, not retroactive: a session
+    /// sampled while live and trashed later stays in `seen`, because it was
+    /// genuinely seen during the window.
     pub fn sample(&mut self, instances: &[Instance]) {
-        self.peak_concurrent_sessions = self.peak_concurrent_sessions.max(instances.len() as u32);
+        let mut concurrent = 0u32;
         for inst in instances {
+            if inst.is_trashed() {
+                continue;
+            }
+            // Counted here rather than from `instances.len()`, which would let
+            // trashed rows keep inflating the peak even with the loop filtered.
+            concurrent += 1;
             let buckets = super::instance_buckets(inst);
             // Refresh an already-seen session's bucket regardless; only gate
             // *new* ids on the cap so a stuck-offline daemon can't grow `seen`
@@ -53,6 +64,7 @@ impl UsageAggregator {
                 self.seen.insert(inst.id.clone(), buckets);
             }
         }
+        self.peak_concurrent_sessions = self.peak_concurrent_sessions.max(concurrent);
     }
 
     /// Max concurrent `session_total` seen across the window.
@@ -164,6 +176,33 @@ mod tests {
             agg.seen.get("s0"),
             Some(&("codex".to_string(), "unset".to_string()))
         );
+    }
+
+    // Trash is excluded from the window the same way it is from the
+    // point-in-time census (#3258), and the exclusion applies at sample time:
+    // a session seen live and trashed afterwards keeps its place in the window.
+    #[test]
+    fn trashed_sessions_are_excluded_at_sample_time() {
+        let mut agg = UsageAggregator::default();
+        let mut already_trashed = inst("gone", "codex", Status::Idle);
+        already_trashed.trash();
+        agg.sample(&[inst("live", "claude", Status::Running), already_trashed]);
+
+        assert_eq!(
+            agg.peak_concurrent_sessions(),
+            1,
+            "a trashed session must not lift the window peak"
+        );
+        assert_eq!(agg.distinct_by_agent().get("codex"), None);
+        assert_eq!(agg.distinct_by_agent().get("claude"), Some(&1));
+
+        // Trashed after being seen: the earlier live observation stands, so the
+        // session stays counted rather than being erased from the window.
+        let mut later_trashed = inst("live", "claude", Status::Running);
+        later_trashed.trash();
+        agg.sample(&[later_trashed]);
+        assert_eq!(agg.distinct_by_agent().get("claude"), Some(&1));
+        assert_eq!(agg.peak_concurrent_sessions(), 1);
     }
 
     #[test]

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -39,13 +39,16 @@ use serde::Serialize;
 /// source bucket) and `plugins_active` (active state for builtin + featured ids
 /// only; unfeatured GitHub and local installs are counted by source but never
 /// named).
-/// v14 (#3258): **breaking meaning change.** Every session census field now
-/// excludes trashed sessions, and the new `session_trashed` reports them
-/// separately. Up to v13 the census counted the raw resident session list, so
-/// `session_total`, the status / sandbox / yolo / structured counts, the
+/// v14 (#3258): **breaking meaning change.** Every point-in-time session census
+/// field now excludes trashed sessions, and the new `session_trashed` reports
+/// them separately. Up to v13 the census counted the raw resident session list,
+/// so `session_total`, the status / sandbox / yolo / structured counts, the
 /// pinned / snoozed / archived triage census, all three `sessions_by_*` maps,
-/// `peak_concurrent_sessions`, and both `distinct_sessions_by_*` maps were
-/// inflated by soft-deleted sessions still inside the trash retention window.
+/// and `peak_concurrent_sessions` were inflated by soft-deleted sessions still
+/// inside the trash retention window. The serve window's
+/// `distinct_sessions_by_*` maps changed too, but they filter at sample time
+/// rather than at flush time, so they are not the same population; see their
+/// field docs.
 /// A v13 series and a v14 series measure different populations and must not be
 /// averaged together; filter on `schema` before trending any of them.
 pub const SCHEMA_VERSION: u32 = 14;
@@ -168,9 +171,10 @@ pub struct UsageSnapshot {
 
     /// Sessions resident at snapshot time, excluding trashed ones (those are
     /// reported separately as `session_trashed`). Archived sessions *are*
-    /// included: archive is a triage state, trash is a pending delete. Every
-    /// census field below counts the same population, so the mutually-exclusive
-    /// maps partition this value exactly.
+    /// included: archive is a triage state, trash is a pending delete. The other
+    /// point-in-time counts and the `sessions_by_*` maps below count this same
+    /// population, so the mutually-exclusive maps partition this value exactly.
+    /// The window-scoped `distinct_sessions_by_*` maps do not; see their docs.
     pub session_total: u32,
     pub session_running: u32,
     pub session_idle: u32,

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -39,7 +39,16 @@ use serde::Serialize;
 /// source bucket) and `plugins_active` (active state for builtin + featured ids
 /// only; unfeatured GitHub and local installs are counted by source but never
 /// named).
-pub const SCHEMA_VERSION: u32 = 13;
+/// v14 (#3258): **breaking meaning change.** Every session census field now
+/// excludes trashed sessions, and the new `session_trashed` reports them
+/// separately. Up to v13 the census counted the raw resident session list, so
+/// `session_total`, the status / sandbox / yolo / structured counts, the
+/// pinned / snoozed / archived triage census, all three `sessions_by_*` maps,
+/// `peak_concurrent_sessions`, and both `distinct_sessions_by_*` maps were
+/// inflated by soft-deleted sessions still inside the trash retention window.
+/// A v13 series and a v14 series measure different populations and must not be
+/// averaged together; filter on `schema` before trending any of them.
+pub const SCHEMA_VERSION: u32 = 14;
 
 /// Which surface emitted the event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -157,6 +166,11 @@ pub struct UsageSnapshot {
     /// Coarse "how many releases behind", counted from the cached release list.
     pub update_releases_behind: crate::update::ReleasesBehind,
 
+    /// Sessions resident at snapshot time, excluding trashed ones (those are
+    /// reported separately as `session_trashed`). Archived sessions *are*
+    /// included: archive is a triage state, trash is a pending delete. Every
+    /// census field below counts the same population, so the mutually-exclusive
+    /// maps partition this value exactly.
     pub session_total: u32,
     pub session_running: u32,
     pub session_idle: u32,
@@ -181,6 +195,15 @@ pub struct UsageSnapshot {
     pub session_pinned: u32,
     pub session_snoozed: u32,
     pub session_archived: u32,
+
+    /// Soft-deleted sessions still resident at snapshot time, i.e. trashed and
+    /// not yet purged by `session.trash_retention_days`. Unlike the triage
+    /// counts above this is *excluded* from `session_total` and from every
+    /// other census field, so `session_total + session_trashed` is the size of
+    /// the raw resident session list. Not a count of trash actions: it moves
+    /// with the retention window and with purge timing, so read it as
+    /// "currently sitting in trash", never as "sessions deleted".
+    pub session_trashed: u32,
 
     /// Allowlisted agent bucket -> session count.
     pub sessions_by_agent: BTreeMap<String, u32>,
@@ -207,6 +230,11 @@ pub struct UsageSnapshot {
     /// sessions caught by a ~30-min sample still contribute their agent mix.
     /// The sum can exceed `session_total`. Populated by `aoe serve`; empty on
     /// the TUI, which does not aggregate.
+    ///
+    /// Trash is applied at sample time, not at flush time: a session already
+    /// trashed when sampled never enters the window, while one sampled live and
+    /// trashed afterwards stays counted. It was genuinely seen, and dropping it
+    /// retroactively would erase real activity from the window.
     pub distinct_sessions_by_agent: BTreeMap<String, u32>,
     /// Coarse model family bucket -> distinct sessions seen across the window.
     /// Same window semantics as [`Self::distinct_sessions_by_agent`]; serve-only.

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -230,6 +230,7 @@ pub fn build_process_start(surface: Surface) -> Option<ProcessStart> {
 /// global state the snapshot builder pulls in.
 struct InstanceMetrics {
     total: u32,
+    trashed: u32,
     running: u32,
     idle: u32,
     error: u32,
@@ -278,8 +279,24 @@ fn aggregate_instances(instances: &[Instance]) -> InstanceMetrics {
     let (mut running, mut idle, mut error, mut acp, mut sandboxed, mut yolo) =
         (0u32, 0u32, 0u32, 0u32, 0u32, 0u32);
     let (mut pinned, mut snoozed, mut archived) = (0u32, 0u32, 0u32);
+    let (mut total, mut trashed) = (0u32, 0u32);
 
     for inst in instances {
+        // Trash is a pending delete, not usage, so it stays out of every census
+        // field below and is reported only as its own count (#3258). The filter
+        // lives here rather than in the callers because all three of them
+        // (`aoe serve`'s flush and sample ticks, the TUI snapshot) hand over the
+        // raw resident list, which keeps trashed rows until the retention window
+        // expires. Counting first, then skipping, is what makes `session_trashed`
+        // observable at all: a caller-side filter would delete the evidence.
+        if inst.is_trashed() {
+            trashed += 1;
+            continue;
+        }
+        // Derived from the surviving rows, never `instances.len()`, so the
+        // mutually-exclusive `by_substrate` map still partitions `total` exactly.
+        total += 1;
+
         match inst.status {
             crate::session::Status::Running => running += 1,
             crate::session::Status::Idle => idle += 1,
@@ -345,7 +362,8 @@ fn aggregate_instances(instances: &[Instance]) -> InstanceMetrics {
     }
 
     InstanceMetrics {
-        total: instances.len() as u32,
+        total,
+        trashed,
         running,
         idle,
         error,
@@ -471,6 +489,7 @@ fn assemble_usage_snapshot(
         session_pinned: metrics.pinned,
         session_snoozed: metrics.snoozed,
         session_archived: metrics.archived,
+        session_trashed: metrics.trashed,
         sessions_by_agent: metrics.by_agent,
         sessions_by_model_bucket: metrics.by_model_bucket,
         sessions_by_substrate: metrics.by_substrate,
@@ -784,6 +803,7 @@ mod tests {
             session_yolo: 0,
             peak_concurrent_sessions: 7,
             session_pinned: 0,
+            session_trashed: 0,
             session_snoozed: 0,
             session_archived: 0,
             sessions_by_agent: BTreeMap::new(),
@@ -812,6 +832,8 @@ mod tests {
 
     // A maintainer with two pinned sessions and one snoozed session must see
     // `session_pinned = 2` and `session_snoozed = 1` (issue #1892, story 1).
+    // Trashed sessions are a pending delete, so they stay out of `total` and
+    // every triage count and are reported only as `trashed` (#3258).
     #[test]
     fn aggregate_counts_each_triage_state() {
         let mut pinned_a = Instance::new("pin-a", "/tmp/a");
@@ -823,13 +845,39 @@ mod tests {
         let mut archived = Instance::new("arch", "/tmp/d");
         archived.archive();
         let untouched = Instance::new("plain", "/tmp/e");
+        let mut trashed = Instance::new("trash", "/tmp/f");
+        trashed.trash();
+        // `trash()` is additive and preserves `archived_at`, so this row reads
+        // both trashed and archived. Trash wins: it must not lift `archived`.
+        let mut trashed_archived = Instance::new("trash-arch", "/tmp/g");
+        trashed_archived.archive();
+        trashed_archived.trash();
 
-        let m = aggregate_instances(&[pinned_a, pinned_b, snoozed, archived, untouched]);
+        let m = aggregate_instances(&[
+            pinned_a,
+            pinned_b,
+            snoozed,
+            archived,
+            untouched,
+            trashed,
+            trashed_archived,
+        ]);
 
         assert_eq!(m.pinned, 2, "two pinned sessions");
         assert_eq!(m.snoozed, 1, "one currently snoozed session");
-        assert_eq!(m.archived, 1, "one archived session");
-        assert_eq!(m.total, 5);
+        assert_eq!(
+            m.archived, 1,
+            "the trashed-then-archived row must not double-count as archived"
+        );
+        assert_eq!(m.trashed, 2, "both trashed rows counted separately");
+        assert_eq!(m.total, 5, "session_total excludes the two trashed rows");
+        // The substrate map partitions the live population, so a trashed row
+        // dropping out of `total` must drop out of the map too.
+        assert_eq!(
+            m.by_substrate.values().sum::<u32>(),
+            m.total,
+            "sessions_by_substrate must still sum to session_total"
+        );
     }
 
     // A snooze whose window has elapsed must not be counted, matching
@@ -862,6 +910,7 @@ mod tests {
         assert!(json["session_pinned"].is_u64());
         assert!(json["session_snoozed"].is_u64());
         assert!(json["session_archived"].is_u64());
+        assert!(json["session_trashed"].is_u64());
     }
 
     // An opted-out install records nothing: `build_usage_snapshot` returns


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Every session census field in `usage_snapshot` counted trashed sessions. Telemetry was the one consumer that never applied the trash filter, while the HTTP API filters per request via `SessionScope` and the TUI filters at render time. So `session_total`, the status counts, `session_sandboxed`, `session_yolo`, `session_structured`, the pinned/snoozed/archived triage census, and all three `sessions_by_*` maps were inflated by soft-deleted sessions still sitting inside `session.trash_retention_days`. Because `trash()` is deliberately additive and preserves `archived_at` so a restore is faithful, a trashed row that had previously been archived also double-voted in `session_archived`.

Nothing on the wire distinguished a trashed session from a live one, so no PostHog query could subtract them. It had to change in the client.

The filter lands at the two aggregation entry points, `aggregate_instances` and `UsageAggregator::sample`, rather than at the three call sites that feed them (`build_serve_snapshot`, the mid-window sample tick, and the TUI's `build_telemetry_snapshot`). Two edits instead of three, no future caller can forget, and the trashed rows stay visible long enough to be counted, which a caller-side filter would have made impossible.

`src/telemetry/aggregate.rs` turned out to be a second, independent defect site that the issue did not name. Its `peak_concurrent_sessions` and both `distinct_sessions_by_*` maps derive from the same unfiltered slice, so fixing only the point-in-time census would have left the serve window skewed. Both files also derived their count from `instances.len()`, which stays wrong even once the loop is filtered, so both now count survivors instead. That is what keeps `sessions_by_substrate` summing exactly to `session_total`; skipping rows in the loop while leaving `total = instances.len()` would have silently broken the partition and corrupted the substrate chart.

New `session_trashed` reports the excluded rows. Without it the coming drop in `session_total` is indistinguishable from a real drop in usage, and trash prevalence stays permanently unmeasurable. It sits outside `session_total`, so `session_total + session_trashed` is the size of the raw resident list. It is not a count of trash actions: it moves with the retention window and with purge timing, so it reads as "currently sitting in trash", never as "sessions deleted". That limitation is documented on the field.

Schema goes to v14, and this is a breaking meaning change rather than an additive one. A v13 series and a v14 series measure different populations and must not be averaged together, which is called out in the `SCHEMA_VERSION` changelog. No gateway change is needed: the sanitizer's generic rule forwards any lowercase-identifier property with a numeric value, so `session_trashed` cannot be rejected, and `schema` already reaches PostHog as a numeric property so the affected dashboard tiles can be keyed on it. Both of those were verified rather than assumed.

The dashboard side is deliberately not in this PR. Once v14 traffic exists I will add a trash-prevalence tile and re-key the affected census tiles to `schema >= 14`. Doing that today would just yield empty charts, since no install is on v14 yet.

Closes #3258

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `cargo test --features serve` and confirm it is green (6257 passed locally).
- [ ] Prove the red direction. In a throwaway checkout of `main`, add a test that builds one live session plus two trashed ones and asserts `aggregate_instances(...).total == 1`; confirm it fails with `left: 3, right: 1`. Do the same against `UsageAggregator::sample` asserting the peak is 1 and confirm `left: 2, right: 1`. Both pass on this branch.
- [ ] Opt in to telemetry, point `AOE_TELEMETRY_ENDPOINT` at a local sink, open two sessions, trash one, and confirm the posted `usage_snapshot` carries `session_total: 1` and `session_trashed: 1`.
- [ ] Archive a session, then trash it. Confirm the snapshot reports `session_archived: 0` and `session_trashed: 1`, so the preserved `archived_at` no longer double-counts.
- [ ] Confirm `sessions_by_substrate` values still sum exactly to `session_total` in that payload, with the trashed session absent from every bucket.
- [ ] Run `aoe serve` against the local sink with a trashed session resident across a sample tick, and confirm `peak_concurrent_sessions` and `distinct_sessions_by_agent` both exclude it.
- [ ] Confirm the payload reports `schema: 14`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Covered by unit tests at the two aggregation boundaries instead, which is the cheapest tier that can actually fail if this regresses. Per the test-economy rule in `AGENTS.md` the new cases went into the existing `aggregate_counts_each_triage_state` as extra rows rather than new test functions; exactly one new test function was added, in `aggregate.rs`, because the window aggregator has no existing trash-related test to extend.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with the design pressure-tested through a two-round multi-model debate before any code was written. The debate killed two worse designs: routing the check through an `included_in_session_census()` helper built on `effective_bucket()`, which is indirection with two callers since `effective_bucket() == Trashed` is definitionally identical to `is_trashed()`, and renaming the redefined metrics, which would have had to spread across the status counts, triage counts, substrate map, agent/model maps, peak, and distinct maps, permanently degrading the schema. It also surfaced the `instances.len()` trap in both files and the `sessions_by_substrate` summation invariant. I made the design calls, reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Exclude trashed sessions from telemetry totals and related census metrics.
- Report retained trashed sessions through `session_trashed`.
- Keep trashed archived sessions out of archived-session counts.
- Preserve earlier live-session observations during aggregation.
- Bump the telemetry schema from v13 to v14.
- Update documentation and test coverage.

These changes align telemetry with API and TUI session counts. Dashboard updates remain deferred until v14 data is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->