### PR TITLE
fix(session): reject shell-injection env keys at every ingestion point

### DIFF
--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -331,9 +331,20 @@ pub(crate) fn shell_escape(val: &str) -> String {
 /// Values are passed through `shell_escape` so spaces, quotes, and shell
 /// metacharacters are preserved literally. Returns an empty string when
 /// the entry list is empty so callers can format unconditionally.
+///
+/// Keys are not escapable here (a shell assignment needs a bare name on the
+/// left), so an entry whose key is not a valid environment variable name is
+/// skipped with a warning rather than concatenated into the command line. The
+/// structured-view sibling [`resolve_host_environment_pairs`] applies the same
+/// rule, so both views drop the same entries.
 pub(crate) fn host_environment_prefix(entries: &[String]) -> String {
     let mut out = String::new();
     for entry in entries {
+        let key = entry.split_once('=').map(|(key, _)| key).unwrap_or(entry);
+        if !is_valid_env_key(key) {
+            tracing::warn!(target: "session.create", "invalid host environment key '{}'; skipping", key);
+            continue;
+        }
         if let Some((key, value)) = entry.split_once('=') {
             let resolved = if let Some(rest) = value.strip_prefix("$$") {
                 Some(format!("${}", rest))
@@ -623,8 +634,9 @@ where
         .collect()
 }
 
-/// Validate an env entry string and return a warning message if it references
-/// a host variable that doesn't exist.
+/// Validate an env entry string and return a warning message when its key is
+/// not a valid environment variable name (the entry is dropped at collection
+/// time) or when it references a host variable that doesn't exist.
 ///
 /// Entry formats:
 /// - `KEY` (bare): pass through from host
@@ -1267,6 +1279,9 @@ environment = ["GH_TOKEN=write_token"]
             (&["MARKER=$$KEEP"], "MARKER='$KEEP' "),
             // Single-quote wrapping with `'\''` escape for the apostrophe.
             (&["X=a b'c$d"], "X='a b'\\''c$d' "),
+            // A key is a bare shell name here and cannot be quoted, so an
+            // invalid one is dropped instead of concatenated into the command.
+            (&["FOO; touch /tmp/pwn; X=1", "GOOD=ok"], "GOOD='ok' "),
         ];
         for (entries, expected) in cases {
             let owned: Vec<String> = entries.iter().map(|s| s.to_string()).collect();

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -632,6 +632,13 @@ where
 /// - `KEY=literal` (no `$`): always valid
 /// - `KEY=$$...`: escaped literal `$`, always valid
 pub fn validate_env_entry(entry: &str) -> Option<String> {
+    let key = entry.split_once('=').map(|(key, _)| key).unwrap_or(entry);
+    if !is_valid_env_key(key) {
+        return Some(format!(
+            "Warning: invalid environment key '{}'; skipping",
+            key
+        ));
+    }
     if let Some((_, value)) = entry.split_once('=') {
         if value.starts_with("$$") {
             // Escaped literal $, always valid
@@ -724,6 +731,10 @@ pub(crate) fn collect_environment(
     // Placed before the configured entries so a freshly-minted secret wins over
     // any same-keyed `sandbox.environment` / `extra_env` entry (first-wins).
     for (key, value) in &sandbox_info.before_start_env {
+        if !is_valid_env_key(key) {
+            tracing::warn!(target: "session.create", "invalid before_start environment key '{}'; skipping", key);
+            continue;
+        }
         if seen_keys.insert(key.clone()) {
             result.push(EnvEntry::Inherit {
                 key: key.clone(),
@@ -733,6 +744,11 @@ pub(crate) fn collect_environment(
     }
 
     for entry in entries {
+        let key = entry.split_once('=').map(|(key, _)| key).unwrap_or(entry);
+        if !is_valid_env_key(key) {
+            tracing::warn!(target: "session.create", "invalid sandbox environment key '{}'; skipping", key);
+            continue;
+        }
         if let Some((key, value)) = entry.split_once('=') {
             if seen_keys.insert(key.to_string()) {
                 if let Some(rest) = value.strip_prefix("$$") {
@@ -1435,6 +1451,50 @@ environment = ["GH_TOKEN=write_token"]
     /// Helper to find an entry by key and check its value
     fn find_entry<'a>(entries: &'a [EnvEntry], key: &str) -> Option<&'a EnvEntry> {
         entries.iter().find(|e| e.key() == key)
+    }
+
+    #[test]
+    fn test_collect_environment_rejects_invalid_config_extra_and_hook_keys() {
+        let config = SandboxConfig {
+            environment: vec![
+                "CFG; touch /tmp/cfg_injected; #=secret".to_string(),
+                "VALID_CONFIG=ok".to_string(),
+            ],
+            ..Default::default()
+        };
+        let base = SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test".to_string(),
+            container_name: "test".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: vec![
+                (
+                    "HOOK$(touch /tmp/hook_injected)".to_string(),
+                    "secret".to_string(),
+                ),
+                ("VALID_HOOK".to_string(), "minted".to_string()),
+            ],
+            container_workdir: None,
+        };
+        let configured = collect_environment(&config, &base);
+        assert!(find_entry(&configured, "VALID_CONFIG").is_some());
+        assert!(find_entry(&configured, "VALID_HOOK").is_some());
+        assert!(!configured
+            .iter()
+            .any(|entry| { entry.key().contains("touch") || entry.key().contains(';') }));
+
+        let mut extra = base;
+        extra.extra_env = Some(vec![
+            "EXTRA`touch /tmp/extra_injected`=secret".to_string(),
+            "VALID_EXTRA=ok".to_string(),
+        ]);
+        let resolved_extra = collect_environment(&config, &extra);
+        assert!(find_entry(&resolved_extra, "VALID_EXTRA").is_some());
+        assert!(!resolved_extra
+            .iter()
+            .any(|entry| { entry.key().contains("touch") || entry.key().contains('`') }));
     }
 
     #[test]

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -1293,10 +1293,11 @@ pub fn resolve_before_session_hooks(profile: &str) -> Vec<String> {
         .before_session
 }
 
-/// Parse `KEY=VALUE` lines from a hook's stdout, ignoring blank lines, lines
-/// with no `=`, and lines whose key is not a valid env var name. Later entries
-/// override earlier ones for the same key. The value is preserved verbatim
-/// (only the line ending is stripped by [`str::lines`]).
+/// Parse `KEY=VALUE` lines from a hook's stdout, ignoring blank lines and lines
+/// with no `=`. Invalid env names are skipped with a warning before they can
+/// reach shell construction. Later entries override earlier ones for the same
+/// key. The value is preserved verbatim (only the line ending is stripped by
+/// [`str::lines`]).
 fn parse_env_kv_lines(stdout: &str) -> Vec<(String, String)> {
     let mut out: Vec<(String, String)> = Vec::new();
     for line in stdout.lines() {
@@ -1305,6 +1306,10 @@ fn parse_env_kv_lines(stdout: &str) -> Vec<(String, String)> {
         };
         let key = key.trim();
         if !super::environment::is_valid_env_key(key) {
+            tracing::warn!(
+                target: "session.create",
+                "hook produced an invalid environment key; skipping"
+            );
             continue;
         }
         out.retain(|(k, _)| k != key);


### PR DESCRIPTION
## Description

Environment keys from `sandbox.environment`, per-session `extra_env`, `before_session` hook stdout, and `validate_env_entry` were only partially validated before feeding command/docker construction. This gates every ingestion point through the existing `is_valid_env_key`, skipping an invalid key (one carrying `;`, backticks, `$(...)`, etc.) with a warning instead of letting it reach shell construction.

- `environment.rs`: guard `validate_env_entry`, and the `before_start_env` and configured-entry loops in `collect_environment`.
- `repo_config.rs`: warn when a hook emits an invalid key (the skip already existed silently).

Extracted from #3230 as a self-contained, orthogonal slice; it does not depend on the OMP session-id capture work and reproduces that PR's exact guards so #3230 rebases cleanly on top.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary: no user-facing contract changed
- [x] For UI changes: no UI change, screenshot not applicable

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: added a focused unit test (`test_collect_environment_rejects_invalid_config_extra_and_hook_keys`) that asserts injection keys from config/extra/hook channels are dropped while valid keys survive; a full-binary e2e is unwarranted for input validation.

## Verification

- `cargo test --lib session::environment::tests::test_collect_environment_rejects_invalid_config_extra_and_hook_keys`
- `cargo clippy -- -D warnings`, `cargo fmt -- --check` (pre-commit)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (Anthropic) in Oh My Pi

**Any Additional AI Details you'd like to share:** Used to analyze #3230 and extract this orthogonal, self-contained slice.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Validates environment keys from all session inputs, including terminal-view host prefixes.
- Skips invalid keys and logs warnings.
- Preserves valid environment entries.
- Adds focused unit tests for configuration, session extras, hooks, and shell prefixes.

## Benefits

- Prevents malformed keys from reaching shell, Docker, tmux, or process environment APIs.
- Improves visibility when invalid configuration is skipped.
- Keeps the existing user-facing behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->