### PR TITLE
fix(cli): error on duplicate session add

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -588,10 +588,6 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     // seed its directory leaf from it); run the path-dependent duplicate check
     // now that `path` points at the final worktree/workspace directory.
     if is_duplicate_session(&instances, &final_title, path.to_str().unwrap_or("")) {
-        println!(
-            "Session already exists with same title and path: {}",
-            final_title
-        );
         cleanup_partial_session(
             &path,
             worktree_info_opt.as_ref(),
@@ -600,7 +596,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             None,
             None,
         );
-        return Ok(());
+        return Err(duplicate_session_error(&final_title));
     }
 
     let mut instance = Instance::new(&final_title, path.to_str().unwrap_or(""));
@@ -1065,10 +1061,6 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     match persist_result {
         Ok(true) => {}
         Ok(false) => {
-            println!(
-                "Session already exists with same title and path: {}",
-                instance.title
-            );
             cleanup_partial_session(
                 &path,
                 instance.worktree_info.as_ref(),
@@ -1081,7 +1073,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 },
                 instance.sandbox_info.as_ref().map(|_| instance.id.as_str()),
             );
-            return Ok(());
+            return Err(duplicate_session_error(&instance.title));
         }
         Err(e) => {
             cleanup_partial_session(
@@ -1338,6 +1330,14 @@ pub fn is_duplicate_session(instances: &[Instance], title: &str, path: &str) -> 
         let existing_path = inst.project_path.trim_end_matches('/');
         existing_path == normalized_path && inst.title == title
     })
+}
+
+fn duplicate_session_error(title: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "Session already exists with same title and path: {}\n\
+         Tip: use a different --title or remove the existing session first",
+        title
+    )
 }
 
 /// Sync mirror of `Supervisor::pick_agent_for_tool` so add-time

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -41,6 +41,67 @@ fn test_cli_add_and_list() {
     );
 }
 
+/// #3224: repeating `aoe add` for the same title and path must report a
+/// conflict instead of exiting successfully while silently retaining the
+/// first session's command override.
+#[test]
+#[parallel]
+fn test_cli_add_duplicate_errors_and_preserves_original_command() {
+    let h = TuiTestHarness::new("cli_add_duplicate");
+    let project = h.project_path();
+    let project = project.to_str().unwrap();
+
+    let first = h.run_cli(&[
+        "add",
+        project,
+        "--title",
+        "Duplicate Session",
+        "--cmd-override",
+        "echo OLD",
+    ]);
+    assert!(
+        first.status.success(),
+        "initial aoe add failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    let duplicate = h.run_cli(&[
+        "add",
+        project,
+        "--title",
+        "Duplicate Session",
+        "--cmd-override",
+        "echo NEW",
+    ]);
+    assert!(
+        !duplicate.status.success(),
+        "duplicate aoe add must return a non-zero status"
+    );
+    assert_eq!(
+        duplicate.status.code(),
+        Some(1),
+        "duplicate aoe add should use the CLI's ordinary error exit status"
+    );
+    let stderr = String::from_utf8_lossy(&duplicate.stderr);
+    assert!(
+        stderr.contains("Session already exists with same title and path")
+            && stderr.contains("different --title"),
+        "duplicate error should identify the collision and offer remediation.\nstderr: {stderr}"
+    );
+
+    let sessions = read_sessions_json(&h);
+    let sessions = sessions.as_array().expect("sessions array");
+    assert_eq!(
+        sessions.len(),
+        1,
+        "duplicate add must not create a second row"
+    );
+    assert_eq!(
+        sessions[0]["command"], "echo OLD",
+        "duplicate add must preserve the original command override"
+    );
+}
+
 /// Regression test for #848: `aoe add` "Next steps" hint should reference
 /// the actual binary name (`aoe`), not the long project name.
 #[test]


### PR DESCRIPTION
## Description

Fixes #3224.

`aoe add` previously treated an existing `(title, path)` pair as a successful no-op. That made a conflicting command override look accepted even though the persisted session continued using its old command.

This change returns the same actionable error from both duplicate paths:

- the normal preflight check
- the final check under the storage lock, which covers concurrent adds

Both paths still perform their existing partial-resource cleanup before returning the error, and the existing session remains unchanged.

This intentionally changes duplicate adds from exit status 0 to 1. That user-visible compatibility change matches the behavior requested in #3224: callers can now distinguish a collision from a successful add instead of silently continuing with stale session configuration.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no documentation change is needed for this error-path correction)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

The regression test adds a session with `echo OLD`, retries the same title and path with `echo NEW`, and verifies that the second command exits 1 with an actionable stderr message while the single persisted row still contains `echo OLD`. The test fails on `main` because the duplicate command exits 0, and passes with this change.

Validation performed:

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --features e2e-tests --test e2e cli::test_cli_add_duplicate_errors_and_preserves_original_command -- --exact --nocapture`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex

**Any Additional AI Details you'd like to share:**

Codex assisted with the bounded issue/duplicate preflight, implementation, regression test, and validation. A separate read-only review checked both duplicate paths, cleanup ordering, stored-session preservation, and the final diff.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Duplicate `aoe add` operations now fail with exit status 1 and provide remediation guidance.
- The check runs before resource creation and during final persistence to handle concurrent adds.
- Existing sessions remain unchanged, and partial resources are still cleaned up.
- Added an end-to-end test for the error, exit status, cleanup, and command preservation.

## Benefits

This prevents duplicate adds from appearing successful and helps callers avoid using stale configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->