### PR TITLE
fix(web): scope skills spec status locators past the update banner

### DIFF
--- a/web/tests/live/skills-management.spec.ts
+++ b/web/tests/live/skills-management.spec.ts
@@ -19,8 +19,34 @@ test("skills panel adopts, edits, creates, and deletes skills", async ({ page },
     },
   });
 
+  // Narrow role queries by text content. `UpdateBanner.tsx` also renders
+  // `role="status"`, and it mounts once the version check resolves, so an
+  // unqualified `getByRole("status")` is ambiguous on any build older than
+  // the latest release and trips strict mode partway through the run.
+  const notice = (text: string) => page.getByRole("status").filter({ hasText: text });
+
   try {
+    // Pin the banner on. Whether it renders otherwise depends on how the
+    // running build's version compares to the latest GitHub release, so the
+    // ambiguity above is invisible on a release-day build and a re-widened
+    // locator would regress silently. Forcing it keeps this spec a real
+    // regression test for #3263.
+    await page.route("**/api/system/update-status", (route) =>
+      route.fulfill({
+        json: {
+          update_check_mode: "notify",
+          current_version: "0.0.1",
+          latest_version: "99.0.0",
+          update_available: true,
+          release_url: null,
+          error: null,
+          dismissed_version: null,
+        },
+      }),
+    );
+
     await page.goto(`${serve.baseUrl}/settings/skills`);
+    await expect(page.getByRole("status", { name: /^Update available/ })).toBeVisible();
 
     await expect(page.getByRole("heading", { name: "Skills Library" })).toBeVisible();
     // Anchored: the detail pane's "Preview" toggle also contains "review", so
@@ -30,14 +56,14 @@ test("skills panel adopts, edits, creates, and deletes skills", async ({ page },
     await expect(page.getByLabel("SKILL.md content")).toHaveAttribute("readonly", "");
 
     await page.getByRole("button", { name: "Adopt into AoE" }).click();
-    await expect(page.getByRole("status")).toContainText("adopted");
+    await expect(notice("adopted")).toBeVisible();
     await expect(page.getByLabel("SKILL.md content")).not.toHaveAttribute("readonly");
     expect(readFileSync(join(serve.home, ".claude", "skills", "review", "SKILL.md"), "utf8")).toBe(original);
 
     const edited = "---\nname: Review\ndescription: Updated review\n---\n\nEdited body\n";
     await page.getByLabel("SKILL.md content").fill(edited);
     await page.getByRole("button", { name: "Save" }).click();
-    await expect(page.getByRole("status")).toContainText("saved");
+    await expect(notice("saved")).toBeVisible();
 
     const persisted = await page.request.get(`${serve.baseUrl}/api/skills/aoe-managed/review`);
     expect(persisted.ok()).toBe(true);
@@ -47,12 +73,12 @@ test("skills panel adopts, edits, creates, and deletes skills", async ({ page },
     await page.getByLabel("New skill directory").fill("new-skill");
     await page.getByLabel("New skill description").fill("Use for new work");
     await page.getByRole("button", { name: "Create" }).click();
-    await expect(page.getByRole("status")).toContainText("created");
+    await expect(notice("created")).toBeVisible();
     await expect(page.getByLabel("SKILL.md content")).toHaveValue(/name: new-skill/);
 
     page.once("dialog", (dialog) => void dialog.accept());
     await page.getByRole("button", { name: "Delete" }).click();
-    await expect(page.getByRole("status")).toContainText("deleted");
+    await expect(notice("deleted")).toBeVisible();
     const removed = await page.request.get(`${serve.baseUrl}/api/skills/aoe-managed/new-skill`);
     expect(removed.status()).toBe(404);
   } finally {


### PR DESCRIPTION
## Description

`UpdateBanner.tsx` renders `role="status"`, so the four unqualified `page.getByRole("status")` calls in `web/tests/live/skills-management.spec.ts` are ambiguous whenever the banner is mounted. The banner only mounts when the running build is behind the latest GitHub release, so the spec passes on main and fails on any PR branched before the current release.

#3263 hit this. Its `created` assertion tripped `strict mode violation: getByRole('status') resolved to 2 elements`, matching both the banner and the toast. That cost a full CI cycle and a rebase before the cause was clear, on a PR whose diff was Rust-only.

Two changes:

- Narrow each query by its expected text, matching the pattern and the rationale already in `disconnect-banner.spec.ts`.
- Pin the banner on with a route stub, so the ambiguity is present on every run rather than only on stale branches. Without it the spec cannot catch a re-widened locator on a release-day build, which is how this survived #3242 in the first place.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A)
- [x] For UI changes: included screenshot or recording (N/A, no product code changes)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

This is a test-only change; no product code is touched, so no `coverage-matrix.json` entry applies. `node tests/validate-coverage-matrix.mjs` passes.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Verified red/green locally against a `--features serve` build. With the stub in place and the locators reverted, the spec reproduces the CI error verbatim:

```
strict mode violation: getByRole('status') resolved to 2 elements:
  - <div role="status" aria-label="Update available: v99.0.0" ...>
```

With them narrowed, it passes. Also clean: `npm run format:check`, `npm run lint`, `npx tsc -b`.

## AI Usage

- [x] AI was used

**AI Model/Tool used:**
Claude Opus 5 (Claude Code)

**Any Additional AI Details you'd like to share:**
Found while reviewing #3263, where this was the failure that blocked an unrelated Rust change. The red/green verification was run locally rather than inferred.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the skills management Playwright tests to use text-filtered status locators.
- Added an update-status route stub so `UpdateBanner.tsx` renders during every test run.
- Preserved existing checks for skill adoption, saving, creation, deletion, persistence, and filesystem changes.
- Prevented strict mode conflicts between the update banner and toast notifications.

## Benefits

- Makes test behavior consistent and predictable.
- Exposes locator conflicts during test runs.
- Changes test code only; product code is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->