### PR TITLE
fix(web): prevent iOS page scroll in alternate-screen terminals

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,6 +45,7 @@ import { usePluginCommands } from "./hooks/usePluginCommands";
 import { useSettingsCommands } from "./hooks/useSettingsCommands";
 import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { useIsCoarsePointer } from "./hooks/useIsCoarsePointer";
+import { useMobileViewportLock } from "./hooks/useMobileViewportLock";
 import { useIsWideViewport } from "./hooks/useIsWideViewport";
 import type { RightPanelView } from "./lib/rightPanelView";
 import { usePaneLayout, dockTabs, dockGroups, dockOf, isActiveTab, isDockCollapsed } from "./lib/paneLayout";
@@ -162,6 +163,7 @@ import { DashboardUpdateBanner } from "./components/DashboardUpdateBanner";
 const LEGACY_TOUR_SEEN_KEY = "aoe-tour-seen";
 
 export default function App() {
+  useMobileViewportLock();
   // Apply the user-selected theme as CSS custom properties on the root
   // element. Runs once on mount + on settings-driven theme changes.
   // The pre-React /theme-bootstrap.js (referenced from index.html)

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -701,6 +701,23 @@ export function MobileLiveTerminal({
     forwardModeRef.current = forwardMode;
     mouseSgrRef.current = mouseSgr;
   }, [forwardMode, mouseSgr]);
+  // WebKit usually honors `touch-action: none` below, but it only decides
+  // that at the start of a gesture. If a fresh frame switches Claude Code
+  // into its alternate-screen mouse mode while a finger is already down,
+  // Safari can keep the root page's pan active and move the whole app under
+  // the fixed terminal input. React's delegated touch listeners are passive,
+  // so install this narrowly scoped native fallback on the terminal itself.
+  // It is intentionally always registered: checking the ref at event time
+  // also covers that between-frame mode transition.
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const stopForwardModePagePan = (event: TouchEvent) => {
+      if (forwardModeRef.current && event.cancelable) event.preventDefault();
+    };
+    el.addEventListener("touchmove", stopForwardModePagePan, { passive: false });
+    return () => el.removeEventListener("touchmove", stopForwardModePagePan);
+  }, []);
   // Sub-notch scroll remainder (px) carried across events, and the last
   // touch Y while forwarding a single-finger drag.
   const wheelAccumRef = useRef(0);

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -8,6 +8,7 @@ import { writeClipboard } from "../lib/clipboard";
 import type { LiveFrame } from "../hooks/useLiveTerminal";
 import { useWebSettings } from "../hooks/useWebSettings";
 import { useIsCoarsePointer } from "../hooks/useIsCoarsePointer";
+import { useTerminalGestureBoundary } from "../hooks/useTerminalGestureBoundary";
 
 // Mobile rendering of a tmux agent pane, mirroring the TUI's live mode:
 // the server streams `capture-pane` snapshots (src/server/live_ws.rs)
