### PR TITLE
fix(web): improve iOS terminal input and scrolling

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,14 @@
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { Puzzle } from "lucide-react";
 import { useMatch, useNavigate, useSearchParams } from "react-router-dom";
 import { IDLE_DECAY_WINDOW_MS, isSessionActive } from "./lib/session";
@@ -696,6 +706,11 @@ function AppContent({
   const [telemetryConsentKnown, setTelemetryConsentKnown] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(() => window.innerWidth >= 768);
   const keyboardProxyRef = useRef<HTMLTextAreaElement>(null);
+  const [keyboardProxy, setKeyboardProxy] = useState<HTMLTextAreaElement | null>(null);
+  const setKeyboardProxyRef = useCallback((element: HTMLTextAreaElement | null) => {
+    keyboardProxyRef.current = element;
+    setKeyboardProxy(element);
+  }, []);
 
   const [serverAbout, setServerAbout] = useState<ServerAbout | null>(null);
   // CityHall client mode collapses the dashboard to a locked-down end-user
@@ -815,20 +830,36 @@ function AppContent({
 
   const focusKeyboardProxy = () => {
     if (window.innerWidth < 768 && navigator.maxTouchPoints > 0) {
-      clearMobileKeyboardProxyInput();
       keyboardProxyRef.current?.focus();
     }
   };
   const closeKeyboardProxy = () => {
     if (window.innerWidth < 768 && navigator.maxTouchPoints > 0) {
-      clearMobileKeyboardProxyInput();
       keyboardProxyRef.current?.blur();
       if (document.activeElement instanceof HTMLTextAreaElement) document.activeElement.blur();
     }
   };
 
+  // The keyboard proxy survives terminal mounts so iOS can retain the focus
+  // authorized by a sidebar tap. Drop its receiver only at a real session
+  // boundary: clearing it while reselecting the active session leaves that
+  // still-mounted terminal without anything to re-register it.
+  const keyboardProxySessionIdRef = useRef(activeSessionId);
+  const transitionKeyboardProxy = useCallback((nextSessionId: string | null) => {
+    if (keyboardProxySessionIdRef.current === nextSessionId) return;
+    keyboardProxySessionIdRef.current = nextSessionId;
+    clearMobileKeyboardProxyInput();
+  }, []);
+
+  // Sidebar selection clears before the proxy can accept another edit. This
+  // also covers browser history and every other route change before the next
+  // input event, without clearing an unchanged session.
+  useLayoutEffect(() => {
+    transitionKeyboardProxy(activeSessionId);
+  }, [activeSessionId, transitionKeyboardProxy]);
+
   useEffect(() => {
-    const proxy = keyboardProxyRef.current;
+    const proxy = keyboardProxy;
     if (!proxy) return;
     const onBeforeInput = (e: InputEvent) => {
       switch (e.inputType) {
@@ -850,7 +881,7 @@ function AppContent({
     };
     proxy.addEventListener("beforeinput", onBeforeInput);
     return () => proxy.removeEventListener("beforeinput", onBeforeInput);
-  }, []);
+  }, [keyboardProxy]);
 
   // Selecting a session in the sidebar should land focus on its canonical
   // "type here" target so the user can start typing without a second click:
@@ -867,6 +898,7 @@ function AppContent({
       const ws = workspaces.find((w) => w.sessions.some((s) => s.id === sessionId));
       if (ws) {
         const picked = ws.sessions.find((s) => s.id === sessionId);
+        transitionKeyboardProxy(sessionId);
         navigate(`/session/${encodeURIComponent(sessionId)}`);
         // iOS does not permit a session's asynchronously mounted terminal
         // input to inherit this sidebar tap's keyboard authorization. The
@@ -891,7 +923,7 @@ function AppContent({
         if (window.innerWidth < 768) setSidebarOpen(false);
       }
     },
-    [navigate, workspaces, focusAgentInput, isCoarse, webSettings.autoOpenKeyboard],
+    [navigate, workspaces, focusAgentInput, isCoarse, transitionKeyboardProxy, webSettings.autoOpenKeyboard],
   );
 
   const handleSelectWorkspace = (workspaceId: string) => {
@@ -900,6 +932,7 @@ function AppContent({
       const running = ws.sessions.find((s) => isSessionActive(s, idleDecayWindowMs));
       const picked = running ?? ws.sessions[0] ?? null;
       if (picked) {
+        transitionKeyboardProxy(picked.id);
         navigate(`/session/${encodeURIComponent(picked.id)}`);
         // See handleSelectSession: keep focus on the persistent keyboard input
         // until the selected surface can receive it.
@@ -915,6 +948,7 @@ function AppContent({
           focusAgentInput(picked);
         }
       } else {
+        transitionKeyboardProxy(null);
         navigate("/");
       }
     }
@@ -2299,7 +2333,7 @@ function AppContent({
         )}
 
         <textarea
-          ref={keyboardProxyRef}
+          ref={setKeyboardProxyRef}
           data-keyboard-proxy
           aria-hidden="true"
           tabIndex={-1}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -86,6 +86,7 @@ import { toastBus, reportError } from "./lib/toastBus";
 import { isAbsolutePath, resolveToRepoRelative, type FileRef } from "./lib/fileRef";
 import { OPEN_SESSION_EVENT } from "./lib/sessionRoute";
 import { dispatchFocusTerminal, requestSessionInputFocus, setPendingTerminalFocus } from "./lib/terminalFocus";
+import { clearMobileKeyboardProxyInput, deliverMobileKeyboardProxyInput } from "./lib/mobileKeyboardProxy";
 import { hydrateWebUiStateFromServer, initWebUiSync } from "./lib/webUiSync";
 import { WorkspaceSidebar, SnoozeModal } from "./components/WorkspaceSidebar";
 import { DeleteSessionDialog } from "./components/DeleteSessionDialog";
@@ -814,9 +815,42 @@ function AppContent({
 
   const focusKeyboardProxy = () => {
     if (window.innerWidth < 768 && navigator.maxTouchPoints > 0) {
+      clearMobileKeyboardProxyInput();
       keyboardProxyRef.current?.focus();
     }
   };
+  const closeKeyboardProxy = () => {
+    if (window.innerWidth < 768 && navigator.maxTouchPoints > 0) {
+      clearMobileKeyboardProxyInput();
+      keyboardProxyRef.current?.blur();
+      if (document.activeElement instanceof HTMLTextAreaElement) document.activeElement.blur();
+    }
+  };
+
+  useEffect(() => {
+    const proxy = keyboardProxyRef.current;
+    if (!proxy) return;
+    const onBeforeInput = (e: InputEvent) => {
+      switch (e.inputType) {
+        case "insertText":
+        case "insertLineBreak":
+        case "insertParagraph":
+        case "deleteContentBackward":
+        case "insertFromPaste":
+          e.preventDefault();
+          deliverMobileKeyboardProxyInput({
+            inputType: e.inputType,
+            data: e.data,
+            isComposing: e.isComposing,
+          });
+          break;
+        default:
+          break;
+      }
+    };
+    proxy.addEventListener("beforeinput", onBeforeInput);
+    return () => proxy.removeEventListener("beforeinput", onBeforeInput);
+  }, []);
 
   // Selecting a session in the sidebar should land focus on its canonical
   // "type here" target so the user can start typing without a second click:
@@ -834,14 +868,21 @@ function AppContent({
       if (ws) {
         const picked = ws.sessions.find((s) => s.id === sessionId);
         navigate(`/session/${encodeURIComponent(sessionId)}`);
-        // On touch devices, raise the soft keyboard within the tap gesture and
-        // latch the terminal/composer to take focus once it mounts (keeping the
-        // keyboard up) — but only when the user opted into auto-open keyboard.
-        // On desktop the proxy is a no-op and we focus the real input directly.
+        // iOS does not permit a session's asynchronously mounted terminal
+        // input to inherit this sidebar tap's keyboard authorization. The
+        // persistent keyboard input keeps the gesture-authorized focus while
+        // a terminal is starting; the terminal consumes its input directly
+        // rather than attempting a second, unreliable focus transfer.
         if (isCoarse) {
-          if (webSettings.autoOpenKeyboard) {
+          // Claude's alternate-screen startup still loses the first keyboard
+          // input on iOS (#3285). Start it as a monitoring view until that
+          // separate transport race is fixed; other terminal agents remain
+          // safe to auto-open.
+          if (picked?.tool === "claude" && picked.view !== "structured") {
+            closeKeyboardProxy();
+          } else if (webSettings.autoOpenKeyboard) {
             focusKeyboardProxy();
-            setPendingTerminalFocus(picked?.view === "structured" ? "composer" : "agent");
+            if (picked?.view === "structured") setPendingTerminalFocus("composer");
           }
         } else {
           focusKeyboardProxy();
@@ -860,12 +901,14 @@ function AppContent({
       const picked = running ?? ws.sessions[0] ?? null;
       if (picked) {
         navigate(`/session/${encodeURIComponent(picked.id)}`);
-        // Mirror handleSelectSession: on touch, raise the keyboard + latch focus
-        // only when auto-open keyboard is enabled; on desktop focus directly.
+        // See handleSelectSession: keep focus on the persistent keyboard input
+        // until the selected surface can receive it.
         if (isCoarse) {
-          if (webSettings.autoOpenKeyboard) {
+          if (picked.tool === "claude" && picked.view !== "structured") {
+            closeKeyboardProxy();
+          } else if (webSettings.autoOpenKeyboard) {
             focusKeyboardProxy();
-            setPendingTerminalFocus(picked.view === "structured" ? "composer" : "agent");
+            if (picked.view === "structured") setPendingTerminalFocus("composer");
           }
         } else {
           focusKeyboardProxy();
@@ -2257,10 +2300,15 @@ function AppContent({
 
         <textarea
           ref={keyboardProxyRef}
+          data-keyboard-proxy
           aria-hidden="true"
           tabIndex={-1}
-          className="fixed opacity-0 w-0 h-0 pointer-events-none"
-          style={{ top: -9999, left: -9999 }}
+          // Keep the element in the visual viewport. Focusing a zero-size
+          // textarea thousands of pixels above an iOS PWA can leave WebKit's
+          // focus scroll in a broken state until the keyboard is toggled.
+          // This matches the live terminal's hidden input geometry.
+          className="fixed bottom-0 left-0 w-px h-px opacity-0 pointer-events-none"
+          style={{ caretColor: "transparent", color: "transparent" }}
         />
       </div>
     </AcpPrefsProvider>

--- a/web/src/components/LiveTerminalView.tsx
+++ b/web/src/components/LiveTerminalView.tsx
@@ -236,7 +236,7 @@ export function LiveTerminalView({ session, active = true, surface = "agent", te
       <div
         aria-hidden="true"
         className={`pointer-events-none absolute inset-0 z-10 ring-inset transition-shadow ${
-          inputFocused ? "ring-2 ring-terminal-active" : "ring-1 ring-surface-700/40"
+          coarse ? "" : inputFocused ? "ring-2 ring-terminal-active" : "ring-1 ring-surface-700/40"
         }`}
       />
 

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties, ReactNode, RefObject } from "react";
 import type { AnsiSegment, AnsiStyle } from "../lib/ansi";
 import { LineParseCache, findCursorCharIndex, splitUrls, textWidth, wrapLine } from "../lib/liveTermLines";
 import { wheelNotches } from "../lib/liveMouse";
+import { registerMobileKeyboardProxyReceiver, type MobileKeyboardProxyInput } from "../lib/mobileKeyboardProxy";
 import { writeClipboard } from "../lib/clipboard";
 import type { LiveFrame } from "../hooks/useLiveTerminal";
 import { useWebSettings } from "../hooks/useWebSettings";
@@ -72,31 +73,32 @@ const SHRINK_DELAY_MS = 1500;
  *  stays at the tight interval. */
 const LIVE_WINDOW_SCREENS = 2;
 /** Forward-mode touch scroll gain: pane lines scrolled per line-height of
- *  finger travel. 1:1 read as sluggish in the field: there is no local
- *  direct-manipulation feel to preserve (content only moves on the network
- *  round trip), and with the soft keyboard up the strip of glass available
- *  for the gesture is short, so covering a transcript took a dozen swipes.
- *  Applied to touch drags and their momentum tail only; desktop wheel deltas
- *  pass through 1:1 (the trackpad supplies its own momentum). */
-const FORWARD_TOUCH_GAIN = 2;
+ *  finger travel. The full-screen app redraws after a network round trip, so
+ *  a large gain makes the delayed response race ahead of the user's finger.
+ *  Keep a small assist for the short area left above the iOS keyboard without
+ *  turning a gentle drag into a wheel burst. */
+const FORWARD_TOUCH_GAIN = 1.25;
 /** Release velocity (px/ms) below which a forward-mode drag ends with no
  *  momentum, so a deliberate slow drag stops where the finger stops. */
 const FLICK_MIN_VELOCITY = 0.3;
-/** Release-velocity cap (px/ms). Real flicks top out around 3-4 px/ms;
- *  synthetic touch streams (e2e) arrive back-to-back with ~1ms deltas whose
- *  raw px/ms is absurd (the AGENTS.md touch-recipe gotcha), and the cap is
- *  what keeps both worlds behaving the same. */
-const FLICK_MAX_VELOCITY = 4;
+/** Release-velocity cap (px/ms). The old 4 px/ms cap created a long wheel
+ *  storm after a modest iPhone flick. A lower cap keeps release inertia as a
+ *  small continuation rather than a second, much faster scroll gesture. */
+const FLICK_MAX_VELOCITY = 1.5;
 /** The finger must have moved this recently (ms) at lift for momentum to
  *  start; a drag-hold-release stops dead, like a native scroller. */
 const FLICK_MAX_PAUSE_MS = 80;
 /** Sliding window (ms) over which the release velocity is measured. */
 const FLICK_VELOCITY_WINDOW_MS = 100;
-/** Per-millisecond exponential decay of momentum velocity, matching
- *  UIScrollView's normal deceleration rate so a flick coasts ~1-2s. */
-const MOMENTUM_DECAY_PER_MS = 0.998;
+/** Per-millisecond exponential decay of momentum velocity. This intentionally
+ *  stops sooner than a native scroller because each forwarded notch redraws a
+ *  remote full-screen app rather than moving local pixels. */
+const MOMENTUM_DECAY_PER_MS = 0.992;
 /** Momentum ends when velocity decays below this (px/ms). */
 const MOMENTUM_STOP_VELOCITY = 0.05;
+/** A full-screen app redraws remotely, so send a bounded stream of wheel
+ * reports rather than dumping an entire fast drag into one network burst. */
+const MAX_QUEUED_TOUCH_NOTCHES = 8;
 
 export interface MobileLiveTerminalProps {
   frame: LiveFrame | null;
@@ -698,6 +700,18 @@ export function MobileLiveTerminal({
   // touch Y while forwarding a single-finger drag.
   const wheelAccumRef = useRef(0);
   const touchForwardYRef = useRef<number | null>(null);
+  const touchWheelQueueRef = useRef<{ notches: number; x: number; y: number; raf: number }>({
+    notches: 0,
+    x: 0,
+    y: 0,
+    raf: 0,
+  });
+  // A custom forward-mode drag does not get native scroll cancellation, so
+  // WebKit may still synthesize a click at its end. Remember meaningful touch
+  // movement and consume that click instead of mistaking a swipe for a tap
+  // that should summon the keyboard.
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+  const suppressTouchClickRef = useRef(false);
   // Base button (0/1/2) of an in-progress forwarded mouse press, so drag/
   // release only forward if the press was (latches like the TUI's
   // `mouse_forward_btn`), plus the last forwarded cell so a pixel-granular
@@ -878,6 +892,10 @@ export function MobileLiveTerminal({
   // renders on desktop too). The FAB and "Back to live" button are siblings of
   // the scroller, not descendants, so tapping them never reaches this handler.
   const focusInputOnTap = useCallback(() => {
+    if (suppressTouchClickRef.current) {
+      suppressTouchClickRef.current = false;
+      return;
+    }
     if (document.activeElement === inputRef.current) return;
     const sel = window.getSelection();
     if (sel && !sel.isCollapsed) return;
@@ -910,9 +928,9 @@ export function MobileLiveTerminal({
   // anywhere on the pane means "scroll the transcript"; the middle row is
   // inside it for any plausible layout. The column keeps the finger's x.
   const forwardWheelDelta = useCallback(
-    (deltaPx: number, clientX: number, clientY: number, touchCell = false) => {
+    (deltaPx: number, clientX: number, clientY: number, touchCell = false, maxNotches = 8) => {
       wheelAccumRef.current += deltaPx;
-      const { notches, remainder } = wheelNotches(wheelAccumRef.current, lineH || 16, 8);
+      const { notches, remainder } = wheelNotches(wheelAccumRef.current, lineH || 16, maxNotches);
       wheelAccumRef.current = remainder;
       if (notches === 0) return;
       const { col, row } = pointerCell(clientX, clientY);
@@ -922,6 +940,50 @@ export function MobileLiveTerminal({
     },
     [lineH, pointerCell, forwardWheel],
   );
+
+  const cancelTouchWheelQueue = useCallback(() => {
+    const queued = touchWheelQueueRef.current;
+    if (queued.raf) cancelAnimationFrame(queued.raf);
+    queued.notches = 0;
+    queued.raf = 0;
+  }, []);
+  const enqueueTouchWheelDelta = useCallback(
+    (deltaPx: number, clientX: number, clientY: number) => {
+      wheelAccumRef.current += deltaPx;
+      const { notches, remainder } = wheelNotches(wheelAccumRef.current, lineH || 16, MAX_QUEUED_TOUCH_NOTCHES);
+      wheelAccumRef.current = remainder;
+      if (notches === 0) return;
+
+      const queued = touchWheelQueueRef.current;
+      const direction = Math.sign(notches);
+      if (queued.notches && Math.sign(queued.notches) !== direction) queued.notches = 0;
+      queued.notches = Math.max(
+        -MAX_QUEUED_TOUCH_NOTCHES,
+        Math.min(MAX_QUEUED_TOUCH_NOTCHES, queued.notches + notches),
+      );
+      queued.x = clientX;
+      queued.y = clientY;
+
+      const flushOne = () => {
+        const state = touchWheelQueueRef.current;
+        state.raf = 0;
+        if (!forwardModeRef.current || state.notches === 0) return;
+        const { col } = pointerCell(state.x, state.y);
+        const row = Math.max(1, Math.round(rowsRef.current / 2));
+        const up = state.notches < 0;
+        forwardWheel(up, mouseSgrRef.current, col, row);
+        state.notches += up ? 1 : -1;
+        if (state.notches !== 0) state.raf = requestAnimationFrame(flushOne);
+      };
+
+      // The first notch starts immediately, so a short, quick swipe is not
+      // held for a frame. The rest drain one per frame, which makes a long
+      // swipe track remote redraws instead of arriving as a wheel storm.
+      if (!queued.raf) flushOne();
+    },
+    [lineH, pointerCell, forwardWheel],
+  );
+  useEffect(() => cancelTouchWheelQueue, [cancelTouchWheelQueue]);
 
   const onWheel = useCallback(
     (e: React.WheelEvent) => {
@@ -967,7 +1029,7 @@ export function MobileLiveTerminal({
         const dt = Math.min(64, Math.max(0, now - state.lastT));
         state.lastT = now;
         // Same sign convention as the drag: finger-space delta, negated.
-        forwardWheelDelta(-state.v * dt * FORWARD_TOUCH_GAIN, state.x, state.y, true);
+        enqueueTouchWheelDelta(-state.v * dt * FORWARD_TOUCH_GAIN, state.x, state.y);
         state.v *= Math.pow(MOMENTUM_DECAY_PER_MS, dt);
         if (Math.abs(state.v) < MOMENTUM_STOP_VELOCITY) {
           momentumRef.current = null;
@@ -977,7 +1039,7 @@ export function MobileLiveTerminal({
       };
       state.raf = requestAnimationFrame(step);
     },
-    [stopMomentum, forwardWheelDelta],
+    [stopMomentum, enqueueTouchWheelDelta],
   );
   // Typed input interrupts the coast. Without this, keystrokes sent in the
   // coast's 1-2s tail interleave with the wheel storm and the app is busy
@@ -988,9 +1050,10 @@ export function MobileLiveTerminal({
   const sendData = useCallback(
     (data: string) => {
       stopMomentum();
+      cancelTouchWheelQueue();
       sendDataRaw(data);
     },
-    [sendDataRaw, stopMomentum],
+    [sendDataRaw, stopMomentum, cancelTouchWheelQueue],
   );
 
   // Mouse button (click/drag) forwarding for a full-screen mouse app, the
@@ -1066,6 +1129,7 @@ export function MobileLiveTerminal({
       // A touch anywhere halts an in-flight momentum coast, the native
       // touch-to-stop convention.
       stopMomentum();
+      cancelTouchWheelQueue();
       flickSamplesRef.current = [];
       if (e.touches.length === 2) {
         pinchRef.current = {
@@ -1078,10 +1142,13 @@ export function MobileLiveTerminal({
         };
         touchForwardYRef.current = null;
         touchScrollStartYRef.current = null;
+        touchStartRef.current = null;
       } else if (e.touches.length === 1 && forwardModeRef.current) {
         // Single-finger drag drives the app's wheel in forward mode.
         const t0 = e.touches[0]!;
         touchForwardYRef.current = t0.clientY;
+        touchStartRef.current = { x: t0.clientX, y: t0.clientY };
+        suppressTouchClickRef.current = false;
         wheelAccumRef.current = 0;
         flickSamplesRef.current = [{ x: t0.clientX, y: t0.clientY, t: performance.now() }];
       } else if (e.touches.length === 1) {
@@ -1092,9 +1159,11 @@ export function MobileLiveTerminal({
         // otherwise re-arm the pin. A tap (no scroll) re-attaches on touchend.
         liveDetachedRef.current = true;
         touchScrollStartYRef.current = e.touches[0]!.clientY;
+        touchStartRef.current = { x: e.touches[0]!.clientX, y: e.touches[0]!.clientY };
+        suppressTouchClickRef.current = false;
       }
     },
-    [fontSize, stopMomentum],
+    [fontSize, stopMomentum, cancelTouchWheelQueue],
   );
   const onTouchMove = useCallback(
     (e: React.TouchEvent) => {
@@ -1118,6 +1187,10 @@ export function MobileLiveTerminal({
         // page pan is suppressed by touch-action: none on the scroller
         // instead (see the style below).
         const t0 = e.touches[0]!;
+        const start = touchStartRef.current;
+        if (start && Math.hypot(t0.clientX - start.x, t0.clientY - start.y) > 8) {
+          suppressTouchClickRef.current = true;
+        }
         const y = t0.clientY;
         const dy = y - touchForwardYRef.current;
         touchForwardYRef.current = y;
@@ -1125,7 +1198,7 @@ export function MobileLiveTerminal({
         const samples = flickSamplesRef.current;
         samples.push({ x: t0.clientX, y, t: now });
         while (samples.length > 1 && now - samples[0]!.t > FLICK_VELOCITY_WINDOW_MS) samples.shift();
-        forwardWheelDelta(-dy * FORWARD_TOUCH_GAIN, t0.clientX, y, true);
+        enqueueTouchWheelDelta(-dy * FORWARD_TOUCH_GAIN, t0.clientX, y);
         return;
       }
       if (e.touches.length === 1 && !forwardModeRef.current && touchScrollStartYRef.current != null) {
@@ -1138,11 +1211,12 @@ export function MobileLiveTerminal({
         // is idempotent; the 8px gate keeps a tap (or a horizontal swipe) from
         // tripping it.
         if (Math.abs(e.touches[0]!.clientY - touchScrollStartYRef.current) > 8) {
+          suppressTouchClickRef.current = true;
           enterReading(rowsRef.current);
         }
       }
     },
-    [forwardWheelDelta, enterReading],
+    [enqueueTouchWheelDelta, enterReading],
   );
   const onTouchEnd = useCallback(
     (e: React.TouchEvent) => {
@@ -1151,6 +1225,26 @@ export function MobileLiveTerminal({
         // still moving. Velocity is read over the recent-sample window, so a
         // drag that paused before lifting (stale last sample) coasts nowhere.
         if (forwardModeRef.current && touchForwardYRef.current != null) {
+          // A quick iOS swipe can coalesce every move into touchend. Include
+          // its final changed touch before deriving both the last notch and
+          // release velocity, otherwise that gesture is indistinguishable
+          // from a tap and appears to have been ignored.
+          const finalTouch = e.changedTouches[0];
+          if (finalTouch) {
+            const dy = finalTouch.clientY - touchForwardYRef.current;
+            if (dy !== 0) {
+              const start = touchStartRef.current;
+              if (start && Math.hypot(finalTouch.clientX - start.x, finalTouch.clientY - start.y) > 8) {
+                suppressTouchClickRef.current = true;
+              }
+              touchForwardYRef.current = finalTouch.clientY;
+              const now = performance.now();
+              const samples = flickSamplesRef.current;
+              samples.push({ x: finalTouch.clientX, y: finalTouch.clientY, t: now });
+              while (samples.length > 1 && now - samples[0]!.t > FLICK_VELOCITY_WINDOW_MS) samples.shift();
+              enqueueTouchWheelDelta(-dy * FORWARD_TOUCH_GAIN, finalTouch.clientX, finalTouch.clientY);
+            }
+          }
           const samples = flickSamplesRef.current;
           const first = samples[0];
           const last = samples[samples.length - 1];
@@ -1164,6 +1258,7 @@ export function MobileLiveTerminal({
         touchActiveRef.current = false;
         touchForwardYRef.current = null;
         touchScrollStartYRef.current = null;
+        touchStartRef.current = null;
         // Settle the live-edge decision deferred by onScroll; momentum
         // scroll events after this keep re-evaluating via onScroll. Ending at
         // the bottom (a tap that never scrolled, or a scroll back down) must
@@ -1185,7 +1280,7 @@ export function MobileLiveTerminal({
         }, 400);
       }
     },
-    [fontKey, fontSize, update, returnToLive, atBottom, startMomentum],
+    [fontKey, fontSize, update, returnToLive, atBottom, startMomentum, enqueueTouchWheelDelta],
   );
   // touchcancel is NOT touchend: iOS fires it when it promotes the drag to
   // native scrolling, with the finger usually STILL down. Treat it as "stop
@@ -1197,6 +1292,7 @@ export function MobileLiveTerminal({
     touchActiveRef.current = false;
     touchForwardYRef.current = null;
     touchScrollStartYRef.current = null;
+    touchStartRef.current = null;
     // A cancelled touch never coasts (native convention); just drop the
     // samples. Any momentum from a PREVIOUS flick was already stopped on
     // this touch's start.
@@ -1337,28 +1433,22 @@ export function MobileLiveTerminal({
   // Native (not React-synthetic) beforeinput: React's onBeforeInput is
   // backed by keypress in Chromium and carries no inputType, so the
   // soft-keyboard input types below would never match through it.
-  useEffect(() => {
-    const ta = inputRef.current;
-    if (!ta) return;
-    const onBeforeInput = (ev: InputEvent) => {
-      if (composingRef.current || ev.isComposing) return;
-      switch (ev.inputType) {
+  const handleMobileKeyboardProxyInput = useCallback(
+    (input: MobileKeyboardProxyInput) => {
+      if (composingRef.current || input.isComposing) return;
+      switch (input.inputType) {
         case "insertText":
-          ev.preventDefault();
-          if (ev.data) sendKeys(ev.data);
+          if (input.data) sendKeys(input.data);
           break;
         case "insertLineBreak":
         case "insertParagraph":
-          ev.preventDefault();
           sendKeys("\r");
           break;
         case "deleteContentBackward":
-          ev.preventDefault();
           sendKeys("\x7f");
           break;
         case "insertFromPaste": {
-          ev.preventDefault();
-          const text = ev.data ?? "";
+          const text = input.data ?? "";
           if (text) {
             // Bracketed paste so agents treat embedded newlines as
             // pasted text, not per-line submits.
@@ -1369,14 +1459,40 @@ export function MobileLiveTerminal({
         default:
           break;
       }
-    };
-    ta.addEventListener("beforeinput", onBeforeInput);
-    return () => ta.removeEventListener("beforeinput", onBeforeInput);
-  }, [sendKeys, sendData, inputRef]);
+    },
+    [sendKeys, sendData],
+  );
+  const handleBeforeInput = useCallback(
+    (ev: InputEvent) => {
+      switch (ev.inputType) {
+        case "insertText":
+        case "insertLineBreak":
+        case "insertParagraph":
+        case "deleteContentBackward":
+        case "insertFromPaste":
+          ev.preventDefault();
+          handleMobileKeyboardProxyInput({
+            inputType: ev.inputType,
+            data: ev.data,
+            isComposing: ev.isComposing,
+          });
+          break;
+        default:
+          break;
+      }
+    },
+    [handleMobileKeyboardProxyInput],
+  );
+  useEffect(() => {
+    const ta = inputRef.current;
+    if (!ta) return;
+    ta.addEventListener("beforeinput", handleBeforeInput);
+    return () => ta.removeEventListener("beforeinput", handleBeforeInput);
+  }, [handleBeforeInput, inputRef]);
 
-  const onKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (composingRef.current || e.nativeEvent.isComposing) return;
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (composingRef.current || e.isComposing) return;
       const seq = specialKeySequence(e);
       if (seq) {
         e.preventDefault();
@@ -1411,9 +1527,9 @@ export function MobileLiveTerminal({
     [sendData],
   );
 
-  const onKeyDownCapture = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (composingRef.current || e.nativeEvent.isComposing) return;
+  const handleKeyDownCapture = useCallback(
+    (e: KeyboardEvent) => {
+      if (composingRef.current || e.isComposing) return;
       if (!e.altKey || e.ctrlKey || e.metaKey) return;
       // Capture printable Alt chords before browser accelerators can claim
       // shortcuts like Alt+V. Special keys are handled by the normal keydown
@@ -1427,12 +1543,12 @@ export function MobileLiveTerminal({
     [sendData],
   );
 
-  const onPaste = useCallback(
-    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+  const handlePaste = useCallback(
+    (e: ClipboardEvent) => {
       // Read clipboard data synchronously: `clipboardData` is not guaranteed
       // to survive an await in every browser.
-      const text = e.clipboardData.getData("text/plain");
-      const imageFiles = Array.from(e.clipboardData.items ?? [])
+      const text = e.clipboardData?.getData("text/plain") ?? "";
+      const imageFiles = Array.from(e.clipboardData?.items ?? [])
         .filter((it) => it.kind === "file")
         .map((it) => it.getAsFile())
         .filter((f): f is File => f != null && f.type.startsWith("image/"));
@@ -1462,17 +1578,50 @@ export function MobileLiveTerminal({
     [sendData, uploadPastedImage],
   );
 
-  const onCompositionStart = useCallback(() => {
+  const handleCompositionStart = useCallback(() => {
     composingRef.current = true;
   }, []);
-  const onCompositionEnd = useCallback(
-    (e: React.CompositionEvent<HTMLTextAreaElement>) => {
+  const handleCompositionEnd = useCallback(
+    (e: CompositionEvent) => {
       composingRef.current = false;
       if (e.data) sendKeys(e.data);
-      if (inputRef.current) inputRef.current.value = "";
+      if (e.currentTarget instanceof HTMLTextAreaElement) e.currentTarget.value = "";
     },
-    [sendKeys, inputRef],
+    [sendKeys],
   );
+
+  // Session selection focuses App's persistent, in-viewport keyboard input
+  // during the sidebar tap. Keep that focus on iOS and handle its real native
+  // events directly. Synthesizing a second event for the terminal textarea
+  // works in desktop tests but iOS can drop it as untrusted input.
+  useEffect(() => {
+    if (!active) return;
+    const proxy = document.querySelector<HTMLTextAreaElement>("[data-keyboard-proxy]");
+    if (!proxy) return;
+    const unregisterProxyInput = registerMobileKeyboardProxyReceiver(handleMobileKeyboardProxyInput);
+
+    proxy.addEventListener("keydown", handleKeyDownCapture, true);
+    proxy.addEventListener("keydown", handleKeyDown);
+    proxy.addEventListener("paste", handlePaste);
+    proxy.addEventListener("compositionstart", handleCompositionStart);
+    proxy.addEventListener("compositionend", handleCompositionEnd);
+    return () => {
+      unregisterProxyInput();
+      proxy.removeEventListener("keydown", handleKeyDownCapture, true);
+      proxy.removeEventListener("keydown", handleKeyDown);
+      proxy.removeEventListener("paste", handlePaste);
+      proxy.removeEventListener("compositionstart", handleCompositionStart);
+      proxy.removeEventListener("compositionend", handleCompositionEnd);
+    };
+  }, [
+    active,
+    handleKeyDownCapture,
+    handleKeyDown,
+    handleMobileKeyboardProxyInput,
+    handlePaste,
+    handleCompositionStart,
+    handleCompositionEnd,
+  ]);
 
   // The cursor is rendered inline by Row (see below): this is the visual row
   // to box, and the column within it. -1 means draw nothing.
@@ -1715,11 +1864,11 @@ export function MobileLiveTerminal({
         autoComplete="off"
         spellCheck={false}
         // Capture phase claims Alt+letter before browser accelerators.
-        onKeyDownCapture={onKeyDownCapture}
-        onKeyDown={onKeyDown}
-        onPaste={onPaste}
-        onCompositionStart={onCompositionStart}
-        onCompositionEnd={onCompositionEnd}
+        onKeyDownCapture={(e) => handleKeyDownCapture(e.nativeEvent)}
+        onKeyDown={(e) => handleKeyDown(e.nativeEvent)}
+        onPaste={(e) => handlePaste(e.nativeEvent)}
+        onCompositionStart={() => handleCompositionStart()}
+        onCompositionEnd={(e) => handleCompositionEnd(e.nativeEvent)}
       />
     </div>
   );

--- a/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
@@ -11,6 +11,7 @@ import { describe, expect, it, vi, beforeAll } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
 import { MobileLiveTerminal } from "../MobileLiveTerminal";
 import type { LiveFrame } from "../../hooks/useLiveTerminal";
+import { deliverMobileKeyboardProxyInput } from "../../lib/mobileKeyboardProxy";
 
 // Both font keys: jsdom's matchMedia reports a fine pointer, so the component
 // reads desktopFontSize; leaving it undefined made fontSize (and every px of
@@ -42,6 +43,7 @@ function frame(over: Partial<LiveFrame>): LiveFrame {
 }
 
 function renderTerm(f: LiveFrame, forwardWheel = vi.fn(), forwardButton = vi.fn(), sendData = vi.fn()) {
+  const inputRef = createRef<HTMLTextAreaElement>();
   const utils = render(
     <MobileLiveTerminal
       frame={f}
@@ -58,14 +60,14 @@ function renderTerm(f: LiveFrame, forwardWheel = vi.fn(), forwardButton = vi.fn(
       forwardButton={forwardButton}
       ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}
       clearCtrl={vi.fn()}
-      inputRef={createRef<HTMLTextAreaElement>()}
+      inputRef={inputRef}
       onInputFocusChange={vi.fn()}
       bottomAlign
       keyboardOpen={false}
     />,
   );
   const scroller = utils.container.querySelector("[data-live-terminal] > div") as HTMLElement;
-  return { ...utils, scroller, forwardWheel, forwardButton, sendData };
+  return { ...utils, scroller, forwardWheel, forwardButton, sendData, inputRef };
 }
 
 describe("MobileLiveTerminal wheel forwarding", () => {
@@ -127,6 +129,30 @@ describe("MobileLiveTerminal wheel forwarding", () => {
     expect(forwardWheel.mock.calls[0][0]).toBe(false); // up === false (wheel down)
   });
 
+  it("uses touchend's final position when iOS coalesces a quick swipe", () => {
+    const { scroller, forwardWheel } = renderTerm(frame({ altScreen: true, mouse: true, mouseSgr: true }));
+    fireEvent.touchStart(scroller, { touches: [{ clientX: 100, clientY: 300 } as Touch] });
+    fireEvent.touchEnd(scroller, {
+      touches: [],
+      changedTouches: [{ clientX: 100, clientY: 220 } as Touch],
+    });
+    expect(forwardWheel).toHaveBeenCalled();
+    expect(forwardWheel.mock.calls[0][0]).toBe(false);
+  });
+
+  it("does not turn a forward-mode swipe into a keyboard-opening click", () => {
+    const { scroller, inputRef } = renderTerm(frame({ altScreen: true, mouse: true, mouseSgr: true }));
+    const touch = (y: number) => ({ clientX: 100, clientY: y }) as Touch;
+    fireEvent.touchStart(scroller, { touches: [touch(300)] });
+    fireEvent.touchMove(scroller, { touches: [touch(220)] });
+    fireEvent.touchEnd(scroller, { touches: [] });
+    // WebKit can synthesize this click even though touch-action:none kept the
+    // browser from recognizing a native scroll. A moved touch must not focus
+    // the hidden terminal input and raise the keyboard.
+    fireEvent.click(scroller);
+    expect(document.activeElement).not.toBe(inputRef.current);
+  });
+
   it("forwards a mouse click (press then release) to a full-screen mouse app", () => {
     const { scroller, forwardButton } = renderTerm(frame({ altScreen: true, mouse: true, mouseSgr: true }));
     fireEvent.pointerDown(scroller, { pointerType: "mouse", button: 0, clientX: 10, clientY: 10 });
@@ -174,11 +200,12 @@ describe("MobileLiveTerminal wheel forwarding", () => {
 
   it("gears a touch drag up by the forward touch gain", () => {
     const { scroller, forwardWheel } = renderTerm(frame({ altScreen: true, mouse: true, mouseSgr: true }));
-    // lineH = 14 * 1.2 = 16.8px: a 34px drag is 2 notches at 1:1; the x2
-    // touch gain makes it 4.
+    // lineH = 14 * 1.2 = 16.8px: a 34px drag produces two notches with the
+    // small assist, but only the first leaves immediately. The second drains
+    // on the next animation frame to avoid a delayed remote redraw jumping.
     fireEvent.touchStart(scroller, { touches: [{ clientX: 100, clientY: 300 } as Touch] });
     fireEvent.touchMove(scroller, { touches: [{ clientX: 100, clientY: 266 } as Touch] });
-    expect(forwardWheel).toHaveBeenCalledTimes(4);
+    expect(forwardWheel).toHaveBeenCalledTimes(1);
   });
 
   it("reports touch wheels at the pane's middle row; desktop wheels keep the pointer cell", () => {
@@ -223,6 +250,23 @@ describe("MobileLiveTerminal wheel forwarding", () => {
     const scroller = utils.container.querySelector("[data-live-terminal] > div") as HTMLElement;
     fireEvent.scroll(scroller);
     expect(enterReading).not.toHaveBeenCalled();
+  });
+
+  it("relays text entered into the session-selection keyboard proxy", () => {
+    const proxy = document.createElement("textarea");
+    proxy.dataset.keyboardProxy = "";
+    document.body.append(proxy);
+    try {
+      const { sendData } = renderTerm(frame({ altScreen: true, mouse: true, mouseSgr: true }));
+      deliverMobileKeyboardProxyInput({
+        inputType: "insertText",
+        data: "hello",
+        isComposing: false,
+      });
+      expect(sendData).toHaveBeenCalledWith("hello");
+    } finally {
+      proxy.remove();
+    }
   });
 });
 

--- a/web/src/hooks/useEdgeSwipe.test.ts
+++ b/web/src/hooks/useEdgeSwipe.test.ts
@@ -124,6 +124,15 @@ describe("useEdgeSwipe anywhere mode", () => {
     dispatchTouch("touchmove", [{ clientX: 300, clientY: 100 }]); // dx = 100 > 90
     expect(onSwipe).toHaveBeenCalledTimes(1);
   });
+
+  it("leaves the left system-back edge alone", () => {
+    const onSwipe = vi.fn();
+    renderHook(() => useEdgeSwipe({ edge: "left", enabled: true, onSwipe, anywhere: true }));
+
+    dispatchTouch("touchstart", [{ clientX: 8, clientY: 100 }]);
+    dispatchTouch("touchmove", [{ clientX: 180, clientY: 100 }]);
+    expect(onSwipe).not.toHaveBeenCalled();
+  });
 });
 
 describe("useEdgeSwipe blurOnSwipe", () => {

--- a/web/src/hooks/useEdgeSwipe.ts
+++ b/web/src/hooks/useEdgeSwipe.ts
@@ -13,6 +13,9 @@ interface EdgeSwipeOptions {
 }
 
 const EDGE_PX = 24;
+// iOS reserves a strip on the left for browser / system back navigation. A
+// from-anywhere sidebar gesture must leave it alone or both handlers fire.
+const SYSTEM_BACK_GUARD_PX = 32;
 const THRESHOLD_PX = 60;
 // A from-anywhere swipe needs to travel further (and stay clearly horizontal)
 // so it doesn't trigger on a stray drag mid-screen.
@@ -41,6 +44,7 @@ export function useEdgeSwipe({ edge, enabled, onSwipe, blurOnSwipe = false, anyw
       if (!t) return;
       const inEdge = edge === "left" ? t.clientX <= EDGE_PX : t.clientX >= window.innerWidth - EDGE_PX;
       if (!anywhere && !inEdge) return;
+      if (anywhere && edge === "left" && t.clientX <= SYSTEM_BACK_GUARD_PX) return;
       tracking = true;
       startX = t.clientX;
       startY = t.clientY;

--- a/web/src/hooks/useLiveTerminal.sizeOwner.test.ts
+++ b/web/src/hooks/useLiveTerminal.sizeOwner.test.ts
@@ -105,6 +105,18 @@ describe("useLiveTerminal size-owner", () => {
     expect(socket.sent.some((m) => m instanceof Uint8Array)).toBe(true);
   });
 
+  it("queues the first typed bytes until a newly selected session connects", () => {
+    const { result } = renderHook(() => useLiveTerminal("s1"));
+    const socket = sockets[0];
+    act(() => result.current.sendData("first"));
+    expect(socket.sent).toHaveLength(0);
+
+    open(socket);
+    const typed = socket.sent.find((m): m is Uint8Array => m instanceof Uint8Array);
+    expect(typed).toBeDefined();
+    expect(new TextDecoder().decode(typed)).toBe("first");
+  });
+
   it("emits a claim message on explicit take-over", () => {
     const { result } = renderHook(() => useLiveTerminal("s1"));
     const socket = sockets[0];

--- a/web/src/hooks/useLiveTerminal.ts
+++ b/web/src/hooks/useLiveTerminal.ts
@@ -18,6 +18,9 @@ import { reportTelemetrySeen } from "../lib/api";
 
 /** Mirrors CLOSE_CODE_PTY_DEAD in src/server/pane.rs. */
 const CLOSE_CODE_PTY_DEAD = 4001;
+/** Keep a short burst typed while a newly selected session's socket opens.
+ * The cap prevents an offline tab from retaining unbounded paste data. */
+const MAX_PENDING_INPUT_BYTES = 64 * 1024;
 
 export interface LiveCursor {
   x: number;
@@ -106,6 +109,7 @@ export function useLiveTerminal(
   // "this terminal was opened", not "the socket reconnected N times". Ported
   // from the removed xterm useTerminal hook.
   const telemetrySeenRef = useRef(false);
+  const pendingInputRef = useRef<Uint8Array<ArrayBuffer>[]>([]);
 
   const storeRef = useRef<{
     snapshot: LiveTerminalState;
@@ -140,9 +144,13 @@ export function useLiveTerminal(
   };
 
   useEffect(() => {
-    if (!sessionId) return;
+    if (!sessionId) {
+      pendingInputRef.current = [];
+      return;
+    }
 
     wsRef.current?.close();
+    pendingInputRef.current = [];
     if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
     if (countdownRef.current) clearInterval(countdownRef.current);
     retryCountRef.current = 0;
@@ -208,6 +216,12 @@ export function useLiveTerminal(
         if (supportsFrameDeflate()) {
           ws.send(JSON.stringify({ type: "caps", deflate: true }));
         }
+        // A session selector opens the iOS keyboard inside its tap gesture,
+        // before this socket can finish connecting. Preserve that first burst
+        // instead of making the keyboard look live while silently dropping it.
+        const pending = pendingInputRef.current;
+        pendingInputRef.current = [];
+        for (const data of pending) ws.send(data);
       };
 
       let hasReceivedData = false;
@@ -375,7 +389,12 @@ export function useLiveTerminal(
     const ws = wsRef.current;
     if (ws?.readyState === WebSocket.OPEN) {
       ws.send(new TextEncoder().encode(data));
+      return;
     }
+    const bytes = new TextEncoder().encode(data);
+    const pending = pendingInputRef.current;
+    const used = pending.reduce((total, item) => total + item.byteLength, 0);
+    if (bytes.byteLength <= MAX_PENDING_INPUT_BYTES - used) pending.push(bytes);
   }, []);
 
   /** Explicit take-over from a read-only viewer: steal the size-owner lock

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -179,6 +179,12 @@ html {
   height: 100dvh;
   overflow: hidden;
   overscroll-behavior: none;
+  overscroll-behavior-x: none;
+  /* Claim horizontal edge drags for the app. On iOS this prevents a swipe
+     from beginning the browser-history gesture while an overlay sidebar is
+     handling the same touch. Terminal forward mode opts into `none` on its
+     own scroller, so its custom vertical gesture remains unaffected. */
+  touch-action: pan-y pinch-zoom;
   /* safe-area insets are handled by the App root, not html, to avoid
      making the document taller than the viewport (which lets iOS scroll
      the page when the keyboard opens, breaking keyboard-height math). */
@@ -199,6 +205,8 @@ body {
   background: var(--color-surface-900);
   color: var(--color-text-primary);
   overscroll-behavior: none;
+  overscroll-behavior-x: none;
+  touch-action: pan-y pinch-zoom;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/web/src/lib/mobileKeyboardProxy.test.ts
+++ b/web/src/lib/mobileKeyboardProxy.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearMobileKeyboardProxyInput,
+  deliverMobileKeyboardProxyInput,
+  registerMobileKeyboardProxyReceiver,
+} from "./mobileKeyboardProxy";
+
+afterEach(clearMobileKeyboardProxyInput);
+
+describe("mobile keyboard proxy", () => {
+  it("delivers input buffered while a session is mounting", () => {
+    deliverMobileKeyboardProxyInput({ inputType: "insertText", data: "first", isComposing: false });
+    const receive = vi.fn();
+    registerMobileKeyboardProxyReceiver(receive);
+    expect(receive).toHaveBeenCalledWith({ inputType: "insertText", data: "first", isComposing: false });
+  });
+
+  it("drops queued input at a session boundary", () => {
+    deliverMobileKeyboardProxyInput({ inputType: "insertText", data: "old", isComposing: false });
+    clearMobileKeyboardProxyInput();
+    const receive = vi.fn();
+    registerMobileKeyboardProxyReceiver(receive);
+    expect(receive).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/mobileKeyboardProxy.ts
+++ b/web/src/lib/mobileKeyboardProxy.ts
@@ -1,0 +1,38 @@
+export interface MobileKeyboardProxyInput {
+  inputType: string;
+  data: string | null;
+  isComposing: boolean;
+}
+
+type Receiver = (input: MobileKeyboardProxyInput) => void;
+
+const MAX_PENDING_INPUTS = 128;
+let receiver: Receiver | null = null;
+let pending: MobileKeyboardProxyInput[] = [];
+
+/** Send a semantic soft-keyboard edit to the active terminal, or retain it
+ * briefly while a newly selected session is still mounting. */
+export function deliverMobileKeyboardProxyInput(input: MobileKeyboardProxyInput) {
+  if (receiver) {
+    receiver(input);
+    return;
+  }
+  if (pending.length < MAX_PENDING_INPUTS) pending.push(input);
+}
+
+/** Make one live terminal the receiver for the persistent iOS keyboard. */
+export function registerMobileKeyboardProxyReceiver(next: Receiver) {
+  receiver = next;
+  const queued = pending;
+  pending = [];
+  for (const input of queued) next(input);
+  return () => {
+    if (receiver === next) receiver = null;
+  };
+}
+
+/** A session change must never send its old keystrokes to the next session. */
+export function clearMobileKeyboardProxyInput() {
+  receiver = null;
+  pending = [];
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -123,6 +123,7 @@
         "tests/mobile-fullscreen-agent-layout.spec.ts"
       ],
       "components": [
+        "web/src/App.tsx",
         "web/src/components/MobileLiveTerminal.tsx",
         "web/src/components/LiveTerminalView.tsx",
         "web/src/hooks/useLiveTerminal.ts"

--- a/web/tests/helpers/terminal-mocks.ts
+++ b/web/tests/helpers/terminal-mocks.ts
@@ -47,7 +47,7 @@ export function makeLiveFrame(opts: { rows?: number; history?: number; window?: 
 
 export async function mockTerminalApis(
   page: Page,
-  opts: { liveHistory?: number; delayLiveWindowShrinkMs?: number } = {},
+  opts: { liveHistory?: number; delayLiveWindowShrinkMs?: number; tool?: string } = {},
 ): Promise<MockHandle> {
   const liveSockets: Array<{ send: (data: string) => void }> = [];
   const handle: MockHandle = {
@@ -85,7 +85,7 @@ export async function mockTerminalApis(
             title: "pinch-test",
             project_path: "/tmp/pinch-test",
             group_path: "/tmp",
-            tool: "claude",
+            tool: opts.tool ?? "claude",
             status: "Running",
             yolo_mode: false,
             created_at: new Date().toISOString(),

--- a/web/tests/mobile-keyboard.spec.ts
+++ b/web/tests/mobile-keyboard.spec.ts
@@ -311,6 +311,35 @@ test.describe("Mobile proxy input keydown handling", () => {
     const sent = await sendKeyAndGetPtySent(page, "Backspace", "Backspace");
     expect(sent).toContain("\x7f");
   });
+
+  test("reselecting the active session preserves keyboard-proxy input", async ({ page }) => {
+    const terminal = await mockTerminalApis(page, { tool: "codex" });
+    await page.goto("/");
+    await page.waitForTimeout(300);
+    await openSession(page);
+
+    await openMobileSidebar(page);
+    await clickSidebarSession(page, "pinch-test");
+    await page.locator("[data-live-terminal]").waitFor({ state: "visible", timeout: 10_000 });
+    await page.waitForTimeout(100);
+
+    const input = await page.evaluate(() => {
+      const proxy = document.querySelector<HTMLTextAreaElement>("[data-keyboard-proxy]");
+      if (!proxy) throw new Error("keyboard proxy not found");
+      const event = new InputEvent("beforeinput", {
+        bubbles: true,
+        cancelable: true,
+        inputType: "insertText",
+        data: "reselected",
+      });
+      const delivered = proxy.dispatchEvent(event);
+      return { data: event.data, delivered, inputType: event.inputType };
+    });
+    expect(input).toEqual({ data: "reselected", delivered: false, inputType: "insertText" });
+    await expect
+      .poll(() => terminal.liveMessages.map((message) => message.toString()).join("\n"))
+      .toContain("reselected");
+  });
 });
 
 test.describe("Mobile keyboard hooks ordering", () => {

--- a/web/tests/mobile-keyboard.spec.ts
+++ b/web/tests/mobile-keyboard.spec.ts
@@ -166,6 +166,19 @@ test.describe("Mobile keyboard detection and layout", () => {
     await expect(page.getByRole("button", { name: "Open keyboard" })).toBeVisible();
   });
 
+  test("Claude terminal selection keeps the keyboard closed", async ({ page }) => {
+    await mockTerminalApis(page);
+    await page.route("**/api/sessions/*/ensure", (r) => r.fulfill({ json: { ok: true } }));
+    await page.goto("/");
+    // The fixture's terminal session uses tool: "claude". Its alternate-screen
+    // startup still drops the first iOS keyboard input, so the selection must
+    // remain usable as a monitoring view until the user opens the keyboard.
+    await seedSettings(page, { mobileFontSize: 10, autoOpenKeyboard: true });
+    await page.reload();
+    await openSession(page);
+    await expect(page.getByRole("button", { name: "Open keyboard" })).toBeVisible();
+  });
+
   test("keyboard FAB tracks input focus, not viewport heuristics", async ({ page }) => {
     await setupAndOpen(page);
 


### PR DESCRIPTION
## Description

Improves the mobile web terminal experience on iOS.

- keeps session-selection keyboard input available while a terminal mounts, and queues early edits until its live socket opens
- prevents a swipe from being treated as a keyboard-opening tap
- smooths alternate-screen scrolling by pacing forwarded wheel reports and handling coalesced touch endings
- keeps the terminal focus ring desktop-only and avoids competing with the iOS left-edge back gesture
- keeps the keyboard closed on entry for Claude terminal sessions, tracked separately in #3285, because Claude still loses its initial mobile keyboard input

Prose by Codex; decisions are njbrake.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Codex

**Any Additional AI Details you'd like to share:**

Implemented and tested by Codex with user-directed product decisions.

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved iOS terminal input during session and workspace selection.
- Preserved input entered before the terminal connection becomes ready.
- Added mobile keyboard proxy support for typing, paste, composition, deletion, and line breaks.
- Improved touch scrolling with smoother wheel pacing, momentum handling, and coalesced touch-end support.
- Prevented swipe gestures from opening the keyboard or interfering with the iOS back gesture.
- Kept Claude terminal keyboards closed on entry.
- Limited terminal focus rings to desktop devices.
- Added Playwright and unit test coverage for the new mobile behaviors.

## Benefits

- Reduces lost input during terminal startup.
- Provides smoother alternate-screen scrolling on iOS.
- Prevents accidental keyboard and navigation behavior.
- Improves confidence through focused regression coverage.

## Further enhancement

- Continue monitoring iOS device behavior for keyboard, scrolling, and gesture edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->