### PR TITLE
fix: preserve working directory after login shell startup

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -5760,8 +5760,8 @@ const CONTAINER_TERMINAL_AUTODETECT_CMD: &str = r#"sh -c 'exec "$(command -v "$(
 /// new-session -c <working_dir>` (see `tmux::Session::create_with_size_env`)
 /// only sets the *shell's* initial cwd; the `-l` login flag below sources
 /// `~/.bash_profile`/`~/.bashrc` (needed for version-manager PATH setup, e.g.
-/// NVM), and anything in those files that changes directory — a user's own
-/// stray `cd`, or a legitimate nvm/pyenv/direnv hook — silently overrides
+/// NVM), and anything in those files that changes directory, such as a user's
+/// own stray `cd` or a legitimate nvm/pyenv/direnv hook, silently overrides
 /// tmux's `-c` before the real agent command ever runs, landing the pane
 /// wherever the profile left it (typically `$HOME`) instead of
 /// `project_path`. This was the actual mechanism behind #3265: `-c` was
@@ -5771,17 +5771,15 @@ const CONTAINER_TERMINAL_AUTODETECT_CMD: &str = r#"sh -c 'exec "$(command -v "$(
 fn wrap_command_ignore_suspend(cmd: &str, working_dir: &str) -> String {
     let user = super::environment::user_shell();
     let posix = super::environment::user_posix_shell();
-    let escaped = cmd.replace('\'', "'\\''");
     // Use login shell (-l) so version-manager PATHs (NVM, etc.) are available.
     // Skip -l when falling back to bash for a non-POSIX user shell (fish, nu,
     // pwsh): bash's login scripts won't contain the user's PATH setup and -l
     // may reset the inherited PATH that already has the correct entries.
     let flag = if user == posix { "-lc" } else { "-c" };
     let cd = super::environment::shell_escape(working_dir);
-    format!(
-        "exec {} {} 'cd {} || exit 1; stty susp undef; exec env {}'",
-        posix, flag, cd, escaped
-    )
+    let script = format!("cd {cd} || exit 1; stty susp undef; exec env {cmd}");
+    let escaped = script.replace('\'', "'\\''");
+    format!("exec {posix} {flag} '{escaped}'")
 }
 
 /// Prepend shell `export` statements to an already-wrapped sandbox command.