@@ -695,29 +696,7 @@ export function MobileLiveTerminal({
   const forwardMode = (frame?.altScreen ?? false) && (frame?.mouse ?? false);
   const mouseSgr = frame?.mouseSgr ?? false;
   const effectiveSpacerLines = forwardMode ? 0 : spacerLines;
-  const forwardModeRef = useRef(forwardMode);
-  const mouseSgrRef = useRef(mouseSgr);
-  useEffect(() => {
-    forwardModeRef.current = forwardMode;
-    mouseSgrRef.current = mouseSgr;
-  }, [forwardMode, mouseSgr]);
-  // WebKit usually honors `touch-action: none` below, but it only decides
-  // that at the start of a gesture. If a fresh frame switches Claude Code
-  // into its alternate-screen mouse mode while a finger is already down,
-  // Safari can keep the root page's pan active and move the whole app under
-  // the fixed terminal input. React's delegated touch listeners are passive,
-  // so install this narrowly scoped native fallback on the terminal itself.
-  // It is intentionally always registered: checking the ref at event time
-  // also covers that between-frame mode transition.
-  useEffect(() => {
-    const el = scrollerRef.current;
-    if (!el) return;
-    const stopForwardModePagePan = (event: TouchEvent) => {
-      if (forwardModeRef.current && event.cancelable) event.preventDefault();
-    };
-    el.addEventListener("touchmove", stopForwardModePagePan, { passive: false });
-    return () => el.removeEventListener("touchmove", stopForwardModePagePan);
-  }, []);
+  const { forwardModeRef, mouseSgrRef } = useTerminalGestureBoundary({ scrollerRef, forwardMode, mouseSgr });
   // Sub-notch scroll remainder (px) carried across events, and the last
   // touch Y while forwarding a single-finger drag.
   const wheelAccumRef = useRef(0);
@@ -903,7 +882,7 @@ export function MobileLiveTerminal({
     if (el.scrollHeight - el.clientHeight - el.scrollTop < 2 && !movingUp) {
       liveDetachedRef.current = false;
     }
-  }, [atBottom, enterReading, reading, returnToLive, scheduleViewSync]);
+  }, [atBottom, enterReading, forwardModeRef, reading, returnToLive, scheduleViewSync]);
 
   const jumpToLatest = useCallback(() => {
     const el = scrollerRef.current;
@@ -967,7 +946,7 @@ export function MobileLiveTerminal({
       const up = notches < 0;
       for (let i = 0; i < Math.abs(notches); i++) forwardWheel(up, mouseSgrRef.current, col, wheelRow);
     },
-    [lineH, pointerCell, forwardWheel],
+    [lineH, pointerCell, forwardWheel, mouseSgrRef],
   );
 
   const cancelTouchWheelQueue = useCallback(() => {
@@ -1010,7 +989,7 @@ export function MobileLiveTerminal({
       // swipe track remote redraws instead of arriving as a wheel storm.
       if (!queued.raf) flushOne();
     },
-    [lineH, pointerCell, forwardWheel],
+    [lineH, pointerCell, forwardWheel, forwardModeRef, mouseSgrRef],
   );
   useEffect(() => cancelTouchWheelQueue, [cancelTouchWheelQueue]);
 
@@ -1021,7 +1000,7 @@ export function MobileLiveTerminal({
       const factor = e.deltaMode === 1 ? lineH || 16 : e.deltaMode === 2 ? (lineH || 16) * (rowsRef.current || 1) : 1;
       forwardWheelDelta(e.deltaY * factor, e.clientX, e.clientY);
     },
-    [lineH, forwardWheelDelta],
+    [lineH, forwardWheelDelta, forwardModeRef],
   );
 
   // --- forward-mode touch momentum -----------------------------------------
@@ -1068,7 +1047,7 @@ export function MobileLiveTerminal({
       };
       state.raf = requestAnimationFrame(step);
     },
-    [stopMomentum, enqueueTouchWheelDelta],
+    [stopMomentum, enqueueTouchWheelDelta, forwardModeRef],
   );
   // Typed input interrupts the coast. Without this, keystrokes sent in the
   // coast's 1-2s tail interleave with the wheel storm and the app is busy
@@ -1108,7 +1087,7 @@ export function MobileLiveTerminal({
         // jsdom / unsupported: capture is a nicety, not required.
       }
     },
-    [pointerCell, forwardButton, inputRef],
+    [pointerCell, forwardButton, inputRef, forwardModeRef, mouseSgrRef],
   );
   const onPointerMove = useCallback(
     (e: React.PointerEvent) => {
@@ -1120,7 +1099,7 @@ export function MobileLiveTerminal({
       lastForwardCellRef.current = { col, row };
       forwardButton(forwardBtnRef.current, false, true, mouseSgrRef.current, col, row);
     },
-    [pointerCell, forwardButton],
+    [pointerCell, forwardButton, mouseSgrRef],
   );
   const endPointerForward = useCallback(
     (e: React.PointerEvent) => {
@@ -1143,7 +1122,7 @@ export function MobileLiveTerminal({
         // Capture may never have been taken (see onPointerDown).
       }
     },
-    [pointerCell, forwardButton, armAgentClipboard],
+    [pointerCell, forwardButton, armAgentClipboard, mouseSgrRef],
   );
 
   // --- pinch zoom (two-finger) ---------------------------------------------
@@ -1192,7 +1171,7 @@ export function MobileLiveTerminal({
         suppressTouchClickRef.current = false;
       }
     },
-    [fontSize, stopMomentum, cancelTouchWheelQueue],
+    [fontSize, stopMomentum, cancelTouchWheelQueue, forwardModeRef],
   );
   const onTouchMove = useCallback(
     (e: React.TouchEvent) => {
@@ -1245,7 +1224,7 @@ export function MobileLiveTerminal({
         }
       }
     },
-    [enqueueTouchWheelDelta, enterReading],
+    [enqueueTouchWheelDelta, enterReading, forwardModeRef],
   );
   const onTouchEnd = useCallback(
     (e: React.TouchEvent) => {
@@ -1309,7 +1288,7 @@ export function MobileLiveTerminal({
         }, 400);
       }
     },
-    [fontKey, fontSize, update, returnToLive, atBottom, startMomentum, enqueueTouchWheelDelta],
+    [fontKey, fontSize, update, returnToLive, atBottom, startMomentum, enqueueTouchWheelDelta, forwardModeRef],
   );
   // touchcancel is NOT touchend: iOS fires it when it promotes the drag to
   // native scrolling, with the finger usually STILL down. Treat it as "stop

--- a/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
@@ -93,9 +93,19 @@ describe("MobileLiveTerminal wheel forwarding", () => {
     expect(scroller.style.touchAction).toBe("none");
   });
 
+  it("cancels a native touch move in forward mode as a WebKit fallback", () => {
+    const { scroller } = renderTerm(frame({ altScreen: true, mouse: true, mouseSgr: true }));
+    const move = new Event("touchmove", { cancelable: true });
+    scroller.dispatchEvent(move);
+    expect(move.defaultPrevented).toBe(true);
+  });
+
   it("leaves touch-action unset outside forward mode (native capture scroll)", () => {
     const { scroller } = renderTerm(frame({ altScreen: false, mouse: false }));
     expect(scroller.style.touchAction).toBe("");
+    const move = new Event("touchmove", { cancelable: true });
+    scroller.dispatchEvent(move);
+    expect(move.defaultPrevented).toBe(false);
   });
 
   it("normalizes line-mode wheel deltas (deltaMode 1)", () => {

--- a/web/src/hooks/useMobileKeyboard.test.ts
+++ b/web/src/hooks/useMobileKeyboard.test.ts
@@ -167,21 +167,6 @@ describe("useMobileKeyboard", () => {
     expect(result.current.keyboardHeight).toBe(0);
   });
 
-  it("snaps stray layout-viewport scroll back to the top on measure", () => {
-    stubMatchMedia(true);
-    const vp = stubVisualViewport(800);
-    Object.defineProperty(window, "scrollY", { configurable: true, value: 120, writable: true });
-
-    renderHook(() => useMobileKeyboard());
-
-    act(() => {
-      vp.fire("scroll");
-      drainRaf();
-    });
-
-    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
-  });
-
   it("starts polling when a text input gains focus", () => {
     stubMatchMedia(true);
     const vp = stubVisualViewport(800);

--- a/web/src/hooks/useMobileKeyboard.ts
+++ b/web/src/hooks/useMobileKeyboard.ts
@@ -13,10 +13,6 @@ import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 // iOS 26 Safari / Android Chrome, where `100dvh` shrinks natively and
 // the flex layout already accounts for it.
 //
-// measure() also snaps back any stray layout-viewport scroll: iOS
-// scrolls the page to reveal a focused input even under overflow:hidden
-// roots, and nothing else ever scrolls the layout viewport.
-//
 // The PTY-era machinery (debounced keyboardOcclusion, the
 // stableViewportHeight root pin) is gone: every mobile terminal surface
 // renders the capture-snapshot live view now, so no PTY needs shielding
@@ -94,17 +90,6 @@ export function useMobileKeyboard() {
       parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--safe-area-bottom")) || 0;
 
     const measure = () => {
-      // iOS scrolls the layout viewport to reveal a focused input even
-      // though the app root is overflow:hidden (the xterm helper
-      // textarea rides the terminal cursor near the bottom of the pane,
-      // so opening the keyboard shoves the whole app up by roughly the
-      // keyboard height and it never comes back). The app never scrolls
-      // the layout viewport itself, so any non-zero scroll here is
-      // WebKit's doing; snap it back so occlusion padding stays the only
-      // thing that moves the terminal.
-      if (window.scrollY !== 0 || document.documentElement.scrollTop !== 0) {
-        window.scrollTo(0, 0);
-      }
       const currentVvH = vv.height;
 
       if (currentVvH > fullHeightRef.current - 50) {
@@ -175,10 +160,6 @@ export function useMobileKeyboard() {
     vv.addEventListener("scroll", handleViewportChange);
     document.addEventListener("focusin", handleFocusIn);
     window.addEventListener("orientationchange", handleOrientationChange);
-    // WebKit's focus-driven layout-viewport scroll does not always move
-    // the visual viewport relative to the layout viewport, so the vv
-    // "scroll" listener alone can miss it; the window scroll event is
-    // the reliable signal for the snap-back in measure().
     window.addEventListener("scroll", handleViewportChange);
     return () => {
       cancelAnimationFrame(rafRef.current);

--- a/web/src/hooks/useMobileViewportLock.test.ts
+++ b/web/src/hooks/useMobileViewportLock.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useMobileViewportLock } from "./useMobileViewportLock";
+
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia;
+  window.scrollTo = vi.fn();
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+    cb(performance.now());
+    return 1;
+  });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("useMobileViewportLock", () => {
+  it("returns document scrolling to the origin on touch devices", () => {
+    Object.defineProperty(window, "scrollY", { configurable: true, value: 120 });
+    renderHook(() => useMobileViewportLock());
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+
+    vi.mocked(window.scrollTo).mockClear();
+    act(() => window.dispatchEvent(new Event("scroll")));
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  it("does not interfere with desktop document scrolling", () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as unknown as typeof window.matchMedia;
+    Object.defineProperty(window, "scrollY", { configurable: true, value: 120 });
+    renderHook(() => useMobileViewportLock());
+    act(() => window.dispatchEvent(new Event("scroll")));
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/useMobileViewportLock.ts
+++ b/web/src/hooks/useMobileViewportLock.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+
+// The dashboard has no document-level scrolling surface. Keep that invariant
+// at the app boundary so a Safari gesture or focus adjustment cannot move a
+// terminal, composer, or toolbar as a single page-sized sheet.
+export function useMobileViewportLock() {
+  useEffect(() => {
+    const media = window.matchMedia?.("(pointer: coarse)");
+    if (!media) return;
+
+    const resetDocumentScroll = () => {
+      if (!media.matches) return;
+      if (window.scrollX !== 0 || window.scrollY !== 0 || document.documentElement.scrollTop !== 0) {
+        window.scrollTo(0, 0);
+      }
+    };
+
+    const onScroll = () => {
+      resetDocumentScroll();
+      requestAnimationFrame(resetDocumentScroll);
+    };
+
+    resetDocumentScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    media.addEventListener?.("change", resetDocumentScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      media.removeEventListener?.("change", resetDocumentScroll);
+    };
+  }, []);
+}

--- a/web/src/hooks/useTerminalGestureBoundary.test.tsx
+++ b/web/src/hooks/useTerminalGestureBoundary.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { useRef } from "react";
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { useTerminalGestureBoundary } from "./useTerminalGestureBoundary";
+
+function Probe({ forwardMode }: { forwardMode: boolean }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useTerminalGestureBoundary({ scrollerRef: ref, forwardMode, mouseSgr: true });
+  return <div ref={ref} />;
+}
+
+describe("useTerminalGestureBoundary", () => {
+  it("cancels alternate-screen touch moves and leaves normal scrolling alone", () => {
+    const { container, rerender } = render(<Probe forwardMode />);
+    const scroller = container.firstElementChild!;
+    const forwardedMove = new Event("touchmove", { cancelable: true });
+    scroller.dispatchEvent(forwardedMove);
+    expect(forwardedMove.defaultPrevented).toBe(true);
+
+    rerender(<Probe forwardMode={false} />);
+    const nativeMove = new Event("touchmove", { cancelable: true });
+    scroller.dispatchEvent(nativeMove);
+    expect(nativeMove.defaultPrevented).toBe(false);
+  });
+});

--- a/web/src/hooks/useTerminalGestureBoundary.ts
+++ b/web/src/hooks/useTerminalGestureBoundary.ts
@@ -1,0 +1,38 @@
+import { useEffect, useLayoutEffect, useRef } from "react";
+import type { RefObject } from "react";
+
+// Owns the boundary between an alternate-screen terminal gesture and the
+// browser viewport. Rendering code can use the returned refs for forwarding,
+// while this hook guarantees that the browser never promotes that gesture into
+// a page pan.
+export function useTerminalGestureBoundary({
+  scrollerRef,
+  forwardMode,
+  mouseSgr,
+}: {
+  scrollerRef: RefObject<HTMLDivElement | null>;
+  forwardMode: boolean;
+  mouseSgr: boolean;
+}) {
+  const forwardModeRef = useRef(forwardMode);
+  const mouseSgrRef = useRef(mouseSgr);
+
+  // A mode frame can land while a finger is down. Publish it before paint so
+  // the native touch listener below owns the next move, not the document.
+  useLayoutEffect(() => {
+    forwardModeRef.current = forwardMode;
+    mouseSgrRef.current = mouseSgr;
+  }, [forwardMode, mouseSgr]);
+
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const stopPagePan = (event: TouchEvent) => {
+      if (forwardModeRef.current && event.cancelable) event.preventDefault();
+    };
+    el.addEventListener("touchmove", stopPagePan, { passive: false });
+    return () => el.removeEventListener("touchmove", stopPagePan);
+  }, [scrollerRef]);
+
+  return { forwardModeRef, mouseSgrRef };
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -211,6 +211,19 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+#root {
+  height: 100%;
+}
+
+@media (pointer: coarse) {
+  #root {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    overflow: hidden;
+  }
+}
+
 /* Structured view markdown — assistant-ui's MarkdownTextPrimitive renders
    raw <p>/<ul>/<ol>/<h*>/<blockquote>/<code> elements (no class
    names). Style them via descendant selectors so the prose looks

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -127,12 +127,14 @@
         "tests/mobile-dom-renderer.spec.ts",
         "tests/keyboard-auto-resize.spec.ts",
         "tests/mobile-keyboard.spec.ts",
-        "tests/mobile-fullscreen-agent-layout.spec.ts"
+        "tests/mobile-fullscreen-agent-layout.spec.ts",
+        "src/hooks/useMobileViewportLock.test.ts"
       ],
       "components": [
         "web/src/App.tsx",
         "web/src/components/MobileLiveTerminal.tsx",
         "web/src/components/LiveTerminalView.tsx",
+        "web/src/hooks/useMobileViewportLock.ts",
         "web/src/hooks/useLiveTerminal.ts"
       ]
     },
@@ -223,11 +225,13 @@
       "specs": [
         "src/lib/__tests__/liveMouse.test.ts",
         "src/hooks/useLiveTerminal.forward.test.ts",
-        "src/components/__tests__/MobileLiveTerminal.forward.test.tsx"
+        "src/components/__tests__/MobileLiveTerminal.forward.test.tsx",
+        "src/hooks/useTerminalGestureBoundary.test.tsx"
       ],
       "components": [
         "web/src/lib/liveMouse.ts",
         "web/src/components/MobileLiveTerminal.tsx",
+        "web/src/hooks/useTerminalGestureBoundary.ts",
         "web/src/hooks/useLiveTerminal.ts"
       ]
     },

--- a/web/tests/live-wheel-forward.spec.ts
+++ b/web/tests/live-wheel-forward.spec.ts
@@ -61,6 +61,16 @@ test("swipe over a full-screen SGR-mouse app forwards SGR wheel bytes", async ({
   // React's delegated touch listeners are passive, so the component cannot
   // preventDefault the native pan (the keyboard-open page-scroll clunk).
   await expect.poll(() => scroller(page).evaluate((el) => getComputedStyle(el).touchAction)).toBe("none");
+  // A direct, non-passive listener backs this up if WebKit decided the
+  // gesture's touch-action before the frame switched into forward mode.
+  await expect
+    .poll(() =>
+      scroller(page).evaluate((el) => {
+        const move = new Event("touchmove", { cancelable: true });
+        return el.dispatchEvent(move);
+      }),
+    )
+    .toBe(false);
   await swipeUp(page);
   await expect.poll(() => texts(handle).some((s) => s.includes("\x1b[<65;"))).toBe(true);
 

--- a/web/tests/mobile-keyboard.spec.ts
+++ b/web/tests/mobile-keyboard.spec.ts
@@ -103,6 +103,26 @@ test.describe("Mobile keyboard detection and layout", () => {
     await openSession(page);
   }
 
+  test("mobile shell is fixed and rejects document-level scroll", async ({ page }) => {
+    await setupAndOpen(page);
+
+    const result = await page.evaluate(() => {
+      const calls: Array<[number, number]> = [];
+      const original = window.scrollTo;
+      Object.defineProperty(window, "scrollTo", {
+        configurable: true,
+        value: (x: number, y: number) => calls.push([x, y]),
+      });
+      Object.defineProperty(document.documentElement, "scrollTop", { configurable: true, value: 120 });
+      window.dispatchEvent(new Event("scroll"));
+      Object.defineProperty(window, "scrollTo", { configurable: true, value: original });
+      return { calls, rootPosition: getComputedStyle(document.getElementById("root")!).position };
+    });
+
+    expect(result.rootPosition).toBe("fixed");
+    expect(result.calls).toContainEqual([0, 0]);
+  });
+
   test("auto-resizes when keyboard opens in Safari browser mode (innerHeight constant)", async ({ page }) => {
     await setupAndOpen(page);
 


### PR DESCRIPTION
## Description

Prevents Safari from handing an alternate-screen terminal swipe to the dashboard page, then makes that protection structural:

- fixes the mobile app root to the viewport and restores any stray document scroll
- isolates alternate-screen gesture cancellation in `useTerminalGestureBoundary`
- keeps keyboard measurement focused on keyboard occlusion, without its former page-scroll repair
- preserves native normal-buffer scrolling and existing alternate-screen wheel forwarding

Prose by Codex; decisions are njbrake.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary, no documentation change is needed for this internal interaction fix
- [x] For UI changes: validated by real iOS smoke testing; no screenshot is useful for a gesture-only change

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Updated the existing mobile terminal coverage-matrix entries with viewport-lock and gesture-boundary tests.

**TUI / CLI (e2e test)**
- [x] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle

## Testing

- `cd web && npm run build`
- `cd web && npm run test:unit`, 3,725 tests passed
- `cd web && npx playwright test --config=playwright.config.ts`
- `cd web && npx playwright test tests/mobile-keyboard.spec.ts tests/live-wheel-forward.spec.ts --config=playwright.config.ts`
- `cd web && npm run format:check`
- `cd web && npm run lint`
- `cd web && npx tsc -b`
- `cd web && node tests/validate-coverage-matrix.mjs`
- Manual iOS Safari smoke test

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Codex

**Any Additional AI Details you'd like to share:** Implemented and tested with Codex under njbrake's direction.

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed iOS Safari page scrolling during alternate-screen terminal gestures.
- Added mobile viewport locking to keep the terminal shell fixed during page scroll events.
- Prevented page panning during mouse-forwarding mode while preserving normal terminal scrolling.
- Removed obsolete keyboard-related scroll correction.
- Added Playwright and Vitest coverage for viewport locking and terminal gestures.

## Benefit

Users can interact with the mobile terminal without accidentally moving the surrounding page. The behavior remains unchanged outside mouse-forwarding mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->