### PR TITLE
fix(web): preserve mobile live input through ownership handshake

### DIFF
--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -171,6 +171,11 @@ enum LiveControlMessage {
     Window { lines: usize },
     #[serde(rename = "cadence")]
     Cadence { fast: bool },
+    /// Request the lock when it is vacant, without resizing or displacing a
+    /// live owner. Mobile startup uses this while the soft keyboard prevents a
+    /// safe grid measurement.
+    #[serde(rename = "claim_if_vacant")]
+    ClaimIfVacant,
     /// Explicit "take over" from a non-owner client: steal the size-owner
     /// lock even from a live holder (a user tap is intentional, unlike the
     /// passive flap the heartbeat guards against).
@@ -1028,6 +1033,28 @@ async fn handle_live_ws(
                                     nudge.notify_one();
                                 }
                             }
+                            LiveControlMessage::ClaimIfVacant => {
+                                // A keyboard-open mobile pane intentionally
+                                // postpones its first resize so it never sends
+                                // keyboard-shrunk rows to tmux. It still needs
+                                // an ownership decision before its gesture-
+                                // bound input buffer can flush. Claim only an
+                                // unheld or stale lock; unlike `claim`, this
+                                // never takes control from another viewer.
+                                let name = tmux_name.clone();
+                                let who = owner_id.clone();
+                                let owned = tokio::task::spawn_blocking(move || {
+                                    crate::tmux::Session::from_name(&name)
+                                        .claim_size_owner(&who, SIZE_OWNER_TTL)
+                                })
+                                .await
+                                .unwrap_or(false);
+                                settings.is_owner.store(owned, Ordering::Relaxed);
+                                let _ = out_tx
+                                    .send(Message::Text(size_owner_json(owned).into()))
+                                    .await;
+                                nudge.notify_one();
+                            }
                             LiveControlMessage::Claim => {
                                 // Explicit take-over: steal the lock even from
                                 // a live holder, then size the window to our
@@ -1318,6 +1345,8 @@ mod tests {
         assert!(matches!(m, LiveControlMessage::Cadence { fast: false }));
         let m: LiveControlMessage = serde_json::from_str(r#"{"type":"claim"}"#).unwrap();
         assert!(matches!(m, LiveControlMessage::Claim));
+        let m: LiveControlMessage = serde_json::from_str(r#"{"type":"claim_if_vacant"}"#).unwrap();
+        assert!(matches!(m, LiveControlMessage::ClaimIfVacant));
         let m: LiveControlMessage =
             serde_json::from_str(r#"{"type":"caps","deflate":true}"#).unwrap();
         assert!(matches!(m, LiveControlMessage::Caps { deflate: true }));

--- a/web/src/components/LiveTerminalView.tsx
+++ b/web/src/components/LiveTerminalView.tsx
@@ -90,6 +90,7 @@ export function LiveTerminalView({ session, active = true, surface = "agent", te
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const [ctrlActive, setCtrlActive] = useState(false);
   const ctrlActiveRef = useRef(false);
+  const clearCtrl = useCallback(() => setCtrlActive(false), []);
   useEffect(() => {
     ctrlActiveRef.current = ctrlActive;
   }, [ctrlActive]);
@@ -249,7 +250,7 @@ export function LiveTerminalView({ session, active = true, surface = "agent", te
         onRetry={live.manualReconnect}
       />
 
-      {live.state.connected && !live.state.isOwner && (
+      {live.state.connected && live.state.ownerKnown && !live.state.isOwner && (
         <div className="absolute left-0 right-0 top-3 flex justify-center z-20 px-3">
           <button
             type="button"
@@ -306,7 +307,7 @@ export function LiveTerminalView({ session, active = true, surface = "agent", te
           forwardWheel={live.forwardWheel}
           forwardButton={live.forwardButton}
           ctrlActiveRef={ctrlActiveRef}
-          clearCtrl={() => setCtrlActive(false)}
+          clearCtrl={clearCtrl}
           inputRef={inputRef}
           onInputFocusChange={setInputFocused}
           bottomAlign={surface === "agent"}

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -586,6 +586,11 @@ export function MobileLiveTerminal({
   // scrollTop alone. Latched, not recomputed per frame, so one paused
   // frame can't re-attach and snap the reader back down.
   const liveDetachedRef = useRef(false);
+  // Opening a keyboard explicitly returns to the agent's prompt. The scroll
+  // event caused by that programmatic move can arrive before React receives
+  // the matching `returnToLive` state update; keep that one event from
+  // immediately re-entering reading mode.
+  const forceLiveRef = useRef(false);
   // A height change observed while pinning was suppressed (finger down,
   // gesture in flight) would otherwise be consumed without effect and
   // the cursor anchor never applied; latch it until a pin actually runs.
@@ -858,6 +863,13 @@ export function MobileLiveTerminal({
     if (!el) return;
     const movingUp = el.scrollTop < onScrollLastTopRef.current - 0.5;
     onScrollLastTopRef.current = el.scrollTop;
+    if (forceLiveRef.current) {
+      if (!reading) forceLiveRef.current = false;
+      else {
+        returnToLive(rowsRef.current * LIVE_WINDOW_SCREENS);
+        return;
+      }
+    }
     if (!atBottom()) {
       enterReading(rowsRef.current);
     } else if (!touchActiveRef.current) {
@@ -874,7 +886,7 @@ export function MobileLiveTerminal({
     if (el.scrollHeight - el.clientHeight - el.scrollTop < 2 && !movingUp) {
       liveDetachedRef.current = false;
     }
-  }, [atBottom, enterReading, returnToLive, scheduleViewSync]);
+  }, [atBottom, enterReading, reading, returnToLive, scheduleViewSync]);
 
   const jumpToLatest = useCallback(() => {
     const el = scrollerRef.current;
@@ -1379,6 +1391,24 @@ export function MobileLiveTerminal({
       if (timer) clearTimeout(timer);
     };
   }, [active, charW, lineH, sendResize, setWindow, pinIfWasAtBottom, keyboardOpen]);
+
+  // Opening the soft keyboard is an intent to type, not to continue reading
+  // scrollback. Return to the live prompt before the keyboard reduces the
+  // viewport; otherwise a stale reading position can leave the agent's input
+  // box below the visible rows until the user scrolls manually.
+  useEffect(() => {
+    if (!keyboardOpen && !focused) return;
+    const id = requestAnimationFrame(() => {
+      const el = scrollerRef.current;
+      if (!el) return;
+      forceLiveRef.current = true;
+      liveDetachedRef.current = false;
+      returnToLive(rowsRef.current * LIVE_WINDOW_SCREENS);
+      el.scrollTop = liveScrollTarget(el);
+      syncView();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [focused, keyboardOpen, liveScrollTarget, returnToLive, syncView]);
 
   // Cadence: fast only while this pane is the active, visible surface AND
   // at the live edge. Reading scrollback drops to idle: the window is

--- a/web/src/components/__tests__/MobileLiveTerminal.scrollPin.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.scrollPin.test.tsx
@@ -184,4 +184,22 @@ describe("MobileLiveTerminal live-edge scroll", () => {
     stream();
     expect(scroller.scrollTop).toBe(bottom());
   });
+
+  it("keeps returning to live when the keyboard scroll races the reading-state update", async () => {
+    const enterReading = vi.fn();
+    const returnToLive = vi.fn();
+    const termProps = { ...props(), reading: true, keyboardOpen: true, enterReading, returnToLive };
+    const { container } = render(<MobileLiveTerminal {...termProps} />);
+    const scroller = container.querySelector("[data-live-terminal] > div") as HTMLElement;
+
+    // The keyboard effect sets the force-live guard before its programmatic
+    // scroll. Model a scroll event that arrives while React still supplies
+    // the old reading prop.
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    scroller.scrollTop = bottom() - 10 * LINE_H;
+    fireEvent.scroll(scroller);
+
+    expect(enterReading).not.toHaveBeenCalled();
+    expect(returnToLive).toHaveBeenCalledTimes(2);
+  });
 });

--- a/web/src/hooks/useLiveTerminal.sizeOwner.test.ts
+++ b/web/src/hooks/useLiveTerminal.sizeOwner.test.ts
@@ -72,10 +72,13 @@ afterEach(() => {
 });
 
 describe("useLiveTerminal size-owner", () => {
-  it("defaults to owner before any size_owner frame", () => {
+  it("waits for a size_owner frame before allowing input", () => {
     const { result } = renderHook(() => useLiveTerminal("s1"));
-    open(sockets[0]);
-    expect(result.current.state.isOwner).toBe(true);
+    const socket = sockets[0];
+    open(socket);
+    expect(result.current.state.isOwner).toBe(false);
+    expect(result.current.state.ownerKnown).toBe(false);
+    expect(socket.sent).toContain(JSON.stringify({ type: "claim_if_vacant" }));
   });
 
   it("becomes read-only on size_owner false and back on true", () => {
@@ -85,12 +88,13 @@ describe("useLiveTerminal size-owner", () => {
 
     deliver(socket, { type: "size_owner", is_owner: false });
     expect(result.current.state.isOwner).toBe(false);
+    expect(result.current.state.ownerKnown).toBe(true);
 
     deliver(socket, { type: "size_owner", is_owner: true });
     expect(result.current.state.isOwner).toBe(true);
   });
 
-  it("drops input while a non-owner, sends it once owner", () => {
+  it("drops input after ownership is denied instead of sending it after a later takeover", () => {
     const { result } = renderHook(() => useLiveTerminal("s1"));
     const socket = sockets[0];
     open(socket);
@@ -101,17 +105,22 @@ describe("useLiveTerminal size-owner", () => {
     expect(socket.sent).toHaveLength(0);
 
     deliver(socket, { type: "size_owner", is_owner: true });
-    act(() => result.current.sendData("x"));
-    expect(socket.sent.some((m) => m instanceof Uint8Array)).toBe(true);
+    expect(socket.sent.some((m) => m instanceof Uint8Array)).toBe(false);
+    act(() => result.current.sendData("y"));
+    const typed = socket.sent.find((m): m is Uint8Array => m instanceof Uint8Array);
+    expect(new TextDecoder().decode(typed)).toBe("y");
   });
 
-  it("queues the first typed bytes until a newly selected session connects", () => {
+  it("queues the first typed bytes until a newly selected session owns the pane", () => {
     const { result } = renderHook(() => useLiveTerminal("s1"));
     const socket = sockets[0];
     act(() => result.current.sendData("first"));
     expect(socket.sent).toHaveLength(0);
 
     open(socket);
+    expect(socket.sent.some((m) => m instanceof Uint8Array)).toBe(false);
+
+    deliver(socket, { type: "size_owner", is_owner: true });
     const typed = socket.sent.find((m): m is Uint8Array => m instanceof Uint8Array);
     expect(typed).toBeDefined();
     expect(new TextDecoder().decode(typed)).toBe("first");
@@ -136,5 +145,38 @@ describe("useLiveTerminal size-owner", () => {
     socket.sent.length = 0;
     act(() => result.current.sendResize(52, 20));
     expect(socket.sent).toContain(JSON.stringify({ type: "resize", cols: 52, rows: 20 }));
+  });
+
+  it("ignores a superseded socket closing after its replacement owns the pane", () => {
+    const { result } = renderHook(() => useLiveTerminal("s1"));
+    const oldSocket = sockets[0];
+    open(oldSocket);
+
+    oldSocket.readyState = FakeWebSocket.CLOSED;
+    act(() => window.dispatchEvent(new Event("online")));
+    const replacement = sockets[1];
+    open(replacement);
+    deliver(replacement, { type: "size_owner", is_owner: true });
+
+    act(() => oldSocket.onclose?.(new CloseEvent("close")));
+    expect(result.current.state.isOwner).toBe(true);
+    expect(result.current.state.ownerKnown).toBe(true);
+  });
+
+  it("resets ownership when the active socket closes", () => {
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useLiveTerminal("s1"));
+      const socket = sockets[0];
+      open(socket);
+      deliver(socket, { type: "size_owner", is_owner: true });
+
+      act(() => socket.onclose?.(new CloseEvent("close")));
+      expect(result.current.state.isOwner).toBe(false);
+      expect(result.current.state.ownerKnown).toBe(false);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 });

--- a/web/src/hooks/useLiveTerminal.ts
+++ b/web/src/hooks/useLiveTerminal.ts
@@ -65,11 +65,12 @@ export interface LiveTerminalState {
   /** Whether this client holds the session's size-owner lock and may
    *  resize/type. Only one client at a time owns it across every surface
    *  (web PTY attach, mobile live view, native TUI); a non-owner renders
-   *  best-effort at the owner's grid and shows a "take over" banner.
-   *  Defaults true so a lone client (and an older server that never sends
-   *  `size_owner`) behaves as owner; the server corrects it within a
-   *  round-trip of the first resize. */
+   *  best-effort at the owner's grid and shows a "take over" banner. */
   isOwner: boolean;
+  /** The server has answered this connection's initial size-owner request.
+   * Until then input is buffered and the UI must not present a takeover
+   * banner as though another viewer had been confirmed. */
+  ownerKnown: boolean;
 }
 
 const INITIAL_STATE: LiveTerminalState = {
@@ -79,7 +80,8 @@ const INITIAL_STATE: LiveTerminalState = {
   retryCountdown: 0,
   frame: null,
   reading: false,
-  isOwner: true,
+  isOwner: false,
+  ownerKnown: false,
 };
 
 export function useLiveTerminal(
@@ -110,6 +112,11 @@ export function useLiveTerminal(
   // from the removed xterm useTerminal hook.
   const telemetrySeenRef = useRef(false);
   const pendingInputRef = useRef<Uint8Array<ArrayBuffer>[]>([]);
+  // A resize and the resulting size-owner result are ordered on the socket,
+  // but React has not necessarily rendered that result when a mobile user
+  // types their first key. Hold that burst until the server confirms this
+  // connection owns the pane instead of relying on a speculative default.
+  const ownerKnownRef = useRef(false);
 
   const storeRef = useRef<{
     snapshot: LiveTerminalState;
@@ -146,11 +153,13 @@ export function useLiveTerminal(
   useEffect(() => {
     if (!sessionId) {
       pendingInputRef.current = [];
+      ownerKnownRef.current = false;
       return;
     }
 
     wsRef.current?.close();
     pendingInputRef.current = [];
+    ownerKnownRef.current = false;
     if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
     if (countdownRef.current) clearInterval(countdownRef.current);
     retryCountRef.current = 0;
@@ -168,6 +177,7 @@ export function useLiveTerminal(
     function connect() {
       if (disposed) return;
       disposeInflater();
+      ownerKnownRef.current = false;
       const proto = location.protocol === "https:" ? "wss:" : "ws:";
       // A leading-slash `wsPath` is an absolute relay path; otherwise it is a
       // per-session suffix under `/sessions/<id>/`.
@@ -190,7 +200,15 @@ export function useLiveTerminal(
       ws.binaryType = "arraybuffer";
       wsRef.current = ws;
 
+      const flushPendingInput = () => {
+        if (wsRef.current !== ws || !ownerKnownRef.current || ws.readyState !== WebSocket.OPEN) return;
+        const pending = pendingInputRef.current;
+        pendingInputRef.current = [];
+        for (const data of pending) ws.send(data);
+      };
+
       ws.onopen = () => {
+        if (wsRef.current !== ws) return;
         if (!telemetrySeenRef.current) {
           telemetrySeenRef.current = true;
           reportTelemetrySeen("web_terminal");
@@ -200,6 +218,10 @@ export function useLiveTerminal(
           connected: true,
           reconnecting: false,
         }));
+        // Negotiate ownership even if mobile keyboard occlusion has deferred
+        // the first safe resize. The server claims only a vacant lock here;
+        // an explicit takeover remains a separate user action.
+        ws.send(JSON.stringify({ type: "claim_if_vacant" }));
         // Replay the component's desired geometry so a reconnected
         // server-side handler matches the client immediately.
         const desired = desiredRef.current;
@@ -216,16 +238,14 @@ export function useLiveTerminal(
         if (supportsFrameDeflate()) {
           ws.send(JSON.stringify({ type: "caps", deflate: true }));
         }
-        // A session selector opens the iOS keyboard inside its tap gesture,
-        // before this socket can finish connecting. Preserve that first burst
-        // instead of making the keyboard look live while silently dropping it.
-        const pending = pendingInputRef.current;
-        pendingInputRef.current = [];
-        for (const data of pending) ws.send(data);
+        // Preserve the selector's gesture-bound first burst, but do not flush
+        // it yet: the resize that establishes size ownership may still be in
+        // flight, especially when a native TUI currently owns the pane.
       };
 
       let hasReceivedData = false;
       const handleMessageText = (text: string) => {
+        if (wsRef.current !== ws) return;
         let msg: {
           type?: string;
           content?: string;
@@ -245,7 +265,11 @@ export function useLiveTerminal(
         }
         if (msg.type === "size_owner") {
           const owner = msg.is_owner ?? true;
-          setState((prev) => (prev.isOwner === owner ? prev : { ...prev, isOwner: owner }));
+          ownerKnownRef.current = true;
+          setState((prev) =>
+            prev.isOwner === owner && prev.ownerKnown ? prev : { ...prev, isOwner: owner, ownerKnown: true },
+          );
+          if (owner) flushPendingInput();
           return;
         }
         if (msg.type === "clipboard") {
@@ -291,6 +315,7 @@ export function useLiveTerminal(
       };
 
       ws.onmessage = (event: MessageEvent) => {
+        if (wsRef.current !== ws) return;
         if (typeof event.data === "string") {
           handleMessageText(event.data);
         } else if (event.data instanceof ArrayBuffer) {
@@ -304,9 +329,10 @@ export function useLiveTerminal(
       };
 
       ws.onclose = (event: CloseEvent) => {
+        if (disposed || wsRef.current !== ws) return;
         disposeInflater();
-        if (disposed) return;
-        setState((prev) => ({ ...prev, connected: false }));
+        ownerKnownRef.current = false;
+        setState((prev) => ({ ...prev, connected: false, isOwner: false, ownerKnown: false }));
         if (event.code === CLOSE_CODE_PTY_DEAD) {
           retryCountRef.current = MAX_RETRIES;
         }
@@ -383,18 +409,22 @@ export function useLiveTerminal(
   }, [sessionId, wsPath, setState]);
 
   const sendData = useCallback((data: string) => {
-    // Only the size owner may type; the server drops a non-owner's input
-    // anyway, but gating here keeps the wire quiet and matches the banner.
-    if (!storeRef.current!.snapshot.isOwner) return;
     const ws = wsRef.current;
-    if (ws?.readyState === WebSocket.OPEN) {
+    const canSend = ownerKnownRef.current && storeRef.current!.snapshot.isOwner;
+    if (canSend && ws?.readyState === WebSocket.OPEN) {
       ws.send(new TextEncoder().encode(data));
       return;
     }
+    // A confirmed non-owner must not leave keystrokes queued for a later
+    // takeover. Only the short, unresolved initial handshake (or a socket
+    // reconnect while we were the owner) may retain input.
+    if (ownerKnownRef.current && !storeRef.current!.snapshot.isOwner) return;
     const bytes = new TextEncoder().encode(data);
     const pending = pendingInputRef.current;
     const used = pending.reduce((total, item) => total + item.byteLength, 0);
-    if (bytes.byteLength <= MAX_PENDING_INPUT_BYTES - used) pending.push(bytes);
+    if (bytes.byteLength <= MAX_PENDING_INPUT_BYTES - used) {
+      pending.push(bytes);
+    }
   }, []);
 
   /** Explicit take-over from a read-only viewer: steal the size-owner lock

--- a/web/tests/helpers/terminal-mocks.ts
+++ b/web/tests/helpers/terminal-mocks.ts
@@ -152,9 +152,12 @@ export async function mockTerminalApis(
       handle.liveMessages.push(Buffer.from(msg));
       try {
         const control = JSON.parse(String(msg)) as { type?: string; rows?: number; lines?: number };
-        if (control.type === "resize" && control.rows) {
+        if (control.type === "claim_if_vacant") {
+          ws.send(JSON.stringify({ type: "size_owner", is_owner: true }));
+        } else if (control.type === "resize" && control.rows) {
           rows = control.rows;
           window = Math.max(window, rows);
+          ws.send(JSON.stringify({ type: "size_owner", is_owner: true }));
           reply();
         } else if (control.type === "window" && control.lines) {
           const shrinking = control.lines < window;

--- a/web/tests/keyboard-auto-resize.spec.ts
+++ b/web/tests/keyboard-auto-resize.spec.ts
@@ -127,18 +127,27 @@ test.describe("Keyboard auto-resize (#1432)", () => {
     expect(extractResizes(handle).length, "keyboard close must not emit a tmux resize").toBe(baselineCount);
   });
 
-  test("Safari mode: the prompt cursor stays visible in the keyboard-shrunk viewport", async ({ page }) => {
+  test("Safari mode: opening the keyboard returns a scrollback reader to the visible prompt", async ({ page }) => {
     const handle = await mockTerminalApis(page);
     await page.goto("/");
     await openSession(page, handle);
     await page.waitForTimeout(1000);
 
-    // The mock screen is a fresh-agent shape: prompt + cursor on the
-    // FIRST screen row, blank rows below. With rows latched, the screen
-    // is now taller than the shrunk viewport; a literal bottom pin would
-    // show only the blank tail and scroll the prompt off the top (the
-    // original bug). The live-edge target must anchor the cursor near
-    // the viewport bottom instead.
+    // Leave the live edge first. Keyboard-open is an explicit intent to type,
+    // so it must return to the prompt rather than retain this reading position.
+    await page.evaluate(() => {
+      const el = document.querySelector<HTMLElement>("[data-live-terminal] > div");
+      if (!el) throw new Error("live terminal scroller missing");
+      el.scrollTop = 0;
+      el.dispatchEvent(new Event("scroll"));
+    });
+    await expect(page.getByRole("button", { name: "Back to live" })).toBeVisible();
+
+    await page.locator('textarea[aria-label="Live terminal input"]').focus();
+
+    // The mock screen is a fresh-agent shape: prompt + cursor on the FIRST
+    // screen row, blank rows below. With rows latched, the live target must
+    // anchor that prompt near the keyboard rather than the literal tail.
     await setKeyboard(page, { open: true, px: 320, pwa: false });
     await page.waitForTimeout(800);
 
@@ -151,6 +160,7 @@ test.describe("Keyboard auto-resize (#1432)", () => {
     expect(m, "live cursor is rendered").not.toBeNull();
     expect(m!.cursorTop, "cursor is not above the viewport").toBeGreaterThanOrEqual(m!.scrollTop - 2);
     expect(m!.cursorTop, "cursor is not below the viewport").toBeLessThanOrEqual(m!.scrollTop + m!.clientHeight);
+    await expect(page.getByRole("button", { name: "Back to live" })).toHaveCount(0);
   });
 
   test("PWA mode: dvh shrink owns the layout; no inset, no tmux resize", async ({ page }) => {


### PR DESCRIPTION
## Description

Fix mobile live-terminal input when a session is selected with the soft keyboard already open. The client now non-destructively negotiates a vacant size-owner lock before its first safe resize, buffers gesture-bound keystrokes until ownership is confirmed, and returns a scrollback reader to the live prompt when they open the keyboard.

This prevents first keystrokes from being lost or delayed until the keyboard closes, without resizing tmux to a keyboard-shrunk grid.

Prose by Codex; decisions are njbrake.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/`; the existing `terminal.mobile-live-view` coverage entry already lists this spec

**TUI / CLI (e2e test)**
- [x] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle

## Testing

- `cargo clippy --features serve -- -D warnings`
- `cargo test --features serve`
- `cd web && npm run format:check && npm run lint && npx tsc -b`
- `cd web && npx vitest run src/hooks/useLiveTerminal.sizeOwner.test.ts`
- `cd web && npx playwright test --config=playwright.config.ts tests/keyboard-auto-resize.spec.ts`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Codex (GPT-5)

**Any Additional AI Details you would like to share:** Assisted investigation, implementation, and tests.

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added safe size-owner negotiation for live terminal sessions.
- Buffered mobile input until ownership is confirmed.
- Returned the terminal to the live prompt when the keyboard opens.
- Improved ownership handling during reconnects and session changes.
- Updated WebSocket mocks and added regression coverage for ownership and keyboard behavior.

## Benefits

Mobile users can type immediately after selecting a session. The terminal avoids resizing to the keyboard-shrunk grid. Reliable ownership handling prevents lost or delayed input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->