### PR TITLE
fix(session): clear the old engine's session state on a tool swap

### DIFF
--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -826,30 +826,27 @@ pub(crate) fn compose_exclusion(
     set
 }
 
-/// Extend [`compose_exclusion`] with the sids of stopped, archived, or
-/// pane-less Claude peers in the same `project_path`, read from
-/// `sessions.json` via `Storage` for the caller's effective profile, plus the
-/// Claude conversations any same-project peer parked when an engine swap moved
-/// it to a different tool.
+/// Extend [`compose_exclusion`] with conversations same-project peers parked
+/// for `current_tool` during an engine swap. For Claude, also include the sids
+/// of stopped, archived, or pane-less peers. Persisted peers are read from
+/// `sessions.json` via `Storage` for the caller's effective profile.
 ///
-/// Used only by the Claude branch of `Instance::try_retroactive_capture`
-/// when the per-instance sidecar is absent or stale: the mtime fallback
-/// over `~/.claude/projects/<encoded-cwd>/` otherwise picks a co-located
-/// stopped peer's jsonl, since [`build_exclusion_set`] only sees live
-/// tmux peers, and the resume binds to the peer's conversation (#2355).
-///
-/// `claude_poll_fn` keeps the live-only exclusion via [`compose_exclusion`]:
-/// it runs on a hot polling path, and live peers already surface in the
-/// tmux env scan.
+/// Used by `Instance::try_retroactive_capture` and snapshotted when its poller
+/// starts. Parked conversations are no longer published in the peer's tmux
+/// environment, so [`build_exclusion_set`] cannot see them. Without this set,
+/// another session can capture the parked conversation before its owner swaps
+/// back. Claude additionally needs stopped peer protection because its mtime
+/// fallback can select a jsonl after the owning tmux pane disappears (#2355).
 ///
 /// Scope: `~/.claude/projects/` is keyed by `$HOME`, not by AoE profile,
 /// but this helper only inspects `sessions.json` for the caller's effective
 /// profile. A stopped peer in a different profile against the same host
 /// `$HOME` will not be excluded; the residual gap is narrower than #2355's
 /// trigger and is left for a follow-up.