@@ -8540,12 +8538,10 @@ mod tests {
     fn test_wrap_command_reasserts_working_dir_after_login_shell() {
         let original = std::env::var("SHELL").ok();
         std::env::set_var("SHELL", "/bin/bash");
-        let wrapped = wrap_command_ignore_suspend("claude", "/tmp/some project's dir");
-        assert!(
-            wrapped.contains("/tmp/some project"),
-            "wrapped command must carry the working_dir path: {}",
-            wrapped,
-        );
+        let temp = tempfile::tempdir().unwrap();
+        let working_dir = temp.path().join("some project's dir");
+        std::fs::create_dir(&working_dir).unwrap();
+        let wrapped = wrap_command_ignore_suspend("pwd", working_dir.to_str().unwrap());
         assert!(
             wrapped.contains("|| exit 1; stty susp undef"),
             "wrapped command must `cd` back to working_dir, with exit-on-failure, \
@@ -8553,7 +8549,7 @@ mod tests {
             wrapped,
         );
         // The cd must run *inside* the login shell's quoted script (after -lc),
-        // not before it -- otherwise it has no effect on where the login
+        // not before it; otherwise it has no effect on where the login
         // shell's own profile sourcing left the cwd.
         let login_script_start = wrapped
             .find("-lc '")
@@ -8563,6 +8559,19 @@ mod tests {
             wrapped[login_script_start..].starts_with("cd "),
             "the cd must be the first statement inside the login shell's script: {}",
             wrapped,
+        );
+        let output = std::process::Command::new("bash")
+            .args(["-c", &wrapped])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "wrapped command failed: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            working_dir.to_string_lossy(),
         );
         match original {
             Some(v) => std::env::set_var("SHELL", v),

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3414,8 +3414,10 @@ impl Instance {
                 shell_escape(&self.id)
             );
             let env_part = format!("{} ", docker_args);
-            let wrapped =
-                wrap_command_ignore_suspend(&container.exec_command(Some(&env_part), &tool_cmd));
+            let wrapped = wrap_command_ignore_suspend(
+                &container.exec_command(Some(&env_part), &tool_cmd),
+                &self.project_path,
+            );
             (
                 Some(prepend_exports(&env_info.exports, wrapped)),
                 is_existing,
@@ -3728,10 +3730,10 @@ impl Instance {
                     let is_existing = self.apply_session_flags(&mut cmd, "host agent");
                     apply_agent_launch_env(&mut cmd, agent);
                     Ok((
-                        Some(wrap_command_ignore_suspend(&format!(
-                            "{}{}",
-                            env_prefix, cmd
-                        ))),
+                        Some(wrap_command_ignore_suspend(
+                            &format!("{}{}", env_prefix, cmd),
+                            &self.project_path,
+                        )),
                         is_existing,
                     ))
                 }
@@ -3750,10 +3752,10 @@ impl Instance {
             let is_existing = self.apply_session_flags(&mut cmd, "host custom");
             apply_agent_launch_env(&mut cmd, agent);
             Ok((
-                Some(wrap_command_ignore_suspend(&format!(
-                    "{}{}",
-                    env_prefix, cmd
-                ))),
+                Some(wrap_command_ignore_suspend(
+                    &format!("{}{}", env_prefix, cmd),
+                    &self.project_path,
+                )),
                 is_existing,
             ))
         }
@@ -5752,7 +5754,21 @@ const CONTAINER_TERMINAL_AUTODETECT_CMD: &str = r#"sh -c 'exec "$(command -v "$(
 /// pane process because fish does not exec the last command in `-c` mode. That
 /// causes `#{pane_current_command}` to report "fish", which triggers a false
 /// restart on reattach. See #757.
-fn wrap_command_ignore_suspend(cmd: &str) -> String {
+///
+/// `working_dir` is re-asserted with an explicit `cd` *inside* the wrapped
+/// script, after the login shell's profile/rc files have already run. `tmux
+/// new-session -c <working_dir>` (see `tmux::Session::create_with_size_env`)
+/// only sets the *shell's* initial cwd; the `-l` login flag below sources
+/// `~/.bash_profile`/`~/.bashrc` (needed for version-manager PATH setup, e.g.
+/// NVM), and anything in those files that changes directory — a user's own
+/// stray `cd`, or a legitimate nvm/pyenv/direnv hook — silently overrides
+/// tmux's `-c` before the real agent command ever runs, landing the pane
+/// wherever the profile left it (typically `$HOME`) instead of
+/// `project_path`. This was the actual mechanism behind #3265: `-c` was
+/// always correct, but the login shell's own rc files re-pointed cwd after
+/// tmux had already set it. Re-`cd`-ing here, right before the final `exec`,
+/// wins regardless of what the profile scripts did in between.
+fn wrap_command_ignore_suspend(cmd: &str, working_dir: &str) -> String {
     let user = super::environment::user_shell();
     let posix = super::environment::user_posix_shell();
     let escaped = cmd.replace('\'', "'\\''");
@@ -5761,9 +5777,10 @@ fn wrap_command_ignore_suspend(cmd: &str) -> String {
     // pwsh): bash's login scripts won't contain the user's PATH setup and -l
     // may reset the inherited PATH that already has the correct entries.
     let flag = if user == posix { "-lc" } else { "-c" };
+    let cd = super::environment::shell_escape(working_dir);
     format!(
-        "exec {} {} 'stty susp undef; exec env {}'",
-        posix, flag, escaped
+        "exec {} {} 'cd {} || exit 1; stty susp undef; exec env {}'",
+        posix, flag, cd, escaped
     )
 }
 
@@ -8383,7 +8400,7 @@ mod tests {
         // Single quotes from shell_escape are escaped by wrap_command_ignore_suspend
         // via the '\'' technique, which correctly round-trips through the shell.
         let cmd = format_env_var_prefix("OPENCODE_PERMISSION", r#"{"*":"allow"}"#, "opencode");
-        let wrapped = wrap_command_ignore_suspend(&cmd);
+        let wrapped = wrap_command_ignore_suspend(&cmd, "/tmp/proj");
         // The inner single quotes from shell_escape become '\'' in the outer wrapper
         assert!(
             wrapped.contains(r#"OPENCODE_PERMISSION='\''{"*":"allow"}'\'' opencode"#),
@@ -8403,7 +8420,7 @@ mod tests {
         // to tolerate the double-exec, which is why this regression hid
         // for several days after #757 merged. See PR #819.
         std::env::set_var("SHELL", "/bin/bash");
-        let wrapped = wrap_command_ignore_suspend("docker exec -it container claude");
+        let wrapped = wrap_command_ignore_suspend("docker exec -it container claude", "/tmp/proj");
         assert!(
             wrapped.starts_with("exec "),
             "test invariant: wrapped must start with `exec ` (else this test \
@@ -8424,7 +8441,7 @@ mod tests {
         );
 
         // Empty exports must pass through unchanged.
-        let wrapped2 = wrap_command_ignore_suspend("docker exec -it container claude");
+        let wrapped2 = wrap_command_ignore_suspend("docker exec -it container claude", "/tmp/proj");
         assert_eq!(prepend_exports(&[], wrapped2.clone()), wrapped2);
     }
 
@@ -8439,7 +8456,7 @@ mod tests {
         let original = std::env::var("SHELL").ok();
         for shell in &["/bin/bash", "/bin/zsh", "/usr/bin/fish", "/usr/bin/nu"] {
             std::env::set_var("SHELL", shell);
-            let wrapped = wrap_command_ignore_suspend("claude");
+            let wrapped = wrap_command_ignore_suspend("claude", "/tmp/proj");
             assert!(
                 wrapped.starts_with("exec "),
                 "SHELL={}: wrapped command must start with 'exec': {}",
@@ -8458,7 +8475,7 @@ mod tests {
     fn test_wrap_command_posix_shell_uses_login() {
         let original = std::env::var("SHELL").ok();
         std::env::set_var("SHELL", "/bin/zsh");
-        let wrapped = wrap_command_ignore_suspend("claude");
+        let wrapped = wrap_command_ignore_suspend("claude", "/tmp/proj");
         // POSIX shell: should use -lc for version-manager PATHs
         assert!(
             wrapped.contains("-lc"),
@@ -8476,7 +8493,7 @@ mod tests {
     fn test_wrap_command_fish_skips_login() {
         let original = std::env::var("SHELL").ok();
         std::env::set_var("SHELL", "/usr/bin/fish");
-        let wrapped = wrap_command_ignore_suspend("claude");
+        let wrapped = wrap_command_ignore_suspend("claude", "/tmp/proj");
         // Fish: should use -c (no -l) because bash's login scripts
         // won't have fish's PATH setup.
         assert!(
@@ -8500,10 +8517,51 @@ mod tests {
     fn test_wrap_command_nu_skips_login() {
         let original = std::env::var("SHELL").ok();
         std::env::set_var("SHELL", "/usr/bin/nu");
-        let wrapped = wrap_command_ignore_suspend("claude");
+        let wrapped = wrap_command_ignore_suspend("claude", "/tmp/proj");
         assert!(
             wrapped.starts_with("exec bash -c "),
             "nu shell should produce 'exec bash -c ...': {}",
+            wrapped,
+        );
+        match original {
+            Some(v) => std::env::set_var("SHELL", v),
+            None => std::env::remove_var("SHELL"),
+        }
+    }
+
+    /// #3265: a login shell's own profile/rc files can `cd` elsewhere
+    /// (a stray line in `~/.bashrc`, or a legitimate nvm/pyenv/direnv hook)
+    /// after tmux's `-c` has already set the pane's cwd, silently landing
+    /// the agent in the wrong directory. The wrapper must re-assert
+    /// `working_dir` inside the login shell's own script, after profile
+    /// sourcing, so it wins regardless of what those files did.
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn test_wrap_command_reasserts_working_dir_after_login_shell() {
+        let original = std::env::var("SHELL").ok();
+        std::env::set_var("SHELL", "/bin/bash");
+        let wrapped = wrap_command_ignore_suspend("claude", "/tmp/some project's dir");
+        assert!(
+            wrapped.contains("/tmp/some project"),
+            "wrapped command must carry the working_dir path: {}",
+            wrapped,
+        );
+        assert!(
+            wrapped.contains("|| exit 1; stty susp undef"),
+            "wrapped command must `cd` back to working_dir, with exit-on-failure, \
+             before disabling suspend and exec'ing the real command: {}",
+            wrapped,
+        );
+        // The cd must run *inside* the login shell's quoted script (after -lc),
+        // not before it -- otherwise it has no effect on where the login
+        // shell's own profile sourcing left the cwd.
+        let login_script_start = wrapped
+            .find("-lc '")
+            .map(|i| i + "-lc '".len())
+            .expect("wrapped command must use -lc for a POSIX $SHELL");
+        assert!(
+            wrapped[login_script_start..].starts_with("cd "),
+            "the cd must be the first statement inside the login shell's script: {}",
             wrapped,
         );
         match original {
@@ -12122,6 +12180,9 @@ mod tests {
                 return;
             }
             let temp = tempdir().unwrap();
+            let project_dir = temp.path().join("project");
+            std::fs::create_dir_all(&project_dir).unwrap();
+            let project_path = project_dir.to_str().unwrap();
             std::env::set_var("HOME", temp.path());
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
@@ -12129,7 +12190,7 @@ mod tests {
             let storage = crate::session::storage::Storage::new_unwatched("fb-test").unwrap();
 
             let stale_sid = "11111111-1111-1111-1111-111111111111".to_string();
-            let mut inst = Instance::new("fallback_dies_test", "/tmp/x");
+            let mut inst = Instance::new("fallback_dies_test", project_path);
             inst.tool = "claude".to_string();
             inst.source_profile = "fb-test".to_string();
             inst.command = "/bin/false".to_string();
@@ -12196,6 +12257,9 @@ mod tests {
                 return;
             }
             let temp = tempdir().unwrap();
+            let project_dir = temp.path().join("project");
+            std::fs::create_dir_all(&project_dir).unwrap();
+            let project_path = project_dir.to_str().unwrap();
             std::env::set_var("HOME", temp.path());
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
@@ -12203,7 +12267,7 @@ mod tests {
             let storage = crate::session::storage::Storage::new_unwatched("fb-test-live").unwrap();
 
             let stale_sid = "22222222-2222-2222-2222-222222222222".to_string();
-            let mut inst = Instance::new("fallback_lives_test", "/tmp/x");
+            let mut inst = Instance::new("fallback_lives_test", project_path);
             inst.tool = "claude".to_string();
             inst.source_profile = "fb-test-live".to_string();
             inst.command = format!(
@@ -12267,6 +12331,9 @@ mod tests {
                 return;
             }
             let temp = tempdir().unwrap();
+            let project_dir = temp.path().join("project");
+            std::fs::create_dir_all(&project_dir).unwrap();
+            let project_path = project_dir.to_str().unwrap();
             std::env::set_var("HOME", temp.path());
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
@@ -12279,7 +12346,7 @@ mod tests {
             let storage = crate::session::storage::Storage::new_unwatched("fb-toggle-off").unwrap();
 
             let stale_sid = "44444444-4444-4444-4444-444444444444".to_string();
-            let mut inst = Instance::new("fallback_toggle_off_test", "/tmp/x");
+            let mut inst = Instance::new("fallback_toggle_off_test", project_path);
             inst.tool = "claude".to_string();
             inst.source_profile = "fb-toggle-off".to_string();
             // Would die if (and only if) `--resume <stale_sid>` reached the
@@ -12336,6 +12403,9 @@ mod tests {
                 return;
             }
             let temp = tempdir().unwrap();
+            let project_dir = temp.path().join("project");
+            std::fs::create_dir_all(&project_dir).unwrap();
+            let project_path = project_dir.to_str().unwrap();
             std::env::set_var("HOME", temp.path());
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
@@ -12349,7 +12419,7 @@ mod tests {
                 crate::session::storage::Storage::new_unwatched("fb-allow-ignores").unwrap();
 
             let stale_sid = "55555555-5555-5555-5555-555555555555".to_string();
-            let mut inst = Instance::new("fallback_allow_ignores_toggle_test", "/tmp/x");
+            let mut inst = Instance::new("fallback_allow_ignores_toggle_test", project_path);
             inst.tool = "claude".to_string();
             inst.source_profile = "fb-allow-ignores".to_string();
             inst.command = "/bin/false".to_string();
@@ -12400,6 +12470,9 @@ mod tests {
                 return;
             }
             let temp = tempdir().unwrap();
+            let project_dir = temp.path().join("project");
+            std::fs::create_dir_all(&project_dir).unwrap();
+            let project_path = project_dir.to_str().unwrap();
             std::env::set_var("HOME", temp.path());
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
@@ -12407,7 +12480,7 @@ mod tests {
             let storage = crate::session::storage::Storage::new_unwatched("fb-loop-break").unwrap();
 
             let stale_sid = "66666666-6666-6666-6666-666666666666".to_string();
-            let mut inst = Instance::new("fallback_loop_break_test", "/tmp/x");
+            let mut inst = Instance::new("fallback_loop_break_test", project_path);
             inst.tool = "claude".to_string();
             inst.source_profile = "fb-loop-break".to_string();
             inst.command = "/bin/false".to_string();
@@ -12487,6 +12560,9 @@ mod tests {
                 return;
             }
             let temp = tempdir().unwrap();
+            let project_dir = temp.path().join("project");
+            std::fs::create_dir_all(&project_dir).unwrap();
+            let project_path = project_dir.to_str().unwrap();
             std::env::set_var("HOME", temp.path());
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
@@ -12494,7 +12570,7 @@ mod tests {
             let storage = crate::session::storage::Storage::new_unwatched("fb-test-grace").unwrap();
 
             let stale_sid = "33333333-3333-3333-3333-333333333333".to_string();
-            let mut inst = Instance::new("fallback_grace_test", "/tmp/x");
+            let mut inst = Instance::new("fallback_grace_test", project_path);
             inst.tool = "claude".to_string();
             inst.source_profile = "fb-test-grace".to_string();
             inst.command = format!(

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -2354,8 +2354,10 @@ mod tests {
 
         let guard = TmuxTestSession::new("aoe_test_missing_dir");
         let session = super::Session::from_name(guard.name());
+        let tmp = tempfile::TempDir::new().unwrap();
+        let missing_dir = tmp.path().join("does-not-exist");
         let result = session.create_with_size(
-            "/nonexistent/definitely-not-here/aoe-3265",
+            missing_dir.to_str().unwrap(),
             Some("sleep 5"),
             None,
             "default",

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -371,13 +371,13 @@ impl Session {
             return Ok(());
         }
 
-        // tmux does not error when `-c <dir>` points at a missing directory —
+        // tmux does not error when `-c <dir>` points at a missing directory;
         // it silently falls back to the server's own `$HOME`, which for a
         // long-running daemon/TUI process is wherever *it* was launched from,
         // not this session's `project_path`. Callers (`Instance::start_with_size_opts`)
         // already reload `project_path` from disk immediately before this call,
         // so a missing directory here means the worktree/project itself is
-        // gone or not yet materialized, not a stale in-memory value — fail
+        // gone or not yet materialized, not a stale in-memory value. Fail
         // loudly instead of silently spawning in the wrong place. See #3265.
         let working_dir_path = std::path::Path::new(working_dir);
         if !working_dir_path.is_dir() {
@@ -392,7 +392,7 @@ impl Session {
         // Diagnostic for #3265 ("fresh/restarted panes spawn with the wrong
         // cwd"): log the exact `-c` value this spawn resolved to, plus its
         // canonicalized form, so a future recurrence (if the guard above
-        // doesn't catch it — e.g. a permissions issue rather than a missing
+        // doesn't catch it, e.g. a permissions issue rather than a missing
         // path) leaves direct evidence of what `working_dir` actually was at
         // the moment of the `tmux new-session` call, instead of requiring a
         // fresh repro under instrumentation.

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -370,6 +370,42 @@ impl Session {
         if self.exists() {
             return Ok(());
         }
+
+        // tmux does not error when `-c <dir>` points at a missing directory —
+        // it silently falls back to the server's own `$HOME`, which for a
+        // long-running daemon/TUI process is wherever *it* was launched from,
+        // not this session's `project_path`. Callers (`Instance::start_with_size_opts`)
+        // already reload `project_path` from disk immediately before this call,
+        // so a missing directory here means the worktree/project itself is
+        // gone or not yet materialized, not a stale in-memory value — fail
+        // loudly instead of silently spawning in the wrong place. See #3265.
+        let working_dir_path = std::path::Path::new(working_dir);
+        if !working_dir_path.is_dir() {
+            bail!(
+                "Cannot create tmux session '{}': working directory '{}' does not exist \
+                 or is not a directory (tmux would otherwise silently fall back to $HOME)",
+                self.name,
+                working_dir
+            );
+        }
+
+        // Diagnostic for #3265 ("fresh/restarted panes spawn with the wrong
+        // cwd"): log the exact `-c` value this spawn resolved to, plus its
+        // canonicalized form, so a future recurrence (if the guard above
+        // doesn't catch it — e.g. a permissions issue rather than a missing
+        // path) leaves direct evidence of what `working_dir` actually was at
+        // the moment of the `tmux new-session` call, instead of requiring a
+        // fresh repro under instrumentation.
+        tracing::debug!(target: "tmux.command",
+            session = %self.name,
+            working_dir,
+            working_dir_canonical = %working_dir_path
+                .canonicalize()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|e| format!("<canonicalize failed: {e}>")),
+            "resolved working directory for tmux new-session"
+        );
+
         let config = super::tmux_option_config(profile);
 
         // Forward the inherited host env (DISPLAY, XDG_*, DBUS, ... plus every
@@ -2300,6 +2336,39 @@ mod tests {
             shown.as_deref(),
             Some("XDG_AOE_ENV_TEST_3075=sentinel-value"),
             "a created agent session must carry the forwarded desktop/session env (#3075)"
+        );
+    }
+
+    /// #3265: tmux silently falls back to its server's `$HOME` when `-c`
+    /// points at a directory that doesn't exist, landing a fresh/restarted
+    /// pane in the daemon's launch directory instead of the session's
+    /// `project_path`. `create_with_size_env` must refuse to spawn rather
+    /// than let that happen invisibly.
+    #[test]
+    #[serial_test::serial]
+    fn test_create_with_size_env_rejects_missing_working_dir() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let guard = TmuxTestSession::new("aoe_test_missing_dir");
+        let session = super::Session::from_name(guard.name());
+        let result = session.create_with_size(
+            "/nonexistent/definitely-not-here/aoe-3265",
+            Some("sleep 5"),
+            None,
+            "default",
+        );
+
+        assert!(
+            result.is_err(),
+            "create_with_size_env must reject a missing working directory instead of \
+             silently falling back to tmux's own $HOME"
+        );
+        assert!(
+            !session.exists(),
+            "no tmux session should have been created"
         );
     }
 


### PR DESCRIPTION
## Description

I traced every spawn call site (CLI `session start`, the TUI's restart/auto-recovery path) and found `project_path`/`working_dir` is threaded through correctly everywhere — `reconcile_from_disk` reloads the right path from disk before every spawn, and `tmux new-session -c <working_dir>` always gets the right value. That part of the code was never the bug.

The actual mechanism, found by building this branch and reproducing #3265 live against a throwaway worktree session:

`wrap_command_ignore_suspend` (`src/session/instance.rs`) runs the real agent command via `bash -lc '...'` — a **login shell**, used deliberately so version-manager PATH setup (NVM, etc.) sourced from the user's profile is available to the agent. But a login shell also sources `~/.bash_profile`/`~/.bashrc`, and **anything in those files that changes directory silently overrides tmux's already-correct `-c`** before the real agent process starts. In my case it was a stray bare `cd` in my own `~/.bashrc` (leftover from disabling a conda-init block) — but the same failure mode fires for anyone with a legitimate nvm/pyenv/direnv hook, or any other profile script that does a `cd`. tmux sets the pane's *initial* cwd correctly; the login shell's own startup then quietly moves it before the agent ever runs.

I confirmed this end-to-end:
1. Built this branch, created a fresh worktree session, and watched its pane land in `$HOME` instead of the worktree — the exact #3265 symptom, on a directory that unquestionably existed.
2. Added a debug log at the tmux spawn site (first commit) and confirmed the `-c` value passed to tmux was **already correct** — the divergence happens strictly after that, inside the shell.
3. `bash -x -lc 'true'` on my own machine traced the exact culprit: `~/.bashrc` line ~52, a bare `cd` with no arguments.
4. Fixed my own `.bashrc`, then instead fixed aoe defensively so this class of bug (anyone's profile scripts, not just mine) can't silently break session cwd again.

`wrap_command_ignore_suspend` now takes `working_dir` and re-asserts it with `cd <dir> || exit 1` as the **first statement inside the login shell's own script**, i.e. after profile/rc sourcing has already run and right before `exec`ing the real agent command. This wins regardless of what the profile did in between, while keeping the intentional benefit of `-l` (PATH setup from version managers). Applied to all three call sites (host agent, host custom command, sandboxed/container).

Also included (first commit, still valid defense-in-depth): `create_with_size_env` now checks the working directory exists before invoking tmux and bails loudly instead of letting tmux's own silent `$HOME` fallback (verified separately: `tmux new-session -c <missing-dir>` succeeds silently) mask a genuinely missing/racing project path, plus a diagnostic `tracing::debug!` of the resolved `-c` value at the spawn site. Not the root cause of the reported symptom, but a real gap with no coverage previously.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: covered instead by targeted unit tests (`test_create_with_size_env_rejects_missing_working_dir`, `test_wrap_command_reasserts_working_dir_after_login_shell`) plus a manual live repro (built the branch, created/stopped/started a real worktree session, inspected `/proc/<pid>/cwd` before and after the fix) — an e2e test would need to fake a user shell profile with a stray `cd`, which felt like more indirection than the unit tests already covering the actual code path

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Sonnet 5), acting on behalf of the repo/issue owner (myself, adRn-s) in an interactive session.

**Any Additional AI Details you'd like to share:** Root cause was found through actual live reproduction (building the branch, spawning real tmux sessions, tracing `/proc/<pid>/cwd`, and `bash -x -lc` tracing my own shell), not just static code reading — an earlier static-only pass had proposed a plausible but ultimately-wrong theory (a missing-directory tmux fallback) before the live repro surfaced the real mechanism (login-shell profile sourcing). Verifying reviewer feedback and responding here directly rather than relaying it through the AI unexamined.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Validate working directories before creating tmux sessions.
- Return clear errors for missing or invalid directories.
- Restore the working directory after login-shell startup.
- Apply this behavior to host, custom, sandboxed, and container sessions.
- Expand tests for invalid paths, shell escaping, directory changes, and resume behavior.
- Use temporary project directories in integration tests.

## Benefits

- Prevents sessions from starting in `$HOME` or another unexpected directory.
- Makes working-directory errors easier to diagnose.
- Provides consistent behavior across session types.
- Confirms that invalid paths do not create sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->