### PR TITLE
fix: repair push notifications and mobile session access

### DIFF
--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -17,8 +17,8 @@ Two more events, **structured view approval** and **structured view question** (
 Status notifications are suppressed when you're already looking at aoe (approvals and questions ignore this):
 
 - **Dashboard focused (per-device):** if the PWA tab is visible and focused, that device shows an in-app toast instead of an OS notification.
-- **TUI active (all devices):** if the `aoe` TUI is running on the server machine, all pushes are suppressed.
-- **Web dashboard active (all devices):** if any browser has the dashboard open and making authenticated requests, all pushes are suppressed. So using the dashboard on your laptop prevents notifications on your phone.
+- **TUI interaction (all devices):** pushes are suppressed for 30 seconds after keyboard, paste, or mouse input in an `aoe` TUI. An unattended TUI does not silence your phone.
+- **Web dashboard foregrounded (all devices):** pushes are suppressed while any dashboard reports that it is visible and focused. Background polling and a backgrounded PWA do not count.
 
 ## Stable HTTPS for persistent PWA installs (read this first if using mobile)
 

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -79,8 +79,8 @@ pub use system::{
     get_profile_settings, get_resolved_theme, get_settings, get_settings_resolved,
     get_settings_schema, get_tips, get_update_status, get_web_ui_state, list_agents, list_groups,
     list_profiles, list_sounds, list_themes, mark_tip_seen, mark_volume_ignores_globs_acknowledged,
-    mark_web_tour_seen, patch_web_ui_state, rename_profile, serve_sound_file, set_show_tips,
-    update_profile_settings, update_settings, update_theme,
+    mark_web_tour_seen, patch_web_ui_state, post_dashboard_presence, rename_profile,
+    serve_sound_file, set_show_tips, update_profile_settings, update_settings, update_theme,
 };
 pub use telemetry::{
     get_telemetry_status, post_telemetry_seen, post_telemetry_structured_interaction,

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -4,16 +4,50 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use axum::{
+    extract::{Extension, State},
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    Json,
+};
 use serde::{Deserialize, Serialize};
 
 use super::validate_profile_name;
 use super::AppState;
+use crate::server::auth::AuthenticatedTokenHash;
 use crate::server::auth::{handler_elevated, AuthenticatedSession, LoopbackTrusted};
 use crate::session::settings_schema::{
     clear_path, rewrite_plugin_sections, runtime_schema, strip_local_only, validate_patch,
     validate_patch_with, PatchRejection, Scope,
 };
+
+/// Foreground state reported by one browser dashboard. This is intentionally
+/// separate from normal API traffic: background polling must not suppress a
+/// phone's push notification.
+#[derive(Deserialize)]
+pub struct DashboardPresenceBody {
+    pub active: bool,
+}
+
+/// `POST /api/presence`. Record or clear this browser's foreground presence.
+/// The device-binding header is already attached to authenticated dashboard
+/// requests. Hashing it gives each browser an ephemeral server-side key without
+/// retaining the secret itself. Older clients without that header fall back to
+/// their authenticated token owner.
+pub async fn post_dashboard_presence(
+    State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedTokenHash>,
+    headers: HeaderMap,
+    Json(body): Json<DashboardPresenceBody>,
+) -> StatusCode {
+    let client = headers
+        .get("x-aoe-device-binding")
+        .and_then(|value| value.to_str().ok())
+        .map(crate::server::push::sha256_token)
+        .unwrap_or(owner.0);
+    state.set_web_presence(client, body.active);
+    StatusCode::NO_CONTENT
+}
 
 // --- Agents ---
 

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -854,7 +854,6 @@ pub async fn auth_middleware(
         source = ?source,
         "auth accepted via token (bootstrap)"
     );
-    state.touch_web_activity();
     if let Some(hash) = matched_token_hash {
         request
             .extensions_mut()
@@ -940,7 +939,6 @@ async fn handle_session_authenticated(
         path = %request.uri().path(),
         "auth accepted via session+binding"
     );
-    state.touch_web_activity();
 
     let owner_hash = match state.token_manager.current_token().await {
         Some(t) => super::push::sha256_token(&t),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -453,11 +453,12 @@ pub struct AppState {
     /// dashboard can tail their host-side log. In-memory; see
     /// `api::plugins::PluginJobRegistry`.
     pub plugin_jobs: Arc<crate::server::api::plugins::PluginJobRegistry>,
-    /// Epoch-millis timestamp of the most recent authenticated API request.
-    /// Updated by auth middleware on every successful auth. The push consumer
-    /// checks this to suppress notifications when someone is actively using
-    /// the web dashboard (on any device).
-    pub last_web_activity: std::sync::atomic::AtomicI64,
+    /// Per-browser foreground dashboard presence. Entries are keyed by a hash
+    /// of the device-binding secret and expire when the browser stops sending
+    /// its visibility heartbeat. Push suppression must not treat ordinary
+    /// polling or a backgrounded PWA as evidence that somebody is looking at
+    /// the dashboard.
+    pub web_presence: std::sync::Mutex<std::collections::HashMap<[u8; 32], i64>>,
     /// Packed sleep-inhibit reconciler snapshot for read-only status reporting:
     /// bit `SLEEP_INHIBIT_SNAPSHOT_ENABLED` is the
     /// `prevent_sleep_when_active` toggle as the reconciler last read it, bit
@@ -611,24 +612,25 @@ impl AppState {
             .clone()
     }
 
-    /// Record that an authenticated web client just made a request.
-    pub fn touch_web_activity(&self) {
-        self.last_web_activity.store(
-            crate::util::now_ms() as i64,
-            std::sync::atomic::Ordering::Relaxed,
-        );
+    /// Record whether one browser is currently foregrounded. Browser identity
+    /// is derived from its device-binding secret, never retained in plaintext.
+    pub fn set_web_presence(&self, client: [u8; 32], active: bool) {
+        let mut presence = self.web_presence.lock().expect("web_presence poisoned");
+        if active {
+            presence.insert(client, crate::util::now_ms() as i64);
+        } else {
+            presence.remove(&client);
+        }
     }
 
-    /// Returns true if an authenticated web request arrived within `threshold`.
+    /// Returns true if any dashboard recently reported itself visible and
+    /// focused. Stale entries are swept here, on the only read path.
     pub fn web_active_within(&self, threshold: std::time::Duration) -> bool {
-        let last = self
-            .last_web_activity
-            .load(std::sync::atomic::Ordering::Relaxed);
-        if last == 0 {
-            return false;
-        }
-        let elapsed_ms = crate::util::now_ms() as i64 - last;
-        elapsed_ms >= 0 && (elapsed_ms as u64) < threshold.as_millis() as u64
+        let now = crate::util::now_ms() as i64;
+        let max_age = threshold.as_millis() as i64;
+        let mut presence = self.web_presence.lock().expect("web_presence poisoned");
+        presence.retain(|_, last| now.saturating_sub(*last) < max_age);
+        !presence.is_empty()
     }
 }
 
@@ -1218,7 +1220,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         push: push_state,
         push_enabled,
         web_config: config.web.clone(),
-        last_web_activity: std::sync::atomic::AtomicI64::new(0),
+        web_presence: std::sync::Mutex::new(std::collections::HashMap::new()),
         sleep_inhibit_snapshot: std::sync::atomic::AtomicU8::new(0),
         telemetry_usage_seen: crate::telemetry::usage_signals::UsageSeenCounters::new(),
         telemetry_web_clients: FormFactorCounters::default(),
@@ -1650,6 +1652,9 @@ fn build_router(state: Arc<AppState>) -> Router {
     use axum::routing::{delete, get, patch, post, put};
 
     let app = Router::new()
+        // Explicit browser visibility heartbeat. Ordinary API requests do not
+        // imply the dashboard is foregrounded, so they must not suppress push.
+        .route("/api/presence", post(api::post_dashboard_presence))
         // Sessions
         .route(
             "/api/sessions",
@@ -2421,6 +2426,8 @@ const CITYHALL_MUTATION_ALLOW: &[(&str, &str)] = &[
     ("POST", "/api/telemetry/consent"),
     ("POST", "/api/telemetry/seen"),
     ("POST", "/api/telemetry/structured-interaction"),
+    // Ephemeral foreground-presence heartbeat. Does not mutate user data.
+    ("POST", "/api/presence"),
     // Per-device UI preferences / client log.
     ("PATCH", "/api/app-state/web-ui-state"),
     ("POST", "/api/app-state/dismiss-update"),
@@ -3004,6 +3011,16 @@ fn apply_tick_status_decisions(
             continue;
         }
         inst.live_status_baseline = prev.get(&inst.id).copied();
+        // A trashed row remains in storage until its retention period ends,
+        // but it is no longer a live session. Do not turn its deliberately
+        // stopped pane into a synthetic Error, and do not emit a status event
+        // that the push consumer could notify about.
+        if inst.is_trashed() {
+            if let Some(live) = inst.live_status_baseline {
+                inst.status = live;
+            }
+            continue;
+        }
         if skip_tmux_decision_for_structured(inst) {
             continue;
         }
@@ -5509,7 +5526,7 @@ pub(crate) fn apply_status_intent(
 ) {
     let Some(intent) = intent else { return };
     // Genuine in-flight terminal states: never fight them.
-    if matches!(inst.status, Status::Deleting | Status::Creating) {
+    if inst.is_trashed() || matches!(inst.status, Status::Deleting | Status::Creating) {
         return;
     }
     let target = match intent {
@@ -5813,7 +5830,6 @@ async fn drain_session_id_updates_in_state(state: &Arc<AppState>) {
 pub mod test_support {
     use super::*;
     use std::collections::HashMap;
-    use std::sync::atomic::AtomicI64;
 
     /// Build a minimal `Arc<AppState>` for helper-equivalence tests. Most
     /// fields are seeded with empty / default values; only `instances`,
@@ -5914,7 +5930,7 @@ pub mod test_support {
             push: None,
             push_enabled: false,
             web_config: crate::session::config::WebConfig::default(),
-            last_web_activity: AtomicI64::new(0),
+            web_presence: std::sync::Mutex::new(HashMap::new()),
             sleep_inhibit_snapshot: std::sync::atomic::AtomicU8::new(0),
             telemetry_usage_seen: crate::telemetry::usage_signals::UsageSeenCounters::new(),
             telemetry_web_clients: FormFactorCounters::default(),
@@ -8724,6 +8740,22 @@ mod tests {
         // The UserPromptSent that follows the respawn then drives Running.
         apply(&mut inst, StatusIntent::Set(Status::Running));
         assert_eq!(inst.status, Status::Running);
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn trailing_acp_event_cannot_change_a_trashed_session_status() {
+        let mut inst = stopped_structured_instance();
+        inst.status = Status::Running;
+        inst.trash();
+
+        apply(&mut inst, StatusIntent::Set(Status::Error));
+
+        assert_eq!(
+            inst.status,
+            Status::Running,
+            "trash teardown must not become a user-facing error transition"
+        );
     }
 
     #[cfg(feature = "serve")]

--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -528,6 +528,25 @@ fn should_fire(
     override_val.unwrap_or(global)
 }
 
+/// A status event can sit in the dwell map while a concurrent user action
+/// trashes its session. The status poller also sees a deliberately torn-down
+/// tmux pane briefly. Check the current row before delivery so neither race
+/// can turn a trashed session into a false "errored" notification.
+fn notification_matches_live_instance(
+    event: NotificationEvent,
+    instance: &crate::session::Instance,
+) -> bool {
+    if instance.is_trashed() {
+        return false;
+    }
+    matches!(
+        (event, instance.status),
+        (NotificationEvent::Waiting, Status::Waiting)
+            | (NotificationEvent::Idle, Status::Idle)
+            | (NotificationEvent::Error, Status::Error)
+    )
+}
+
 async fn fire_due_pushes(
     app_state: std::sync::Arc<super::AppState>,
     client: &reqwest::Client,
@@ -630,6 +649,9 @@ async fn fire_due_pushes(
             dwell.remove(&instance_id);
             continue;
         };
+        if !notification_matches_live_instance(event, instance) {
+            continue;
+        }
         if !should_fire(event, &web_config, Some(instance)) {
             continue;
         }
@@ -1480,6 +1502,30 @@ mod tests {
 
         // Error unaffected: per-event-type overrides don't cross-pollute.
         assert!(should_fire(NotificationEvent::Error, &web, Some(&inst)));
+    }
+
+    #[test]
+    fn notification_delivery_requires_a_current_live_matching_status() {
+        use crate::session::Instance;
+
+        let mut inst = Instance::new("t", "/tmp");
+        inst.status = Status::Waiting;
+        assert!(notification_matches_live_instance(
+            NotificationEvent::Waiting,
+            &inst
+        ));
+        assert!(!notification_matches_live_instance(
+            NotificationEvent::Error,
+            &inst
+        ));
+
+        // Trash deliberately stops the pane. A late poll result must not turn
+        // that teardown into a false error notification.
+        inst.trash();
+        assert!(!notification_matches_live_instance(
+            NotificationEvent::Waiting,
+            &inst
+        ));
     }
 
     #[test]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -698,28 +698,43 @@ pub fn collect_startup_config_warnings(profile: &str) -> Option<String> {
 // ── TUI presence ────────────────────────────────────────────────────────────
 //
 // Each running TUI process drops a `<pid>` file under `tui-presence/` and
-// refreshes its mtime on the heartbeat tick. This lets us (a) tell the push
-// consumer whether *any* TUI is watching, and (b) count how many TUIs are
-// alive so the footer can surface "another instance is watching" when two
-// `aoe` TUIs run at once (the launcher TUI isn't tmux-backed, so there's no
-// tmux client list to read). A presence file is considered live while its
-// mtime is fresh; stale ones (crash without cleanup) are swept on read.
+// refreshes its mtime on the heartbeat tick. This lets the footer surface
+// "another instance is watching" when two `aoe` TUIs run at once (the launcher
+// TUI isn't tmux-backed, so there's no tmux client list to read). A presence
+// file is considered live while its mtime is fresh; stale ones (crash without
+// cleanup) are swept on read.
+//
+// Push suppression deliberately uses a separate `tui-activity/` directory.
+// A live TUI can sit unattended while an agent needs attention, so process
+// liveness is not evidence that the user is looking at it. Activity files are
+// touched only for real keyboard, paste, and mouse input.
 
 const TUI_PRESENCE_DIR: &str = "tui-presence";
+const TUI_ACTIVITY_DIR: &str = "tui-activity";
 
-fn presence_dir() -> Option<std::path::PathBuf> {
-    get_app_dir().ok().map(|d| d.join(TUI_PRESENCE_DIR))
+fn tui_dir(name: &str) -> Option<std::path::PathBuf> {
+    get_app_dir().ok().map(|d| d.join(name))
 }
 
-fn own_presence_file() -> Option<std::path::PathBuf> {
-    presence_dir().map(|d| d.join(std::process::id().to_string()))
+fn own_tui_file(name: &str) -> Option<std::path::PathBuf> {
+    tui_dir(name).map(|d| d.join(std::process::id().to_string()))
 }
 
 /// Write (or touch) this process's presence file so the push consumer knows
 /// a TUI is running and other TUIs can count us. Called periodically from the
 /// TUI event loop.
 pub fn write_tui_heartbeat() {
-    if let Some(dir) = presence_dir() {
+    if let Some(dir) = tui_dir(TUI_PRESENCE_DIR) {
+        let _ = fs::create_dir_all(&dir);
+        let _ = fs::write(dir.join(std::process::id().to_string()), b"");
+    }
+}
+
+/// Record real user input in this TUI. Push notification suppression reads
+/// this separately from the process-liveness heartbeat, so an unattended TUI
+/// cannot permanently silence a phone's notifications.
+pub fn write_tui_activity() {
+    if let Some(dir) = tui_dir(TUI_ACTIVITY_DIR) {
         let _ = fs::create_dir_all(&dir);
         let _ = fs::write(dir.join(std::process::id().to_string()), b"");
     }
@@ -727,7 +742,10 @@ pub fn write_tui_heartbeat() {
 
 /// Remove this process's presence file on TUI exit.
 pub fn clear_tui_heartbeat() {
-    if let Some(file) = own_presence_file() {
+    if let Some(file) = own_tui_file(TUI_PRESENCE_DIR) {
+        let _ = fs::remove_file(file);
+    }
+    if let Some(file) = own_tui_file(TUI_ACTIVITY_DIR) {
         let _ = fs::remove_file(file);
     }
 }
@@ -736,7 +754,11 @@ pub fn clear_tui_heartbeat() {
 /// any stale entries left behind by crashed processes. Returns the number of
 /// live TUIs (including this process, if its file is fresh).
 pub fn count_active_tuis(threshold: Duration) -> usize {
-    let dir = match presence_dir() {
+    count_fresh_tui_files(TUI_PRESENCE_DIR, threshold)
+}
+
+fn count_fresh_tui_files(dir_name: &str, threshold: Duration) -> usize {
+    let dir = match tui_dir(dir_name) {
         Some(d) => d,
         None => return 0,
     };
@@ -761,11 +783,11 @@ pub fn count_active_tuis(threshold: Duration) -> usize {
     live
 }
 
-/// Returns true if any TUI presence file was modified within `threshold`.
-/// Used by the push consumer to suppress notifications when the user is
-/// actively watching a TUI.
+/// Returns true if any TUI received real input within `threshold`. Used by the
+/// push consumer to suppress notifications only while a user is interacting
+/// with a TUI, rather than merely while a TUI process is alive.
 pub fn is_tui_active(threshold: Duration) -> bool {
-    count_active_tuis(threshold) > 0
+    count_fresh_tui_files(TUI_ACTIVITY_DIR, threshold) > 0
 }
 
 #[cfg(test)]
@@ -899,6 +921,12 @@ mod tests {
         // Our own heartbeat counts as one live TUI.
         write_tui_heartbeat();
         assert_eq!(count_active_tuis(Duration::from_secs(30)), 1);
+        assert!(
+            !is_tui_active(Duration::from_secs(30)),
+            "a live but untouched TUI must not suppress phone notifications"
+        );
+
+        write_tui_activity();
         assert!(is_tui_active(Duration::from_secs(30)));
 
         // A second instance's presence file bumps the count to two.
@@ -908,6 +936,7 @@ mod tests {
         // A zero threshold makes every file stale; they're swept and the
         // directory is left empty.
         assert_eq!(count_active_tuis(Duration::ZERO), 0);
+        assert_eq!(count_fresh_tui_files(TUI_ACTIVITY_DIR, Duration::ZERO), 0);
         assert!(!is_tui_active(Duration::from_secs(30)));
         assert_eq!(fs::read_dir(&pdir).unwrap().count(), 0);
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -864,14 +864,14 @@ impl App {
         // never double-stop a session when run side by side.
         const SESSION_IDLE_REAP_INTERVAL: Duration = Duration::from_secs(60);
         // A presence file counts as live while its mtime is within this window.
-        // Larger than HEARTBEAT_INTERVAL so a couple of missed beats (busy loop,
+        // Larger than the liveness heartbeat so a couple of missed beats (busy loop,
         // brief stall) don't drop an instance; matches the push consumer.
         const PRESENCE_FRESH_WINDOW: Duration = Duration::from_secs(30);
 
-        // Signal that the TUI is active so the web push consumer can
-        // suppress notifications while the user is watching the dashboard, and
-        // so other TUIs can count this instance.
+        // Register this TUI as live for the footer, and as recently interacted
+        // with for short-lived push suppression.
         crate::session::write_tui_heartbeat();
+        crate::session::write_tui_activity();
         self.home.active_tui_count = crate::session::count_active_tuis(PRESENCE_FRESH_WINDOW);
 
         // Telemetry (opt-in, no-op otherwise): announce this surface on boot,
@@ -934,6 +934,7 @@ impl App {
                             if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
                                 continue;
                             }
+                            crate::session::write_tui_activity();
                             // Paste-burst detector for VoiceInk + Mosh ergonomics.
                             // Mosh strips bracketed-paste markers, so pasted
                             // dictation arrives as a stream of individual KeyEvents
@@ -1167,6 +1168,9 @@ impl App {
                             continue;
                         }
                         Some(Ok(Event::Mouse(mouse))) => {
+                            if !matches!(mouse.kind, MouseEventKind::Moved) {
+                                crate::session::write_tui_activity();
+                            }
                             // Structured preview mouse routing is deliberately
                             // thin: the transcript is ordinary preview content,
                             // so drags fall through to the home view's own
@@ -1551,6 +1555,7 @@ impl App {
                             continue;
                         }
                         Some(Ok(Event::Paste(text))) => {
+                            crate::session::write_tui_activity();
                             // An ACTIVE structured view owns pasted text (it
                             // goes to its composer, same as the full-screen
                             // view). A merely-mounted preview must NOT eat

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@ import { useMatch, useNavigate, useSearchParams } from "react-router-dom";
 import { IDLE_DECAY_WINDOW_MS, isSessionActive } from "./lib/session";
 import { diffSelectionStale } from "./lib/diffSelection";
 import { useSessions } from "./hooks/useSessions";
+import { useDashboardPresence } from "./hooks/useDashboardPresence";
 import { clearAcpCache } from "./hooks/useAcpSession";
 import { clearDraft, sweepOrphanDrafts } from "./lib/acpDrafts";
 import { AcpPrefsProvider } from "./lib/acpPrefs";
@@ -301,6 +302,7 @@ function AppContent({
   onLogout: () => void;
   onSettingsRefresh: () => Promise<void> | void;
 }) {
+  useDashboardPresence();
   // Wire the localStorage write chokepoint and pull the server-side UI-state
   // blob into localStorage. AppContent only mounts past auth, so this runs as
   // the authenticated user. Background (does NOT gate render): blocking first

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { SessionResponse } from "../lib/types";
 import { getStatusTextClass, isSessionActive } from "../lib/session";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
+import { useIsWideViewport } from "../hooks/useIsWideViewport";
 import { AOE_BRAND_MARK_COLORS, AOE_BRAND_MARK_TEXT_SHADOW } from "../lib/brandMark";
 import { TOUR_ANCHORS, type TourAnchorId } from "../lib/tourSteps";
 import { PluginCards } from "./plugin/PluginSlots";
@@ -29,6 +30,7 @@ export function Dashboard({
   canManageProjects = true,
 }: Props) {
   const idleDecayWindowMs = useIdleDecayWindowMs();
+  const isWideViewport = useIsWideViewport();
   const stats = useMemo(() => {
     const projects = new Set<string>();
     let total = 0;
@@ -53,7 +55,7 @@ export function Dashboard({
     () =>
       sessions
         .filter((session) => !session.trashed_at)
-        .sort((a, b) => recentSessionTimestamp(b).localeCompare(recentSessionTimestamp(a)) || b.id.localeCompare(a.id))
+        .sort((a, b) => recentSessionTimestamp(b) - recentSessionTimestamp(a) || b.id.localeCompare(a.id))
         .slice(0, 5),
     [sessions],
   );
@@ -136,7 +138,7 @@ export function Dashboard({
       {/* The desktop sidebar is always available, but mobile starts at this
           dashboard. Keep a small, direct route back into the sessions the user
           was just working with instead of making them open the full picker. */}
-      {recentSessions.length > 0 && (
+      {!isWideViewport && recentSessions.length > 0 && (
         <section className="md:hidden mb-4 w-full max-w-md" aria-labelledby="recent-sessions-heading">
           <h2
             id="recent-sessions-heading"
@@ -150,7 +152,7 @@ export function Dashboard({
                 key={session.id}
                 type="button"
                 onClick={() => onSelectSession(session.id)}
-                className="flex w-full items-center gap-3 border-b border-surface-700/40 px-3 py-2.5 text-left last:border-b-0 hover:bg-surface-850 active:bg-surface-800 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-brand-600"
+                className="flex w-full cursor-pointer items-center gap-3 border-b border-surface-700/40 px-3 py-2.5 text-left last:border-b-0 hover:bg-surface-850 active:bg-surface-800 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-brand-600"
               >
                 <span
                   aria-hidden="true"
@@ -250,8 +252,9 @@ export function Dashboard({
   );
 }
 
-function recentSessionTimestamp(session: SessionResponse): string {
-  return session.last_accessed_at ?? session.created_at ?? "";
+function recentSessionTimestamp(session: SessionResponse): number {
+  const timestamp = Date.parse(session.last_accessed_at ?? session.created_at);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
 }
 
 function ActionPane({

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from "react";
 import type { SessionResponse } from "../lib/types";
-import { isSessionActive } from "../lib/session";
+import { getStatusTextClass, isSessionActive } from "../lib/session";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
 import { AOE_BRAND_MARK_COLORS, AOE_BRAND_MARK_TEXT_SHADOW } from "../lib/brandMark";
 import { TOUR_ANCHORS, type TourAnchorId } from "../lib/tourSteps";
 import { PluginCards } from "./plugin/PluginSlots";
+import { StatusGlyph } from "./StatusGlyph";
 
 interface Props {
   sessions: SessionResponse[];
@@ -20,6 +21,7 @@ interface Props {
 
 export function Dashboard({
   sessions,
+  onSelectSession,
   onNewSession,
   onCloneFromUrl,
   onToggleSidebar,
@@ -47,9 +49,17 @@ export function Dashboard({
     }
     return { total, active, waiting, errors, projects: projects.size };
   }, [idleDecayWindowMs, sessions]);
+  const recentSessions = useMemo(
+    () =>
+      sessions
+        .filter((session) => !session.trashed_at)
+        .sort((a, b) => recentSessionTimestamp(b).localeCompare(recentSessionTimestamp(a)) || b.id.localeCompare(a.id))
+        .slice(0, 5),
+    [sessions],
+  );
 
   return (
-    <div className="flex-1 flex flex-col items-center justify-center bg-surface-950 px-4">
+    <div className="flex-1 flex flex-col items-center justify-start overflow-y-auto bg-surface-950 px-4 py-6 md:justify-center md:py-0">
       {/* Logo + Title */}
       <svg viewBox="0 0 128 128" className="w-12 h-12 md:w-16 md:h-16 mb-3" aria-hidden="true">
         <defs>
@@ -123,6 +133,53 @@ export function Dashboard({
         </div>
       )}
 
+      {/* The desktop sidebar is always available, but mobile starts at this
+          dashboard. Keep a small, direct route back into the sessions the user
+          was just working with instead of making them open the full picker. */}
+      {recentSessions.length > 0 && (
+        <section className="md:hidden mb-4 w-full max-w-md" aria-labelledby="recent-sessions-heading">
+          <h2
+            id="recent-sessions-heading"
+            className="mb-2 px-1 text-[11px] font-mono uppercase tracking-[0.16em] text-text-muted"
+          >
+            Recent sessions
+          </h2>
+          <div className="overflow-hidden rounded-lg border border-surface-700/40 bg-surface-900">
+            {recentSessions.map((session) => (
+              <button
+                key={session.id}
+                type="button"
+                onClick={() => onSelectSession(session.id)}
+                className="flex w-full items-center gap-3 border-b border-surface-700/40 px-3 py-2.5 text-left last:border-b-0 hover:bg-surface-850 active:bg-surface-800 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-brand-600"
+              >
+                <span
+                  aria-hidden="true"
+                  className={`shrink-0 font-mono text-sm leading-none ${getStatusTextClass(session, idleDecayWindowMs)}`}
+                >
+                  <StatusGlyph
+                    status={session.status}
+                    createdAt={session.created_at ?? null}
+                    idleEnteredAt={session.idle_entered_at}
+                    dormant={session.dormant}
+                  />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-mono text-sm font-medium text-text-primary">
+                    {session.title}
+                  </span>
+                  <span className="block truncate text-xs text-text-muted">
+                    {session.main_repo_path || session.project_path}
+                  </span>
+                </span>
+                <span aria-hidden="true" className="text-text-dim">
+                  ›
+                </span>
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+
       {/* Mobile sidebar toggle */}
       <button
         onClick={onToggleSidebar}
@@ -191,6 +248,10 @@ export function Dashboard({
       )}
     </div>
   );
+}
+
+function recentSessionTimestamp(session: SessionResponse): string {
+  return session.last_accessed_at ?? session.created_at ?? "";
 }
 
 function ActionPane({

--- a/web/src/components/__tests__/DashboardRecentSessions.test.tsx
+++ b/web/src/components/__tests__/DashboardRecentSessions.test.tsx
@@ -30,7 +30,8 @@ describe("Dashboard mobile recent sessions", () => {
     const onSelectSession = vi.fn();
     const sessions = [
       session("old", "2026-01-02T00:00:00Z"),
-      session("new", "2026-01-07T00:00:00Z"),
+      session("whole-second", "2026-01-07T00:00:00+00:00"),
+      session("new", "2026-01-07T00:00:00.500+00:00"),
       session("middle", "2026-01-04T00:00:00Z"),
       session("four", "2026-01-05T00:00:00Z"),
       session("five", "2026-01-06T00:00:00Z"),
@@ -52,10 +53,10 @@ describe("Dashboard mobile recent sessions", () => {
     expect(recent.className).toContain("md:hidden");
     expect(withinText(recent)).toEqual([
       "Session new",
+      "Session whole-second",
       "Session five",
       "Session four",
       "Session middle",
-      "Session six",
     ]);
     expect(screen.queryByText("Session old")).toBeNull();
     expect(screen.queryByText("Session trash")).toBeNull();

--- a/web/src/components/__tests__/DashboardRecentSessions.test.tsx
+++ b/web/src/components/__tests__/DashboardRecentSessions.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Dashboard } from "../Dashboard";
+import type { SessionResponse } from "../../lib/types";
+
+afterEach(cleanup);
+
+function session(id: string, lastAccessedAt: string): SessionResponse {
+  return {
+    id,
+    title: `Session ${id}`,
+    project_path: `/repo/${id}`,
+    main_repo_path: `/repo/${id}`,
+    status: "Idle",
+    created_at: "2026-01-01T00:00:00Z",
+    last_accessed_at: lastAccessedAt,
+    idle_entered_at: null,
+    dormant: false,
+    archived_at: null,
+    snoozed_until: null,
+    trashed_at: null,
+  } as SessionResponse;
+}
+
+describe("Dashboard mobile recent sessions", () => {
+  it("shows the five newest live sessions in recency order and opens the selected row", () => {
+    const onSelectSession = vi.fn();
+    const sessions = [
+      session("old", "2026-01-02T00:00:00Z"),
+      session("new", "2026-01-07T00:00:00Z"),
+      session("middle", "2026-01-04T00:00:00Z"),
+      session("four", "2026-01-05T00:00:00Z"),
+      session("five", "2026-01-06T00:00:00Z"),
+      session("six", "2026-01-03T00:00:00Z"),
+      { ...session("trash", "2026-01-08T00:00:00Z"), trashed_at: "2026-01-08T00:00:00Z" },
+    ];
+
+    const { container } = render(
+      <Dashboard
+        sessions={sessions}
+        onSelectSession={onSelectSession}
+        onNewSession={vi.fn()}
+        onCloneFromUrl={vi.fn()}
+        onToggleSidebar={vi.fn()}
+      />,
+    );
+
+    const recent = screen.getByLabelText("Recent sessions");
+    expect(recent.className).toContain("md:hidden");
+    expect(withinText(recent)).toEqual([
+      "Session new",
+      "Session five",
+      "Session four",
+      "Session middle",
+      "Session six",
+    ]);
+    expect(screen.queryByText("Session old")).toBeNull();
+    expect(screen.queryByText("Session trash")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Session new/ }));
+    expect(onSelectSession).toHaveBeenCalledWith("new");
+    expect(container.querySelectorAll("section[aria-labelledby='recent-sessions-heading']")).toHaveLength(1);
+  });
+});
+
+function withinText(section: HTMLElement): string[] {
+  return Array.from(section.querySelectorAll("button span.font-mono.text-sm.font-medium")).map((el) => el.textContent);
+}

--- a/web/src/hooks/__tests__/useIsWideViewport.test.tsx
+++ b/web/src/hooks/__tests__/useIsWideViewport.test.tsx
@@ -24,6 +24,9 @@ function stubMatchMedia(initialMatches: boolean) {
       matches = next;
       listeners.forEach((cb) => cb());
     },
+    setWithoutEvent(next: boolean) {
+      matches = next;
+    },
     listenerCount: () => listeners.size,
   };
 }
@@ -56,5 +59,15 @@ describe("useIsWideViewport", () => {
     expect(ctl.listenerCount()).toBe(1);
     unmount();
     expect(ctl.listenerCount()).toBe(0);
+  });
+
+  it("updates on a viewport resize when the browser skips the media-query event", () => {
+    const ctl = stubMatchMedia(false);
+    const { result } = renderHook(() => useIsWideViewport());
+
+    ctl.setWithoutEvent(true);
+    act(() => window.dispatchEvent(new Event("resize")));
+
+    expect(result.current).toBe(true);
   });
 });

--- a/web/src/hooks/useDashboardPresence.test.ts
+++ b/web/src/hooks/useDashboardPresence.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useDashboardPresence } from "./useDashboardPresence";
+
+describe("useDashboardPresence", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("reports foreground use, then clears presence when the dashboard is hidden", () => {
+    let visible = true;
+    vi.spyOn(document, "visibilityState", "get").mockImplementation(() => (visible ? "visible" : "hidden"));
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    const fetchMock = vi.fn().mockResolvedValue(new Response());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { unmount } = renderHook(() => useDashboardPresence());
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/presence",
+      expect.objectContaining({ body: '{"active":true}', keepalive: false }),
+    );
+
+    visible = false;
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/presence",
+      expect.objectContaining({ body: '{"active":false}', keepalive: true }),
+    );
+
+    unmount();
+  });
+});

--- a/web/src/hooks/useDashboardPresence.ts
+++ b/web/src/hooks/useDashboardPresence.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+
+const PRESENCE_INTERVAL_MS = 10_000;
+
+function isForeground(): boolean {
+  return document.visibilityState === "visible" && document.hasFocus();
+}
+
+/**
+ * Report only genuine foreground dashboard use to the server's push
+ * suppression logic. Session polling continues in a backgrounded browser,
+ * but that traffic must not make a phone miss a notification.
+ */
+export function useDashboardPresence(): void {
+  useEffect(() => {
+    const report = (active: boolean, keepalive = false) => {
+      void fetch("/api/presence", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ active }),
+        keepalive,
+      }).catch(() => {
+        // Presence is best effort. A failed heartbeat naturally expires.
+      });
+    };
+    const update = () => {
+      const active = isForeground();
+      report(active, !active);
+    };
+    const clear = () => report(false, true);
+
+    update();
+    const interval = window.setInterval(update, PRESENCE_INTERVAL_MS);
+    document.addEventListener("visibilitychange", update);
+    window.addEventListener("focus", update);
+    window.addEventListener("blur", clear);
+    window.addEventListener("pageshow", update);
+    window.addEventListener("pagehide", clear);
+
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", update);
+      window.removeEventListener("focus", update);
+      window.removeEventListener("blur", clear);
+      window.removeEventListener("pageshow", update);
+      window.removeEventListener("pagehide", clear);
+      clear();
+    };
+  }, []);
+}

--- a/web/src/hooks/useIsWideViewport.ts
+++ b/web/src/hooks/useIsWideViewport.ts
@@ -20,7 +20,11 @@ export function useIsWideViewport(): boolean {
     const mql = window.matchMedia("(min-width: 768px)");
     const onChange = () => setIsWide(mql.matches);
     mql.addEventListener?.("change", onChange);
-    return () => mql.removeEventListener?.("change", onChange);
+    window.addEventListener("resize", onChange);
+    return () => {
+      mql.removeEventListener?.("change", onChange);
+      window.removeEventListener("resize", onChange);
+    };
   }, []);
   return isWide;
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -99,6 +99,13 @@
       "components": ["web/src/components/Dashboard.tsx"]
     },
     {
+      "id": "dashboard.mobile-recent-sessions",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": ["src/components/__tests__/DashboardRecentSessions.test.tsx", "tests/dashboard.spec.ts"],
+      "components": ["web/src/components/Dashboard.tsx"]
+    },
+    {
       "id": "app-shell.dashboard-update-banner",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -261,11 +261,13 @@ test.describe("Mobile responsive", () => {
       expect.stringContaining("Session six"),
     ]);
 
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await expect(recent).not.toBeAttached();
+
+    await page.setViewportSize({ width: 375, height: 812 });
+    await expect(recent).toBeVisible();
     await recent.getByRole("button", { name: /Session new/ }).click();
     await expect(page).toHaveURL(/\/session\/new$/);
-
-    await page.setViewportSize({ width: 1280, height: 720 });
-    await expect(recent).toBeHidden();
   });
 
   test("hamburger opens sidebar overlay on mobile", async ({ page }) => {

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -208,6 +208,66 @@ test.describe("Mobile responsive", () => {
     await expect(page.getByRole("button", { name: NEW_SESSION_PANE_NAME })).toBeVisible();
   });
 
+  test("mobile home offers the five most recent sessions while desktop keeps them hidden", async ({ page }) => {
+    const sessions = [
+      ["old", "2026-01-02T00:00:00Z"],
+      ["new", "2026-01-07T00:00:00Z"],
+      ["middle", "2026-01-04T00:00:00Z"],
+      ["four", "2026-01-05T00:00:00Z"],
+      ["five", "2026-01-06T00:00:00Z"],
+      ["six", "2026-01-03T00:00:00Z"],
+      ["trash", "2026-01-08T00:00:00Z"],
+    ].map(([id, last_accessed_at]) => ({
+      id,
+      title: `Session ${id}`,
+      project_path: `/repo/${id}`,
+      artifact_dir: `/tmp/${id}`,
+      group_path: "",
+      tool: "claude",
+      status: "Idle",
+      dormant: false,
+      yolo_mode: false,
+      created_at: "2026-01-01T00:00:00Z",
+      last_accessed_at,
+      idle_entered_at: null,
+      last_error: null,
+      branch: null,
+      main_repo_path: `/repo/${id}`,
+      is_sandboxed: false,
+      scratch: false,
+      favorited: false,
+      has_managed_worktree: false,
+      has_terminal: true,
+      profile: "default",
+      cleanup_defaults: {},
+      remote_owner: null,
+      notify_on_waiting: null,
+      notify_on_idle: null,
+      notify_on_error: null,
+      trashed_at: id === "trash" ? "2026-01-08T00:00:00Z" : null,
+    }));
+    await page.route("**/api/sessions", (route) => route.fulfill({ json: { sessions, workspace_ordering: [] } }));
+
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/");
+    const recent = page.getByLabel("Recent sessions");
+    await expect(recent).toBeVisible();
+    await expect(recent.getByRole("button")).toHaveCount(5);
+    await expect(recent.getByRole("button").allTextContents()).resolves.toEqual([
+      expect.stringContaining("Session new"),
+      expect.stringContaining("Session five"),
+      expect.stringContaining("Session four"),
+      expect.stringContaining("Session middle"),
+      expect.stringContaining("Session six"),
+    ]);
+
+    await recent.getByRole("button", { name: /Session new/ }).click();
+    await expect(page).toHaveURL(/\/session\/new$/);
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await expect(recent).toBeHidden();
+  });
+
   test("hamburger opens sidebar overlay on mobile", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");


### PR DESCRIPTION
## Description

Repairs dashboard push-notification suppression by recording active foreground use per device instead of treating background polling or a running TUI as activity. It also prevents trashed sessions and stale ACP events from producing false error notifications.

Adds a mobile-only home-page list of the five most recently accessed, non-trashed sessions for quick reopening.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording, responsive behavior is covered by the mocked Playwright user-story test

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

**TUI / CLI (e2e test)**
- [x] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle

Additional validation: `cargo fmt --check`, `cargo clippy --features serve -- -D warnings`, `cargo test --features serve --lib`, focused Rust notification tests, `npm run format:check`, `npm run lint`, `npx tsc -b`, the mobile Vitest test, coverage-matrix validation, and `npx playwright test tests/dashboard.spec.ts --config=playwright.config.ts`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Codex

**Any Additional AI Details you would like to share:** Implemented and validated with Codex under maintainer direction.

- [x] I am an AI Agent filling out this form

Prose by Codex; decisions are njbrake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved push-notification accuracy by tracking real foreground activity in the dashboard and TUI.
- Excluded background polling, unattended TUI sessions, trashed sessions, and stale status events from notifications.
- Added a mobile-only list of the five most recently accessed active sessions.
- Added presence APIs, documentation updates, and Rust, Vitest, and Playwright coverage.
- Improved viewport detection during window resizing.

## Benefits

- Reduces false error notifications.
- Improves notification accuracy across devices.
- Helps mobile users reopen recent sessions quickly.
- Further enhancement could include monitoring presence-heartbeat failures and expanding mobile interaction coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->