### PR TITLE
fix(cli): harden tmux dispatch for headless add --launch and send

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -319,6 +319,16 @@ pub struct AgentDef {
     /// newlines within a paste rather than as "submit". A delay longer than the
     /// agent's burst window lets the suppression expire before Enter arrives.
     pub send_keys_enter_delay_ms: u64,
+    /// Pane-content substring (matched case-insensitively) that indicates
+    /// this agent's TUI has finished booting and is ready to accept input,
+    /// if known. `None` means no such per-agent signal is known yet;
+    /// callers fall back to a generic content-settle heuristic
+    /// (`tmux::Session::wait_until_content_settles`), which cannot tell a
+    /// genuinely idle prompt from a still-booting pane that merely hasn't
+    /// printed anything new in the last couple of samples. Used to avoid
+    /// typing into a pane before the agent is actually listening (see `aoe
+    /// send`'s pre-send wait).
+    pub ready_marker: Option<&'static str>,
     /// One-line install command shown when the agent is missing from PATH.
     pub install_hint: &'static str,
     /// Static keystroke sequences for answering this agent's own interactive
@@ -714,6 +724,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::ClaudeFork,
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint: "npm install -g @anthropic-ai/claude-code",
         permission_response: Some(PermissionResponse {
             allow: &[KeyToken::Literal("1")],
@@ -739,6 +750,11 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Flag("--fork"),
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        // Live-tested by an external headless-dispatch wrapper against
+        // real unattended runs: opencode's TUI shows this placeholder in
+        // its input box once it's finished booting and is ready to accept
+        // input, well before it necessarily prints anything else.
+        ready_marker: Some("ask anything"),
         install_hint: "curl -fsSL https://opencode.ai/install | bash",
         permission_response: Some(PermissionResponse {
             allow: &[KeyToken::Named("Enter")],
@@ -772,6 +788,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint: "pip install mistral-vibe",
         permission_response: None,
     },
@@ -805,6 +822,7 @@ pub const AGENTS: &[AgentDef] = &[
         // Enter keys arriving within that window after a character stream are
         // swallowed as newlines instead of triggering submit. 150ms > 120ms.
         send_keys_enter_delay_ms: 150,
+        ready_marker: None,
         install_hint: "npm install -g @openai/codex",
         permission_response: None,
     },
@@ -860,6 +878,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint: "npm install -g @google/gemini-cli",
         permission_response: None,
     },
@@ -886,6 +905,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint: "see https://docs.cursor.com/cli",
         permission_response: None,
     },
@@ -913,6 +933,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint: "see https://docs.github.com/en/copilot/github-copilot-in-the-cli",
         permission_response: None,
     },
@@ -935,6 +956,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint: "npm install -g @earendil-works/pi-coding-agent",
         permission_response: None,
     },
@@ -956,6 +978,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint: "npm install -g droid",
         permission_response: None,
     },
@@ -989,6 +1012,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Unsupported,
         host_only: true,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint: "brew install --cask mozilla-ai/tap/settl",
         permission_response: None,
     },
@@ -1028,6 +1052,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint:
             "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
         permission_response: None,
@@ -1075,6 +1100,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint: "curl -fsSL https://cli.kiro.dev/install | bash",
         permission_response: None,
     },
@@ -1104,6 +1130,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint: "npm install -g @qwen-code/qwen-code",
         permission_response: None,
     },
@@ -1125,6 +1152,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
         permission_response: None,
     },
@@ -1164,6 +1192,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint: "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
         permission_response: None,
     },
