### PR TITLE
fix(web): align forwarded mouse clicks with live grid

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -910,20 +910,26 @@ export function MobileLiveTerminal({
     inputRef.current?.focus();
   }, [inputRef]);
 
-  // Map a viewport point to the app's 1-based pane cell for the forwarded
-  // wheel event (apps mostly ignore the exact cell, but send a sane one).
+  // Map a viewport point to the app's 1-based pane cell. The grid can be
+  // bottom-aligned and its trailing blank rows are trimmed, so its origin is
+  // the rendered content rather than the scroller's box.
   const pointerCell = useCallback(
     (clientX: number, clientY: number) => {
       const el = scrollerRef.current;
       if (!el || charW <= 0 || lineH <= 0) return { col: 1, row: 1 };
       const r = el.getBoundingClientRect();
+      const content = el.querySelector<HTMLElement>("[data-live-content]");
+      const gridTop = content?.getBoundingClientRect().top ?? r.top;
       const cols = renderCols > 0 ? renderCols : 1;
       const rows = Math.max(1, screenRows || rowsRef.current);
       const col = Math.min(cols, Math.max(1, Math.floor((clientX - r.left) / charW) + 1));
-      const row = Math.min(rows, Math.max(1, Math.floor((clientY - r.top) / lineH) + 1));
+      const visualRow = Math.floor((clientY - gridTop) / lineH) - effectiveSpacerLines;
+      const firstScreenLine = Math.max(0, lines.length - screenRows);
+      const screenTopVisual = visual.lineStartRow[firstScreenLine] ?? 0;
+      const row = Math.min(rows, Math.max(1, visualRow - screenTopVisual + 1));
       return { col, row };
     },
-    [charW, lineH, renderCols, screenRows],
+    [charW, lineH, renderCols, screenRows, effectiveSpacerLines, lines.length, visual],
   );
 
   // Translate an accumulated pixel delta (positive = toward newer/down)

--- a/web/tests/live-click-forward.spec.ts
+++ b/web/tests/live-click-forward.spec.ts
@@ -62,6 +62,25 @@ test("a left click on a full-screen SGR-mouse app forwards press + release", asy
   await expect.poll(() => anyMatch(handle, /\x1b\[<0;\d+;\d+m/)).toBe(true);
 });
 
+test("a click on a bottom-aligned row reports that row to the mouse app", async ({ page }) => {
+  const handle = await setup(page);
+  const lines = ["first", "second", "third", ...Array<string>(21).fill("")];
+  handle.pushLiveFrame({
+    content: `${lines.join("\n")}\n`,
+    rows: 24,
+    history: 120,
+    altScreen: true,
+    mouse: true,
+    mouseSgr: true,
+  });
+  const secondRow = page.getByText("second", { exact: true });
+  await expect(secondRow).toBeVisible();
+  const box = (await secondRow.boundingBox())!;
+
+  await pointer(page, "pointerdown", box.x + 10, box.y + box.height / 2);
+  await expect.poll(() => texts(handle).find((text) => /\x1b\[<0;\d+;\d+M/.test(text))).toMatch(/\x1b\[<0;\d+;2M/);
+});
+
 test("dragging forwards a motion report (button + 32) per new cell", async ({ page }) => {
   const handle = await setup(page);
   pushFrame(handle, { altScreen: true, mouse: true, mouseSgr: true });


### PR DESCRIPTION
## Description

Fix forwarded mouse-button coordinates in the web live terminal when the grid is bottom-aligned and trailing blank rows are trimmed.

The previous mapping measured rows from the scroller's top edge, while rendering starts at the actual content grid. This made clicks land too low, commonly by one row. The new mapping uses the rendered grid's top and converts through the screen's visual-row offset.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**

- [x] Added or updated a Playwright spec under `web/tests/`; the existing `terminal.mobile-live-click-forward-e2e` coverage-matrix entry already covers this flow.

**TUI / CLI (e2e test)**

- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Codex (GPT-5)

**Any Additional AI Details you'd like to share:** Investigated the issue report, implemented the coordinate mapping fix, and added the browser regression test.

- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed mouse-click row mapping for bottom-aligned live terminals with trimmed blank rows.
- Updated coordinate handling for visual-row offsets, spacers, wrapping, and bottom alignment.
- Added Playwright regression coverage for clicks on the second rendered row.

## Benefits

- Mouse clicks now target the correct terminal row.
- The regression test helps prevent future coordinate-mapping issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->