### PR TITLE
feat(web): add conversation font size controls to the structured view

### DIFF
--- a/docs/guides/web/settings.md
+++ b/docs/guides/web/settings.md
@@ -33,14 +33,25 @@ TUI/`config.toml`-only.
 **Sessions > Structured view > Conversation display** sets the base font size
 of the structured-view conversation transcript, separately for mobile and
 desktop. Prose, headings, lists, tables, and fenced code all scale from that
-base, so shrinking it fits more of a transcript on a phone screen. The
-breakpoint is 768px; resizing the window across it switches between the two
-values live.
+base, so shrinking it fits more of a transcript on a phone screen.
+
+The mobile value applies when the device has a coarse primary pointer (touch)
+*and* the viewport is narrower than 768px, the same rule the rest of the
+dashboard uses to decide what counts as mobile. A touch laptop and a narrowed
+desktop window both keep the desktop value. The switch happens live, so
+resizing the window or rotating a phone reflows the transcript without a
+reload.
 
 Each axis runs from 6px to 28px in 1px steps and defaults to 14px, the same
 range as the terminal font sizes under **Web Dashboard > Terminal**, so the two
 sliders read alike. Drag the slider or pick the exact size from the px dropdown
 next to it; the two stay in sync.
+
+The number you pick is relative to your browser's own font-size setting rather
+than an absolute pixel size: the 14px default renders at 14px with the usual
+16px browser default, and at 17.5px if you have raised your browser's base font
+size to 20px. Every size scales by that same factor, so the setting stacks with
+browser-level zoom or accessibility preferences instead of overriding them.
 
 Both values are dashboard preferences rather than agent config: they live in
 the `aoe-web-settings` browser storage entry, which the dashboard mirrors to

--- a/docs/guides/web/settings.md
+++ b/docs/guides/web/settings.md
@@ -3,7 +3,8 @@
 The settings view mirrors the TUI settings layout so muscle memory
 carries over. It is grouped into tabs you can edit per profile or
 globally. This page maps the tabs and covers the web-only pieces:
-the profile picker, connected-device tracking, and step-up elevation.
+the conversation font size, the profile picker, connected-device
+tracking, and step-up elevation.
 For running the server, see the [Web Dashboard overview](../web-dashboard.md).
 
 ![The settings view with its tab groups and profile picker](../../assets/web/settings.png)
@@ -26,6 +27,27 @@ panel is generated from the same settings schema as the TUI, so a field
 declared once appears on both surfaces and they never drift. The only host-side
 knob the dashboard does not surface is the host environment list, which stays
 TUI/`config.toml`-only.
+
+## Conversation font size
+
+**Sessions > Structured view > Conversation display** sets the base font size
+of the structured-view conversation transcript, separately for mobile and
+desktop. Prose, headings, lists, tables, and fenced code all scale from that
+base, so shrinking it fits more of a transcript on a phone screen. The
+breakpoint is 768px; resizing the window across it switches between the two
+values live.
+
+Each axis runs from 6px to 28px in 1px steps and defaults to 14px, the same
+range as the terminal font sizes under **Web Dashboard > Terminal**, so the two
+sliders read alike. Drag the slider or pick the exact size from the px dropdown
+next to it; the two stay in sync.
+
+Both values are dashboard preferences rather than agent config: they live in
+the `aoe-web-settings` browser storage entry, which the dashboard mirrors to
+the daemon's web-UI state, so they follow you to your other browsers and
+devices the same way the terminal font sizes do. They are stored separately
+from the terminal font sizes and are not part of the agent config schema, so
+they are not per profile and do not appear in `config.toml`.
 
 ## Profiles
 

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -28,6 +28,7 @@ import { PluginsSettings } from "./settings/PluginsSettings";
 import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 import { PluginSettingsSections } from "./settings/PluginSettingsSections";
 import { SettingsHeader } from "./settings/SettingsHeader";
+import { StructuredViewDisplaySettings } from "./settings/StructuredViewDisplaySettings";
 import { ProfilesSection } from "./profiles/ProfilesSection";
 import { SECTION_TO_TAB, type SettingsSearchHit } from "./settings/settingsSearchIndex";
 