@@ -1185,6 +1214,7 @@ pub const AGENTS: &[AgentDef] = &[
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,
         send_keys_enter_delay_ms: 0,
+        ready_marker: None,
         install_hint: "curl -fsSL https://omp.sh/install | sh",
         permission_response: Some(PermissionResponse {
             allow: &[KeyToken::Named("Enter")],
@@ -1513,6 +1543,12 @@ pub fn send_keys_enter_delay(tool: &str) -> u64 {
     get_agent(tool)
         .map(|a| a.send_keys_enter_delay_ms)
         .unwrap_or(0)
+}
+
+/// The known-ready pane-content marker for this agent, if any. See
+/// `AgentDef::ready_marker`.
+pub fn ready_marker(tool: &str) -> Option<&'static str> {
+    get_agent(tool).and_then(|a| a.ready_marker)
 }
 
 /// All canonical agent names in registry order.

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1177,11 +1177,25 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 }
 
                 let tmux_session = crate::tmux::Session::new(&instance.id, &instance.title)?;
-                tmux_session.attach()?;
+                if std::io::stdout().is_terminal() {
+                    tmux_session.attach()?;
+                } else {
+                    // No controlling terminal (LaunchAgent, cron, or any
+                    // other headless caller): `tmux attach-session` needs a
+                    // TTY and would fail even though the session above
+                    // started fine. Skip the attach instead of letting that
+                    // failure roll a successful launch back to an error.
+                    println!(
+                        "(no controlling terminal; session started without attaching. \
+                         Use `aoe session attach {}` to view it.)",
+                        final_title
+                    );
+                }
 
-                // The poller ran throughout the attached session but the CLI
-                // never drained it, dropping the observed id on detach. Drain it
-                // now (short bound: it is almost always already queued).
+                // The poller ran throughout the attach (or the launch above,
+                // headless) but the CLI never drained it, dropping the
+                // observed id. Drain it now (short bound: it is almost
+                // always already queued).
                 let file_watch = crate::file_watch::FileWatchService::noop();
                 crate::session::sync::capture_launched_session_id_blocking(
                     &mut instance,

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1188,7 +1188,8 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                     // to an error.
                     println!(
                         "(no controlling terminal; session started without attaching. \
-                         Use `aoe session attach {}` to view it.)",
+                         Use `aoe -p {} session attach {}` to view it.)",
+                        shell_words::quote(storage.profile()),
                         shell_words::quote(&instance.id)
                     );
                 }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1177,18 +1177,19 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 }
 
                 let tmux_session = crate::tmux::Session::new(&instance.id, &instance.title)?;
-                if std::io::stdout().is_terminal() {
+                if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
                     tmux_session.attach()?;
                 } else {
                     // No controlling terminal (LaunchAgent, cron, or any
                     // other headless caller): `tmux attach-session` needs a
-                    // TTY and would fail even though the session above
-                    // started fine. Skip the attach instead of letting that
-                    // failure roll a successful launch back to an error.
+                    // TTY on both ends and would fail even though the
+                    // session above started fine. Skip the attach instead
+                    // of letting that failure roll a successful launch back
+                    // to an error.
                     println!(
                         "(no controlling terminal; session started without attaching. \
                          Use `aoe session attach {}` to view it.)",
-                        final_title
+                        shell_words::quote(&final_title)
                     );
                 }
 
@@ -1228,7 +1229,10 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     } else {
         println!();
         println!("Next steps:");
-        println!("  aoe session start {}   # Start the session", final_title);
+        println!(
+            "  aoe session start {}   # Start the session",
+            shell_words::quote(&final_title)
+        );
         println!("  aoe                         # Open TUI and press Enter to attach");
     }
 

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1189,7 +1189,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                     println!(
                         "(no controlling terminal; session started without attaching. \
                          Use `aoe session attach {}` to view it.)",
-                        shell_words::quote(&final_title)
+                        shell_words::quote(&instance.id)
                     );
                 }
 

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -69,8 +69,8 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
         );
     }
 
-    // Wait for the pane's content to settle before typing. A pane that
-    // exists is not necessarily an agent that's finished booting: a session
+    // Wait for the pane to become ready before typing. A pane that exists
+    // is not necessarily an agent that's finished booting: a session
     // started by an earlier, separate `aoe session start` reports
     // `EnsureReadyOutcome::AlreadyAlive` above with no wait at all, and
     // agents with no interposed shell (e.g. opencode) clear the pane's
@@ -79,7 +79,10 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
     // message typed into that window is silently dropped with no error.
     // Bounded so a genuinely busy/streaming agent doesn't block `send`
     // forever.
-    tmux_session.wait_until_content_settles(std::time::Duration::from_secs(5));
+    tmux_session.wait_until_ready(
+        std::time::Duration::from_secs(5),
+        crate::agents::ready_marker(&tool),
+    );
 
     let delay = crate::agents::send_keys_enter_delay(&tool);
     tmux_session.send_keys_with_delay(&args.message, delay)?;

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -69,6 +69,18 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
         );
     }
 