-pub(crate) fn compose_exclusion_with_stopped_peers(
+pub(crate) fn compose_exclusion_with_persisted_peers(
     current_instance_id: &str,
     current_project_path: &str,
+    current_tool: &str,
     profile: &str,
     retroactive_capture_excludes: &HashSet<String>,
 ) -> HashSet<String> {
@@ -873,24 +870,19 @@ pub(crate) fn compose_exclusion_with_stopped_peers(
         if canonicalize_or_raw(&inst.project_path) != canonical_current {
             continue;
         }
-        // A peer that swapped away from Claude still owns the Claude
-        // conversation it parked, and intends to resume it on a swap back. It is
-        // excluded regardless of the liveness gate below and regardless of the
-        // peer's current tool: the peer's pane is running some other engine, so
-        // nothing about that pane being alive makes this conversation available.
-        // Without this the parked sid is in no exclusion set at all (it left
-        // `agent_session_id`, and the peer no longer passes the `tool` filter),
-        // and the mtime fallback would hand the peer's transcript to whichever
-        // id-less Claude session in this directory asks next.
+        // A peer that swapped away still owns the conversation it parked and
+        // intends to resume it on a swap back. It is excluded regardless of the
+        // peer's current tool or liveness: its pane is running another engine,
+        // so the live tmux ownership scan cannot discover this id.
         if let Some(parked) = inst
             .prior_tool_session_ids
-            .get("claude")
+            .get(current_tool)
             .and_then(|p| p.agent_session_id.as_deref())
             .filter(|s| !s.is_empty())
         {
             set.insert(parked.to_string());
         }
-        if inst.tool != "claude" {
+        if current_tool != "claude" || inst.tool != "claude" {
             continue;
         }
         let should_exclude = matches!(inst.status, crate::session::Status::Stopped)

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -828,7 +828,9 @@ pub(crate) fn compose_exclusion(
 
 /// Extend [`compose_exclusion`] with the sids of stopped, archived, or
 /// pane-less Claude peers in the same `project_path`, read from
-/// `sessions.json` via `Storage` for the caller's effective profile.
+/// `sessions.json` via `Storage` for the caller's effective profile, plus the
+/// Claude conversations any same-project peer parked when an engine swap moved
+/// it to a different tool.
 ///
 /// Used only by the Claude branch of `Instance::try_retroactive_capture`
 /// when the per-instance sidecar is absent or stale: the mtime fallback
@@ -868,10 +870,27 @@ pub(crate) fn compose_exclusion_with_stopped_peers(
         if inst.id == current_instance_id {
             continue;
         }
-        if inst.tool != "claude" {
+        if canonicalize_or_raw(&inst.project_path) != canonical_current {
             continue;
         }
-        if canonicalize_or_raw(&inst.project_path) != canonical_current {
+        // A peer that swapped away from Claude still owns the Claude
+        // conversation it parked, and intends to resume it on a swap back. It is
+        // excluded regardless of the liveness gate below and regardless of the
+        // peer's current tool: the peer's pane is running some other engine, so
+        // nothing about that pane being alive makes this conversation available.
+        // Without this the parked sid is in no exclusion set at all (it left
+        // `agent_session_id`, and the peer no longer passes the `tool` filter),
+        // and the mtime fallback would hand the peer's transcript to whichever
+        // id-less Claude session in this directory asks next.
+        if let Some(parked) = inst
+            .prior_tool_session_ids
+            .get("claude")
+            .and_then(|p| p.agent_session_id.as_deref())
+            .filter(|s| !s.is_empty())
+        {
+            set.insert(parked.to_string());
+        }
+        if inst.tool != "claude" {
             continue;
         }
         let should_exclude = matches!(inst.status, crate::session::Status::Stopped)

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -11402,6 +11402,68 @@ mod tests {
                 assert_eq!(inst.agent_session_id.as_deref(), Some(mine));
             }
 
+            // Companion to the above for the engine swap: the peer is not a
+            // Claude session any more (it swapped to pi), so it no longer
+            // passes the `tool` filter in
+            // `compose_exclusion_with_stopped_peers`, and its Claude sid moved
+            // out of `agent_session_id` into `prior_tool_session_ids`. Unless
+            // parked ids are excluded too, the peer's Claude transcript is in no
+            // exclusion set at all and the mtime fallback hands it to this
+            // instance, which both steals the conversation the peer intends to
+            // resume on a swap back and leaks its context.
+            #[test]
+            #[serial]
+            fn mtime_fallback_skips_peer_sid_parked_by_a_tool_swap() {
+                let temp = tempdir().unwrap();
+                let _guard = claude_home_guard(&temp);
+
+                let project_path = "/tmp/aoe-test-parked-peer";
+                let claude_dir = temp
+                    .path()
+                    .join(".claude")
+                    .join("projects")
+                    .join(encode_claude_project_path(project_path));
+                fs::create_dir_all(&claude_dir).unwrap();
+
+                let mine = "55555555-5555-4555-8555-555555555555";
+                let parked = "66666666-6666-4666-8666-666666666666";
+                let now = SystemTime::now();
+                write_jsonl_with_mtime(
+                    &claude_dir.join(format!("{mine}.jsonl")),
+                    now - Duration::from_secs(120),
+                );
+                write_jsonl_with_mtime(
+                    &claude_dir.join(format!("{parked}.jsonl")),
+                    now - Duration::from_secs(5),
+                );
+
+                let profile = "verify-parked-peer";
+                let mut peer_inst = Instance::new("swapped-peer-id", project_path);
+                peer_inst.source_profile = profile.to_string();
+                peer_inst.tool = "claude".to_string();
+                peer_inst.agent_session_id = Some(parked.to_string());
+                // The peer is mid-life and running: only its Claude
+                // conversation is parked, not the row.
+                peer_inst.status = Status::Running;
+                peer_inst.swap_tool("pi");
+                assert_eq!(peer_inst.tool, "pi");
+                super::seed_disk_for_sidecar_test(profile, &peer_inst);
+
+                let mut inst = Instance::new("verify-parked", project_path);
+                inst.source_profile = profile.to_string();
+                inst.tool = "claude".to_string();
+                inst.agent_session_id = Some(mine.to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, _is_existing) = inst.acquire_session_id();
+                assert_eq!(
+                    sid.as_deref(),
+                    Some(mine),
+                    "the parked peer's fresher transcript must not be adopted"
+                );
+                assert_eq!(inst.agent_session_id.as_deref(), Some(mine));
+            }
+
             // Companion to the above for #2858: the stopped peer's stored
             // `project_path` is an UNNORMALIZED spelling of the same
             // directory (`<parent>/decoy/../wt` vs `<parent>/wt`), as the

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1780,6 +1780,17 @@ impl Instance {
         // Effort vocabularies are adapter-specific, so the old agent's pick is
         // meaningless to the new one; it falls back to the new agent's default.
         self.acp_effort = None;
+        // Same for the pinned model: `claude-opus-4-7` means nothing to codex,
+        // and it is re-injected on every spawn, so it has to go too.
+        self.agent_model = None;
+        // `acp_mode_id` deliberately stays. It is the session's approval
+        // posture, and clearing it does not fall back to "default": the spawn
+        // path's mode gate is `acp_mode_id.is_some() || yolo_mode`, whose
+        // `None` arm resolves the adapter's *bypass* mode id, so dropping an
+        // explicit restrictive mode from a `yolo_mode` row would silently
+        // escalate the new agent to auto-approve. An unrecognized mode id is a
+        // warn-and-continue no-op instead, which is the safe failure. The
+        // structured-view agent switch passes it through for the same reason.
         self.import_pending = None;
         self.fork_pending = None;
         // The pinned structured-view agent belongs to the old tool; clearing it

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1755,6 +1755,39 @@ impl Instance {
         self.extra_args = src.extra_args.clone();
     }
 
+    /// Drop every piece of session state that is scoped to the agent this
+    /// instance is moving *away* from, for a post-creation `tool` swap (the
+    /// TUI restart dialog's engine swap).
+    ///
+    /// Session ids live in per-agent namespaces: a Claude UUID means nothing
+    /// to codex or gemini, but `is_valid_session_id` accepts any shape, so a
+    /// carried-over sid makes the next launch emit `--resume <foreign-sid>`
+    /// and the new engine starts by failing to resume. #3077 made the swap
+    /// reach disk, which is what exposed this. Mirrors the state the
+    /// structured-view agent switch clears (`POST /api/acp/:id/switch`).
+    ///
+    /// Callers must persist the result themselves: `merge_from_tui`
+    /// deliberately does not sync these fields (the capture pollers own
+    /// `agent_session_id` through CAS writes), so an in-memory-only reset is
+    /// reverted by `reconcile_from_disk` on the next launch.
+    pub(crate) fn reset_agent_session_for_tool_swap(&mut self) {
+        self.agent_session_id = None;
+        self.resume_probe_failed_sid = None;
+        // A pin/clear/fork directive names an id in the old agent's namespace,
+        // so it cannot survive the swap either.
+        self.resume_intent = ResumeIntent::Default;
+        self.acp_session_id = None;
+        // Effort vocabularies are adapter-specific, so the old agent's pick is
+        // meaningless to the new one; it falls back to the new agent's default.
+        self.acp_effort = None;
+        self.import_pending = None;
+        self.fork_pending = None;
+        // The pinned structured-view agent belongs to the old tool; clearing it
+        // lets the spawn path pick the new tool's default agent instead of
+        // silently keeping the old backend alive across the swap.
+        self.agent_name = None;
+    }
+
     /// Apply a passively-detected status transition to a disk row. Touches
     /// the same three fields as [`Self::merge_from_tui`] (`status`,
     /// `idle_entered_at`, `last_accessed_at`); the real distinction is the

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1,6 +1,6 @@
 //! Session instance definition and operations
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -464,6 +464,28 @@ where
     Ok(opt.filter(|s| !s.trim().is_empty()))
 }
 
+/// The session ids one agent left behind when an engine swap moved a row to a
+/// different `tool`, parked in `Instance::prior_tool_session_ids` under that
+/// agent's name so a swap back can resume where it left off. Both fields are
+/// per-agent namespaces, which is exactly why they cannot travel with the row.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct PriorToolSession {
+    /// The tmux-path conversation id, as `Instance::agent_session_id`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) agent_session_id: Option<String>,
+    /// The structured-view conversation id, as `Instance::acp_session_id`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) acp_session_id: Option<String>,
+}
+
+impl PriorToolSession {
+    /// Nothing worth parking: an agent that never got a conversation id (never
+    /// launched, or `/clear`ed) leaves no entry behind.
+    fn is_empty(&self) -> bool {
+        self.agent_session_id.is_none() && self.acp_session_id.is_none()
+    }
+}
+
 /// User intent gating `acquire_session_id`, persisted independently of the
 /// poller's observation in `agent_session_id`. CLI/REST/TUI write intent;
 /// the poller writes observation. Disjoint writers, no race.
@@ -829,6 +851,20 @@ pub struct Instance {
         deserialize_with = "deserialize_session_id"
     )]
     pub agent_session_id: Option<String>,
+
+    /// Session ids this row used under a *previous* `tool`, keyed by that
+    /// tool's name, so an engine swap back (`claude` -> `pi` -> `claude`)
+    /// resumes the original conversation instead of starting a third one.
+    /// Written and read only by [`Self::swap_tool`], which parks the outgoing
+    /// agent's ids and consumes the incoming agent's entry, so the map holds at
+    /// most one entry per tool the row has ever run under.
+    ///
+    /// `resume_probe_failed_sid` is deliberately not parked with them: a
+    /// restored sid is worth one fresh probe (the conversation may well still
+    /// be there), and if it is gone the resume-fallback cascade already starts
+    /// a new session instead. Additive: absent in older rows, no migration.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub(crate) prior_tool_session_ids: HashMap<String, PriorToolSession>,
 
     /// Durable loop-breaker for ambiguous resume-probe failures. When this
     /// equals `agent_session_id`, startup recovery skips automatic resume so a
@@ -1440,6 +1476,7 @@ impl Instance {
             #[cfg(feature = "serve")]
             pending_initial_turn_attachments: Vec::new(),
             acp_mode_id: None,
+            prior_tool_session_ids: HashMap::new(),
             scratch: false,
             worktree_info: None,
             workspace_info: None,
@@ -1755,28 +1792,53 @@ impl Instance {
         self.extra_args = src.extra_args.clone();
     }
 
-    /// Drop every piece of session state that is scoped to the agent this
-    /// instance is moving *away* from, for a post-creation `tool` swap (the
-    /// TUI restart dialog's engine swap).
+    /// Move this row to a different `tool` (the TUI restart dialog's engine
+    /// swap), parking the outgoing agent's session ids and picking up the
+    /// incoming agent's, if it has been here before.
     ///
     /// Session ids live in per-agent namespaces: a Claude UUID means nothing
     /// to codex or gemini, but `is_valid_session_id` accepts any shape, so a
     /// carried-over sid makes the next launch emit `--resume <foreign-sid>`
     /// and the new engine starts by failing to resume. #3077 made the swap
-    /// reach disk, which is what exposed this. Mirrors the state the
-    /// structured-view agent switch clears (`POST /api/acp/:id/switch`).
+    /// reach disk, which is what exposed this. The rest of what this clears
+    /// mirrors the structured-view agent switch (`POST /api/acp/:id/switch`).
+    ///
+    /// A no-op when `new_tool` is the current tool, so a caller may apply it
+    /// to a disk row and an in-memory row independently without the second
+    /// call double-stashing.
     ///
     /// Callers must persist the result themselves: `merge_from_tui`
     /// deliberately does not sync these fields (the capture pollers own
-    /// `agent_session_id` through CAS writes), so an in-memory-only reset is
+    /// `agent_session_id` through CAS writes), so an in-memory-only swap is
     /// reverted by `reconcile_from_disk` on the next launch.
-    pub(crate) fn reset_agent_session_for_tool_swap(&mut self) {
-        self.agent_session_id = None;
+    pub(crate) fn swap_tool(&mut self, new_tool: &str) {
+        if new_tool == self.tool {
+            return;
+        }
+        // Park the outgoing agent's conversation under its own name so a swap
+        // back to it resumes there instead of starting a third conversation.
+        let outgoing = PriorToolSession {
+            agent_session_id: self.agent_session_id.take(),
+            acp_session_id: self.acp_session_id.take(),
+        };
+        if !outgoing.is_empty() {
+            self.prior_tool_session_ids
+                .insert(self.tool.clone(), outgoing);
+        }
+        self.tool = new_tool.to_string();
+        // Consumed, not copied: the row owns exactly one live conversation per
+        // agent, and leaving the entry behind would let a later swap restore an
+        // id this session has since replaced.
+        let restored = self
+            .prior_tool_session_ids
+            .remove(new_tool)
+            .unwrap_or_default();
+        self.agent_session_id = restored.agent_session_id;
+        self.acp_session_id = restored.acp_session_id;
         self.resume_probe_failed_sid = None;
         // A pin/clear/fork directive names an id in the old agent's namespace,
         // so it cannot survive the swap either.
         self.resume_intent = ResumeIntent::Default;
-        self.acp_session_id = None;
         // Effort vocabularies are adapter-specific, so the old agent's pick is
         // meaningless to the new one; it falls back to the new agent's default.
         self.acp_effort = None;
@@ -9012,20 +9074,65 @@ mod tests {
         assert_eq!(inst.agent_session_id, deserialized.agent_session_id);
     }
 
-    // Test: agent switch clears session ID
+    /// An engine swap parks the outgoing agent's conversation ids under its own
+    /// name and picks the incoming agent's back up, so claude -> pi -> claude
+    /// lands in the original Claude conversation instead of a third one. The
+    /// per-agent selectors go; the approval posture stays (clearing it resolves
+    /// the adapter's bypass mode on a `yolo_mode` row).
+    ///
+    /// Replaces a test that hand-assigned `agent_session_id = None` and then
+    /// asserted it was None, which could not fail.
     #[test]
-    fn test_agent_switch_clears_session_id() {
+    fn swap_tool_parks_and_restores_per_tool_session_ids() {
         let mut inst = Instance::new("Test", "/home/user/project");
         inst.tool = "claude".to_string();
         inst.agent_session_id = Some("claude-session-123".to_string());
+        inst.acp_session_id = Some("acp-claude-1".to_string());
+        inst.resume_probe_failed_sid = Some("claude-session-123".to_string());
+        inst.acp_effort = Some("high".to_string());
+        inst.agent_model = Some("claude-opus-4-7".to_string());
+        inst.agent_name = Some("claude-code".to_string());
+        inst.acp_mode_id = Some("plan".to_string());
 
-        // Simulate agent switch by clearing session ID
-        inst.agent_session_id = None;
-        inst.tool = "opencode".to_string();
+        inst.swap_tool("pi");
+        assert_eq!(inst.tool, "pi");
+        assert_eq!(
+            inst.agent_session_id, None,
+            "a Claude sid would make pi launch with --resume <foreign-sid>"
+        );
+        assert_eq!(inst.acp_session_id, None);
+        assert_eq!(inst.acp_effort, None);
+        assert_eq!(inst.agent_model, None);
+        assert_eq!(inst.agent_name, None);
+        assert_eq!(inst.resume_probe_failed_sid, None);
+        assert_eq!(inst.acp_mode_id.as_deref(), Some("plan"));
 
-        // Session ID should be None after switch
-        assert!(inst.agent_session_id.is_none());
-        assert_eq!(inst.tool, "opencode");
+        // pi runs and captures a sid of its own, then the user swaps back.
+        inst.agent_session_id = Some("pi-session-9".to_string());
+        inst.swap_tool("claude");
+        assert_eq!(
+            inst.agent_session_id.as_deref(),
+            Some("claude-session-123"),
+            "swapping back must resume the parked Claude conversation"
+        );
+        assert_eq!(inst.acp_session_id.as_deref(), Some("acp-claude-1"));
+        assert_eq!(
+            inst.prior_tool_session_ids["pi"]
+                .agent_session_id
+                .as_deref(),
+            Some("pi-session-9"),
+            "pi's conversation is the parked one now"
+        );
+        assert!(
+            !inst.prior_tool_session_ids.contains_key("claude"),
+            "a restored entry is consumed, so a later swap cannot resurrect it"
+        );
+
+        // Same-tool call is a no-op: the caller applies the swap to the disk row
+        // and the in-memory row independently, and the second must not re-park.
+        inst.swap_tool("claude");
+        assert_eq!(inst.agent_session_id.as_deref(), Some("claude-session-123"));
+        assert!(!inst.prior_tool_session_ids.contains_key("claude"));
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2616,31 +2616,27 @@ impl Instance {
         !self.has_command_override() && self.profile_host_environment().is_empty()
     }
 
-    /// Full set of session IDs that retroactive capture must skip for THIS
-    /// instance: the live tmux-discovered set plus any sids the
-    /// resume-fallback cascade has explicitly cleared. Composed of
-    /// `build_exclusion_set` (live tmux scan) and
-    /// `self.retroactive_capture_excludes` (cascade memory) so the caller
-    /// gets the complete picture in one call.
+    /// Full set of session IDs capture must skip for this instance: live tmux
+    /// ownership, cascade-cleared ids, and conversations same-project peers
+    /// parked while running another tool.
     fn retroactive_capture_exclusion_set(&self) -> HashSet<String> {
-        super::capture::compose_exclusion(&self.id, &self.retroactive_capture_excludes)
+        super::capture::compose_exclusion_with_persisted_peers(
+            &self.id,
+            &self.project_path,
+            &self.tool,
+            &self.effective_profile(),
+            &self.retroactive_capture_excludes,
+        )
     }
 
     pub(crate) fn try_retroactive_capture(&self) -> Option<String> {
         let result: Option<String> = match self.tool.as_str() {
             "claude" => {
-                // Claude-only: extend the live-tmux exclusion with stopped,
-                // archived, or pane-less peer sids read from sessions.json so
+                // Claude additionally extends the common live and parked-id
+                // exclusion with stopped, archived, or pane-less peer sids so
                 // the mtime fallback skips peers whose jsonl outlived their
-                // tmux session (#2355). Other tool arms call
-                // `retroactive_capture_exclusion_set()` directly for the
-                // live-only set.
-                let exclusion = super::capture::compose_exclusion_with_stopped_peers(
-                    &self.id,
-                    &self.project_path,
-                    &self.effective_profile(),
-                    &self.retroactive_capture_excludes,
-                );
+                // tmux session (#2355).
+                let exclusion = self.retroactive_capture_exclusion_set();
                 if self.is_sandboxed() {
                     let container_name = self.sandbox_info.as_ref()?.container_name.clone();
                     capture_claude_session_id_in_container(
@@ -4532,11 +4528,11 @@ impl Instance {
         let mut poller = SessionPoller::new(tmux_session_name.clone());
         let instance_id = self.id.clone();
         let initial_known = self.agent_session_id.clone();
-        // Snapshot per-instance excludes at poller-spawn time. Explicit sid
-        // invalidation inserts into `retroactive_capture_excludes` before any
-        // fresh poller starts, so the first immediate poll won't re-import the
-        // invalidated sid.
-        let extra_excludes = self.retroactive_capture_excludes.clone();
+        // Snapshot persisted peer ownership and per-instance excludes at
+        // poller-spawn time. This keeps storage reads off the hot polling path
+        // while preventing the poller from adopting a conversation another row
+        // parked during a tool swap.
+        let extra_excludes = self.retroactive_capture_exclusion_set();
 
         let poll_fn: Box<dyn Fn() -> Option<String> + Send + 'static> = match tool {
             "claude" => {
@@ -11354,7 +11350,7 @@ mod tests {
             // #2355: when a co-located stopped peer leaves a fresher jsonl in
             // the shared `~/.claude/projects/<encoded-cwd>/` dir, the mtime
             // fallback must skip the peer's sid. `build_exclusion_set` only
-            // sees live tmux peers; `compose_exclusion_with_stopped_peers`
+            // sees live tmux peers; `compose_exclusion_with_persisted_peers`
             // adds the stopped peer's sid from `sessions.json` so this
             // instance's own (older) jsonl wins.
             #[test]
@@ -11405,7 +11401,7 @@ mod tests {
             // Companion to the above for the engine swap: the peer is not a
             // Claude session any more (it swapped to pi), so it no longer
             // passes the `tool` filter in
-            // `compose_exclusion_with_stopped_peers`, and its Claude sid moved
+            // `compose_exclusion_with_persisted_peers`, and its Claude sid moved
             // out of `agent_session_id` into `prior_tool_session_ids`. Unless
             // parked ids are excluded too, the peer's Claude transcript is in no
             // exclusion set at all and the mtime fallback hands it to this
@@ -11446,8 +11442,22 @@ mod tests {
                 // conversation is parked, not the row.
                 peer_inst.status = Status::Running;
                 peer_inst.swap_tool("pi");
-                assert_eq!(peer_inst.tool, "pi");
+                peer_inst.agent_session_id = Some("pi-session-parked".to_string());
+                peer_inst.swap_tool("codex");
+                assert_eq!(peer_inst.tool, "codex");
                 super::seed_disk_for_sidecar_test(profile, &peer_inst);
+
+                let pi_exclusion = crate::session::capture::compose_exclusion_with_persisted_peers(
+                    "other-pi-instance",
+                    project_path,
+                    "pi",
+                    profile,
+                    &std::collections::HashSet::new(),
+                );
+                assert!(
+                    pi_exclusion.contains("pi-session-parked"),
+                    "parked ids must be protected for every resumable tool"
+                );
 
                 let mut inst = Instance::new("verify-parked", project_path);
                 inst.source_profile = profile.to_string();
@@ -11469,7 +11479,7 @@ mod tests {
             // directory (`<parent>/decoy/../wt` vs `<parent>/wt`), as the
             // default `../{repo-name}-worktrees/{branch}` template used to
             // produce. A raw string comparison in
-            // `compose_exclusion_with_stopped_peers` drops the peer from the
+            // `compose_exclusion_with_persisted_peers` drops the peer from the
             // exclusion and re-opens the #2355 steal; the canonicalized
             // comparison must keep it.
             #[test]
@@ -11537,7 +11547,7 @@ mod tests {
 
             // Companion to the above: same setup but the peer is archived
             // instead of stopped, exercising the `is_archived()` branch of
-            // `compose_exclusion_with_stopped_peers`.
+            // `compose_exclusion_with_persisted_peers`.
             #[test]
             #[serial]
             fn mtime_fallback_skips_archived_peer_sid() {

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -422,14 +422,13 @@ impl HomeView {
                 .map(|i| i.tool.clone())
                 .unwrap_or_default();
             if target_tool != current_tool {
-                self.mutate_instance(&id, |inst| {
-                    inst.tool = target_tool.to_string();
-                    // The old engine's session id (and the rest of its
-                    // per-agent session state) must not follow the row to the
-                    // new engine; see `reset_agent_session_for_tool_swap`.
-                    inst.reset_agent_session_for_tool_swap();
-                });
-                self.persist_tool_swap_reset(&id);
+                // `swap_tool` (not a plain `tool` assignment) because the old
+                // engine's session id must not follow the row to the new
+                // engine: it parks the outgoing ids under the outgoing tool and
+                // restores the incoming tool's, if the row has been there
+                // before.
+                self.mutate_instance(&id, |inst| inst.swap_tool(target_tool));
+                self.persist_tool_swap(&id, target_tool);
             }
         }
 
@@ -538,18 +537,23 @@ impl HomeView {
         Ok(())
     }
 
-    /// Land an engine swap's session reset on the disk row.
+    /// Land an engine swap's session bookkeeping on the disk row.
     ///
     /// `save()` syncs `tool`/`command`/`extra_args` through `merge_from_tui`
     /// but deliberately leaves `agent_session_id` and friends to their CAS
-    /// writers, so the reset needs its own write: without it,
+    /// writers, so the swap needs its own write: without it,
     /// `reconcile_from_disk` restores the old engine's sid on the launch that
     /// follows and the new engine spawns with `--resume <foreign-sid>`.
+    ///
+    /// `swap_tool` runs against the disk row rather than copying the in-memory
+    /// result over it, because the capture pollers may have written a fresher
+    /// sid to disk than this snapshot carries; parking whatever disk holds is
+    /// what makes the swap-back restore the real conversation.
     ///
     /// Best-effort. A failed write leaves the stale sid on disk (the restart
     /// still runs, and its resume-probe fallback recovers by starting fresh),
     /// so it is logged rather than surfaced as a restart failure.
-    fn persist_tool_swap_reset(&self, id: &str) {
+    fn persist_tool_swap(&self, id: &str, new_tool: &str) {
         let Some(profile) = self.instances.get(id).map(|i| i.source_profile.clone()) else {
             return;
         };
@@ -558,22 +562,23 @@ impl HomeView {
                 target: "tui.home",
                 profile = %profile,
                 id = %id,
-                "persist_tool_swap_reset: no storage registered for profile; \
+                "persist_tool_swap: no storage registered for profile; \
                  the old engine's session id stays on disk"
             );
             return;
         };
         let id_owned = id.to_string();
+        let new_tool = new_tool.to_string();
         if let Err(e) = storage.update(|instances, _groups| {
             if let Some(disk) = instances.iter_mut().find(|i| i.id == id_owned) {
-                disk.reset_agent_session_for_tool_swap();
+                disk.swap_tool(&new_tool);
             }
             Ok(())
         }) {
             tracing::error!(
                 target: "tui.home",
                 id = %id,
-                "persist_tool_swap_reset: failed to clear the old engine's session state: {e}"
+                "persist_tool_swap: failed to move the old engine's session state aside: {e}"
             );
         }
     }

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -424,7 +424,12 @@ impl HomeView {
             if target_tool != current_tool {
                 self.mutate_instance(&id, |inst| {
                     inst.tool = target_tool.to_string();
+                    // The old engine's session id (and the rest of its
+                    // per-agent session state) must not follow the row to the
+                    // new engine; see `reset_agent_session_for_tool_swap`.
+                    inst.reset_agent_session_for_tool_swap();
                 });
+                self.persist_tool_swap_reset(&id);
             }
         }
 
@@ -531,6 +536,46 @@ impl HomeView {
             wake_message,
         });
         Ok(())
+    }
+
+    /// Land an engine swap's session reset on the disk row.
+    ///
+    /// `save()` syncs `tool`/`command`/`extra_args` through `merge_from_tui`
+    /// but deliberately leaves `agent_session_id` and friends to their CAS
+    /// writers, so the reset needs its own write: without it,
+    /// `reconcile_from_disk` restores the old engine's sid on the launch that
+    /// follows and the new engine spawns with `--resume <foreign-sid>`.
+    ///
+    /// Best-effort. A failed write leaves the stale sid on disk (the restart
+    /// still runs, and its resume-probe fallback recovers by starting fresh),
+    /// so it is logged rather than surfaced as a restart failure.
+    fn persist_tool_swap_reset(&self, id: &str) {
+        let Some(profile) = self.instances.get(id).map(|i| i.source_profile.clone()) else {
+            return;
+        };
+        let Some(storage) = self.storages.get(&profile) else {
+            tracing::warn!(
+                target: "tui.home",
+                profile = %profile,
+                id = %id,
+                "persist_tool_swap_reset: no storage registered for profile; \
+                 the old engine's session id stays on disk"
+            );
+            return;
+        };
+        let id_owned = id.to_string();
+        if let Err(e) = storage.update(|instances, _groups| {
+            if let Some(disk) = instances.iter_mut().find(|i| i.id == id_owned) {
+                disk.reset_agent_session_for_tool_swap();
+            }
+            Ok(())
+        }) {
+            tracing::error!(
+                target: "tui.home",
+                id = %id,
+                "persist_tool_swap_reset: failed to clear the old engine's session state: {e}"
+            );
+        }
     }
 
     pub(super) fn delete_selected(&mut self, options: &DeleteOptions) -> anyhow::Result<()> {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -9512,14 +9512,31 @@ fn restart_selected_session_tool_swap_clears_old_agent_session_state() {
     let mut env = create_test_env_with_sessions(1);
     let id = env.view.instance_at(0).id.clone();
     env.view.selected_session = Some(id.clone());
-    env.view.mutate_instance(&id, |inst| {
+    let seed = |inst: &mut Instance| {
         inst.tool = "claude".to_string();
         inst.agent_session_id = Some("11111111-2222-3333-4444-555555555555".to_string());
         inst.acp_session_id = Some("acp-sess-1".to_string());
         inst.agent_name = Some("claude-code".to_string());
         inst.acp_effort = Some("high".to_string());
-    });
-    env.view.save().unwrap();
+        inst.agent_model = Some("claude-opus-4-7".to_string());
+        // The approval posture is deliberately NOT reset; see the comment in
+        // `reset_agent_session_for_tool_swap`.
+        inst.acp_mode_id = Some("plan".to_string());
+    };
+    env.view.mutate_instance(&id, seed);
+    // Seed the disk row directly rather than through `save()`: `merge_from_tui`
+    // syncs only status + launch config, so a `save()` here would leave these
+    // fields absent on disk and the disk assertions below would pass
+    // vacuously.
+    env.view
+        .storages
+        .get("test")
+        .unwrap()
+        .update(|instances, _groups| {
+            seed(instances.iter_mut().find(|i| i.id == id).unwrap());
+            Ok(())
+        })
+        .unwrap();
 
     env.view
         .restart_selected_session(None, Some("codex"), None, None)
@@ -9531,6 +9548,16 @@ fn restart_selected_session_tool_swap_clears_old_agent_session_state() {
     assert_eq!(inst.acp_session_id, None);
     assert_eq!(inst.agent_name, None);
     assert_eq!(inst.acp_effort, None);
+    assert_eq!(
+        inst.agent_model, None,
+        "the old agent's model must be dropped"
+    );
+    assert_eq!(
+        inst.acp_mode_id.as_deref(),
+        Some("plan"),
+        "the approval posture must survive: clearing it resolves the adapter's \
+         bypass mode on a yolo_mode row"
+    );
 
     let disk = Storage::new_unwatched("test").unwrap().load().unwrap();
     let row = disk.iter().find(|i| i.id == id).unwrap();
@@ -9541,6 +9568,8 @@ fn restart_selected_session_tool_swap_clears_old_agent_session_state() {
     );
     assert_eq!(row.acp_session_id, None);
     assert_eq!(row.agent_name, None);
+    assert_eq!(row.agent_model, None);
+    assert_eq!(row.acp_mode_id.as_deref(), Some("plan"));
 }
 
 #[test]

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -9500,6 +9500,49 @@ fn restart_selected_session_debounces_via_cooldown_map() {
     );
 }
 
+/// An engine swap must not carry the old agent's session state to the new
+/// one, in memory OR on disk. Session ids are per-agent namespaces, so a
+/// carried-over sid makes the next launch emit `--resume <foreign-sid>`; and
+/// an in-memory-only reset is reverted by `reconcile_from_disk` (which is why
+/// this asserts the disk row too). Follow-on to #3077, which is what made the
+/// swap reach disk in the first place.
+#[test]
+#[serial]
+fn restart_selected_session_tool_swap_clears_old_agent_session_state() {
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instance_at(0).id.clone();
+    env.view.selected_session = Some(id.clone());
+    env.view.mutate_instance(&id, |inst| {
+        inst.tool = "claude".to_string();
+        inst.agent_session_id = Some("11111111-2222-3333-4444-555555555555".to_string());
+        inst.acp_session_id = Some("acp-sess-1".to_string());
+        inst.agent_name = Some("claude-code".to_string());
+        inst.acp_effort = Some("high".to_string());
+    });
+    env.view.save().unwrap();
+
+    env.view
+        .restart_selected_session(None, Some("codex"), None, None)
+        .unwrap();
+
+    let inst = env.view.instance_at(0);
+    assert_eq!(inst.tool, "codex");
+    assert_eq!(inst.agent_session_id, None, "in-memory sid must be dropped");
+    assert_eq!(inst.acp_session_id, None);
+    assert_eq!(inst.agent_name, None);
+    assert_eq!(inst.acp_effort, None);
+
+    let disk = Storage::new_unwatched("test").unwrap().load().unwrap();
+    let row = disk.iter().find(|i| i.id == id).unwrap();
+    assert_eq!(
+        row.agent_session_id, None,
+        "the old engine's sid must be gone from disk too, else reconcile_from_disk \
+         restores it and the new engine launches with --resume <foreign-sid>"
+    );
+    assert_eq!(row.acp_session_id, None);
+    assert_eq!(row.agent_name, None);
+}
+
 #[test]
 #[serial]
 fn restart_selected_session_surfaces_resume_failed_after_async_restart() {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -9520,7 +9520,7 @@ fn restart_selected_session_tool_swap_clears_old_agent_session_state() {
         inst.acp_effort = Some("high".to_string());
         inst.agent_model = Some("claude-opus-4-7".to_string());
         // The approval posture is deliberately NOT reset; see the comment in
-        // `reset_agent_session_for_tool_swap`.
+        // `Instance::swap_tool`.
         inst.acp_mode_id = Some("plan".to_string());
     };
     env.view.mutate_instance(&id, seed);
@@ -9570,6 +9570,15 @@ fn restart_selected_session_tool_swap_clears_old_agent_session_state() {
     assert_eq!(row.agent_name, None);
     assert_eq!(row.agent_model, None);
     assert_eq!(row.acp_mode_id.as_deref(), Some("plan"));
+    // Parked, not discarded: the disk row is the one a swap back reads, so this
+    // is what makes claude -> codex -> claude resumable. Round-trip mechanics
+    // are covered by `swap_tool_parks_and_restores_per_tool_session_ids`.
+    let parked = row.prior_tool_session_ids.get("claude").unwrap();
+    assert_eq!(
+        parked.agent_session_id.as_deref(),
+        Some("11111111-2222-3333-4444-555555555555")
+    );
+    assert_eq!(parked.acp_session_id.as_deref(), Some("acp-sess-1"));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Follow-on bug to #3077, plus the swap-back recovery that bug was hiding.

### The bug

Now that the restart dialog's engine swap reaches disk, the row keeps the
**previous** agent's session state. Session ids live in per-agent namespaces and
`is_valid_session_id` accepts any shape, so `acquire_session_id` hands back the
stored Claude UUID and the next launch emits `--resume <foreign-sid>` against
codex / pi / gemini. The new engine starts by failing to resume and the row
lands in the "resume failed for sid ...; preserved for explicit retry" state.
Before #3077 the swap was reverted from disk on every launch, so it never got
far enough to hit this.

The same carry-over affects the per-agent selectors: `acp_session_id` (rejected
by a different backend), `acp_effort` and `agent_model` (adapter-specific
vocabularies, re-applied on every spawn), `agent_name` (a pinned agent from the
old tool meant a structured-view swap silently kept running the old backend),
and the one-shot `import_pending` / `fork_pending` seeds.

`acp_mode_id` deliberately survives. It is the session's approval posture, and
clearing it does not fall back to "default": the spawn-path mode gate is
`acp_mode_id.is_some() || yolo_mode` (`src/acp/supervisor.rs:1750`) and the
`None` arm resolves the adapter's **bypass** mode id, so dropping an explicit
restrictive mode from a `yolo_mode` row would silently escalate the new agent to
auto-approve. An unrecognized mode id is warn-and-continue instead, which is the
safe failure, and it is why `POST /api/acp/:id/switch` passes the field through.

### Swap-back recovery

Clearing the sid alone made `claude` -> `pi` -> `claude` start a *third*
conversation. `acquire_session_id`'s retroactive-capture branch cannot recover
it, because the restart kills the tmux session first and that branch is gated on
one existing. The only escape was `aoe session set-session-id <session> <uuid>`,
which needs the user to know the raw uuid.

So `Instance::swap_tool` parks the outgoing agent's `agent_session_id` and
`acp_session_id` in a new `prior_tool_session_ids` map, keyed by the outgoing
tool, and consumes the incoming tool's entry on the way in. Swapping back
resumes where that engine left off. The field is additive (`#[serde(default)]`,
skipped when empty), so no migration; it holds at most one entry per tool the
row has ever run under.

`resume_probe_failed_sid` is deliberately not parked with them: a restored sid
is worth one fresh probe, and if the conversation is gone the resume-fallback
cascade already starts a new session.

### Persistence

The swap is written to the disk row through its own `Storage::update` rather
than riding along on `save()`: `merge_from_tui` deliberately leaves
`agent_session_id` and friends to their CAS writers (the capture pollers), so an
in-memory-only swap would be reverted by `reconcile_from_disk` on the very
launch it needs to affect. It runs `swap_tool` *against* the disk row rather
than copying the in-memory result over it, because a poller may have written a
fresher sid to disk than the TUI snapshot carries, and parking whatever disk
holds is what makes the swap-back restore the real conversation. `swap_tool` is
a no-op on a same-tool call, so applying it to both rows cannot double-park.

The write is best-effort and logged, not surfaced as a restart failure; a failed
write leaves the stale sid on disk, which the existing resume-probe fallback
already recovers from by starting fresh.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A)
- [ ] For UI changes: included screenshot or recording (N/A, no visual change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: an e2e test would need two real agent binaries
  installed to observe the swapped launch, so the regression is covered one tier
  down instead, in two tests:
  - `swap_tool_parks_and_restores_per_tool_session_ids` (`src/session/instance.rs`)
    drives the `claude` -> `pi` -> `claude` round trip: the foreign sid is gone
    on the way out, the parked one comes back on the way in, the restored entry
    is consumed, the per-agent selectors clear, `acp_mode_id` survives, and a
    same-tool call is a no-op. It replaces `test_agent_switch_clears_session_id`,
    which hand-assigned `agent_session_id = None` and then asserted it was None,
    so test-fn count is unchanged.
  - `restart_selected_session_tool_swap_clears_old_agent_session_state`
    (`src/tui/home/tests.rs`) drives the real swap path through
    `restart_selected_session` and asserts the **disk** row, which is the half
    that actually regressed (an in-memory-only reset passes memory assertions
    and still ships the bug). Verified non-vacuous: removing only the
    `persist_tool_swap` call fails it with the stale sid still on disk. Its disk
    seed goes through `Storage::update` rather than `save()`, because
    `merge_from_tui` syncs only status + launch config and the assertions would
    otherwise pass on fields that were never written.

`cargo test --lib` green (4416 passed with `--skip file_watch::`), `cargo fmt`
and `cargo clippy --all-targets` clean. The 7 `file_watch::tests` failures on my
machine reproduce identically with this branch stashed, so they are a local
fs-watcher flake, not from this change.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 5)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Preserve session IDs for each tool during engine swaps.
- Clear stale tool-specific state when a session restarts with a different tool.
- Persist the reset state to prevent stale data from returning.
- Keep restarts successful when persistence fails.
- Prevent parked sessions from being claimed by unrelated session capture.
- Add regression coverage for in-memory and persisted state.

## Benefits

Tool swaps no longer inherit session data from the previous tool. Restart behavior is more reliable, and returning to a previous tool can restore its saved session IDs.

## Technical details

`Instance::swap_tool` stores and restores per-tool session IDs. It clears stale model, ACP, import, fork, and agent state while preserving `acp_mode_id`. Tool changes persist the updated state before restart. Session capture excludes parked session IDs from retroactive recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->