@@ -815,12 +816,14 @@ export function SettingsView({
             {/* Tour anchor for the per-agent defaults step (#2631). Anchored on
                 this top-of-tab intro, not the defaults widget itself, so
                 react-joyride never has to scroll a far-down, async-growing
-                target into view (which made it loop and never advance). */}
+                target into view (which made it loop and never advance). Keep it
+                first in the tab for the same reason. */}
             <p className="text-xs text-text-dim" {...tourAnchor(TOUR_ANCHORS.settingsAgentDefaults)}>
               Defaults for structured-view (ACP) sessions: which agent starts, how many workers run at once, how much
               history is replayed on reconnect, and the per-agent model, mode, and thinking defaults below. These apply
               when a session renders in the structured view instead of a raw terminal.
             </p>
+            <StructuredViewDisplaySettings />
             <SchemaSection
               section="acp"
               schema={schema}

--- a/web/src/components/TerminalSettings.tsx
+++ b/web/src/components/TerminalSettings.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 
 import { useWebSettings } from "../hooks/useWebSettings";
 import { detectInstalledFonts } from "../lib/fontDetect";
-import { MAX_FONT_SIZE, MIN_FONT_SIZE } from "../lib/fontSizeRange";
 import {
   MAX_PERSISTENT_TERMINALS,
   MIN_PERSISTENT_TERMINALS,
@@ -26,8 +25,6 @@ export function TerminalSettings() {
           label="Mobile font size"
           testIdPrefix="terminal-mobile-font-size"
           value={settings.mobileFontSize}
-          min={MIN_FONT_SIZE}
-          max={MAX_FONT_SIZE}
           onChange={(value) => update({ mobileFontSize: value })}
           description="Font size for web terminal sessions on mobile devices, including tmux-backed sessions. Pinch the terminal with two fingers to zoom; the new size is saved here."
         />
@@ -36,8 +33,6 @@ export function TerminalSettings() {
           label="Desktop font size"
           testIdPrefix="terminal-desktop-font-size"
           value={settings.desktopFontSize}
-          min={MIN_FONT_SIZE}
-          max={MAX_FONT_SIZE}
           onChange={(value) => update({ desktopFontSize: value })}
           description="Font size for web terminal sessions on desktop, including tmux-backed sessions. Hold Ctrl and scroll over the terminal (or pinch on a trackpad) to zoom; the new size is saved here."
         />

--- a/web/src/components/TerminalSettings.tsx
+++ b/web/src/components/TerminalSettings.tsx
@@ -2,13 +2,13 @@ import { useMemo } from "react";
 
 import { useWebSettings } from "../hooks/useWebSettings";
 import { detectInstalledFonts } from "../lib/fontDetect";
+import { MAX_FONT_SIZE, MIN_FONT_SIZE } from "../lib/fontSizeRange";
 import {
   MAX_PERSISTENT_TERMINALS,
   MIN_PERSISTENT_TERMINALS,
   normalizePersistentTerminalLimit,
 } from "../lib/persistentTerminals";
-
-const FONT_SIZES = Array.from({ length: 23 }, (_, i) => i + 6); // 6..28
+import { FontSizeControl } from "./settings/FontSizeControl";
 
 export function TerminalSettings() {
   const { settings, update } = useWebSettings();
@@ -22,65 +22,25 @@ export function TerminalSettings() {
       <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">Terminal</h3>
 
       <div className="space-y-4">
-        <div>
-          <label className="block text-[13px] text-text-secondary mb-2">Mobile font size</label>
-          <div className="flex items-center gap-3">
-            <input
-              type="range"
-              min={6}
-              max={28}
-              step={1}
-              value={settings.mobileFontSize}
-              onChange={(e) => update({ mobileFontSize: Number(e.target.value) })}
-              className="flex-1 accent-brand-600 h-1.5"
-            />
-            <select
-              value={settings.mobileFontSize}
-              onChange={(e) => update({ mobileFontSize: Number(e.target.value) })}
-              className="bg-surface-800 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary font-mono w-16 text-center"
-            >
-              {FONT_SIZES.map((s) => (
-                <option key={s} value={s}>
-                  {s}px
-                </option>
-              ))}
-            </select>
-          </div>
-          <p className="text-[11px] text-text-muted mt-1">
-            Font size for web terminal sessions on mobile devices, including tmux-backed sessions. Pinch the terminal
-            with two fingers to zoom; the new size is saved here.
-          </p>
-        </div>
+        <FontSizeControl
+          label="Mobile font size"
+          testIdPrefix="terminal-mobile-font-size"
+          value={settings.mobileFontSize}
+          min={MIN_FONT_SIZE}
+          max={MAX_FONT_SIZE}
+          onChange={(value) => update({ mobileFontSize: value })}
+          description="Font size for web terminal sessions on mobile devices, including tmux-backed sessions. Pinch the terminal with two fingers to zoom; the new size is saved here."
+        />
 
-        <div>
-          <label className="block text-[13px] text-text-secondary mb-2">Desktop font size</label>
-          <div className="flex items-center gap-3">
-            <input
-              type="range"
-              min={6}
-              max={28}
-              step={1}
-              value={settings.desktopFontSize}
-              onChange={(e) => update({ desktopFontSize: Number(e.target.value) })}
-              className="flex-1 accent-brand-600 h-1.5"
-            />
-            <select
-              value={settings.desktopFontSize}
-              onChange={(e) => update({ desktopFontSize: Number(e.target.value) })}
-              className="bg-surface-800 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary font-mono w-16 text-center"
-            >
-              {FONT_SIZES.map((s) => (
-                <option key={s} value={s}>
-                  {s}px
-                </option>
-              ))}
-            </select>
-          </div>
-          <p className="text-[11px] text-text-muted mt-1">
-            Font size for web terminal sessions on desktop, including tmux-backed sessions. Hold Ctrl and scroll over
-            the terminal (or pinch on a trackpad) to zoom; the new size is saved here.
-          </p>
-        </div>
+        <FontSizeControl
+          label="Desktop font size"
+          testIdPrefix="terminal-desktop-font-size"
+          value={settings.desktopFontSize}
+          min={MIN_FONT_SIZE}
+          max={MAX_FONT_SIZE}
+          onChange={(value) => update({ desktopFontSize: value })}
+          description="Font size for web terminal sessions on desktop, including tmux-backed sessions. Hold Ctrl and scroll over the terminal (or pinch on a trackpad) to zoom; the new size is saved here."
+        />
 
         <div>
           <label htmlFor="terminal-font-family" className="block text-[13px] text-text-secondary mb-2">

--- a/web/src/components/acp/Markdown.test.tsx
+++ b/web/src/components/acp/Markdown.test.tsx
@@ -115,6 +115,16 @@ describe("Markdown wrapper config", () => {
     const node = container.querySelector(".acp-markdown");
     expect(node).not.toBeNull();
   });
+
+  it("takes its base size from the conversation font-size variable, not a fixed utility", () => {
+    const { container } = render(<Markdown text="x" />);
+    const node = container.querySelector(".acp-markdown") as HTMLElement;
+    // `.acp-markdown-body` is what index.css binds to
+    // var(--acp-conversation-font-size); a `text-sm`-style utility here would
+    // outrank it and defeat the user's setting.
+    expect(node.classList.contains("acp-markdown-body")).toBe(true);
+    expect([...node.classList].some((c) => /^text-(xs|sm|base|lg|\[)/.test(c))).toBe(false);
+  });
 });
 
 describe("Blockquote override", () => {

--- a/web/src/components/acp/Markdown.tsx
+++ b/web/src/components/acp/Markdown.tsx
@@ -248,15 +248,22 @@ function ShikiSyntaxHighlighter({ language, code }: SyntaxHighlighterProps) {
     };
   }, [language, code, shiki.theme, shiki.appearance]);
 
+  // `leading-[1.3333]` restores what `text-xs` used to supply here: Tailwind
+  // registers `--tw-leading` as `inherits: false`, so the old `text-xs` fell
+  // back to its own 1.3333 ratio rather than the root's `leading-relaxed`.
+  // The em-based size carries no line-height of its own, so without this the
+  // block would inherit 1.625 and code would render noticeably looser.
   if (html) {
     return (
       <div
-        className="overflow-x-auto px-3 py-2 text-[0.86em] [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0"
+        className="overflow-x-auto px-3 py-2 text-[0.86em] leading-[1.3333] [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0"
         dangerouslySetInnerHTML={{ __html: html }}
       />
     );
   }
-  return <pre className="overflow-x-auto px-3 py-2 text-[0.86em] font-mono text-text-primary">{code}</pre>;
+  return (
+    <pre className="overflow-x-auto px-3 py-2 text-[0.86em] leading-[1.3333] font-mono text-text-primary">{code}</pre>
+  );
 }
 
 /** Header strip above each code block: language label + copy button. */

--- a/web/src/components/acp/Markdown.tsx
+++ b/web/src/components/acp/Markdown.tsx
@@ -68,7 +68,7 @@ export function Markdown({ text, smooth = false, breaks = false }: Props) {
       preprocess={() => text}
       smooth={smooth}
       remarkPlugins={remarkPlugins}
-      className="acp-markdown text-sm leading-relaxed"
+      className="acp-markdown acp-markdown-body leading-relaxed"
       components={{
         SyntaxHighlighter: ShikiSyntaxHighlighter,
         CodeHeader,
@@ -251,18 +251,18 @@ function ShikiSyntaxHighlighter({ language, code }: SyntaxHighlighterProps) {
   if (html) {
     return (
       <div
-        className="overflow-x-auto px-3 py-2 text-xs [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0"
+        className="overflow-x-auto px-3 py-2 text-[0.86em] [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0"
         dangerouslySetInnerHTML={{ __html: html }}
       />
     );
   }
-  return <pre className="overflow-x-auto px-3 py-2 text-xs font-mono text-text-primary">{code}</pre>;
+  return <pre className="overflow-x-auto px-3 py-2 text-[0.86em] font-mono text-text-primary">{code}</pre>;
 }
 
 /** Header strip above each code block: language label + copy button. */
 function CodeHeader({ language, code }: CodeHeaderProps) {
   return (
-    <div className="flex items-center justify-between border-b border-surface-800 bg-surface-950 px-3 py-1 text-[11px] font-mono uppercase tracking-wider text-text-dim">
+    <div className="flex items-center justify-between border-b border-surface-800 bg-surface-950 px-3 py-1 text-[0.79em] font-mono uppercase tracking-wider text-text-dim">
       <span>{language ?? "text"}</span>
       <button
         type="button"

--- a/web/src/components/acp/StructuredView.layout.test.ts
+++ b/web/src/components/acp/StructuredView.layout.test.ts
@@ -1,3 +1,8 @@
+// @vitest-environment jsdom
+//
+// jsdom (not node) because importing StructuredView pulls in useWebSettings,
+// whose module-level default snapshot reads window.innerWidth.
+//
 // Layout-decision test for the structured-view root keyboard reservation
 // added in #2011. The pure helper lets us check the inline style across the
 // iOS-regular-Safari case (keyboardHeight > 0) and the layout-shrinking

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -62,6 +62,7 @@ import { useIsCoarsePointer } from "../../hooks/useIsCoarsePointer";
 import { useIsWideViewport } from "../../hooks/useIsWideViewport";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
 import { ChromeCollapseHandle, CollapsibleRegion } from "../CollapsibleChrome";
+import { useWebSettings } from "../../hooks/useWebSettings";
 import { dispatchFocusTerminal } from "../../lib/terminalFocus";
 import { shouldFocusComposerOnThreadTap } from "./threadTapFocus";
 import type {
@@ -223,17 +224,40 @@ export function structuredViewRootStyle(keyboardHeight: number): React.CSSProper
   return keyboardHeight > 0 ? { paddingBottom: keyboardHeight } : undefined;
 }
 
+/** Publishes both conversation font-size preferences as scoped custom
+ *  properties on the structured-view root; `index.css` picks the active one via
+ *  a media query, so crossing the 768px breakpoint reflows without a reload and
+ *  without a JS width probe. Merged on top of the keyboard reservation rather
+ *  than replacing it. Both sizes arrive already clamped from `useWebSettings`,
+ *  which is the single normalization boundary for stored prefs. */
+function structuredViewFontStyle(
+  keyboardHeight: number,
+  mobileFontSize: number,
+  desktopFontSize: number,
+): React.CSSProperties {
+  return {
+    ...structuredViewRootStyle(keyboardHeight),
+    "--acp-conversation-font-size-mobile": `${mobileFontSize}px`,
+    "--acp-conversation-font-size-desktop": `${desktopFontSize}px`,
+  } as React.CSSProperties;
+}
+
 /** Fixed-height flex root for the structured view, owning the mobile-keyboard
  *  reservation (see {@link structuredViewRootStyle}). Exported and kept tiny so
  *  the hook-to-style wiring is testable without mounting the assistant-ui
  *  runtime, mirroring the #1282 rate-limit-recovery extraction. */
 export function StructuredViewRoot({ children }: { children: React.ReactNode }) {
   const { keyboardHeight } = useMobileKeyboard();
+  const { settings } = useWebSettings();
   return (
     <div
       data-testid="structured-view-root"
-      className="flex h-full flex-col bg-surface-900 text-text-primary"
-      style={structuredViewRootStyle(keyboardHeight)}
+      className="acp-conversation-scope flex h-full flex-col bg-surface-900 text-text-primary"
+      style={structuredViewFontStyle(
+        keyboardHeight,
+        settings.structuredMobileFontSize,
+        settings.structuredDesktopFontSize,
+      )}
     >
       {children}
     </div>

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -63,6 +63,7 @@ import { useIsWideViewport } from "../../hooks/useIsWideViewport";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
 import { ChromeCollapseHandle, CollapsibleRegion } from "../CollapsibleChrome";
 import { useWebSettings } from "../../hooks/useWebSettings";
+import { conversationFontSizeRem } from "../../lib/conversationFontSize";
 import { dispatchFocusTerminal } from "../../lib/terminalFocus";
 import { shouldFocusComposerOnThreadTap } from "./threadTapFocus";
 import type {
@@ -226,10 +227,13 @@ export function structuredViewRootStyle(keyboardHeight: number): React.CSSProper
 
 /** Publishes both conversation font-size preferences as scoped custom
  *  properties on the structured-view root; `index.css` picks the active one via
- *  a media query, so crossing the 768px breakpoint reflows without a reload and
- *  without a JS width probe. Merged on top of the keyboard reservation rather
- *  than replacing it. Both sizes arrive already clamped from `useWebSettings`,
- *  which is the single normalization boundary for stored prefs. */
+ *  the same coarse-pointer + narrow-viewport rule the rest of the dashboard
+ *  classifies mobile with, so a resize or an orientation change reflows without
+ *  a reload and without a JS width probe. Merged on top of the keyboard
+ *  reservation rather than replacing it. The stored px values are published as
+ *  `rem` (see {@link conversationFontSizeRem}) so the transcript still tracks
+ *  the reader's root font size. Both sizes arrive already clamped from
+ *  `useWebSettings`, the single normalization boundary for stored prefs. */
 function structuredViewFontStyle(
   keyboardHeight: number,
   mobileFontSize: number,
@@ -237,8 +241,8 @@ function structuredViewFontStyle(
 ): React.CSSProperties {
   return {
     ...structuredViewRootStyle(keyboardHeight),
-    "--acp-conversation-font-size-mobile": `${mobileFontSize}px`,
-    "--acp-conversation-font-size-desktop": `${desktopFontSize}px`,
+    "--acp-conversation-font-size-mobile": conversationFontSizeRem(mobileFontSize),
+    "--acp-conversation-font-size-desktop": conversationFontSizeRem(desktopFontSize),
   } as React.CSSProperties;
 }
 

--- a/web/src/components/acp/__tests__/StructuredViewRoot.test.tsx
+++ b/web/src/components/acp/__tests__/StructuredViewRoot.test.tsx
@@ -45,7 +45,10 @@ describe("StructuredViewRoot (#2011)", () => {
     expect(screen.getByTestId("structured-view-root").style.paddingBottom).toBe("");
   });
 
-  it("publishes both conversation font-size custom properties without dropping the keyboard reservation", () => {
+  // The stored setting is an integer px value but reaches CSS as `rem`, so a
+  // reader who raised their browser's root font size keeps scaling: absolute
+  // px would pin the transcript at the authored size and ignore that setting.
+  it("publishes both conversation font sizes as rem without dropping the keyboard reservation", () => {
     mockKeyboard.current = { isMobile: true, keyboardOpen: true, keyboardHeight: 300 };
     window.localStorage.setItem(
       "aoe-web-settings",
@@ -57,11 +60,22 @@ describe("StructuredViewRoot (#2011)", () => {
       </StructuredViewRoot>,
     );
     const root = screen.getByTestId("structured-view-root");
-    expect(root.style.getPropertyValue("--acp-conversation-font-size-mobile")).toBe("11px");
-    expect(root.style.getPropertyValue("--acp-conversation-font-size-desktop")).toBe("18px");
-    // The breakpoint that picks between them lives in CSS, so the root must
-    // carry the scope class the media query keys off.
+    expect(root.style.getPropertyValue("--acp-conversation-font-size-mobile")).toBe("0.6875rem");
+    expect(root.style.getPropertyValue("--acp-conversation-font-size-desktop")).toBe("1.125rem");
+    // The coarse-pointer + narrow-viewport rule that picks between them lives
+    // in CSS, so the root must carry the scope class it keys off.
     expect(root.classList.contains("acp-conversation-scope")).toBe(true);
     expect(root.style.paddingBottom).toBe("300px");
+  });
+
+  it("publishes the 14px default as 0.875rem, matching the pre-setting text-sm base", () => {
+    render(
+      <StructuredViewRoot>
+        <div>child</div>
+      </StructuredViewRoot>,
+    );
+    const root = screen.getByTestId("structured-view-root");
+    expect(root.style.getPropertyValue("--acp-conversation-font-size-mobile")).toBe("0.875rem");
+    expect(root.style.getPropertyValue("--acp-conversation-font-size-desktop")).toBe("0.875rem");
   });
 });

--- a/web/src/components/acp/__tests__/StructuredViewRoot.test.tsx
+++ b/web/src/components/acp/__tests__/StructuredViewRoot.test.tsx
@@ -21,6 +21,7 @@ import { StructuredViewRoot } from "../StructuredView";
 
 afterEach(() => {
   cleanup();
+  window.localStorage.clear();
   mockKeyboard.current = { isMobile: false, keyboardOpen: false, keyboardHeight: 0 };
 });
 
@@ -42,5 +43,25 @@ describe("StructuredViewRoot (#2011)", () => {
       </StructuredViewRoot>,
     );
     expect(screen.getByTestId("structured-view-root").style.paddingBottom).toBe("");
+  });
+
+  it("publishes both conversation font-size custom properties without dropping the keyboard reservation", () => {
+    mockKeyboard.current = { isMobile: true, keyboardOpen: true, keyboardHeight: 300 };
+    window.localStorage.setItem(
+      "aoe-web-settings",
+      JSON.stringify({ structuredMobileFontSize: 11, structuredDesktopFontSize: 18 }),
+    );
+    render(
+      <StructuredViewRoot>
+        <div>child</div>
+      </StructuredViewRoot>,
+    );
+    const root = screen.getByTestId("structured-view-root");
+    expect(root.style.getPropertyValue("--acp-conversation-font-size-mobile")).toBe("11px");
+    expect(root.style.getPropertyValue("--acp-conversation-font-size-desktop")).toBe("18px");
+    // The breakpoint that picks between them lives in CSS, so the root must
+    // carry the scope class the media query keys off.
+    expect(root.classList.contains("acp-conversation-scope")).toBe(true);
+    expect(root.style.paddingBottom).toBe("300px");
   });
 });

--- a/web/src/components/settings/FontSizeControl.tsx
+++ b/web/src/components/settings/FontSizeControl.tsx
@@ -1,8 +1,8 @@
+import { MAX_FONT_SIZE, MIN_FONT_SIZE } from "../../lib/fontSizeRange";
+
 interface FontSizeControlProps {
   label: string;
   value: number;
-  min: number;
-  max: number;
   onChange: (value: number) => void;
   description?: string;
   /** Prefix for the slider/select `data-testid`s, so a settings panel with two
@@ -10,11 +10,14 @@ interface FontSizeControlProps {
   testIdPrefix: string;
 }
 
+const OPTIONS = Array.from({ length: MAX_FONT_SIZE - MIN_FONT_SIZE + 1 }, (_, i) => MIN_FONT_SIZE + i);
+
 /** Slider + px select pair shared by the terminal and conversation font-size
  *  settings. Both controls write the same value so they stay synchronized; the
- *  select offers every integer step in range. */
-export function FontSizeControl({ label, value, min, max, onChange, description, testIdPrefix }: FontSizeControlProps) {
-  const options = Array.from({ length: max - min + 1 }, (_, i) => min + i);
+ *  select offers every integer step in range. The range is not a prop: every
+ *  font-size control in the dashboard spans {@link MIN_FONT_SIZE}-{@link
+ *  MAX_FONT_SIZE}, and users compare the sliders side by side. */
+export function FontSizeControl({ label, value, onChange, description, testIdPrefix }: FontSizeControlProps) {
   return (
     <div>
       <label className="block text-[13px] text-text-secondary mb-2">{label}</label>
@@ -23,8 +26,8 @@ export function FontSizeControl({ label, value, min, max, onChange, description,
           type="range"
           aria-label={label}
           data-testid={`${testIdPrefix}-slider`}
-          min={min}
-          max={max}
+          min={MIN_FONT_SIZE}
+          max={MAX_FONT_SIZE}
           step={1}
           value={value}
           onChange={(e) => onChange(Number(e.target.value))}
@@ -37,7 +40,7 @@ export function FontSizeControl({ label, value, min, max, onChange, description,
           onChange={(e) => onChange(Number(e.target.value))}
           className="bg-surface-800 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary font-mono w-16 text-center"
         >
-          {options.map((s) => (
+          {OPTIONS.map((s) => (
             <option key={s} value={s}>
               {s}px
             </option>

--- a/web/src/components/settings/FontSizeControl.tsx
+++ b/web/src/components/settings/FontSizeControl.tsx
@@ -1,0 +1,50 @@
+interface FontSizeControlProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (value: number) => void;
+  description?: string;
+  /** Prefix for the slider/select `data-testid`s, so a settings panel with two
+   *  of these controls stays addressable in tests. */
+  testIdPrefix: string;
+}
+
+/** Slider + px select pair shared by the terminal and conversation font-size
+ *  settings. Both controls write the same value so they stay synchronized; the
+ *  select offers every integer step in range. */
+export function FontSizeControl({ label, value, min, max, onChange, description, testIdPrefix }: FontSizeControlProps) {
+  const options = Array.from({ length: max - min + 1 }, (_, i) => min + i);
+  return (
+    <div>
+      <label className="block text-[13px] text-text-secondary mb-2">{label}</label>
+      <div className="flex items-center gap-3">
+        <input
+          type="range"
+          aria-label={label}
+          data-testid={`${testIdPrefix}-slider`}
+          min={min}
+          max={max}
+          step={1}
+          value={value}
+          onChange={(e) => onChange(Number(e.target.value))}
+          className="flex-1 accent-brand-600 h-1.5"
+        />
+        <select
+          aria-label={`${label} (px)`}
+          data-testid={`${testIdPrefix}-select`}
+          value={value}
+          onChange={(e) => onChange(Number(e.target.value))}
+          className="bg-surface-800 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary font-mono w-16 text-center"
+        >
+          {options.map((s) => (
+            <option key={s} value={s}>
+              {s}px
+            </option>
+          ))}
+        </select>
+      </div>
+      {description && <p className="text-[11px] text-text-muted mt-1">{description}</p>}
+    </div>
+  );
+}

--- a/web/src/components/settings/StructuredViewDisplaySettings.tsx
+++ b/web/src/components/settings/StructuredViewDisplaySettings.tsx
@@ -1,0 +1,41 @@
+import { useWebSettings } from "../../hooks/useWebSettings";
+import { MAX_FONT_SIZE, MIN_FONT_SIZE } from "../../lib/fontSizeRange";
+import { FontSizeControl } from "./FontSizeControl";
+
+/** Dashboard display preferences for the structured view. These are not agent
+ *  config, so they live in `aoe-web-settings` rather than the ACP schema, and
+ *  apply live to the conversation transcript only. Like the rest of that entry
+ *  they are mirrored to the daemon's web-UI state by `webUiSync`, so they are
+ *  not per-browser.
+ *
+ *  Values are read already clamped: `useWebSettings` normalizes both fields in
+ *  `normalizeSnapshot`, so no re-clamping is needed here. */
+export function StructuredViewDisplaySettings() {
+  const { settings, update } = useWebSettings();
+
+  return (
+    <div className="space-y-4">
+      <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted">Conversation display</h3>
+
+      <FontSizeControl
+        label="Mobile font size"
+        testIdPrefix="structured-mobile-font-size"
+        value={settings.structuredMobileFontSize}
+        min={MIN_FONT_SIZE}
+        max={MAX_FONT_SIZE}
+        onChange={(value) => update({ structuredMobileFontSize: value })}
+        description="Font size for Structured View conversation content on mobile devices. Separate from the terminal font size, and shared with your other browsers like the rest of the dashboard preferences."
+      />
+
+      <FontSizeControl
+        label="Desktop font size"
+        testIdPrefix="structured-desktop-font-size"
+        value={settings.structuredDesktopFontSize}
+        min={MIN_FONT_SIZE}
+        max={MAX_FONT_SIZE}
+        onChange={(value) => update({ structuredDesktopFontSize: value })}
+        description="Font size for Structured View conversation content on desktop devices. Separate from the terminal font size, and shared with your other browsers like the rest of the dashboard preferences."
+      />
+    </div>
+  );
+}

--- a/web/src/components/settings/StructuredViewDisplaySettings.tsx
+++ b/web/src/components/settings/StructuredViewDisplaySettings.tsx
@@ -1,5 +1,4 @@
 import { useWebSettings } from "../../hooks/useWebSettings";
-import { MAX_FONT_SIZE, MIN_FONT_SIZE } from "../../lib/fontSizeRange";
 import { FontSizeControl } from "./FontSizeControl";
 
 /** Dashboard display preferences for the structured view. These are not agent
@@ -21,8 +20,6 @@ export function StructuredViewDisplaySettings() {
         label="Mobile font size"
         testIdPrefix="structured-mobile-font-size"
         value={settings.structuredMobileFontSize}
-        min={MIN_FONT_SIZE}
-        max={MAX_FONT_SIZE}
         onChange={(value) => update({ structuredMobileFontSize: value })}
         description="Font size for Structured View conversation content on mobile devices. Separate from the terminal font size, and shared with your other browsers like the rest of the dashboard preferences."
       />
@@ -31,8 +28,6 @@ export function StructuredViewDisplaySettings() {
         label="Desktop font size"
         testIdPrefix="structured-desktop-font-size"
         value={settings.structuredDesktopFontSize}
-        min={MIN_FONT_SIZE}
-        max={MAX_FONT_SIZE}
         onChange={(value) => update({ structuredDesktopFontSize: value })}
         description="Font size for Structured View conversation content on desktop devices. Separate from the terminal font size, and shared with your other browsers like the rest of the dashboard preferences."
       />

--- a/web/src/components/settings/__tests__/StructuredViewDisplaySettings.test.tsx
+++ b/web/src/components/settings/__tests__/StructuredViewDisplaySettings.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+//
+// Contract test for the structured-view conversation font-size controls. Like
+// DiffSettings / TerminalSettings these are dashboard preferences persisted
+// through useWebSettings + localStorage (key `aoe-web-settings`, which
+// webUiSync mirrors server-side), never PATCH /api/settings, so the contract is
+// the JSON shape written to that key plus the defaulting/clamping applied when
+// reading it back.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { StructuredViewDisplaySettings } from "../StructuredViewDisplaySettings";
+import { TerminalSettings } from "../../TerminalSettings";
+import { getWebSettingsSnapshot } from "../../../hooks/useWebSettings";
+
+const KEY = "aoe-web-settings";
+
+function readStored(): Record<string, unknown> {
+  const raw = window.localStorage.getItem(KEY);
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(cleanup);
+
+describe("StructuredViewDisplaySettings localStorage contract", () => {
+  it("defaults both sliders to 14px", () => {
+    const { getByTestId } = render(<StructuredViewDisplaySettings />);
+    expect((getByTestId("structured-mobile-font-size-slider") as HTMLInputElement).value).toBe("14");
+    expect((getByTestId("structured-desktop-font-size-slider") as HTMLInputElement).value).toBe("14");
+  });
+
+  // The two panels are the only font-size sliders in the dashboard and users
+  // compare them side by side, so they span one shared range. Rendering both
+  // catches a panel that re-hardcodes its own bounds.
+  it("spans the same slider range as the terminal font-size controls", () => {
+    const conversation = render(<StructuredViewDisplaySettings />);
+    const terminal = render(<TerminalSettings />);
+    const bounds = (root: ReturnType<typeof render>, testId: string) => {
+      const el = root.getByTestId(testId) as HTMLInputElement;
+      return [el.min, el.max];
+    };
+    const expected = bounds(terminal, "terminal-mobile-font-size-slider");
+    expect(expected).toEqual(["6", "28"]);
+    for (const testId of [
+      "terminal-desktop-font-size-slider",
+      "structured-mobile-font-size-slider",
+      "structured-desktop-font-size-slider",
+    ]) {
+      const root = testId.startsWith("terminal-") ? terminal : conversation;
+      expect(bounds(root, testId), testId).toEqual(expected);
+      expect([...root.getByTestId(testId.replace("-slider", "-select")).children].length, testId).toBe(23);
+    }
+  });
+
+  it("writes each axis independently and leaves the terminal sizes alone", () => {
+    const { getByTestId } = render(<StructuredViewDisplaySettings />);
+
+    fireEvent.change(getByTestId("structured-mobile-font-size-slider"), { target: { value: "11" } });
+    expect(readStored().structuredMobileFontSize).toBe(11);
+    expect(readStored().structuredDesktopFontSize).toBe(14);
+
+    fireEvent.change(getByTestId("structured-desktop-font-size-select"), { target: { value: "18" } });
+    expect(readStored().structuredMobileFontSize).toBe(11);
+    expect(readStored().structuredDesktopFontSize).toBe(18);
+
+    // The terminal font sizes are a separate preference and must not move.
+    expect(readStored().mobileFontSize).toBe(8);
+    expect(readStored().desktopFontSize).toBe(14);
+  });
+
+  it("keeps the slider and the px select synchronized on both axes", () => {
+    const { getByTestId } = render(<StructuredViewDisplaySettings />);
+
+    fireEvent.change(getByTestId("structured-mobile-font-size-select"), { target: { value: "20" } });
+    expect((getByTestId("structured-mobile-font-size-slider") as HTMLInputElement).value).toBe("20");
+
+    fireEvent.change(getByTestId("structured-desktop-font-size-slider"), { target: { value: "10" } });
+    expect((getByTestId("structured-desktop-font-size-select") as HTMLInputElement).value).toBe("10");
+  });
+
+  it("survives a reread and reflects the stored values on remount", () => {
+    const first = render(<StructuredViewDisplaySettings />);
+    fireEvent.change(first.getByTestId("structured-mobile-font-size-slider"), { target: { value: "12" } });
+    cleanup();
+
+    expect(getWebSettingsSnapshot().structuredMobileFontSize).toBe(12);
+    const { getByTestId } = render(<StructuredViewDisplaySettings />);
+    expect((getByTestId("structured-mobile-font-size-slider") as HTMLInputElement).value).toBe("12");
+  });
+
+  it("backfills settings saved before these fields existed, and clamps junk", () => {
+    const cases: Array<[unknown, unknown, number, number]> = [
+      // [stored mobile, stored desktop, expected mobile, expected desktop]
+      [undefined, undefined, 14, 14], // pre-existing settings blob
+      [0, -5, 6, 6], // a zero/negative size must never reach CSS
+      ["9999", 1e9, 28, 28], // absurd values clamp to the max
+      ["16", "13", 16, 13], // stringy but sane values coerce
+      [Number.NaN, "not a number", 14, 14], // NaN falls back to the default
+      [12.4, 12.6, 12, 13], // fractional values round
+    ];
+    for (const [mobile, desktop, expectedMobile, expectedDesktop] of cases) {
+      window.localStorage.setItem(
+        KEY,
+        JSON.stringify({ mobileFontSize: 8, structuredMobileFontSize: mobile, structuredDesktopFontSize: desktop }),
+      );
+      const { getByTestId } = render(<StructuredViewDisplaySettings />);
+      const label = `${String(mobile)}/${String(desktop)}`;
+      expect((getByTestId("structured-mobile-font-size-slider") as HTMLInputElement).value, label).toBe(
+        String(expectedMobile),
+      );
+      expect((getByTestId("structured-desktop-font-size-slider") as HTMLInputElement).value, label).toBe(
+        String(expectedDesktop),
+      );
+      cleanup();
+    }
+  });
+});

--- a/web/src/hooks/useWebSettings.ts
+++ b/web/src/hooks/useWebSettings.ts
@@ -1,5 +1,6 @@
 import { useCallback, useSyncExternalStore } from "react";
 
+import { DEFAULT_CONVERSATION_FONT_SIZE, normalizeConversationFontSize } from "../lib/conversationFontSize";
 import { DEFAULT_PERSISTENT_TERMINALS, normalizePersistentTerminalLimit } from "../lib/persistentTerminals";
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 
@@ -8,6 +9,12 @@ const STORAGE_KEY = "aoe-web-settings";
 export interface WebSettings {
   mobileFontSize: number;
   desktopFontSize: number;
+  /** Base font size (px) for the structured-view conversation transcript on
+   *  mobile. Independent of `mobileFontSize`, which sizes terminal cells. */
+  structuredMobileFontSize: number;
+  /** Base font size (px) for the structured-view conversation transcript on
+   *  desktop. Independent of `desktopFontSize`. */
+  structuredDesktopFontSize: number;
   terminalFontFamily: string;
   autoOpenKeyboard: boolean;
   persistentTerminals: boolean;
@@ -41,6 +48,8 @@ function getDefaults(): WebSettings {
   return {
     mobileFontSize: 8,
     desktopFontSize: 14,
+    structuredMobileFontSize: DEFAULT_CONVERSATION_FONT_SIZE,
+    structuredDesktopFontSize: DEFAULT_CONVERSATION_FONT_SIZE,
     terminalFontFamily: "",
     autoOpenKeyboard: true,
     persistentTerminals: false,
@@ -68,6 +77,10 @@ function normalizeSnapshot(settings: WebSettings): WebSettings {
     persistentTerminals:
       typeof settings.persistentTerminals === "boolean" ? settings.persistentTerminals : defaults.persistentTerminals,
     maxPersistentTerminals: normalizePersistentTerminalLimit(settings.maxPersistentTerminals),
+    // A malformed value here reaches CSS directly, so clamp it rather than let
+    // the transcript render at NaN/0px.
+    structuredMobileFontSize: normalizeConversationFontSize(settings.structuredMobileFontSize),
+    structuredDesktopFontSize: normalizeConversationFontSize(settings.structuredDesktopFontSize),
     // localStorage is user-editable: a corrupted stringy "false" must not read
     // truthy and silently auto-open panes the user disabled.
     sidebarCompact: normalizeBool(settings.sidebarCompact, defaults.sidebarCompact),

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -229,14 +229,18 @@ body {
    names). Style them via descendant selectors so the prose looks
    right inside the structured-view conversation. */
 /* The structured-view root publishes both conversation font-size preferences as
-   custom properties; the breakpoint picks the active one in CSS so resizing the
-   window across 768px switches sizes without a reload. */
+   custom properties; CSS picks the active one, so a resize or an orientation
+   change switches sizes without a reload. Desktop is the default and mobile is
+   the override, keyed on the same classifier `clientFormFactor()` uses: coarse
+   primary pointer AND a viewport below the 768px `md` breakpoint. A touch
+   laptop and a narrow desktop window both stay on the desktop size, matching
+   how the rest of the dashboard decides what "mobile" means. */
 .acp-conversation-scope {
-  --acp-conversation-font-size: var(--acp-conversation-font-size-mobile, 14px);
+  --acp-conversation-font-size: var(--acp-conversation-font-size-desktop, 0.875rem);
 }
-@media (min-width: 768px) {
+@media (pointer: coarse) and (max-width: 767.98px) {
   .acp-conversation-scope {
-    --acp-conversation-font-size: var(--acp-conversation-font-size-desktop, 14px);
+    --acp-conversation-font-size: var(--acp-conversation-font-size-mobile, 0.875rem);
   }
 }
 /* Only the conversation renderer (Markdown.tsx) opts in. The other
@@ -412,24 +416,24 @@ body {
 }
 
 /* Child typography for the opted-in conversation renderer only, in `em` so the
-   whole hierarchy scales with the user's base size. These tie on specificity
-   with the `.acp-markdown <type>` rules above and win on source order, so they
-   must stay after them. Ratios reproduce the `rem` values at the 14px default;
-   the other `.acp-markdown` consumers set their own base (tool cards render at
+   whole hierarchy scales with the user's base size. The doubled class outranks
+   the single-class `.acp-markdown <type>` rules above regardless of where they
+   sit in the file. Ratios reproduce the `rem` values at the 14px default; the
+   other `.acp-markdown` consumers set their own base (tool cards render at
    11px) and keep the fixed `rem` sizes. */
-.acp-markdown-body h1 {
+.acp-markdown.acp-markdown-body h1 {
   font-size: 1.43em; /* 20px at the 14px default */
 }
-.acp-markdown-body h2 {
+.acp-markdown.acp-markdown-body h2 {
   font-size: 1.29em; /* 18px at the 14px default */
 }
-.acp-markdown-body h3 {
+.acp-markdown.acp-markdown-body h3 {
   font-size: 1.14em; /* 16px at the 14px default */
 }
-.acp-markdown-body th {
+.acp-markdown.acp-markdown-body th {
   font-size: 0.79em; /* 11px at the 14px default */
 }
-.acp-markdown-body td {
+.acp-markdown.acp-markdown-body td {
   font-size: 0.86em; /* 12px at the 14px default */
 }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -228,6 +228,26 @@ body {
    raw <p>/<ul>/<ol>/<h*>/<blockquote>/<code> elements (no class
    names). Style them via descendant selectors so the prose looks
    right inside the structured-view conversation. */
+/* The structured-view root publishes both conversation font-size preferences as
+   custom properties; the breakpoint picks the active one in CSS so resizing the
+   window across 768px switches sizes without a reload. */
+.acp-conversation-scope {
+  --acp-conversation-font-size: var(--acp-conversation-font-size-mobile, 14px);
+}
+@media (min-width: 768px) {
+  .acp-conversation-scope {
+    --acp-conversation-font-size: var(--acp-conversation-font-size-desktop, 14px);
+  }
+}
+/* Only the conversation renderer (Markdown.tsx) opts in. The other
+   `.acp-markdown` consumers (tool-card bodies, the diff pane's file viewer)
+   keep their own explicit sizes, so the child typography below stays in `rem`
+   for them and is re-expressed in `em` under `.acp-markdown-body` only. */
+.acp-markdown-body {
+  /* Fallback matches the previous fixed `text-sm` for transcript markdown
+     rendered outside the structured-view root (e.g. the skills manager). */
+  font-size: var(--acp-conversation-font-size, 0.875rem);
+}
 .acp-markdown p {
   margin: 0.5rem 0;
 }
@@ -389,6 +409,28 @@ body {
 }
 .acp-markdown tbody tr:last-child td {
   border-bottom: none;
+}
+
+/* Child typography for the opted-in conversation renderer only, in `em` so the
+   whole hierarchy scales with the user's base size. These tie on specificity
+   with the `.acp-markdown <type>` rules above and win on source order, so they
+   must stay after them. Ratios reproduce the `rem` values at the 14px default;
+   the other `.acp-markdown` consumers set their own base (tool cards render at
+   11px) and keep the fixed `rem` sizes. */
+.acp-markdown-body h1 {
+  font-size: 1.43em; /* 20px at the 14px default */
+}
+.acp-markdown-body h2 {
+  font-size: 1.29em; /* 18px at the 14px default */
+}
+.acp-markdown-body h3 {
+  font-size: 1.14em; /* 16px at the 14px default */
+}
+.acp-markdown-body th {
+  font-size: 0.79em; /* 11px at the 14px default */
+}
+.acp-markdown-body td {
+  font-size: 0.86em; /* 12px at the 14px default */
 }
 
 /* Subtle scrollbar styling */

--- a/web/src/lib/conversationFontSize.ts
+++ b/web/src/lib/conversationFontSize.ts
@@ -20,3 +20,13 @@ export function normalizeConversationFontSize(value: unknown): number {
   if (!Number.isFinite(n)) return DEFAULT_CONVERSATION_FONT_SIZE;
   return Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, Math.round(n)));
 }
+
+/** The setting is authored and stored as an integer px value because that is
+ *  what the slider and the px select speak, but it reaches CSS as `rem` against
+ *  the 16px default root size. Publishing absolute px would pin the transcript
+ *  to 14px for a reader who raised their browser's root font size; as `rem` the
+ *  default 14 still renders at 14px on a 16px root and at 17.5px on a 20px one,
+ *  and a user-picked size scales by the same factor. */
+export function conversationFontSizeRem(px: number): string {
+  return `${px / 16}rem`;
+}

--- a/web/src/lib/conversationFontSize.ts
+++ b/web/src/lib/conversationFontSize.ts
@@ -1,0 +1,22 @@
+import { MAX_FONT_SIZE, MIN_FONT_SIZE } from "./fontSizeRange";
+
+/** Font size (px) for the structured-view conversation transcript. Client-local
+ *  and stored separately from the terminal font sizes: the transcript is
+ *  proportional prose, the terminal is a fixed-cell grid, and users size them
+ *  for different reasons. The two controls span the same range
+ *  ({@link MIN_FONT_SIZE}-{@link MAX_FONT_SIZE}) so they read alike. See the
+ *  settings under `Settings -> Structured view`. */
+export const DEFAULT_CONVERSATION_FONT_SIZE = 14;
+
+/** localStorage is user-editable, so a stringy, fractional, NaN, or wildly
+ *  out-of-range value must not reach CSS as `NaNpx` or a 0px transcript. */
+export function normalizeConversationFontSize(value: unknown): number {
+  // Only numbers and non-blank numeric strings are candidates. Coercing
+  // everything through Number() would turn `null` (what JSON.stringify writes
+  // for a NaN) and `""` into 0, which then clamps to the minimum instead of
+  // falling back to the default.
+  const n =
+    typeof value === "number" ? value : typeof value === "string" && value.trim() !== "" ? Number(value) : Number.NaN;
+  if (!Number.isFinite(n)) return DEFAULT_CONVERSATION_FONT_SIZE;
+  return Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, Math.round(n)));
+}

--- a/web/src/lib/fontSizeRange.ts
+++ b/web/src/lib/fontSizeRange.ts
@@ -1,0 +1,7 @@
+/** Px range shared by every font-size control in the dashboard: the terminal
+ *  sizes under `Web Dashboard -> Terminal` and the structured-view conversation
+ *  sizes under `Sessions -> Structured view`. One declaration rather than a
+ *  copy per panel, so the two sliders always span the same steps and a value
+ *  carried between them stays in bounds. */
+export const MIN_FONT_SIZE = 6;
+export const MAX_FONT_SIZE = 28;

--- a/web/tests/acp-conversation-font-size.spec.ts
+++ b/web/tests/acp-conversation-font-size.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "./helpers/mockedTest";
+import { agentMessageChunk, mockAcpSession, openStructuredSession, stopped } from "./helpers/acpMock";
+
+// User story: the transcript font size is a browser-local preference with a
+// separate mobile and desktop value, and crossing 768px must switch between
+// them live.
+//
+// Mocked Playwright rather than Vitest because the whole contract is a CSS
+// media query resolving a custom property into a computed font size: jsdom
+// evaluates neither, so a unit test could only re-assert the inline variables
+// (which StructuredViewRoot.test.tsx already covers). One test walks both
+// viewports and the proportional child scaling, per the "one test per
+// behavior" rule.
+test.describe("structured view conversation font size", () => {
+  test("resolves the stored mobile/desktop sizes across the 768px breakpoint and scales markdown with them", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "aoe-web-settings",
+        JSON.stringify({ structuredMobileFontSize: 11, structuredDesktopFontSize: 20 }),
+      );
+    });
+
+    const mock = await mockAcpSession(page, {
+      title: "story-font-size",
+      initialEvents: [agentMessageChunk("# heading\n\nplain paragraph text"), stopped()],
+    });
+    await page.setViewportSize({ width: 1200, height: 800 });
+    await openStructuredSession(page, mock);
+
+    const body = page.locator(".acp-markdown-body").first();
+    await expect(body).toBeVisible({ timeout: 10_000 });
+    const fontSizeOf = (locator = body) => locator.evaluate((el) => getComputedStyle(el).fontSize);
+
+    expect(await fontSizeOf()).toBe("20px");
+    // Headings are `em`, so the whole hierarchy follows the base rather than
+    // only paragraphs changing (1.43em * 20px).
+    const heading = body.locator("h1").first();
+    expect(await fontSizeOf(heading)).toBe("28.6px");
+
+    // Crossing the breakpoint swaps to the mobile value with no reload.
+    await page.setViewportSize({ width: 500, height: 800 });
+    await expect.poll(() => fontSizeOf()).toBe("11px");
+    expect(await fontSizeOf(heading)).toBe("15.73px");
+
+    await page.setViewportSize({ width: 1200, height: 800 });
+    await expect.poll(() => fontSizeOf()).toBe("20px");
+  });
+});

--- a/web/tests/acp-conversation-font-size.spec.ts
+++ b/web/tests/acp-conversation-font-size.spec.ts
@@ -33,7 +33,7 @@ async function openTranscript(page: Page) {
 
   const mock = await mockAcpSession(page, {
     title: "story-font-size",
-    initialEvents: [agentMessageChunk("# heading\n\nplain paragraph text"), stopped()],
+    initialEvents: [agentMessageChunk("# heading\n\nplain paragraph text\n\n```\nfenced code\n```"), stopped()],
   });
   await openStructuredSession(page, mock);
 
@@ -43,6 +43,14 @@ async function openTranscript(page: Page) {
 }
 
 const fontSizeOf = (locator: ReturnType<Page["locator"]>) => locator.evaluate((el) => getComputedStyle(el).fontSize);
+
+/** Computed line-height as a ratio of the element's own font size, so the
+ *  assertion holds at any base size. */
+const leadingRatioOf = (locator: ReturnType<Page["locator"]>) =>
+  locator.evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return Number.parseFloat(cs.lineHeight) / Number.parseFloat(cs.fontSize);
+  });
 
 test.describe("structured view conversation font size (fine pointer)", () => {
   test.use({ viewport: { width: 1200, height: 800 }, hasTouch: false });
@@ -55,6 +63,14 @@ test.describe("structured view conversation font size (fine pointer)", () => {
     // Headings are `em`, so the whole hierarchy follows the base rather than
     // only paragraphs changing (1.43em * 20px).
     expect(await fontSizeOf(heading)).toBe("28.6px");
+
+    // Fenced code scales with the base (0.86em) but keeps the tight leading the
+    // old `text-xs` gave it: Tailwind's `--tw-leading` is `inherits: false`, so
+    // an em-sized block with no leading of its own would silently pick up the
+    // root's `leading-relaxed` (1.625) and render code much looser than before.
+    const codeBlock = body.locator("pre").first();
+    expect(await fontSizeOf(codeBlock)).toBe("17.2px");
+    expect(await leadingRatioOf(codeBlock)).toBeCloseTo(1.3333, 3);
 
     // A narrow desktop window is not mobile: without the pointer term this
     // would wrongly drop to the mobile size.

--- a/web/tests/acp-conversation-font-size.spec.ts
+++ b/web/tests/acp-conversation-font-size.spec.ts
@@ -1,50 +1,95 @@
 import { test, expect } from "./helpers/mockedTest";
+import { devices, type Page } from "@playwright/test";
 import { agentMessageChunk, mockAcpSession, openStructuredSession, stopped } from "./helpers/acpMock";
 
-// User story: the transcript font size is a browser-local preference with a
-// separate mobile and desktop value, and crossing 768px must switch between
-// them live.
+// User story: the transcript font size is a dashboard preference with a
+// separate mobile and desktop value, and the dashboard's own mobile classifier
+// (coarse primary pointer AND a viewport below 768px, the rule
+// `clientFormFactor()` uses) decides which one applies.
 //
-// Mocked Playwright rather than Vitest because the whole contract is a CSS
-// media query resolving a custom property into a computed font size: jsdom
-// evaluates neither, so a unit test could only re-assert the inline variables
-// (which StructuredViewRoot.test.tsx already covers). One test walks both
-// viewports and the proportional child scaling, per the "one test per
-// behavior" rule.
-test.describe("structured view conversation font size", () => {
-  test("resolves the stored mobile/desktop sizes across the 768px breakpoint and scales markdown with them", async ({
-    page,
-  }) => {
-    await page.addInitScript(() => {
+// Mocked Playwright rather than Vitest because the whole contract is a media
+// query resolving a custom property into a computed font size: jsdom evaluates
+// neither pointer capability nor `rem`, so a unit test could only re-assert the
+// inline variables (which StructuredViewRoot.test.tsx already covers).
+//
+// Split into two describes because pointer capability is fixed per browser
+// context: Playwright cannot flip `(pointer: coarse)` mid-page the way it can
+// resize a viewport. Each context still exercises a live viewport change, which
+// is the resize case users actually hit.
+
+const MOBILE_SIZE = 11;
+const DESKTOP_SIZE = 20;
+
+async function openTranscript(page: Page) {
+  await page.addInitScript(
+    ([mobile, desktop]) => {
       window.localStorage.setItem(
         "aoe-web-settings",
-        JSON.stringify({ structuredMobileFontSize: 11, structuredDesktopFontSize: 20 }),
+        JSON.stringify({ structuredMobileFontSize: mobile, structuredDesktopFontSize: desktop }),
       );
-    });
+    },
+    [MOBILE_SIZE, DESKTOP_SIZE],
+  );
 
-    const mock = await mockAcpSession(page, {
-      title: "story-font-size",
-      initialEvents: [agentMessageChunk("# heading\n\nplain paragraph text"), stopped()],
-    });
-    await page.setViewportSize({ width: 1200, height: 800 });
-    await openStructuredSession(page, mock);
+  const mock = await mockAcpSession(page, {
+    title: "story-font-size",
+    initialEvents: [agentMessageChunk("# heading\n\nplain paragraph text"), stopped()],
+  });
+  await openStructuredSession(page, mock);
 
-    const body = page.locator(".acp-markdown-body").first();
-    await expect(body).toBeVisible({ timeout: 10_000 });
-    const fontSizeOf = (locator = body) => locator.evaluate((el) => getComputedStyle(el).fontSize);
+  const body = page.locator(".acp-markdown-body").first();
+  await expect(body).toBeVisible({ timeout: 10_000 });
+  return body;
+}
 
-    expect(await fontSizeOf()).toBe("20px");
+const fontSizeOf = (locator: ReturnType<Page["locator"]>) => locator.evaluate((el) => getComputedStyle(el).fontSize);
+
+test.describe("structured view conversation font size (fine pointer)", () => {
+  test.use({ viewport: { width: 1200, height: 800 }, hasTouch: false });
+
+  test("uses the desktop size at any width and scales it with the browser root font size", async ({ page }) => {
+    const body = await openTranscript(page);
+    const heading = body.locator("h1").first();
+
+    expect(await fontSizeOf(body)).toBe("20px");
     // Headings are `em`, so the whole hierarchy follows the base rather than
     // only paragraphs changing (1.43em * 20px).
-    const heading = body.locator("h1").first();
     expect(await fontSizeOf(heading)).toBe("28.6px");
 
-    // Crossing the breakpoint swaps to the mobile value with no reload.
+    // A narrow desktop window is not mobile: without the pointer term this
+    // would wrongly drop to the mobile size.
     await page.setViewportSize({ width: 500, height: 800 });
-    await expect.poll(() => fontSizeOf()).toBe("11px");
+    await expect.poll(() => fontSizeOf(body)).toBe("20px");
+
+    // The size is published as `rem`, so raising the browser/root font size
+    // scales the transcript proportionally (20 setting = 1.25rem = 25px at a
+    // 20px root) instead of pinning it to the authored px.
+    await page.evaluate(() => {
+      document.documentElement.style.fontSize = "20px";
+    });
+    await expect.poll(() => fontSizeOf(body)).toBe("25px");
+  });
+});
+
+// iPhone 13 gives width 390 (< 768), pointer:coarse and hasTouch. Drop
+// `defaultBrowserType`: Playwright forbids it in a describe-level `test.use`
+// (it would force a new worker) and the project already pins chromium.
+const { defaultBrowserType: _iphoneBrowser, ...iPhone13 } = devices["iPhone 13"];
+
+test.describe("structured view conversation font size (coarse pointer)", () => {
+  test.use(iPhone13);
+
+  test("uses the mobile size when narrow and the desktop size once the viewport widens", async ({ page }) => {
+    const body = await openTranscript(page);
+    const heading = body.locator("h1").first();
+
+    expect(await fontSizeOf(body)).toBe("11px");
     expect(await fontSizeOf(heading)).toBe("15.73px");
 
-    await page.setViewportSize({ width: 1200, height: 800 });
-    await expect.poll(() => fontSizeOf()).toBe("20px");
+    // Still a coarse pointer, but a tablet-width viewport is classified
+    // desktop, and the swap happens live with no reload.
+    await page.setViewportSize({ width: 900, height: 800 });
+    await expect.poll(() => fontSizeOf(body)).toBe("20px");
+    expect(await fontSizeOf(heading)).toBe("28.6px");
   });
 });

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1728,6 +1728,24 @@
       "components": ["web/src/components/settings/DiffSettings.tsx", "web/src/components/SettingsView.tsx"]
     },
     {
+      "id": "settings.structured-view-font-size",
+      "kind": "mocked-playwright",
+      "risk": "low",
+      "specs": [
+        "src/components/settings/__tests__/StructuredViewDisplaySettings.test.tsx",
+        "src/components/acp/__tests__/StructuredViewRoot.test.tsx",
+        "src/components/acp/Markdown.test.tsx",
+        "tests/acp-conversation-font-size.spec.ts"
+      ],
+      "components": [
+        "web/src/components/settings/StructuredViewDisplaySettings.tsx",
+        "web/src/components/settings/FontSizeControl.tsx",
+        "web/src/components/TerminalSettings.tsx",
+        "web/src/lib/fontSizeRange.ts",
+        "web/src/components/SettingsView.tsx"
+      ]
+    },
+    {
       "id": "settings.panels-section",
       "kind": "vitest",
       "risk": "low",


### PR DESCRIPTION
Hi, @njbrake and @Seluj78. Thank you for your reply in the issue. I cannot find any option for reviewer selection in the PR page. Sorry that I will just let it go.
Closes #3290.
Implement the structured-view font size controls in the settings page, aligning with the existing terminal font size control. Below are generated by Claude:

## Description

The structured-view transcript was pinned to `text-sm` with a handful of fixed `rem` child sizes, so there was no way to fit more conversation on a phone screen short of zooming the whole dashboard.

This adds a mobile and a desktop conversation font size (6-28px in 1px steps, default 14px) under **Settings > Sessions > Structured view > Conversation display**.

- Both are dashboard preferences stored in the existing `aoe-web-settings` entry via `useWebSettings`, deliberately separate from the terminal font sizes: the transcript is proportional prose, the terminal is a fixed-cell grid, and users size them for different reasons. Like the rest of that entry they ride the existing `webUiSync` mirror to the daemon's web-UI state, so they follow the user across browsers; the agent config schema is untouched, and the values are not per profile.
- The structured-view root publishes both values as scoped custom properties, and CSS picks the active one using the dashboard's canonical mobile classifier: a coarse primary pointer and a viewport narrower than 768px. This keeps a narrow desktop window on the desktop size and switches a narrow touch device to the mobile size, with no reload or JS width probe. The stored integer values are published as `rem` relative to the 16px baseline, preserving browser root-font-size accessibility preferences. The style object is merged on top of the existing `structuredViewRootStyle(keyboardHeight)` reservation rather than replacing it, keeping the iOS keyboard layout behavior from #2011 intact.
- Only the conversation renderer opts into the variable, via a new `.acp-markdown-body` class. The other `.acp-markdown` consumers (tool-card bodies, the diff pane's file viewer) keep their own explicit sizes: those base rules stay in `rem` and the `em` ratios are re-declared under `.acp-markdown-body` only. Markdown child typography (headings, table cells, fenced code, code header) uses `em` so the whole hierarchy scales together; the ratios reproduce the previous `text-sm` appearance at the 14px setting with the normal 16px browser root, while continuing to honor larger browser default font sizes.
- The other caller of the `Markdown` component, the skills manager, renders outside the structured-view root and so resolves the variable's `0.875rem` fallback, which is exactly the `text-sm` it had before.
- Persisted values are clamped on read: localStorage is user-editable and the value reaches CSS directly, so a `null`, stringy, fractional, or absurd size must not render the transcript at NaN or 0px.
- `TerminalSettings` was migrated onto the extracted `FontSizeControl`, removing a hand-rolled duplicate of the same slider/select/description markup. The shared control also gives the terminal sliders and selects the `aria-label`s they previously lacked.
- The px range is declared once in `web/src/lib/fontSizeRange.ts` and consumed by both panels and by the conversation clamp, so the two sliders span identical steps and cannot drift apart.

## Screenshots

Captured on a 390x844 mobile viewport against a real `aoe serve` with a scripted agent turn.

| 6px (minimum) | 22px | 28px (maximum) |
| --- | --- | --- |
| <img width="390" height="844" alt="transcript-6px" src="https://github.com/user-attachments/assets/99f52c93-8894-4bc7-a628-af7906a223e4" /> | <img width="390" height="844" alt="transcript-22px" src="https://github.com/user-attachments/assets/9bff80a9-947b-4cd1-aa5f-0ac8326696d8" /> | <img width="390" height="844" alt="transcript-28px" src="https://github.com/user-attachments/assets/e756e0e2-1469-4fd6-8238-9b6f101d7975" /> |

The new panel, at the 14px default:

<img width="390" height="844" alt="settings-conversation-display" src="https://github.com/user-attachments/assets/e29c1e50-69f9-425b-9940-eb89d92f23fe" />

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (`docs/guides/web/settings.md`)
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Tests added:

- `web/tests/acp-conversation-font-size.spec.ts` (mocked Playwright): stores 11px mobile / 20px desktop and exercises the dashboard's coarse-pointer + narrow-viewport classifier in separate fine- and coarse-pointer browser contexts. A narrow fine-pointer desktop remains at the desktop size, while a narrow touch device uses the mobile size and switches back to desktop when widened. The spec also verifies proportional `h1` scaling and that `rem` output follows a changed browser root font size. jsdom evaluates neither media queries nor custom properties, so Playwright covers the browser-level cascade.
- `web/src/components/settings/__tests__/StructuredViewDisplaySettings.test.tsx` (Vitest): the localStorage contract - defaults, independent per-axis writes, slider/select sync, remount persistence, and a table covering backfill plus junk clamping. It also renders `TerminalSettings` alongside and asserts all four sliders carry the same bounds and step count, so a panel that re-hardcodes its own range fails.
- `web/src/components/acp/__tests__/StructuredViewRoot.test.tsx`: both custom properties are published as `rem` without dropping the keyboard reservation, the 14px default maps to `0.875rem`, and the root carries the scope class used by the responsive media query.
- `web/src/components/acp/Markdown.test.tsx`: the conversation renderer carries `.acp-markdown-body` and no fixed `text-*` utility that would outrank the variable.

Coverage matrix entry: `settings.structured-view-font-size`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 5)

**Any Additional AI Details you'd like to share:**

Implementation, tests, and docs were drafted with Claude Code and reviewed and verified locally.

- [ ] I am an AI Agent filling out this form (check box if true)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added separate mobile and desktop font-size controls for Structured View conversations.
- Added synchronized sliders and selectors with a 6–28px range and a 14px default.
- Stored settings in `aoe-web-settings`, separate from terminal font sizes.
- Applied changes immediately across responsive layouts.
- Updated Markdown typography to scale consistently while preserving other dashboard Markdown sizes.
- Reused the shared font-size control for terminal settings.
- Added validation that rounds and clamps stored values.
- Added Vitest and Playwright coverage for settings, responsive switching, scaling, and code-block line height.
- Updated settings documentation and the coverage matrix.

## Benefits

Users can adjust conversation readability without changing terminal settings. The settings respond to mobile and desktop layouts without a page reload. Invalid stored values no longer create unsupported font sizes.

## Potential follow-up

Consider adding a reset option if more conversation display settings are added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->