+    // Wait for the pane's content to settle before typing. A pane that
+    // exists is not necessarily an agent that's finished booting: a session
+    // started by an earlier, separate `aoe session start` reports
+    // `EnsureReadyOutcome::AlreadyAlive` above with no wait at all, and
+    // agents with no interposed shell (e.g. opencode) clear the pane's
+    // "running a shell" check almost immediately even though their own TUI
+    // can still take several more seconds to render and accept input. A
+    // message typed into that window is silently dropped with no error.
+    // Bounded so a genuinely busy/streaming agent doesn't block `send`
+    // forever.
+    tmux_session.wait_until_content_settles(std::time::Duration::from_secs(5));
+
     let delay = crate::agents::send_keys_enter_delay(&tool);
     tmux_session.send_keys_with_delay(&args.message, delay)?;
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1412,11 +1412,15 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let mut wake_succeeded = false;
     if !wake_msg.is_empty() && !matches!(outcome, StartOutcome::ResumeFailed { .. }) {
         // Restart re-execs the agent at a blank prompt; nudge it back into
-        // its prior task. Poll capture-pane for steady-state output instead
-        // of a blind sleep, so the keys land as soon as the agent is at a
-        // prompt and don't get stranded mid-banner on slow machines.
+        // its prior task. Wait for a real readiness signal when one is
+        // known for this agent, falling back to steady-state pane output
+        // otherwise, so the keys land as soon as the agent is at a prompt
+        // and don't get stranded mid-banner on slow machines.
         let tmux_session = crate::tmux::Session::new(&session_id, &title)?;
-        tmux_session.wait_until_content_settles(std::time::Duration::from_secs(5));
+        tmux_session.wait_until_ready(
+            std::time::Duration::from_secs(5),
+            crate::agents::ready_marker(&tool),
+        );
 
         if tmux_session.exists() {
             let delay = crate::agents::send_keys_enter_delay(&tool);

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1415,9 +1415,9 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         // its prior task. Poll capture-pane for steady-state output instead
         // of a blind sleep, so the keys land as soon as the agent is at a
         // prompt and don't get stranded mid-banner on slow machines.
-        wait_for_pane_ready(&session_id, &title, std::time::Duration::from_secs(5)).await;
-
         let tmux_session = crate::tmux::Session::new(&session_id, &title)?;
+        tmux_session.wait_until_content_settles(std::time::Duration::from_secs(5));
+
         if tmux_session.exists() {
             let delay = crate::agents::send_keys_enter_delay(&tool);
             match tmux_session.send_keys_with_delay(&wake_msg, delay) {
@@ -1491,32 +1491,6 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         }
     }
     Ok(())
-}
-
-/// Poll the tmux pane until capture-pane content stops changing for two
-/// consecutive samples (the agent has finished printing its startup banner
-/// and is sitting at a prompt) or `max_wait` elapses. Failsafe: always
-/// returns by `max_wait` so the caller's send-keys still runs even if the
-/// pane never settles.
-async fn wait_for_pane_ready(session_id: &str, title: &str, max_wait: std::time::Duration) {
-    let Ok(tmux) = crate::tmux::Session::new(session_id, title) else {
-        return;
-    };
-    let poll_interval = std::time::Duration::from_millis(200);
-    let start = std::time::Instant::now();
-    let mut last: Option<String> = None;
-    while start.elapsed() < max_wait {
-        tokio::time::sleep(poll_interval).await;
-        let Ok(now) = tmux.capture_pane(5) else {
-            continue;
-        };
-        if now.trim().len() > 20 {
-            if last.as_deref() == Some(&now) {
-                return;
-            }
-            last = Some(now);
-        }
-    }
 }
 
 async fn attach_session(profile: &str, args: SessionIdArgs) -> Result<()> {

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -640,13 +640,14 @@ impl Session {
     pub fn wait_until_ready(&self, max_wait: std::time::Duration, ready_marker: Option<&str>) {
         let poll_interval = std::time::Duration::from_millis(200);
         let deadline = std::time::Instant::now() + max_wait;
+        let ready_marker = ready_marker.map(str::to_lowercase);
         let mut last: Option<String> = None;
         while std::time::Instant::now() < deadline {
             std::thread::sleep(poll_interval);
             let Ok(now) = self.capture_pane(5) else {
                 continue;
             };
-            if let Some(marker) = ready_marker {
+            if let Some(marker) = ready_marker.as_deref() {
                 if now.to_lowercase().contains(marker) {
                     return;
                 }
@@ -1804,6 +1805,7 @@ mod tests {
             .status()
             .expect("tmux new-session");
         assert!(status.success());
+        refresh_session_cache();
 
         let session = Session::from_name(&name);
         let start = std::time::Instant::now();

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -615,17 +615,29 @@ impl Session {
         }
     }
 
-    /// Poll the pane until captured content stops changing across two
-    /// consecutive samples (the agent has finished printing its startup
-    /// banner and is sitting idle) or `max_wait` elapses. Failsafe: always
-    /// returns by `max_wait`, so a caller's next action (e.g. `send-keys`)
-    /// still runs even if the pane's content never settles, such as an agent
-    /// that is genuinely still streaming output.
+    /// Wait for the pane to become ready for input, or `max_wait` to elapse.
+    /// Failsafe: always returns by `max_wait`, so a caller's next action
+    /// (e.g. `send-keys`) still runs even if the pane never becomes ready,
+    /// such as an agent that is genuinely still streaming output.
+    ///
+    /// When `ready_marker` is `Some` (see `AgentDef::ready_marker`), polls
+    /// for that substring actually appearing in the captured pane content
+    /// (matched case-insensitively) -- a real, agent-specific readiness
+    /// signal.
+    ///
+    /// When `ready_marker` is `None` (no such signal is known for this
+    /// agent yet), falls back to a generic heuristic: content stops
+    /// changing across two consecutive samples. This is weaker -- a short,
+    /// static "still loading" screen can satisfy it before the agent is
+    /// actually listening -- but it is strictly better than sending
+    /// immediately, and is the same heuristic `aoe session restart`'s
+    /// wake-message send already relied on before per-agent markers
+    /// existed.
     ///
     /// Shared by `aoe session restart`'s post-restart wake message and `aoe
     /// send`'s pre-send wait: both need to avoid typing into a pane whose
     /// agent has not finished rendering yet.
-    pub fn wait_until_content_settles(&self, max_wait: std::time::Duration) {
+    pub fn wait_until_ready(&self, max_wait: std::time::Duration, ready_marker: Option<&str>) {
         let poll_interval = std::time::Duration::from_millis(200);
         let deadline = std::time::Instant::now() + max_wait;
         let mut last: Option<String> = None;
@@ -634,6 +646,12 @@ impl Session {
             let Ok(now) = self.capture_pane(5) else {
                 continue;
             };
+            if let Some(marker) = ready_marker {
+                if now.to_lowercase().contains(marker) {
+                    return;
+                }
+                continue;
+            }
             if now.trim().len() > 20 {
                 if last.as_deref() == Some(now.as_str()) {
                     return;
@@ -1751,6 +1769,55 @@ mod tests {
                 "input {input:?}"
             );
         }
+    }
+
+    /// Direct, timing-based proof that `wait_until_ready` with a known
+    /// marker actually blocks until that marker appears, rather than
+    /// returning early on a merely-static pane -- the gap in the generic
+    /// content-settle fallback (a short "still loading" screen can look
+    /// "settled" long before the agent is really listening).
+    #[test]
+    fn wait_until_ready_blocks_until_the_marker_appears() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let guard = TmuxTestSession::new("aoe_test_ready_marker");
+        let name = guard.name().to_string();
+        // A short, static "booting" line appears immediately and would
+        // satisfy the generic settle heuristic well under 700ms; the real
+        // marker text only appears after the sleep.
+        let status = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &name,
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sh",
+                "-c",
+                "echo booting; sleep 0.7; echo 'ask anything...'; sleep 30",
+            ])
+            .status()
+            .expect("tmux new-session");
+        assert!(status.success());
+
+        let session = Session::from_name(&name);
+        let start = std::time::Instant::now();
+        session.wait_until_ready(std::time::Duration::from_secs(3), Some("ask anything"));
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed >= std::time::Duration::from_millis(600),
+            "returned before the marker could plausibly have appeared: {elapsed:?}"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "should have returned promptly once the marker appeared, not idled toward the bound: {elapsed:?}"
+        );
     }
 
     #[test]

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -615,6 +615,34 @@ impl Session {
         }
     }
 
+    /// Poll the pane until captured content stops changing across two
+    /// consecutive samples (the agent has finished printing its startup
+    /// banner and is sitting idle) or `max_wait` elapses. Failsafe: always
+    /// returns by `max_wait`, so a caller's next action (e.g. `send-keys`)
+    /// still runs even if the pane's content never settles, such as an agent
+    /// that is genuinely still streaming output.
+    ///
+    /// Shared by `aoe session restart`'s post-restart wake message and `aoe
+    /// send`'s pre-send wait: both need to avoid typing into a pane whose
+    /// agent has not finished rendering yet.
+    pub fn wait_until_content_settles(&self, max_wait: std::time::Duration) {
+        let poll_interval = std::time::Duration::from_millis(200);
+        let deadline = std::time::Instant::now() + max_wait;
+        let mut last: Option<String> = None;
+        while std::time::Instant::now() < deadline {
+            std::thread::sleep(poll_interval);
+            let Ok(now) = self.capture_pane(5) else {
+                continue;
+            };
+            if now.trim().len() > 20 {
+                if last.as_deref() == Some(now.as_str()) {
+                    return;
+                }
+                last = Some(now);
+            }
+        }
+    }
+
     /// Capture the whole first window, panes composited, for the passive
     /// preview.
     ///
@@ -1077,9 +1105,10 @@ impl Session {
         if use_paste_buffer {
             Self::send_via_paste_buffer(&target, text)?;
         } else {
+            let payload = pad_slash_command_for_autocomplete(text);
             // `--` ends option parsing so lines beginning with `-` (markdown
             // bullets, CLI flags in prompts) are not misread as tmux flags.
-            Self::tmux_send(&target, &["-l", "--", text])?;
+            Self::tmux_send(&target, &["-l", "--", &payload])?;
         }
 
         if enter_delay_ms > 0 {
@@ -1521,6 +1550,23 @@ fn raw_byte_batches(bytes: &[u8]) -> Vec<Vec<String>> {
         .collect()
 }
 
+/// Whether `text` should get a trailing space appended before being typed
+/// via the literal (non-paste-buffer) keystroke path in
+/// [`Session::send_keys_with_delay`]. A message that opens with `/` triggers
+/// some agents' own slash-command autocomplete dropdown (e.g. opencode); the
+/// dropdown then consumes the terminating `Enter` sent after this payload as
+/// navigation instead of submit, leaving the command typed but never
+/// delivered. A trailing space closes the dropdown as it's typed, so the
+/// following `Enter` submits normally instead. Every other message keeps its
+/// exact bytes. Pure so the padding decision is unit-testable without tmux.
+fn pad_slash_command_for_autocomplete(text: &str) -> std::borrow::Cow<'_, str> {
+    if text.trim_start().starts_with('/') {
+        std::borrow::Cow::Owned(format!("{text} "))
+    } else {
+        std::borrow::Cow::Borrowed(text)
+    }
+}
+
 /// Build the argument list for tmux new-session command. Shared by the
 /// agent session and the paired/container terminal sessions (their
 /// invocations are identical; only the session-name prefix differs).
@@ -1686,6 +1732,25 @@ mod tests {
     #[test]
     fn raw_byte_batches_empty_payload_sends_nothing() {
         assert!(raw_byte_batches(&[]).is_empty());
+    }
+
+    #[test]
+    fn pads_slash_prefixed_messages_only() {
+        let cases = [
+            ("/audit", "/audit "),
+            ("/", "/ "),
+            ("  /audit", "  /audit "),
+            ("audit", "audit"),
+            ("please run /audit", "please run /audit"),
+            ("", ""),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                pad_slash_command_for_autocomplete(input),
+                expected,
+                "input {input:?}"
+            );
+        }
     }
 
     #[test]

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -1830,8 +1830,8 @@ fn test_cli_stop_trap_redirects() {
 }
 
 /// Fake agent that prints a substantial startup banner, sleeps to simulate a
-/// slow-booting TUI, then reads exactly one line and echoes it back in a
-/// greppable form.
+/// slow-booting TUI, then prints opencode's real input-ready placeholder
+/// text and reads exactly one line, echoing it back in a greppable form.
 fn install_slow_boot_agent(h: &TuiTestHarness) -> std::path::PathBuf {
     let dir = h.home_path().join("fake-bin");
     std::fs::create_dir_all(&dir).expect("create fake-bin dir");
@@ -1841,7 +1841,7 @@ echo '=== Fake Agent booting ==='\n\
 echo 'Loading modules...'\n\
 sleep 1\n\
 echo '==========================='\n\
-echo '> Ready for input'\n\
+echo 'Ask anything...'\n\
 read -r line\n\
 echo \"GOT:[$line]\"\n\
 sleep 60\n";
@@ -1858,10 +1858,17 @@ sleep 60\n";
 /// `aoe send` right after `aoe session start` -- the sequence a headless
 /// dispatcher with no controlling terminal must use, since it cannot rely on
 /// `aoe add --launch`'s own attach -- must not race the agent's own boot: it
-/// waits for the pane to settle (`Session::wait_until_content_settles`)
-/// before typing, instead of typing into a still-booting pane whenever
-/// `ensure_pane_ready` reports `AlreadyAlive` (a pane that already exists
-/// gets no wait at all otherwise).
+/// waits for a real per-agent readiness marker (`Session::wait_until_ready`,
+/// `AgentDef::ready_marker`) before typing, instead of typing into a
+/// still-booting pane whenever `ensure_pane_ready` reports `AlreadyAlive` (a
+/// pane that already exists gets no wait at all otherwise). `--tool
+/// opencode` exercises the real registered marker ("ask anything") rather
+/// than the generic content-settle fallback. This test proves end-to-end
+/// delivery still works; the deterministic proof that the wait actually
+/// blocks until the marker appears (not just until the pane looks quiet)
+/// lives in `wait_until_ready_blocks_until_the_marker_appears` in
+/// `src/tmux/session.rs`, since canonical tty input buffering alone would
+/// let a message typed before boot survive to `read -r` here regardless.
 #[test]
 #[parallel]
 fn test_cli_send_waits_for_slow_boot_before_typing() {
@@ -1877,7 +1884,7 @@ fn test_cli_send_waits_for_slow_boot_before_typing() {
         "-t",
         "SlowBootSend",
         "--tool",
-        "claude",
+        "opencode",
         "--cmd-override",
         fake_agent.to_str().unwrap(),
     ]);

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -1828,3 +1828,122 @@ fn test_cli_stop_trap_redirects() {
         );
     }
 }
+
+/// Fake agent that prints a substantial startup banner, sleeps to simulate a
+/// slow-booting TUI, then reads exactly one line and echoes it back in a
+/// greppable form.
+fn install_slow_boot_agent(h: &TuiTestHarness) -> std::path::PathBuf {
+    let dir = h.home_path().join("fake-bin");
+    std::fs::create_dir_all(&dir).expect("create fake-bin dir");
+    let script_path = dir.join("fake-slow-agent");
+    let script = "#!/bin/sh\n\
+echo '=== Fake Agent booting ==='\n\
+echo 'Loading modules...'\n\
+sleep 1\n\
+echo '==========================='\n\
+echo '> Ready for input'\n\
+read -r line\n\
+echo \"GOT:[$line]\"\n\
+sleep 60\n";
+    std::fs::write(&script_path, script).expect("write fake agent script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake agent script");
+    }
+    script_path
+}
+
+/// `aoe send` right after `aoe session start` -- the sequence a headless
+/// dispatcher with no controlling terminal must use, since it cannot rely on
+/// `aoe add --launch`'s own attach -- must not race the agent's own boot: it
+/// waits for the pane to settle (`Session::wait_until_content_settles`)
+/// before typing, instead of typing into a still-booting pane whenever
+/// `ensure_pane_ready` reports `AlreadyAlive` (a pane that already exists
+/// gets no wait at all otherwise).
+#[test]
+#[parallel]
+fn test_cli_send_waits_for_slow_boot_before_typing() {
+    require_tmux!();
+
+    let h = TuiTestHarness::new("cli_send_settle_wait");
+    let fake_agent = install_slow_boot_agent(&h);
+    let project = h.project_path();
+
+    let add_output = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-t",
+        "SlowBootSend",
+        "--tool",
+        "claude",
+        "--cmd-override",
+        fake_agent.to_str().unwrap(),
+    ]);
+    assert!(
+        add_output.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let sessions = read_sessions_json(&h);
+    let session_id = sessions[0]["id"]
+        .as_str()
+        .expect("session should have id")
+        .to_string();
+
+    let start_output = h.run_cli(&["session", "start", &session_id]);
+    assert!(
+        start_output.status.success(),
+        "aoe session start failed: {}",
+        String::from_utf8_lossy(&start_output.stderr)
+    );
+
+    // Send immediately: `aoe session start` returns as soon as the tmux pane
+    // exists, well before the fake agent's 1s boot delay elapses, exactly
+    // mirroring a headless dispatcher that has no controlling terminal to
+    // attach with and so cannot use `aoe add --launch`'s readiness instead.
+    let send_output = h.run_cli(&["send", &session_id, "hello there"]);
+    assert!(
+        send_output.status.success(),
+        "aoe send failed: {}",
+        String::from_utf8_lossy(&send_output.stderr)
+    );
+
+    // Poll the pane for the echoed line: it only appears once the fake
+    // agent's `read -r line` has actually returned, proving the message was
+    // delivered end to end rather than lost during boot.
+    let sock = h.home_path().join("tmux.sock");
+    let truncated_id = &session_id[..8.min(session_id.len())];
+    let tmux_name = format!(
+        "{}SlowBootSend_{}",
+        agent_of_empires::tmux::SESSION_PREFIX,
+        truncated_id
+    );
+    let mut content = String::new();
+    for _ in 0..50 {
+        let out = Command::new("tmux")
+            .arg("-S")
+            .arg(&sock)
+            .args(["capture-pane", "-t", &format!("{tmux_name}:^.0"), "-p"])
+            .output();
+        if let Ok(out) = out {
+            content = String::from_utf8_lossy(&out.stdout).to_string();
+            if content.contains("GOT:[hello there]") {
+                break;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+    assert!(
+        content.contains("GOT:[hello there]"),
+        "expected the fake agent to echo the sent message; pane content:\n{content}"
+    );
+
+    let _ = Command::new("tmux")
+        .arg("-S")
+        .arg(&sock)
+        .args(["kill-session", "-t", &tmux_name])
+        .output();
+}

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -1874,7 +1874,10 @@ sleep 60\n";
 fn test_cli_send_waits_for_slow_boot_before_typing() {
     require_tmux!();
 
-    let h = TuiTestHarness::new("cli_send_settle_wait");
+    let mut h = TuiTestHarness::new("cli_send_settle_wait");
+    // Install an `opencode` shim so `is_agent_available` passes (the test
+    // uses `--tool opencode` which triggers the built-in tool check).
+    h.install_path_command("opencode");
     let fake_agent = install_slow_boot_agent(&h);
     let project = h.project_path();
 

--- a/tests/e2e/kiro_launch.rs
+++ b/tests/e2e/kiro_launch.rs
@@ -91,12 +91,13 @@ fn pane_start_command(sock: &std::path::Path, session: &str) -> String {
 }
 
 /// Run `aoe add --launch ...` for a kiro session and return the command tmux
-/// was told to run. `--launch` creates the tmux session and then attempts a
-/// foreground attach, which fails under the test's non-TTY stdio; that attach
-/// failure is expected and irrelevant here, so the exit status is not asserted.
-/// The session (and its recorded pane command) is created regardless, and
-/// `launched_tmux_name` fails loudly if it wasn't. The returned guard kills the
-/// session when the caller's scope ends, including on assertion panic.
+/// was told to run. `--launch` starts the tmux session and, since the test
+/// harness's `run_cli` has no controlling terminal, skips the interactive
+/// attach step instead of failing because of it; the exit status IS asserted
+/// here to cover that behavior. The session (and its recorded pane command)
+/// is created regardless, and `launched_tmux_name` fails loudly if it
+/// wasn't. The returned guard kills the session when the caller's scope
+/// ends, including on assertion panic.
 fn launch_kiro_and_read_command(
     h: &mut TuiTestHarness,
     title: &str,
@@ -121,7 +122,12 @@ fn launch_kiro_and_read_command(
         "--launch",
     ];
     args.extend_from_slice(extra);
-    let _ = h.run_cli(&args);
+    let output = h.run_cli(&args);
+    assert!(
+        output.status.success(),
+        "aoe add --launch should succeed without a controlling terminal: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let session = launched_tmux_name(h, title);
     let socket = h.home_path().join("tmux.sock");

--- a/tests/e2e/permission_response_e2e.rs
+++ b/tests/e2e/permission_response_e2e.rs
@@ -60,12 +60,9 @@ fn test_respond_to_permission_allow_sends_bare_digit() {
 
     let project = h.project_path();
     // `--launch` starts the tmux session (spawning the fake claude script)
-    // and then tries to attach the CLI process's own terminal to it; that
-    // attach fails here because `run_cli` has no tty, but the tmux session
-    // is already live by that point, which is all this test needs. Don't
-    // assert success; asserting on it would depend on that terminal-attach
-    // side effect, not on session creation/launch.
-    h.run_cli(&[
+    // and skips the interactive terminal-attach step, since `run_cli` has no
+    // controlling terminal; the exit status is asserted to cover that.
+    let output = h.run_cli(&[
         "add",
         project.to_str().unwrap(),
         "-t",
@@ -76,6 +73,11 @@ fn test_respond_to_permission_allow_sends_bare_digit() {
         fake_claude.to_str().unwrap(),
         "--launch",
     ]);
+    assert!(
+        output.status.success(),
+        "aoe add --launch should succeed without a controlling terminal: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     h.spawn_tui();
     h.wait_for(" aoe ");
@@ -107,8 +109,8 @@ fn test_respond_to_permission_deny_sends_bare_digit() {
     let fake_claude = install_fake_claude_prompt(&h);
 
     let project = h.project_path();
-    // See the allow test above for why the add-launch output isn't asserted.
-    h.run_cli(&[
+    // See the allow test above: the exit status now IS asserted.
+    let output = h.run_cli(&[
         "add",
         project.to_str().unwrap(),
         "-t",
@@ -119,6 +121,11 @@ fn test_respond_to_permission_deny_sends_bare_digit() {
         fake_claude.to_str().unwrap(),
         "--launch",
     ]);
+    assert!(
+        output.status.success(),
+        "aoe add --launch should succeed without a controlling terminal: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     h.spawn_tui();
     h.wait_for(" aoe ");


### PR DESCRIPTION
## Description
Hardens `aoe add --launch` and `aoe send` for headless dispatch (LaunchAgent, cron, or any caller with no controlling terminal), found while porting a wrapper script off the raw opencode HTTP API:

- `aoe add --launch` no longer fails with exit 1 when stdout isn't a terminal (the interactive attach step needs a TTY it doesn't have); it skips the attach and reports success since the session already started fine.
- `aoe send` now waits for the target pane's content to settle before typing (reusing the poller `aoe session restart`'s wake-message send already relies on, extracted into `tmux::Session`), instead of typing immediately whenever the pane merely exists (`EnsureReadyOutcome::AlreadyAlive` previously got no wait at all).
- A message starting with `/` is padded with a trailing space before the terminating Enter, so an agent's own slash-command autocomplete dropdown doesn't swallow the Enter and leave the command typed-but-unsubmitted.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`: tightened `kiro_launch.rs` and `permission_response_e2e.rs` to assert `--launch` now succeeds without a TTY (previously they explicitly skipped the exit-code check because of this bug), and added `test_cli_send_waits_for_slow_boot_before_typing` in `cli.rs` proving `aoe send` delivers a message to a session that's still mid-boot. Also added a pure unit test for the slash-command padding decision.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** anthropic/claude-sonnet-5, via an agentic coding harness (OpenCode/omp-based)

**Any Additional AI Details you'd like to share:** Implementation, tests, and this description were produced by the AI agent under my direction and review; I verified the diff, ran the test suite, and did a manual smoke test of `aoe add --launch` from a genuine non-TTY subprocess before opening this PR.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- `aoe add --launch` now succeeds without a controlling terminal. It skips interactive attachment and prints a quoted attach command.
- `aoe send` waits for the target pane to become ready before sending input.
- Agents can define readiness markers. Readiness matching is case-insensitive, with content settling used when no marker exists.
- Slash-prefixed messages receive trailing-space padding before submission. This prevents autocomplete from consuming the command.
- Added unit and end-to-end tests for headless launch, slow startup, readiness detection, and slash-command handling.
- Updated tests to refresh stale tmux session state and verify successful headless execution.

## Benefits

These changes improve message delivery during slow startup. They also make tmux launches reliable in CI, automation, and other headless environments.

## Technical notes

- Added `Session::wait_until_ready`.
- Added `AgentDef.ready_marker` and the `ready_marker` lookup function.
- Updated session restart and send flows to use agent-specific readiness checks.
- Added a delayed OpenCode agent scenario to test input delivery during slow startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->