### PR TITLE
feat(agents): add omp permission_response with optional allow_always

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -350,8 +350,9 @@ pub struct PermissionResponse {
     /// Keystrokes that select "allow once" / "yes" for this single request.
     pub allow: &'static [KeyToken],
     /// Keystrokes that select "allow always" / "don't ask again" for the
-    /// remainder of the session.
-    pub allow_always: &'static [KeyToken],
+    /// remainder of the session. `None` when the agent's prompt has no such
+    /// choice.
+    pub allow_always: Option<&'static [KeyToken]>,
     /// Keystrokes that select "deny" / "no".
     pub deny: &'static [KeyToken],
 }
@@ -716,7 +717,7 @@ pub const AGENTS: &[AgentDef] = &[
         install_hint: "npm install -g @anthropic-ai/claude-code",
         permission_response: Some(PermissionResponse {
             allow: &[KeyToken::Literal("1")],
-            allow_always: &[KeyToken::Literal("2")],
+            allow_always: Some(&[KeyToken::Literal("2")]),
             deny: &[KeyToken::Literal("3")],
         }),
     },
@@ -741,11 +742,11 @@ pub const AGENTS: &[AgentDef] = &[
         install_hint: "curl -fsSL https://opencode.ai/install | bash",
         permission_response: Some(PermissionResponse {
             allow: &[KeyToken::Named("Enter")],
-            allow_always: &[
+            allow_always: Some(&[
                 KeyToken::Named("Right"),
                 KeyToken::Named("Enter"),
                 KeyToken::Named("Enter"),
-            ],
+            ]),
             deny: &[
                 KeyToken::Named("Right"),
                 KeyToken::Named("Right"),
@@ -1185,7 +1186,11 @@ pub const AGENTS: &[AgentDef] = &[
         host_only: false,
         send_keys_enter_delay_ms: 0,
         install_hint: "curl -fsSL https://omp.sh/install | sh",
-        permission_response: None,
+        permission_response: Some(PermissionResponse {
+            allow: &[KeyToken::Named("Enter")],
+            allow_always: None,
+            deny: &[KeyToken::Named("Down"), KeyToken::Named("Enter")],
+        }),
     },
 ];
 

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -340,7 +340,7 @@ pub enum KeyToken {
     Named(&'static str),
 }
 
-/// The three keystroke sequences that answer an agent's own interactive
+/// The keystroke sequences that answer an agent's own interactive
 /// permission prompt, mapped once by hand per agent and never derived from
 /// pane content. The user visually confirms a prompt is actually showing
 /// before invoking the respond-to-prompt action; the software does not detect

--- a/src/tui/dialogs/permission_response.rs
+++ b/src/tui/dialogs/permission_response.rs
@@ -29,7 +29,7 @@ fn focused_choice_style(theme: &Theme) -> Style {
     Style::default().fg(fg).bg(theme.selection).bold()
 }
 
-/// Which of the three static choices the user picked.
+/// Which choice the user picked; not every agent offers `AllowAlways`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PermissionResponseChoice {
     Allow,
@@ -42,6 +42,9 @@ pub struct PermissionResponseDialog {
     choices: Vec<(&'static str, PermissionResponseChoice)>,
     /// Index of the focused choice within `choices`.
     focused: usize,
+    /// Whether `choices` includes `AllowAlways`; computed once in `new`
+    /// instead of re-scanning `choices` from `handle_key` and `render`.
+    supports_allow_always: bool,
 }
 
 const ALL_CHOICES: [(&str, PermissionResponseChoice); 3] = [
@@ -55,24 +58,22 @@ impl PermissionResponseDialog {
         session_title: &str,
         allow_always: Option<&'static [crate::agents::KeyToken]>,
     ) -> Self {
+        let supports_allow_always = allow_always.is_some();
         let choices = ALL_CHOICES
             .into_iter()
             .filter(|(_, choice)| {
-                allow_always.is_some() || *choice != PermissionResponseChoice::AllowAlways
+                supports_allow_always || *choice != PermissionResponseChoice::AllowAlways
             })
             .collect();
         Self {
             session_title: session_title.to_string(),
             choices,
             focused: 0,
+            supports_allow_always,
         }
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<PermissionResponseChoice> {
-        let supports_allow_always = self
-            .choices
-            .iter()
-            .any(|(_, choice)| *choice == PermissionResponseChoice::AllowAlways);
         match key.code {
             KeyCode::Esc => DialogResult::Cancel,
             KeyCode::Enter => DialogResult::Submit(self.choices[self.focused].1),
@@ -84,8 +85,10 @@ impl PermissionResponseDialog {
                 self.focused = (self.focused + 1) % self.choices.len();
                 DialogResult::Continue
             }
+            // a/d mirror structured_view/input.rs; A offered only when the
+            // agent has allow_always.
             KeyCode::Char('a') => DialogResult::Submit(PermissionResponseChoice::Allow),
-            KeyCode::Char('A') if supports_allow_always => {
+            KeyCode::Char('A') if self.supports_allow_always => {
                 DialogResult::Submit(PermissionResponseChoice::AllowAlways)
             }
             KeyCode::Char('d') | KeyCode::Char('D') => {
@@ -150,11 +153,7 @@ impl PermissionResponseDialog {
         );
 
         let mut hint = String::from("a=allow");
-        if self
-            .choices
-            .iter()
-            .any(|(_, choice)| *choice == PermissionResponseChoice::AllowAlways)
-        {
+        if self.supports_allow_always {
             hint.push_str("  A=always");
         }
         hint.push_str("  d=deny  Esc=cancel");
@@ -174,13 +173,19 @@ mod tests {
     use super::*;
     use crossterm::event::KeyModifiers;
 
+    /// Non-empty stand-in for a real agent's `allow_always` mapping. `Some(&[])`
+    /// would also satisfy `.is_some()` but reads as "supported with zero
+    /// keystrokes", a footgun if copy-pasted into a real `AgentDef`.
+    const ALLOW_ALWAYS: Option<&[crate::agents::KeyToken]> =
+        Some(&[crate::agents::KeyToken::Literal("2")]);
+
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
     }
 
     #[test]
     fn enter_submits_focused_default_allow() {
-        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
+        let mut dialog = PermissionResponseDialog::new("test", ALLOW_ALWAYS);
         let result = dialog.handle_key(key(KeyCode::Enter));
         assert!(matches!(
             result,
@@ -190,7 +195,7 @@ mod tests {
 
     #[test]
     fn a_submits_allow_directly() {
-        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
+        let mut dialog = PermissionResponseDialog::new("test", ALLOW_ALWAYS);
         let result = dialog.handle_key(key(KeyCode::Char('a')));
         assert!(matches!(
             result,
@@ -200,7 +205,7 @@ mod tests {
 
     #[test]
     fn shift_a_submits_allow_always_directly() {
-        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
+        let mut dialog = PermissionResponseDialog::new("test", ALLOW_ALWAYS);
         let result = dialog.handle_key(key(KeyCode::Char('A')));
         assert!(matches!(
             result,
@@ -210,7 +215,7 @@ mod tests {
 
     #[test]
     fn d_submits_deny_directly() {
-        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
+        let mut dialog = PermissionResponseDialog::new("test", ALLOW_ALWAYS);
         let result = dialog.handle_key(key(KeyCode::Char('d')));
         assert!(matches!(
             result,
@@ -220,7 +225,7 @@ mod tests {
 
     #[test]
     fn right_cycles_focus_and_enter_submits_it() {
-        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
+        let mut dialog = PermissionResponseDialog::new("test", ALLOW_ALWAYS);
         dialog.handle_key(key(KeyCode::Right));
         let result = dialog.handle_key(key(KeyCode::Enter));
         assert!(matches!(
@@ -231,7 +236,7 @@ mod tests {
 
     #[test]
     fn left_wraps_focus_backward() {
-        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
+        let mut dialog = PermissionResponseDialog::new("test", ALLOW_ALWAYS);
         dialog.handle_key(key(KeyCode::Left));
         let result = dialog.handle_key(key(KeyCode::Enter));
         assert!(matches!(
@@ -242,7 +247,7 @@ mod tests {
 
     #[test]
     fn esc_cancels() {
-        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
+        let mut dialog = PermissionResponseDialog::new("test", ALLOW_ALWAYS);
         let result = dialog.handle_key(key(KeyCode::Esc));
         assert!(matches!(result, DialogResult::Cancel));
     }

--- a/src/tui/dialogs/permission_response.rs
+++ b/src/tui/dialogs/permission_response.rs
@@ -2,10 +2,10 @@
 //! CLI's "Do you want to proceed?" style prompt) by sending the exact
 //! keystrokes a human would type, without attaching to the session.
 //!
-//! Always offers the same three choices regardless of what's actually on
-//! screen: AoE never parses pane content to detect or validate a pending
-//! prompt (see `AgentDef.permission_response`); the user has already seen
-//! the prompt before pressing the shortcut that opens this dialog.
+//! AoE never parses pane content to detect or validate a pending prompt
+//! (see `AgentDef.permission_response`); the user has already seen the
+//! prompt before pressing the shortcut that opens this dialog. The Allow
+//! Always choice is offered only when the agent's mapping has one.
 
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::prelude::*;
@@ -39,41 +39,55 @@ pub enum PermissionResponseChoice {
 
 pub struct PermissionResponseDialog {
     session_title: String,
-    /// Index of the focused choice: 0=Allow, 1=Allow Always, 2=Deny.
+    choices: Vec<(&'static str, PermissionResponseChoice)>,
+    /// Index of the focused choice within `choices`.
     focused: usize,
 }
 
-const CHOICES: [(&str, PermissionResponseChoice); 3] = [
+const ALL_CHOICES: [(&str, PermissionResponseChoice); 3] = [
     ("Allow", PermissionResponseChoice::Allow),
     ("Allow Always", PermissionResponseChoice::AllowAlways),
     ("Deny", PermissionResponseChoice::Deny),
 ];
 
 impl PermissionResponseDialog {
-    pub fn new(session_title: &str) -> Self {
+    pub fn new(
+        session_title: &str,
+        allow_always: Option<&'static [crate::agents::KeyToken]>,
+    ) -> Self {
+        let choices = ALL_CHOICES
+            .into_iter()
+            .filter(|(_, choice)| {
+                allow_always.is_some() || *choice != PermissionResponseChoice::AllowAlways
+            })
+            .collect();
         Self {
             session_title: session_title.to_string(),
+            choices,
             focused: 0,
         }
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<PermissionResponseChoice> {
+        let supports_allow_always = self
+            .choices
+            .iter()
+            .any(|(_, choice)| *choice == PermissionResponseChoice::AllowAlways);
         match key.code {
             KeyCode::Esc => DialogResult::Cancel,
-            KeyCode::Enter => DialogResult::Submit(CHOICES[self.focused].1),
+            KeyCode::Enter => DialogResult::Submit(self.choices[self.focused].1),
             KeyCode::Left | KeyCode::Up => {
-                self.focused = (self.focused + CHOICES.len() - 1) % CHOICES.len();
+                self.focused = (self.focused + self.choices.len() - 1) % self.choices.len();
                 DialogResult::Continue
             }
             KeyCode::Right | KeyCode::Down | KeyCode::Tab => {
-                self.focused = (self.focused + 1) % CHOICES.len();
+                self.focused = (self.focused + 1) % self.choices.len();
                 DialogResult::Continue
             }
-            // Mirrors structured_view's a/A/d mnemonics (src/tui/structured_view/input.rs)
-            // for the same three decisions, so the shortcut is consistent whether the
-            // user is inside the structured view or answering from the sidebar.
             KeyCode::Char('a') => DialogResult::Submit(PermissionResponseChoice::Allow),
-            KeyCode::Char('A') => DialogResult::Submit(PermissionResponseChoice::AllowAlways),
+            KeyCode::Char('A') if supports_allow_always => {
+                DialogResult::Submit(PermissionResponseChoice::AllowAlways)
+            }
             KeyCode::Char('d') | KeyCode::Char('D') => {
                 DialogResult::Submit(PermissionResponseChoice::Deny)
             }
@@ -119,7 +133,7 @@ impl PermissionResponseDialog {
         frame.render_widget(header, chunks[0]);
 
         let mut spans = Vec::new();
-        for (i, (label, _)) in CHOICES.iter().enumerate() {
+        for (i, (label, _)) in self.choices.iter().enumerate() {
             if i > 0 {
                 spans.push(Span::raw("   "));
             }
@@ -135,9 +149,18 @@ impl PermissionResponseDialog {
             chunks[1],
         );
 
+        let mut hint = String::from("a=allow");
+        if self
+            .choices
+            .iter()
+            .any(|(_, choice)| *choice == PermissionResponseChoice::AllowAlways)
+        {
+            hint.push_str("  A=always");
+        }
+        hint.push_str("  d=deny  Esc=cancel");
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(
-                "a=allow  A=always  d=deny  Esc=cancel",
+                hint,
                 Style::default().fg(theme.dimmed),
             )))
             .alignment(Alignment::Center),
@@ -157,7 +180,7 @@ mod tests {
 
     #[test]
     fn enter_submits_focused_default_allow() {
-        let mut dialog = PermissionResponseDialog::new("test");
+        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
         let result = dialog.handle_key(key(KeyCode::Enter));
         assert!(matches!(
             result,
@@ -167,7 +190,7 @@ mod tests {
 
     #[test]
     fn a_submits_allow_directly() {
-        let mut dialog = PermissionResponseDialog::new("test");
+        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
         let result = dialog.handle_key(key(KeyCode::Char('a')));
         assert!(matches!(
             result,
@@ -177,7 +200,7 @@ mod tests {
 
     #[test]
     fn shift_a_submits_allow_always_directly() {
-        let mut dialog = PermissionResponseDialog::new("test");
+        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
         let result = dialog.handle_key(key(KeyCode::Char('A')));
         assert!(matches!(
             result,
@@ -187,7 +210,7 @@ mod tests {
 
     #[test]
     fn d_submits_deny_directly() {
-        let mut dialog = PermissionResponseDialog::new("test");
+        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
         let result = dialog.handle_key(key(KeyCode::Char('d')));
         assert!(matches!(
             result,
@@ -197,7 +220,7 @@ mod tests {
 
     #[test]
     fn right_cycles_focus_and_enter_submits_it() {
-        let mut dialog = PermissionResponseDialog::new("test");
+        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
         dialog.handle_key(key(KeyCode::Right));
         let result = dialog.handle_key(key(KeyCode::Enter));
         assert!(matches!(
@@ -208,7 +231,7 @@ mod tests {
 
     #[test]
     fn left_wraps_focus_backward() {
-        let mut dialog = PermissionResponseDialog::new("test");
+        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
         dialog.handle_key(key(KeyCode::Left));
         let result = dialog.handle_key(key(KeyCode::Enter));
         assert!(matches!(
@@ -219,9 +242,23 @@ mod tests {
 
     #[test]
     fn esc_cancels() {
-        let mut dialog = PermissionResponseDialog::new("test");
+        let mut dialog = PermissionResponseDialog::new("test", Some(&[]));
         let result = dialog.handle_key(key(KeyCode::Esc));
         assert!(matches!(result, DialogResult::Cancel));
+    }
+
+    #[test]
+    fn allow_always_unsupported_is_skipped_and_shift_a_is_noop() {
+        let mut dialog = PermissionResponseDialog::new("test", None);
+        assert_eq!(dialog.choices.len(), 2);
+        let result = dialog.handle_key(key(KeyCode::Char('A')));
+        assert!(matches!(result, DialogResult::Continue));
+        dialog.handle_key(key(KeyCode::Right));
+        let result = dialog.handle_key(key(KeyCode::Enter));
+        assert!(matches!(
+            result,
+            DialogResult::Submit(PermissionResponseChoice::Deny)
+        ));
     }
 
     #[test]

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -6416,19 +6416,19 @@ impl HomeView {
         }
         let title = inst.title.clone();
         let tool = inst.tool.clone();
-        let supported = crate::agents::get_agent(&tool)
-            .and_then(|a| a.permission_response)
-            .is_some();
-        if !supported {
+        let Some(response) = crate::agents::get_agent(&tool).and_then(|a| a.permission_response)
+        else {
             self.info_dialog = Some(InfoDialog::new(
                 "Not Supported",
                 &format!("{} doesn't support quick permission responses yet.", tool),
             ));
             return;
-        }
+        };
         self.pending_permission_response_session = Some(id);
-        self.permission_response_dialog =
-            Some(crate::tui::dialogs::PermissionResponseDialog::new(&title));
+        self.permission_response_dialog = Some(crate::tui::dialogs::PermissionResponseDialog::new(
+            &title,
+            response.allow_always,
+        ));
     }
 
     /// Open the send-message dialog for the currently-selected running session.

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -5537,7 +5537,9 @@ impl HomeView {
         else {
             return;
         };
-        let tokens = permission_response_tokens(&response, choice);
+        let Some(tokens) = permission_response_tokens(&response, choice) else {
+            return;
+        };
         let tmux_session = match crate::tmux::Session::new(&inst.id, &inst.title) {
             Ok(s) => s,
             Err(e) => {
@@ -5563,12 +5565,12 @@ impl HomeView {
 fn permission_response_tokens(
     response: &crate::agents::PermissionResponse,
     choice: crate::tui::dialogs::PermissionResponseChoice,
-) -> &'static [crate::agents::KeyToken] {
+) -> Option<&'static [crate::agents::KeyToken]> {
     use crate::tui::dialogs::PermissionResponseChoice::*;
     match choice {
-        Allow => response.allow,
+        Allow => Some(response.allow),
         AllowAlways => response.allow_always,
-        Deny => response.deny,
+        Deny => Some(response.deny),
     }
 }
 
@@ -5582,12 +5584,12 @@ mod permission_response_tokens_tests {
     fn maps_each_choice_to_its_own_field() {
         let response = PermissionResponse {
             allow: &[KeyToken::Literal("1")],
-            allow_always: &[KeyToken::Literal("2")],
+            allow_always: Some(&[KeyToken::Literal("2")]),
             deny: &[KeyToken::Literal("3")],
         };
         assert_eq!(
             permission_response_tokens(&response, PermissionResponseChoice::Allow),
-            response.allow
+            Some(response.allow)
         );
         assert_eq!(
             permission_response_tokens(&response, PermissionResponseChoice::AllowAlways),
@@ -5595,7 +5597,20 @@ mod permission_response_tokens_tests {
         );
         assert_eq!(
             permission_response_tokens(&response, PermissionResponseChoice::Deny),
-            response.deny
+            Some(response.deny)
+        );
+    }
+
+    #[test]
+    fn allow_always_none_maps_to_none() {
+        let response = PermissionResponse {
+            allow: &[KeyToken::Named("Enter")],
+            allow_always: None,
+            deny: &[KeyToken::Named("Down"), KeyToken::Named("Enter")],
+        };
+        assert_eq!(
+            permission_response_tokens(&response, PermissionResponseChoice::AllowAlways),
+            None
         );
     }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -18271,6 +18271,19 @@ mod permission_response_dialog {
 
     #[test]
     #[serial]
+    fn agent_without_allow_always_still_opens_dialog() {
+        let mut env = create_test_env_empty();
+        let id = add_session_with_tool(&mut env.view, "session-one", "omp");
+        env.view.selected_session = Some(id);
+        let _ = env.view.handle_key(key(KeyCode::Char('a')), None);
+        assert!(
+            env.view.permission_response_dialog.is_some(),
+            "an agent with allow_always: None must still support allow/deny"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn structured_session_is_a_no_op() {
         let mut env = create_test_env_empty();
         let id = add_session_with_tool(&mut env.view, "session-one", "claude");


### PR DESCRIPTION
## Description
Maps Oh My Pi's (`omp`) terminal tool-approval prompt (`Enter` to allow, `Down`+`Enter` to deny) to the sidebar quick permission-response feature added in #2764. OMP's prompt (`ExtensionToolWrapper` in `packages/coding-agent/src/extensibility/extensions/wrapper.ts`) is a plain two-choice `Approve`/`Deny` list with no in-prompt "always allow" option, so `PermissionResponse.allow_always` is now `Option<&[KeyToken]>` instead of a required field. The respond-to-permission dialog now builds its choice list dynamically: it drops the "Allow Always" choice (and its `Shift+A` shortcut) for any agent whose mapping has none, rather than offering a button that would silently no-op.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the tmux keystroke-injection mechanism (`send_key_tokens`, including `KeyToken::Named` sequences) already has dedicated unit + e2e coverage from #2764, and only `claude` gets a full e2e fixture as the feature's representative (`opencode`'s `Named` tokens aren't e2e-tested either). Added unit coverage instead: `test_omp_agent_definition` (agent detection, untouched from main), `permission_response_tokens_tests::allow_always_none_maps_to_none`, `dialogs::permission_response::tests::allow_always_unsupported_is_skipped_and_shift_a_is_noop` (2-choice dialog, `Shift+A` no-ops), and `agent_without_allow_always_still_opens_dialog`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** anthropic/claude-sonnet-5 via Oh My Pi (omp), orchestrated interactively with human review/redirection at each step.

**Any Additional AI Details you'd like to share:** Keystroke mapping was verified against `omp://approval-mode.md` / `omp://keybindings.md` docs and the shipped `omp` binary's bundled JS (via `strings`), not guessed.

- [x] I am an AI Agent filling out this form (check box if true)



This PR adds Oh My Pi (`omp`) support to the quick permission-response flow.

It maps `omp` approval prompts to allow with `Enter` and deny with `Down` + `Enter`. It makes `allow_always` optional because `omp` does not provide that choice. The dialog hides "Allow Always" and its `Shift+A` shortcut when unsupported.

The flow now safely ignores unavailable permission-response actions. Tests cover `omp`, optional "Allow Always" support, and dialog behavior.

Benefits:
- Supports another agent.
- Prevents unavailable actions from appearing.
- Keeps choices and shortcuts aligned with agent capabilities.