### PR TITLE
feat(tui): add optional memory diagnostics strip

### DIFF
--- a/src/process/linux.rs
+++ b/src/process/linux.rs
@@ -132,6 +132,71 @@ pub(super) fn sample_memory() -> super::metrics::MemorySample {
     }
 }
 
+pub(super) fn sample_system() -> super::metrics::SystemReading {
+    let stat = fs::read_to_string("/proc/stat").unwrap_or_default();
+    let cpu = stat.lines().next().and_then(|line| {
+        let values: Vec<u64> = line
+            .split_whitespace()
+            .skip(1)
+            .filter_map(|value| value.parse().ok())
+            .collect();
+        (!values.is_empty()).then(|| {
+            (
+                values.iter().sum(),
+                values.get(3).copied().unwrap_or(0) + values.get(4).copied().unwrap_or(0),
+            )
+        })
+    });
+    let load = fs::read_to_string("/proc/loadavg").ok().and_then(|value| {
+        let values: Vec<f64> = value
+            .split_whitespace()
+            .take(3)
+            .filter_map(|part| part.parse().ok())
+            .collect();
+        (values.len() == 3).then(|| [values[0], values[1], values[2]])
+    });
+    let mem = fs::read_to_string("/proc/meminfo").unwrap_or_default();
+    let field = |name: &str| {
+        mem.lines()
+            .find(|line| line.starts_with(name))
+            .and_then(|line| line.split_whitespace().nth(1)?.parse::<u64>().ok())
+            .unwrap_or(0)
+            * 1024
+    };
+    let total = field("SwapTotal:");
+    let free = field("SwapFree:");
+    (cpu, None, load, (total, total.saturating_sub(free)))
+}
+
+pub(super) fn process_snapshot() -> Vec<super::metrics::ProcessRecord> {
+    let hz = unsafe { libc::sysconf(libc::_SC_CLK_TCK) }.max(1) as f64;
+    let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) }.max(1) as u64;
+    let Ok(entries) = fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let pid = entry.file_name().to_str()?.parse::<u32>().ok()?;
+            let stat = fs::read_to_string(entry.path().join("stat")).ok()?;
+            let end = stat.rfind(')')?;
+            let fields: Vec<&str> = stat[end + 2..].split_whitespace().collect();
+            let ppid = fields.get(1)?.parse().ok()?;
+            let utime: u64 = fields.get(11)?.parse().ok()?;
+            let stime: u64 = fields.get(12)?.parse().ok()?;
+            let start_id = fields.get(19)?.parse().ok()?;
+            let rss_pages: i64 = fields.get(21)?.parse().ok()?;
+            Some(super::metrics::ProcessRecord {
+                pid,
+                ppid,
+                start_id,
+                rss_bytes: rss_pages.max(0) as u64 * page,
+                cpu_seconds: (utime + stime) as f64 / hz,
+            })
+        })
+        .collect()
+}
+
 fn kib_to_bytes(kib: u64) -> u64 {
     kib.saturating_mul(1024)
 }

--- a/src/process/linux.rs
+++ b/src/process/linux.rs
@@ -17,7 +17,7 @@ pub(super) fn collect_pid_tree(pid: u32) -> Vec<u32> {
 }
 
 /// Scan `/proc` once and group every live PID by its parent.
-fn build_children_map() -> HashMap<u32, Vec<u32>> {
+pub(super) fn build_children_map() -> HashMap<u32, Vec<u32>> {
     let mut children_map: HashMap<u32, Vec<u32>> = HashMap::new();
     let proc_dir = Path::new("/proc");
     let Ok(entries) = fs::read_dir(proc_dir) else {
@@ -97,6 +97,74 @@ pub(super) fn processes_matching(
         }
     }
     found
+}
+
+/// Sample system memory from `/proc` and `/sys`: a handful of small pseudo-file
+/// reads, cheap enough for the background sampler. Any file that is missing or
+/// unparseable leaves its field at the default (0 for the always-present RAM
+/// figures, `None` for the optional ones) so a transient read never fabricates
+/// a reading.
+pub(super) fn sample_memory() -> super::metrics::MemorySample {
+    let meminfo = fs::read_to_string("/proc/meminfo").unwrap_or_default();
+    let total = parse_meminfo_field(&meminfo, "MemTotal").map(kib_to_bytes);
+    let avail = parse_meminfo_field(&meminfo, "MemAvailable").map(kib_to_bytes);
+
+    let psi_mem_some_avg10 =
+        parse_psi_some_avg10(&fs::read_to_string("/proc/pressure/memory").unwrap_or_default());
+    let psi_io_some_avg10 =
+        parse_psi_some_avg10(&fs::read_to_string("/proc/pressure/io").unwrap_or_default());
+
+    // Both figures must be known together: a 0 available against a real total
+    // reads as 100% used, a false Critical. Old kernels (and WSL1) omit
+    // MemAvailable, so require both and otherwise report "unknown" (0/0), which
+    // the renderer shows as counts-only.
+    let (total_bytes, available_bytes) = match (total, avail) {
+        (Some(t), Some(a)) => (t, a),
+        _ => (0, 0),
+    };
+
+    super::metrics::MemorySample {
+        total_bytes,
+        available_bytes,
+        psi_mem_some_avg10,
+        psi_io_some_avg10,
+        macos_pressure_level: None,
+    }
+}
+
+fn kib_to_bytes(kib: u64) -> u64 {
+    kib.saturating_mul(1024)
+}
+
+/// Parse a `/proc/meminfo` line like `MemAvailable:   12345 kB` into its kB
+/// value. All meminfo size fields are in kB. Returns `None` if the key is
+/// absent or the value is not a number.
+fn parse_meminfo_field(meminfo: &str, key: &str) -> Option<u64> {
+    for line in meminfo.lines() {
+        let Some((name, rest)) = line.split_once(':') else {
+            continue;
+        };
+        if name.trim() != key {
+            continue;
+        }
+        // `rest` is like "   12345 kB"; the first whitespace token is the value.
+        return rest.split_whitespace().next()?.parse().ok();
+    }
+    None
+}
+
+/// Parse the `some avg10` stall percentage from a `/proc/pressure/*` file. The
+/// `some` line looks like `some avg10=0.00 avg60=0.00 avg300=0.00 total=12345`.
+/// `None` if absent (e.g. PSI not compiled into the kernel), never a false 0.0.
+fn parse_psi_some_avg10(psi: &str) -> Option<f32> {
+    for line in psi.lines() {
+        let mut fields = line.split_whitespace();
+        if fields.next() != Some("some") {
+            continue;
+        }
+        return fields.find_map(|kv| kv.strip_prefix("avg10=")?.parse().ok());
+    }
+    None
 }
 
 /// Per-boot identity from `/proc/sys/kernel/random/boot_id`: constant for the
@@ -265,5 +333,58 @@ mod tests {
         assert_eq!(parse_stat_field(stat, 3), Some(1233)); // ppid
         assert_eq!(parse_stat_field(stat, 4), Some(1234)); // pgrp
         assert_eq!(parse_stat_field(stat, 7), Some(1234)); // tpgid
+    }
+
+    const MEMINFO: &str = "\
+MemTotal:       32791036 kB
+MemFree:         1234567 kB
+MemAvailable:    9876543 kB
+Cached:          5678901 kB
+";
+
+    #[test]
+    fn test_parse_meminfo_field() {
+        let cases = [
+            ("MemTotal", Some(32791036)),
+            ("MemAvailable", Some(9876543)),
+            ("MemFree", Some(1234567)),
+            ("Nonexistent", None),
+            // Substring of a real key must not match (split on ':' + trim).
+            ("Mem", None),
+        ];
+        for (key, expected) in cases {
+            assert_eq!(parse_meminfo_field(MEMINFO, key), expected, "{key}");
+        }
+    }
+
+    #[test]
+    fn test_sample_used_derivation() {
+        // used = total - available, and used_fraction tracks it.
+        let total = parse_meminfo_field(MEMINFO, "MemTotal")
+            .map(kib_to_bytes)
+            .unwrap();
+        let avail = parse_meminfo_field(MEMINFO, "MemAvailable")
+            .map(kib_to_bytes)
+            .unwrap();
+        let sample = super::super::metrics::MemorySample {
+            total_bytes: total,
+            available_bytes: avail,
+            ..Default::default()
+        };
+        assert_eq!(sample.used_bytes(), total - avail);
+        assert!((sample.used_fraction() - (total - avail) as f64 / total as f64).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_parse_psi_some_avg10() {
+        let psi = "\
+some avg10=1.23 avg60=4.56 avg300=7.89 total=123456789
+full avg10=0.10 avg60=0.20 avg300=0.30 total=42
+";
+        assert_eq!(parse_psi_some_avg10(psi), Some(1.23));
+        // PSI not compiled in / empty file -> None (not a false 0.0).
+        assert_eq!(parse_psi_some_avg10(""), None);
+        // Only a `full` line, no `some` -> None.
+        assert_eq!(parse_psi_some_avg10("full avg10=5.0 total=9"), None);
     }
 }

--- a/src/process/macos.rs
+++ b/src/process/macos.rs
@@ -12,7 +12,7 @@ pub(super) fn collect_pid_tree(pid: u32) -> Vec<u32> {
 }
 
 /// Build a map of parent PID -> list of child PIDs by parsing `ps` output once
-fn build_children_map() -> HashMap<u32, Vec<u32>> {
+pub(super) fn build_children_map() -> HashMap<u32, Vec<u32>> {
     let mut children_map: HashMap<u32, Vec<u32>> = HashMap::new();
 
     let Ok(output) = Command::new("ps").args(["-o", "pid=,ppid=", "-A"]).output() else {
@@ -74,6 +74,110 @@ pub(super) fn processes_matching(
         }
     }
     found
+}
+
+/// Sample system memory via `sysctl` and `vm_stat`, matching this module's
+/// existing shell-out convention. Populates total/available RAM and the native
+/// memory-pressure level; PSI has no macOS analogue and stays `None`.
+pub(super) fn sample_memory() -> super::metrics::MemorySample {
+    // Require both figures: total comes from a reliable sysctl but available is
+    // parsed from vm_stat, so a vm_stat failure alone would otherwise read as a
+    // false 100%. Report "unknown" (0/0) unless both are present.
+    let (total_bytes, available_bytes) = match (
+        sysctl_u64("hw.memsize"),
+        read_vm_stat().and_then(|s| parse_vm_stat_available(&s)),
+    ) {
+        (Some(total), Some(available)) => (total, available),
+        _ => (0, 0),
+    };
+
+    super::metrics::MemorySample {
+        total_bytes,
+        available_bytes,
+        psi_mem_some_avg10: None,
+        psi_io_some_avg10: None,
+        macos_pressure_level: sysctl_u64("kern.memorystatus_vm_pressure_level").map(|v| v as u8),
+    }
+}
+
+fn sysctl_string(key: &str) -> Option<String> {
+    let out = Command::new("sysctl").args(["-n", key]).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!s.is_empty()).then_some(s)
+}
+
+fn sysctl_u64(key: &str) -> Option<u64> {
+    sysctl_string(key)?.parse().ok()
+}
+
+fn read_vm_stat() -> Option<String> {
+    let out = Command::new("vm_stat").output().ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Derive "available" bytes from `vm_stat`: (free + inactive) pages times the
+/// reported page size. Inactive pages are reclaimable, so this mirrors the
+/// spirit of Linux `MemAvailable`. It is an approximation, which is why macOS
+/// leans on the native pressure level for its band rather than this number.
+fn parse_vm_stat_available(vm_stat: &str) -> Option<u64> {
+    let page_size = parse_vm_stat_page_size(vm_stat)?;
+    let free = parse_vm_stat_pages(vm_stat, "Pages free")?;
+    let inactive = parse_vm_stat_pages(vm_stat, "Pages inactive")?;
+    Some((free + inactive).saturating_mul(page_size))
+}
+
+/// The page size from the `vm_stat` header: `Mach Virtual Memory Statistics:
+/// (page size of 16384 bytes)`.
+fn parse_vm_stat_page_size(vm_stat: &str) -> Option<u64> {
+    let line = vm_stat.lines().next()?;
+    let after = line.split("page size of").nth(1)?;
+    after.split_whitespace().next()?.parse().ok()
+}
+
+/// A `vm_stat` page-count line like `Pages free:    123456.` (trailing period).
+fn parse_vm_stat_pages(vm_stat: &str, key: &str) -> Option<u64> {
+    for line in vm_stat.lines() {
+        let Some((name, rest)) = line.split_once(':') else {
+            continue;
+        };
+        if name.trim() != key {
+            continue;
+        }
+        return rest.trim().trim_end_matches('.').parse().ok();
+    }
+    None
+}
+
+#[cfg(test)]
+mod memory_tests {
+    use super::*;
+
+    const VM_STAT: &str = "\
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                              123456.
+Pages active:                            654321.
+Pages inactive:                          200000.
+Pages speculative:                        10000.
+Pages wired down:                        300000.
+";
+
+    #[test]
+    fn test_parse_vm_stat_available() {
+        assert_eq!(parse_vm_stat_page_size(VM_STAT), Some(16384));
+        assert_eq!(parse_vm_stat_pages(VM_STAT, "Pages free"), Some(123456));
+        assert_eq!(parse_vm_stat_pages(VM_STAT, "Pages inactive"), Some(200000));
+        // available = (free + inactive) * page_size
+        assert_eq!(
+            parse_vm_stat_available(VM_STAT),
+            Some((123456 + 200000) * 16384)
+        );
+        assert_eq!(parse_vm_stat_pages(VM_STAT, "Pages nonexistent"), None);
+    }
 }
 
 /// Per-boot identity from `kern.bootsessionuuid`: a UUID fixed for the boot's

--- a/src/process/macos.rs
+++ b/src/process/macos.rs
@@ -131,24 +131,39 @@ pub(super) fn sample_system() -> super::metrics::SystemReading {
 
 pub(super) fn process_snapshot() -> Vec<super::metrics::ProcessRecord> {
     let Ok(output) = Command::new("ps")
-        .args(["-axo", "pid=,ppid=,rss=,time="])
+        .args(["-axo", "pid=,ppid=,rss=,time=,lstart="])
         .output()
     else {
         return Vec::new();
     };
     String::from_utf8_lossy(&output.stdout)
         .lines()
-        .filter_map(|line| {
-            let fields: Vec<&str> = line.split_whitespace().collect();
-            Some(super::metrics::ProcessRecord {
-                pid: fields.first()?.parse().ok()?,
-                ppid: fields.get(1)?.parse().ok()?,
-                rss_bytes: fields.get(2)?.parse::<u64>().ok()?.saturating_mul(1024),
-                cpu_seconds: parse_ps_time(fields.get(3)?)?,
-                start_id: 0,
-            })
-        })
+        .filter_map(parse_process_record)
         .collect()
+}
+
+fn parse_process_record(line: &str) -> Option<super::metrics::ProcessRecord> {
+    let fields: Vec<&str> = line.split_whitespace().collect();
+    let started_at = fields.get(4..)?;
+    if started_at.is_empty() {
+        return None;
+    }
+    Some(super::metrics::ProcessRecord {
+        pid: fields.first()?.parse().ok()?,
+        ppid: fields.get(1)?.parse().ok()?,
+        rss_bytes: fields.get(2)?.parse::<u64>().ok()?.saturating_mul(1024),
+        cpu_seconds: parse_ps_time(fields.get(3)?)?,
+        start_id: stable_process_start_id(started_at),
+    })
+}
+
+fn stable_process_start_id(fields: &[&str]) -> u64 {
+    fields
+        .iter()
+        .flat_map(|field| field.bytes().chain(std::iter::once(0)))
+        .fold(0xcbf29ce484222325, |hash, byte| {
+            (hash ^ u64::from(byte)).wrapping_mul(0x100000001b3)
+        })
 }
 
 fn parse_swap(value: &str) -> (u64, u64) {
@@ -172,15 +187,22 @@ fn parse_swap(value: &str) -> (u64, u64) {
 }
 
 fn parse_ps_time(value: &str) -> Option<f64> {
-    let parts: Vec<f64> = value
+    let (days, clock) = if let Some((days, clock)) = value.split_once('-') {
+        (days.parse::<f64>().ok()?, clock)
+    } else {
+        (0.0, value)
+    };
+    let parts: Vec<f64> = clock
         .split(':')
-        .filter_map(|part| part.parse().ok())
-        .collect();
-    match parts.as_slice() {
-        [minutes, seconds] => Some(minutes * 60.0 + seconds),
-        [hours, minutes, seconds] => Some(hours * 3600.0 + minutes * 60.0 + seconds),
-        _ => None,
-    }
+        .map(str::parse)
+        .collect::<Result<_, _>>()
+        .ok()?;
+    let seconds = match parts.as_slice() {
+        [minutes, seconds] => minutes * 60.0 + seconds,
+        [hours, minutes, seconds] => hours * 3600.0 + minutes * 60.0 + seconds,
+        _ => return None,
+    };
+    Some(days * 86_400.0 + seconds)
 }
 
 fn sysctl_string(key: &str) -> Option<String> {
@@ -260,6 +282,29 @@ Pages wired down:                        300000.
             Some((123456 + 200000) * 16384)
         );
         assert_eq!(parse_vm_stat_pages(VM_STAT, "Pages nonexistent"), None);
+    }
+
+    #[test]
+    fn process_record_parses_stable_identity_and_cpu_time() {
+        let time_cases = [
+            ("03:04", Some(184.0)),
+            ("02:03:04", Some(7_384.0)),
+            ("1-02:03:04", Some(93_784.0)),
+            ("1-02:x:04", None),
+            ("1-02:03:bad", None),
+        ];
+        for (value, expected) in time_cases {
+            assert_eq!(parse_ps_time(value), expected, "CPU time {value}");
+        }
+
+        let line = "42 1 512 1-02:03:04 Thu Aug 13 12:34:56 2026";
+        let record = parse_process_record(line).unwrap();
+        assert_eq!(record.cpu_seconds, 93_784.0);
+        assert_ne!(record.start_id, 0);
+        assert_eq!(
+            record.start_id,
+            parse_process_record(line).unwrap().start_id
+        );
     }
 }
 

--- a/src/process/macos.rs
+++ b/src/process/macos.rs
@@ -100,6 +100,89 @@ pub(super) fn sample_memory() -> super::metrics::MemorySample {
     }
 }
 
+pub(super) fn sample_system() -> super::metrics::SystemReading {
+    let cpu = Command::new("ps")
+        .args(["-A", "-o", "%cpu="])
+        .output()
+        .ok()
+        .map(|output| {
+            let total_percent: f64 = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .filter_map(|line| line.trim().parse::<f64>().ok())
+                .sum();
+            let cpus = std::thread::available_parallelism()
+                .map(usize::from)
+                .unwrap_or(1);
+            (total_percent / 100.0 / cpus as f64).clamp(0.0, 1.0)
+        });
+    let load = sysctl_string("vm.loadavg").and_then(|value| {
+        let values: Vec<f64> = value
+            .replace(['{', '}'], "")
+            .split_whitespace()
+            .filter_map(|part| part.parse().ok())
+            .collect();
+        (values.len() >= 3).then(|| [values[0], values[1], values[2]])
+    });
+    let swap = sysctl_string("vm.swapusage")
+        .map(|value| parse_swap(&value))
+        .unwrap_or((0, 0));
+    (None, cpu, load, swap)
+}
+
+pub(super) fn process_snapshot() -> Vec<super::metrics::ProcessRecord> {
+    let Ok(output) = Command::new("ps")
+        .args(["-axo", "pid=,ppid=,rss=,time="])
+        .output()
+    else {
+        return Vec::new();
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let fields: Vec<&str> = line.split_whitespace().collect();
+            Some(super::metrics::ProcessRecord {
+                pid: fields.first()?.parse().ok()?,
+                ppid: fields.get(1)?.parse().ok()?,
+                rss_bytes: fields.get(2)?.parse::<u64>().ok()?.saturating_mul(1024),
+                cpu_seconds: parse_ps_time(fields.get(3)?)?,
+                start_id: 0,
+            })
+        })
+        .collect()
+}
+
+fn parse_swap(value: &str) -> (u64, u64) {
+    let parse = |label: &str| {
+        let raw = value
+            .split_whitespace()
+            .skip_while(|part| *part != label)
+            .nth(2)?;
+        let (number, multiplier) = if let Some(number) = raw.strip_suffix('G') {
+            (number, 1u64 << 30)
+        } else if let Some(number) = raw.strip_suffix('M') {
+            (number, 1u64 << 20)
+        } else if let Some(number) = raw.strip_suffix('K') {
+            (number, 1u64 << 10)
+        } else {
+            (raw, 1)
+        };
+        Some((number.parse::<f64>().ok()? * multiplier as f64) as u64)
+    };
+    (parse("total").unwrap_or(0), parse("used").unwrap_or(0))
+}
+
+fn parse_ps_time(value: &str) -> Option<f64> {
+    let parts: Vec<f64> = value
+        .split(':')
+        .filter_map(|part| part.parse().ok())
+        .collect();
+    match parts.as_slice() {
+        [minutes, seconds] => Some(minutes * 60.0 + seconds),
+        [hours, minutes, seconds] => Some(hours * 3600.0 + minutes * 60.0 + seconds),
+        _ => None,
+    }
+}
+
 fn sysctl_string(key: &str) -> Option<String> {
     let out = Command::new("sysctl").args(["-n", key]).output().ok()?;
     if !out.status.success() {

--- a/src/process/metrics.rs
+++ b/src/process/metrics.rs
@@ -1,83 +1,282 @@
-//! System memory + agent-count sampling for the TUI diagnostics strip.
-//!
-//! The strip answers one question: how close is the machine to a memory
-//! thrash, and how many agents/processes are driving it. The headline signal
-//! is memory headroom (`1 - available/total`), because on a box with a
-//! RAM-backed tmpfs the unreclaimable `Shmem` collapses `MemAvailable` while
-//! kernel pressure-stall counters can still read zero; `MemAvailable` already
-//! excludes tmpfs/shmem, so it is the number that actually moves. PSI is
-//! carried as a secondary escalation signal, not the plotted line.
-//!
-//! PSI is Linux only, so it is `None` on macOS, where the native pressure
-//! level stands in for the color band instead.
+//! Host and AoE-agent resource sampling for the TUI system-health views.
 
-use crate::session::Instance;
+use std::collections::{HashMap, HashSet};
+use std::time::Instant;
 
-/// One memory reading. Byte fields are absolute bytes. `total_bytes == 0` means
-/// the RAM figures could not be read this sample (both are read together, so a
-/// half-read never fabricates a false 100%); the renderer shows counts only.
-/// The `Option` pressure fields are `None` where the platform does not expose
-/// them, so a Linux-only signal never reads as a false all-clear on macOS.
+use crate::session::{Instance, Status};
+
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct MemorySample {
-    /// Total physical RAM in bytes (`MemTotal`). 0 when unknown this sample.
     pub total_bytes: u64,
-    /// Kernel estimate of RAM available for new work without swapping
-    /// (`MemAvailable`). Already excludes unreclaimable tmpfs/shmem, so this
-    /// is the honest "distance to the wall" figure and the plotted line, and
-    /// it already moves when tmpfs or zram grows.
     pub available_bytes: u64,
-    /// Memory pressure stall, `some` share over the last 10s (percent 0..=100)
-    /// from `/proc/pressure/memory`. Linux only.
     pub psi_mem_some_avg10: Option<f32>,
-    /// I/O pressure stall, `some` share over the last 10s (percent 0..=100)
-    /// from `/proc/pressure/io`. Carried because a fast thrash can raise io
-    /// pressure ahead of memory pressure. Linux only.
     pub psi_io_some_avg10: Option<f32>,
-    /// macOS native pressure level (`kern.memorystatus_vm_pressure_level`):
-    /// 1 = normal, 2 = warn, 4 = critical. macOS only; `None` on Linux, which
-    /// derives its band from headroom + PSI instead.
     pub macos_pressure_level: Option<u8>,
 }
 
 impl MemorySample {
-    /// Bytes in use, derived as `total - available` so the plotted line, the
-    /// percentage, and the used/total readout can never disagree.
     pub fn used_bytes(&self) -> u64 {
         self.total_bytes.saturating_sub(self.available_bytes)
     }
 
-    /// Fraction of RAM used, `0.0..=1.0`. This is the plotted headroom line.
-    /// Returns 0.0 when the RAM figures are unknown this sample (`total == 0`).
     pub fn used_fraction(&self) -> f64 {
-        if self.total_bytes == 0 {
-            return 0.0;
+        if self.total_bytes > 0 {
+            self.used_bytes() as f64 / self.total_bytes as f64
+        } else {
+            0.0
         }
-        self.used_bytes() as f64 / self.total_bytes as f64
     }
 }
 
-/// Count of agents and their processes, both scoped to AoE-managed sessions.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
-pub struct AgentCounts {
-    /// Live agent sessions (one per instance whose agent process is alive).
-    pub agents: usize,
-    /// Total processes across those agents' process trees.
+pub struct SystemSample {
+    pub cpu_fraction: Option<f64>,
+    pub load_average: Option<[f64; 3]>,
+    pub swap_total_bytes: u64,
+    pub swap_used_bytes: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AgentMetric {
+    pub id: String,
+    pub title: String,
+    pub cpu_fraction: Option<f64>,
+    pub rss_bytes: u64,
     pub procs: usize,
 }
 
-/// One diagnostics tick: a memory reading plus the agent/proc counts. This is
-/// the value the [`crate::tui::metrics_poller::MetricsPoller`] produces and the
-/// diagnostics widget renders.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
-pub struct MetricsSnapshot {
-    pub memory: MemorySample,
-    pub counts: AgentCounts,
+pub struct AgentCounts {
+    pub agents: usize,
+    pub procs: usize,
 }
 
-/// Sample system memory for the current platform. Cheap: on Linux a handful of
-/// `/proc` + `/sys` reads. Intended to run on a background worker, never the
-/// render thread.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct MetricsSnapshot {
+    pub memory: MemorySample,
+    pub system: SystemSample,
+    pub counts: AgentCounts,
+    pub agents: Vec<AgentMetric>,
+}
+
+#[derive(Debug, Clone)]
+struct ProcessRecord {
+    pid: u32,
+    ppid: u32,
+    start_id: u64,
+    rss_bytes: u64,
+    cpu_seconds: f64,
+}
+
+type SystemReading = (
+    Option<(u64, u64)>,
+    Option<f64>,
+    Option<[f64; 3]>,
+    (u64, u64),
+);
+
+#[derive(Default)]
+pub(crate) struct MetricsSampler {
+    last_at: Option<Instant>,
+    last_host_cpu: Option<(u64, u64)>,
+    last_process_cpu: HashMap<(u32, u64), f64>,
+}
+
+impl MetricsSampler {
+    pub(crate) fn sample(&mut self, instances: &[Instance]) -> MetricsSnapshot {
+        let now = Instant::now();
+        let elapsed = self.last_at.map(|at| now.duration_since(at).as_secs_f64());
+        let memory = sample_memory();
+        let (host_cpu, direct_cpu, load_average, swap) = sample_system();
+        let cpu_fraction = direct_cpu.or_else(|| {
+            self.last_host_cpu
+                .zip(host_cpu)
+                .and_then(|((old_total, old_idle), (total, idle))| {
+                    let total_delta = total.checked_sub(old_total)?;
+                    let idle_delta = idle.checked_sub(old_idle)?;
+                    (total_delta > 0).then(|| {
+                        (total_delta.saturating_sub(idle_delta)) as f64 / total_delta as f64
+                    })
+                })
+        });
+
+        let processes = process_snapshot();
+        let agents = aggregate_agents(instances, &processes, elapsed, &self.last_process_cpu);
+        let counts = AgentCounts {
+            agents: agents.len(),
+            procs: agents.iter().map(|a| a.procs).sum(),
+        };
+
+        self.last_at = Some(now);
+        self.last_host_cpu = host_cpu;
+        self.last_process_cpu = processes
+            .iter()
+            .map(|p| ((p.pid, p.start_id), p.cpu_seconds))
+            .collect();
+
+        MetricsSnapshot {
+            memory,
+            system: SystemSample {
+                cpu_fraction,
+                load_average,
+                swap_total_bytes: swap.0,
+                swap_used_bytes: swap.1,
+            },
+            counts,
+            agents,
+        }
+    }
+}
+
+fn eligible_instance(inst: &Instance) -> bool {
+    !inst.is_structured()
+        && !inst.is_archived()
+        && !inst.is_trashed()
+        && !inst.is_snoozed()
+        && matches!(
+            inst.status,
+            Status::Running | Status::Waiting | Status::Idle
+        )
+}
+
+fn aggregate_agents(
+    instances: &[Instance],
+    processes: &[ProcessRecord],
+    elapsed: Option<f64>,
+    previous: &HashMap<(u32, u64), f64>,
+) -> Vec<AgentMetric> {
+    let by_parent: HashMap<u32, Vec<u32>> = {
+        let mut map: HashMap<u32, Vec<u32>> = HashMap::new();
+        for p in processes {
+            map.entry(p.ppid).or_default().push(p.pid);
+        }
+        map
+    };
+    let by_pid: HashMap<u32, &ProcessRecord> = processes.iter().map(|p| (p.pid, p)).collect();
+    let mut claimed = HashSet::new();
+    let mut rows = Vec::new();
+
+    let eligible: Vec<Instance> = instances
+        .iter()
+        .filter(|i| eligible_instance(i))
+        .cloned()
+        .collect();
+    let alive = crate::session::recovery::orphaned_agents_alive(&eligible);
+    for (inst, is_alive) in eligible.iter().zip(alive) {
+        if !is_alive {
+            continue;
+        }
+        let session_name = crate::tmux::Session::resolve_name(&inst.id, &inst.title);
+        let Some(root) = crate::process::get_pane_pid(&session_name) else {
+            continue;
+        };
+        if !by_pid.contains_key(&root) {
+            continue;
+        }
+        let mut stack = vec![root];
+        let mut pids = Vec::new();
+        while let Some(pid) = stack.pop() {
+            if !claimed.insert(pid) {
+                continue;
+            }
+            pids.push(pid);
+            if let Some(children) = by_parent.get(&pid) {
+                stack.extend(children);
+            }
+        }
+        let rss_bytes = pids
+            .iter()
+            .filter_map(|pid| by_pid.get(pid))
+            .map(|p| p.rss_bytes)
+            .sum();
+        let cpu_fraction = elapsed.filter(|v| *v > 0.0).map(|seconds| {
+            pids.iter()
+                .filter_map(|pid| by_pid.get(pid))
+                .filter_map(|p| {
+                    let old = previous.get(&(p.pid, p.start_id))?;
+                    Some((p.cpu_seconds - old).max(0.0))
+                })
+                .sum::<f64>()
+                / seconds
+                / logical_cpus() as f64
+        });
+        rows.push(AgentMetric {
+            id: inst.id.clone(),
+            title: inst.title.clone(),
+            cpu_fraction,
+            rss_bytes,
+            procs: pids.len(),
+        });
+    }
+
+    #[cfg(feature = "serve")]
+    for rec in crate::process::worker_registry::list()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(crate::process::worker_registry::is_record_live)
+    {
+        let Some(root) = by_pid.get(&rec.pid) else {
+            continue;
+        };
+        if !claimed.insert(root.pid) {
+            continue;
+        }
+        let mut stack = vec![root.pid];
+        let mut pids = Vec::new();
+        while let Some(pid) = stack.pop() {
+            if pid != root.pid && !claimed.insert(pid) {
+                continue;
+            }
+            pids.push(pid);
+            if let Some(children) = by_parent.get(&pid) {
+                stack.extend(children);
+            }
+        }
+        let rss_bytes = pids
+            .iter()
+            .filter_map(|pid| by_pid.get(pid))
+            .map(|p| p.rss_bytes)
+            .sum();
+        let cpu_fraction = elapsed.filter(|v| *v > 0.0).map(|seconds| {
+            pids.iter()
+                .filter_map(|pid| by_pid.get(pid))
+                .filter_map(|p| {
+                    let old = previous.get(&(p.pid, p.start_id))?;
+                    Some((p.cpu_seconds - old).max(0.0))
+                })
+                .sum::<f64>()
+                / seconds
+                / logical_cpus() as f64
+        });
+        let title = instances
+            .iter()
+            .find(|i| i.id == rec.session_id)
+            .map(|i| i.title.clone())
+            .unwrap_or_else(|| rec.agent_name.clone());
+        rows.push(AgentMetric {
+            id: rec.session_id,
+            title,
+            cpu_fraction,
+            rss_bytes,
+            procs: pids.len(),
+        });
+    }
+
+    rows.sort_by(|a, b| {
+        b.cpu_fraction
+            .partial_cmp(&a.cpu_fraction)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    rows
+}
+
+fn logical_cpus() -> usize {
+    std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1)
+}
+
 pub(crate) fn sample_memory() -> MemorySample {
     #[cfg(target_os = "linux")]
     {
@@ -93,57 +292,170 @@ pub(crate) fn sample_memory() -> MemorySample {
     }
 }
 
-/// Count live AoE-managed agents and the total processes in their trees.
-///
-/// `agents` reuses the same batched liveness check the recovery paths use
-/// (one process-table walk, scoped to AoE via the injected instance-id env
-/// marker). `procs` counts every process across the live agents' trees in a
-/// single further walk (see [`crate::process::count_pids_in_trees`]). ACP
-/// agents that run detached with no tmux pane are folded in under the `serve`
-/// feature, where the worker registry exists.
-pub(crate) fn count_running_agents(insts: &[Instance]) -> AgentCounts {
-    let alive = crate::session::recovery::orphaned_agents_alive(insts);
-    let mut roots: Vec<u32> = insts
-        .iter()
-        .zip(alive.iter())
-        .filter(|(_, &is_alive)| is_alive)
-        .filter_map(|(inst, _)| agent_root_pid(inst))
-        .collect();
+#[cfg(target_os = "linux")]
+fn sample_system() -> SystemReading {
+    let stat = std::fs::read_to_string("/proc/stat").unwrap_or_default();
+    let cpu = stat.lines().next().and_then(|line| {
+        let values: Vec<u64> = line
+            .split_whitespace()
+            .skip(1)
+            .filter_map(|v| v.parse().ok())
+            .collect();
+        (!values.is_empty()).then(|| {
+            (
+                values.iter().sum(),
+                values.get(3).copied().unwrap_or(0) + values.get(4).copied().unwrap_or(0),
+            )
+        })
+    });
+    let load = std::fs::read_to_string("/proc/loadavg").ok().and_then(|s| {
+        let vals: Vec<f64> = s
+            .split_whitespace()
+            .take(3)
+            .filter_map(|v| v.parse().ok())
+            .collect();
+        (vals.len() == 3).then(|| [vals[0], vals[1], vals[2]])
+    });
+    let mem = std::fs::read_to_string("/proc/meminfo").unwrap_or_default();
+    let field = |name: &str| {
+        mem.lines()
+            .find(|l| l.starts_with(name))
+            .and_then(|l| l.split_whitespace().nth(1)?.parse::<u64>().ok())
+            .unwrap_or(0)
+            * 1024
+    };
+    let total = field("SwapTotal:");
+    let free = field("SwapFree:");
+    (cpu, None, load, (total, total.saturating_sub(free)))
+}
 
-    let acp_roots = live_acp_agent_pids();
-    let agents = alive.iter().filter(|&&a| a).count() + acp_roots.len();
-    roots.extend(acp_roots);
+#[cfg(target_os = "linux")]
+fn process_snapshot() -> Vec<ProcessRecord> {
+    let hz = unsafe { libc::sysconf(libc::_SC_CLK_TCK) }.max(1) as f64;
+    let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) }.max(1) as u64;
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let pid = entry.file_name().to_str()?.parse::<u32>().ok()?;
+            let stat = std::fs::read_to_string(entry.path().join("stat")).ok()?;
+            let end = stat.rfind(')')?;
+            let f: Vec<&str> = stat[end + 2..].split_whitespace().collect();
+            let ppid = f.get(1)?.parse().ok()?;
+            let utime: u64 = f.get(11)?.parse().ok()?;
+            let stime: u64 = f.get(12)?.parse().ok()?;
+            let start_id = f.get(19)?.parse().ok()?;
+            let rss_pages: i64 = f.get(21)?.parse().ok()?;
+            Some(ProcessRecord {
+                pid,
+                ppid,
+                start_id,
+                rss_bytes: rss_pages.max(0) as u64 * page,
+                cpu_seconds: (utime + stime) as f64 / hz,
+            })
+        })
+        .collect()
+}
 
-    AgentCounts {
-        agents,
-        procs: crate::process::count_pids_in_trees(&roots),
+#[cfg(target_os = "macos")]
+fn sample_system() -> SystemReading {
+    let cpu = std::process::Command::new("ps")
+        .args(["-A", "-o", "%cpu="])
+        .output()
+        .ok()
+        .map(|output| {
+            let total_percent: f64 = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .filter_map(|line| line.trim().parse::<f64>().ok())
+                .sum();
+            (total_percent / 100.0 / logical_cpus() as f64).clamp(0.0, 1.0)
+        });
+    let load = std::process::Command::new("sysctl")
+        .args(["-n", "vm.loadavg"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            let s = String::from_utf8_lossy(&o.stdout).replace(['{', '}'], "");
+            let v: Vec<f64> = s
+                .split_whitespace()
+                .filter_map(|x| x.parse().ok())
+                .collect();
+            (v.len() >= 3).then(|| [v[0], v[1], v[2]])
+        });
+    let swap = std::process::Command::new("sysctl")
+        .args(["-n", "vm.swapusage"])
+        .output()
+        .ok()
+        .map(|output| parse_macos_swap(&String::from_utf8_lossy(&output.stdout)))
+        .unwrap_or((0, 0));
+    (None, cpu, load, swap)
+}
+
+#[cfg(target_os = "macos")]
+fn parse_macos_swap(value: &str) -> (u64, u64) {
+    let parse = |label: &str| {
+        let raw = value
+            .split_whitespace()
+            .skip_while(|part| *part != label)
+            .nth(2)?;
+        let (number, multiplier) = if let Some(number) = raw.strip_suffix('G') {
+            (number, 1u64 << 30)
+        } else if let Some(number) = raw.strip_suffix('M') {
+            (number, 1u64 << 20)
+        } else if let Some(number) = raw.strip_suffix('K') {
+            (number, 1u64 << 10)
+        } else {
+            (raw, 1)
+        };
+        Some((number.parse::<f64>().ok()? * multiplier as f64) as u64)
+    };
+    (parse("total").unwrap_or(0), parse("used").unwrap_or(0))
+}
+
+#[cfg(target_os = "macos")]
+fn process_snapshot() -> Vec<ProcessRecord> {
+    let Ok(out) = std::process::Command::new("ps")
+        .args(["-axo", "pid=,ppid=,rss=,time="])
+        .output()
+    else {
+        return Vec::new();
+    };
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|line| {
+            let f: Vec<&str> = line.split_whitespace().collect();
+            let pid = f.first()?.parse().ok()?;
+            let ppid = f.get(1)?.parse().ok()?;
+            let rss_bytes = f.get(2)?.parse::<u64>().ok()?.saturating_mul(1024);
+            let cpu_seconds = parse_ps_time(f.get(3)?)?;
+            Some(ProcessRecord {
+                pid,
+                ppid,
+                start_id: 0,
+                rss_bytes,
+                cpu_seconds,
+            })
+        })
+        .collect()
+}
+
+#[cfg(target_os = "macos")]
+fn parse_ps_time(value: &str) -> Option<f64> {
+    let parts: Vec<f64> = value.split(':').filter_map(|v| v.parse().ok()).collect();
+    match parts.as_slice() {
+        [m, s] => Some(m * 60.0 + s),
+        [h, m, s] => Some(h * 3600.0 + m * 60.0 + s),
+        _ => None,
     }
 }
 
-/// The root PID of an instance's agent process, via the tmux pane PID that
-/// `aoe` already uses elsewhere. Resolves the session's live name (a
-/// smart-renamed session keeps its original tmux name), so the lookup does not
-/// go stale when the title moves. `None` when the session has no live pane.
-fn agent_root_pid(inst: &Instance) -> Option<u32> {
-    let session_name = crate::tmux::Session::resolve_name(&inst.id, &inst.title);
-    crate::process::get_pane_pid(&session_name)
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn sample_system() -> SystemReading {
+    (None, None, None, (0, 0))
 }
-
-/// Root PIDs of detached ACP agents (structured-view workers with no tmux
-/// pane). Empty without the `serve` feature, where the worker registry that
-/// tracks them does not exist.
-fn live_acp_agent_pids() -> Vec<u32> {
-    #[cfg(feature = "serve")]
-    {
-        crate::process::worker_registry::list()
-            .unwrap_or_default()
-            .into_iter()
-            .filter(crate::process::worker_registry::is_record_live)
-            .map(|rec| rec.pid)
-            .collect()
-    }
-    #[cfg(not(feature = "serve"))]
-    {
-        Vec::new()
-    }
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn process_snapshot() -> Vec<ProcessRecord> {
+    Vec::new()
 }

--- a/src/process/metrics.rs
+++ b/src/process/metrics.rs
@@ -1,0 +1,149 @@
+//! System memory + agent-count sampling for the TUI diagnostics strip.
+//!
+//! The strip answers one question: how close is the machine to a memory
+//! thrash, and how many agents/processes are driving it. The headline signal
+//! is memory headroom (`1 - available/total`), because on a box with a
+//! RAM-backed tmpfs the unreclaimable `Shmem` collapses `MemAvailable` while
+//! kernel pressure-stall counters can still read zero; `MemAvailable` already
+//! excludes tmpfs/shmem, so it is the number that actually moves. PSI is
+//! carried as a secondary escalation signal, not the plotted line.
+//!
+//! PSI is Linux only, so it is `None` on macOS, where the native pressure
+//! level stands in for the color band instead.
+
+use crate::session::Instance;
+
+/// One memory reading. Byte fields are absolute bytes. `total_bytes == 0` means
+/// the RAM figures could not be read this sample (both are read together, so a
+/// half-read never fabricates a false 100%); the renderer shows counts only.
+/// The `Option` pressure fields are `None` where the platform does not expose
+/// them, so a Linux-only signal never reads as a false all-clear on macOS.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct MemorySample {
+    /// Total physical RAM in bytes (`MemTotal`). 0 when unknown this sample.
+    pub total_bytes: u64,
+    /// Kernel estimate of RAM available for new work without swapping
+    /// (`MemAvailable`). Already excludes unreclaimable tmpfs/shmem, so this
+    /// is the honest "distance to the wall" figure and the plotted line, and
+    /// it already moves when tmpfs or zram grows.
+    pub available_bytes: u64,
+    /// Memory pressure stall, `some` share over the last 10s (percent 0..=100)
+    /// from `/proc/pressure/memory`. Linux only.
+    pub psi_mem_some_avg10: Option<f32>,
+    /// I/O pressure stall, `some` share over the last 10s (percent 0..=100)
+    /// from `/proc/pressure/io`. Carried because a fast thrash can raise io
+    /// pressure ahead of memory pressure. Linux only.
+    pub psi_io_some_avg10: Option<f32>,
+    /// macOS native pressure level (`kern.memorystatus_vm_pressure_level`):
+    /// 1 = normal, 2 = warn, 4 = critical. macOS only; `None` on Linux, which
+    /// derives its band from headroom + PSI instead.
+    pub macos_pressure_level: Option<u8>,
+}
+
+impl MemorySample {
+    /// Bytes in use, derived as `total - available` so the plotted line, the
+    /// percentage, and the used/total readout can never disagree.
+    pub fn used_bytes(&self) -> u64 {
+        self.total_bytes.saturating_sub(self.available_bytes)
+    }
+
+    /// Fraction of RAM used, `0.0..=1.0`. This is the plotted headroom line.
+    /// Returns 0.0 when the RAM figures are unknown this sample (`total == 0`).
+    pub fn used_fraction(&self) -> f64 {
+        if self.total_bytes == 0 {
+            return 0.0;
+        }
+        self.used_bytes() as f64 / self.total_bytes as f64
+    }
+}
+
+/// Count of agents and their processes, both scoped to AoE-managed sessions.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct AgentCounts {
+    /// Live agent sessions (one per instance whose agent process is alive).
+    pub agents: usize,
+    /// Total processes across those agents' process trees.
+    pub procs: usize,
+}
+
+/// One diagnostics tick: a memory reading plus the agent/proc counts. This is
+/// the value the [`crate::tui::metrics_poller::MetricsPoller`] produces and the
+/// diagnostics widget renders.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct MetricsSnapshot {
+    pub memory: MemorySample,
+    pub counts: AgentCounts,
+}
+
+/// Sample system memory for the current platform. Cheap: on Linux a handful of
+/// `/proc` + `/sys` reads. Intended to run on a background worker, never the
+/// render thread.
+pub(crate) fn sample_memory() -> MemorySample {
+    #[cfg(target_os = "linux")]
+    {
+        super::linux::sample_memory()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        super::macos::sample_memory()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        MemorySample::default()
+    }
+}
+
+/// Count live AoE-managed agents and the total processes in their trees.
+///
+/// `agents` reuses the same batched liveness check the recovery paths use
+/// (one process-table walk, scoped to AoE via the injected instance-id env
+/// marker). `procs` counts every process across the live agents' trees in a
+/// single further walk (see [`crate::process::count_pids_in_trees`]). ACP
+/// agents that run detached with no tmux pane are folded in under the `serve`
+/// feature, where the worker registry exists.
+pub(crate) fn count_running_agents(insts: &[Instance]) -> AgentCounts {
+    let alive = crate::session::recovery::orphaned_agents_alive(insts);
+    let mut roots: Vec<u32> = insts
+        .iter()
+        .zip(alive.iter())
+        .filter(|(_, &is_alive)| is_alive)
+        .filter_map(|(inst, _)| agent_root_pid(inst))
+        .collect();
+
+    let acp_roots = live_acp_agent_pids();
+    let agents = alive.iter().filter(|&&a| a).count() + acp_roots.len();
+    roots.extend(acp_roots);
+
+    AgentCounts {
+        agents,
+        procs: crate::process::count_pids_in_trees(&roots),
+    }
+}
+
+/// The root PID of an instance's agent process, via the tmux pane PID that
+/// `aoe` already uses elsewhere. Resolves the session's live name (a
+/// smart-renamed session keeps its original tmux name), so the lookup does not
+/// go stale when the title moves. `None` when the session has no live pane.
+fn agent_root_pid(inst: &Instance) -> Option<u32> {
+    let session_name = crate::tmux::Session::resolve_name(&inst.id, &inst.title);
+    crate::process::get_pane_pid(&session_name)
+}
+
+/// Root PIDs of detached ACP agents (structured-view workers with no tmux
+/// pane). Empty without the `serve` feature, where the worker registry that
+/// tracks them does not exist.
+fn live_acp_agent_pids() -> Vec<u32> {
+    #[cfg(feature = "serve")]
+    {
+        crate::process::worker_registry::list()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(crate::process::worker_registry::is_record_live)
+            .map(|rec| rec.pid)
+            .collect()
+    }
+    #[cfg(not(feature = "serve"))]
+    {
+        Vec::new()
+    }
+}

--- a/src/process/metrics.rs
+++ b/src/process/metrics.rs
@@ -60,15 +60,15 @@ pub struct MetricsSnapshot {
 }
 
 #[derive(Debug, Clone)]
-struct ProcessRecord {
-    pid: u32,
-    ppid: u32,
-    start_id: u64,
-    rss_bytes: u64,
-    cpu_seconds: f64,
+pub(super) struct ProcessRecord {
+    pub(super) pid: u32,
+    pub(super) ppid: u32,
+    pub(super) start_id: u64,
+    pub(super) rss_bytes: u64,
+    pub(super) cpu_seconds: f64,
 }
 
-type SystemReading = (
+pub(super) type SystemReading = (
     Option<(u64, u64)>,
     Option<f64>,
     Option<[f64; 3]>,
@@ -292,170 +292,32 @@ pub(crate) fn sample_memory() -> MemorySample {
     }
 }
 
-#[cfg(target_os = "linux")]
 fn sample_system() -> SystemReading {
-    let stat = std::fs::read_to_string("/proc/stat").unwrap_or_default();
-    let cpu = stat.lines().next().and_then(|line| {
-        let values: Vec<u64> = line
-            .split_whitespace()
-            .skip(1)
-            .filter_map(|v| v.parse().ok())
-            .collect();
-        (!values.is_empty()).then(|| {
-            (
-                values.iter().sum(),
-                values.get(3).copied().unwrap_or(0) + values.get(4).copied().unwrap_or(0),
-            )
-        })
-    });
-    let load = std::fs::read_to_string("/proc/loadavg").ok().and_then(|s| {
-        let vals: Vec<f64> = s
-            .split_whitespace()
-            .take(3)
-            .filter_map(|v| v.parse().ok())
-            .collect();
-        (vals.len() == 3).then(|| [vals[0], vals[1], vals[2]])
-    });
-    let mem = std::fs::read_to_string("/proc/meminfo").unwrap_or_default();
-    let field = |name: &str| {
-        mem.lines()
-            .find(|l| l.starts_with(name))
-            .and_then(|l| l.split_whitespace().nth(1)?.parse::<u64>().ok())
-            .unwrap_or(0)
-            * 1024
-    };
-    let total = field("SwapTotal:");
-    let free = field("SwapFree:");
-    (cpu, None, load, (total, total.saturating_sub(free)))
-}
-
-#[cfg(target_os = "linux")]
-fn process_snapshot() -> Vec<ProcessRecord> {
-    let hz = unsafe { libc::sysconf(libc::_SC_CLK_TCK) }.max(1) as f64;
-    let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) }.max(1) as u64;
-    let Ok(entries) = std::fs::read_dir("/proc") else {
-        return Vec::new();
-    };
-    entries
-        .filter_map(Result::ok)
-        .filter_map(|entry| {
-            let pid = entry.file_name().to_str()?.parse::<u32>().ok()?;
-            let stat = std::fs::read_to_string(entry.path().join("stat")).ok()?;
-            let end = stat.rfind(')')?;
-            let f: Vec<&str> = stat[end + 2..].split_whitespace().collect();
-            let ppid = f.get(1)?.parse().ok()?;
-            let utime: u64 = f.get(11)?.parse().ok()?;
-            let stime: u64 = f.get(12)?.parse().ok()?;
-            let start_id = f.get(19)?.parse().ok()?;
-            let rss_pages: i64 = f.get(21)?.parse().ok()?;
-            Some(ProcessRecord {
-                pid,
-                ppid,
-                start_id,
-                rss_bytes: rss_pages.max(0) as u64 * page,
-                cpu_seconds: (utime + stime) as f64 / hz,
-            })
-        })
-        .collect()
-}
-
-#[cfg(target_os = "macos")]
-fn sample_system() -> SystemReading {
-    let cpu = std::process::Command::new("ps")
-        .args(["-A", "-o", "%cpu="])
-        .output()
-        .ok()
-        .map(|output| {
-            let total_percent: f64 = String::from_utf8_lossy(&output.stdout)
-                .lines()
-                .filter_map(|line| line.trim().parse::<f64>().ok())
-                .sum();
-            (total_percent / 100.0 / logical_cpus() as f64).clamp(0.0, 1.0)
-        });
-    let load = std::process::Command::new("sysctl")
-        .args(["-n", "vm.loadavg"])
-        .output()
-        .ok()
-        .and_then(|o| {
-            let s = String::from_utf8_lossy(&o.stdout).replace(['{', '}'], "");
-            let v: Vec<f64> = s
-                .split_whitespace()
-                .filter_map(|x| x.parse().ok())
-                .collect();
-            (v.len() >= 3).then(|| [v[0], v[1], v[2]])
-        });
-    let swap = std::process::Command::new("sysctl")
-        .args(["-n", "vm.swapusage"])
-        .output()
-        .ok()
-        .map(|output| parse_macos_swap(&String::from_utf8_lossy(&output.stdout)))
-        .unwrap_or((0, 0));
-    (None, cpu, load, swap)
-}
-
-#[cfg(target_os = "macos")]
-fn parse_macos_swap(value: &str) -> (u64, u64) {
-    let parse = |label: &str| {
-        let raw = value
-            .split_whitespace()
-            .skip_while(|part| *part != label)
-            .nth(2)?;
-        let (number, multiplier) = if let Some(number) = raw.strip_suffix('G') {
-            (number, 1u64 << 30)
-        } else if let Some(number) = raw.strip_suffix('M') {
-            (number, 1u64 << 20)
-        } else if let Some(number) = raw.strip_suffix('K') {
-            (number, 1u64 << 10)
-        } else {
-            (raw, 1)
-        };
-        Some((number.parse::<f64>().ok()? * multiplier as f64) as u64)
-    };
-    (parse("total").unwrap_or(0), parse("used").unwrap_or(0))
-}
-
-#[cfg(target_os = "macos")]
-fn process_snapshot() -> Vec<ProcessRecord> {
-    let Ok(out) = std::process::Command::new("ps")
-        .args(["-axo", "pid=,ppid=,rss=,time="])
-        .output()
-    else {
-        return Vec::new();
-    };
-    String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .filter_map(|line| {
-            let f: Vec<&str> = line.split_whitespace().collect();
-            let pid = f.first()?.parse().ok()?;
-            let ppid = f.get(1)?.parse().ok()?;
-            let rss_bytes = f.get(2)?.parse::<u64>().ok()?.saturating_mul(1024);
-            let cpu_seconds = parse_ps_time(f.get(3)?)?;
-            Some(ProcessRecord {
-                pid,
-                ppid,
-                start_id: 0,
-                rss_bytes,
-                cpu_seconds,
-            })
-        })
-        .collect()
-}
-
-#[cfg(target_os = "macos")]
-fn parse_ps_time(value: &str) -> Option<f64> {
-    let parts: Vec<f64> = value.split(':').filter_map(|v| v.parse().ok()).collect();
-    match parts.as_slice() {
-        [m, s] => Some(m * 60.0 + s),
-        [h, m, s] => Some(h * 3600.0 + m * 60.0 + s),
-        _ => None,
+    #[cfg(target_os = "linux")]
+    {
+        super::linux::sample_system()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        super::macos::sample_system()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        (None, None, None, (0, 0))
     }
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn sample_system() -> SystemReading {
-    (None, None, None, (0, 0))
-}
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 fn process_snapshot() -> Vec<ProcessRecord> {
-    Vec::new()
+    #[cfg(target_os = "linux")]
+    {
+        super::linux::process_snapshot()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        super::macos::process_snapshot()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        Vec::new()
+    }
 }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -19,6 +19,9 @@ mod linux;
 #[cfg(target_os = "macos")]
 mod macos;
 
+/// System memory + agent-count sampling for the TUI diagnostics strip.
+pub(crate) mod metrics;
+
 /// Protocol-agnostic plumbing for supervised worker subprocesses, lifted
 /// out of `src/acp/` so the future plugin host can reuse it. Serve-gated
 /// because its only consumer today is the serve-gated `acp` module.
@@ -440,6 +443,37 @@ fn sleep_inhibit_child_held_alive(child: &mut Option<Child>, exit_reason: &str) 
             true
         }
         _ => false,
+    }
+}
+
+/// Count the distinct PIDs across every `roots` process tree, building the
+/// parent -> children map ONCE and descending it for each root: counting N
+/// trees costs one process table scan (a `/proc` walk on Linux, a `ps` fork on
+/// macOS), not N. Roots whose trees overlap are de-duplicated so a shared
+/// descendant is counted once. Returns 0 on unsupported platforms.
+pub(crate) fn count_pids_in_trees(roots: &[u32]) -> usize {
+    if roots.is_empty() {
+        return 0;
+    }
+    #[cfg(target_os = "linux")]
+    let children_map = linux::build_children_map();
+    #[cfg(target_os = "macos")]
+    let children_map = macos::build_children_map();
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        let mut all = Vec::new();
+        for &root in roots {
+            all.push(root);
+            collect_descendants_from_map(root, &children_map, &mut all);
+        }
+        all.sort_unstable();
+        all.dedup();
+        all.len()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        roots.len()
     }
 }
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -446,37 +446,6 @@ fn sleep_inhibit_child_held_alive(child: &mut Option<Child>, exit_reason: &str) 
     }
 }
 
-/// Count the distinct PIDs across every `roots` process tree, building the
-/// parent -> children map ONCE and descending it for each root: counting N
-/// trees costs one process table scan (a `/proc` walk on Linux, a `ps` fork on
-/// macOS), not N. Roots whose trees overlap are de-duplicated so a shared
-/// descendant is counted once. Returns 0 on unsupported platforms.
-pub(crate) fn count_pids_in_trees(roots: &[u32]) -> usize {
-    if roots.is_empty() {
-        return 0;
-    }
-    #[cfg(target_os = "linux")]
-    let children_map = linux::build_children_map();
-    #[cfg(target_os = "macos")]
-    let children_map = macos::build_children_map();
-
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    {
-        let mut all = Vec::new();
-        for &root in roots {
-            all.push(root);
-            collect_descendants_from_map(root, &children_map, &mut all);
-        }
-        all.sort_unstable();
-        all.dedup();
-        all.len()
-    }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    {
-        roots.len()
-    }
-}
-
 /// Kill a process and all its descendants
 /// Sends SIGTERM first, then SIGKILL to any survivors
 pub fn kill_process_tree(pid: u32) {

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -644,6 +644,8 @@ pub async fn get_tips(State(_state): State<Arc<AppState>>) -> impl IntoResponse 
         let signals = crate::tips::TipSignals {
             new_session_with_selection_count: config.app_state.new_session_with_selection_count,
             used_new_from_selection: config.app_state.used_new_from_selection,
+            system_health_tip_earned: config.app_state.system_health_tip_earned,
+            used_system_health: config.app_state.used_system_health,
         };
         let seen = &config.app_state.tips_seen;
         let tips = crate::tips::eligible(crate::tips::TipSurface::Web, &signals)

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -867,6 +867,16 @@ pub struct AppStateConfig {
     #[serde(default)]
     pub used_new_from_selection: bool,
 
+    /// Set after six live agents have been observed for three consecutive
+    /// health samples, making the System Health discovery tip eligible.
+    #[serde(default)]
+    pub system_health_tip_earned: bool,
+
+    /// Set once the detailed System Health view has been opened. Users who
+    /// found it themselves do not need its earned discovery tip.
+    #[serde(default)]
+    pub used_system_health: bool,
+
     /// Server-side mirror of the web dashboard's syncable UI state, keyed by
     /// the frontend's localStorage key (the value is the opaque string the
     /// browser stored). Single-tenant: there is one user, so these prefs
@@ -3848,16 +3858,22 @@ mod tests {
         assert!(app.tips_seen.is_empty());
         assert_eq!(app.new_session_with_selection_count, 0);
         assert!(!app.used_new_from_selection);
+        assert!(!app.system_health_tip_earned);
+        assert!(!app.used_system_health);
 
         let toml = r#"
             tips_seen = ["new-from-selection"]
             new_session_with_selection_count = 4
             used_new_from_selection = true
+            system_health_tip_earned = true
+            used_system_health = true
         "#;
         let app: AppStateConfig = toml::from_str(toml).unwrap();
         assert_eq!(app.tips_seen, vec!["new-from-selection"]);
         assert_eq!(app.new_session_with_selection_count, 4);
         assert!(app.used_new_from_selection);
+        assert!(app.system_health_tip_earned);
+        assert!(app.used_system_health);
 
         // Round-trips back out.
         let serialized = toml::to_string(&app).unwrap();

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -898,6 +898,13 @@ pub struct SessionConfig {
     #[setting(label = "YOLO Mode Default", widget = "toggle")]
     pub yolo_mode_default: bool,
 
+    /// Show the memory diagnostics strip at the bottom of the home view: a
+    /// live memory-pressure sparkline plus the running agent and process
+    /// counts. Off by default; also toggleable with a keybinding.
+    #[serde(default)]
+    #[setting(label = "Show diagnostics pane", widget = "toggle")]
+    pub show_diagnostics_pane: bool,
+
     /// Forward AoE's whole environment to host sessions instead of just the
     /// desktop vars (DISPLAY, XDG_*, DBUS). Lets vars like GOPATH reach an
     /// agent without naming each one in the Host Environment list. AoE's own
@@ -1554,6 +1561,7 @@ impl Default for SessionConfig {
         Self {
             default_tool: None,
             yolo_mode_default: false,
+            show_diagnostics_pane: false,
             inherit_host_environment: false,
             agent_extra_args: HashMap::new(),
             agent_command_override: HashMap::new(),

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -898,11 +898,11 @@ pub struct SessionConfig {
     #[setting(label = "YOLO Mode Default", widget = "toggle")]
     pub yolo_mode_default: bool,
 
-    /// Show the memory diagnostics strip at the bottom of the home view: a
-    /// live memory-pressure sparkline plus the running agent and process
-    /// counts. Off by default; also toggleable with a keybinding.
+    /// Show the compact system-health strip below the session list. It reports
+    /// CPU, memory pressure, and running agent and process counts. Off by
+    /// default; also toggleable from the command palette.
     #[serde(default)]
-    #[setting(label = "Show diagnostics pane", widget = "toggle")]
+    #[setting(label = "Show system health strip", widget = "toggle")]
     pub show_diagnostics_pane: bool,
 
     /// Forward AoE's whole environment to host sessions instead of just the

--- a/src/tips.rs
+++ b/src/tips.rs
@@ -27,6 +27,10 @@ pub struct TipSignals {
     /// Whether the user has already used `N` (new-from-selection). Once true,
     /// the tip teaching it is suppressed; they've discovered the feature.
     pub used_new_from_selection: bool,
+    /// Whether concurrent load has earned the System Health discovery tip.
+    pub system_health_tip_earned: bool,
+    /// Whether the user has already opened the detailed System Health view.
+    pub used_system_health: bool,
 }
 
 /// Number of `new_session_with_selection` opens before the "new from
@@ -34,6 +38,8 @@ pub struct TipSignals {
 /// their first session, but someone who keeps opening `n` with a row selected
 /// eventually learns about `N`.
 pub const NEW_FROM_SELECTION_TIP_THRESHOLD: u32 = 3;
+pub const SYSTEM_HEALTH_AGENT_THRESHOLD: usize = 6;
+pub const SYSTEM_HEALTH_SAMPLE_THRESHOLD: u8 = 3;
 
 /// Which surface a tip is meant for. A tip lists every surface it applies to in
 /// [`Tip::surfaces`], so keyboard-only hints (the `N` shortcut) stay out of the
@@ -99,6 +105,10 @@ fn earned_new_from_selection(signals: &TipSignals) -> bool {
         && signals.new_session_with_selection_count >= NEW_FROM_SELECTION_TIP_THRESHOLD
 }
 
+fn earned_system_health(signals: &TipSignals) -> bool {
+    signals.system_health_tip_earned && !signals.used_system_health
+}
+
 /// The full catalog, in display order.
 pub fn catalog() -> &'static [Tip] {
     CATALOG
@@ -116,6 +126,15 @@ static CATALOG: &[Tip] = &[
                all of them from the session you have selected.",
         trigger: TipTrigger::Earned(earned_new_from_selection),
         // Teaches a keyboard shortcut, so it only makes sense in the TUI.
+        surfaces: &[TipSurface::Tui],
+    },
+    Tip {
+        id: "system-health",
+        title: "See what your agents are costing",
+        body: "You have 6 or more agents running. Turn on the System Health strip in \
+               Settings, or open System Health from the command palette, to see CPU, \
+               memory, load, swap, and per-agent usage.",
+        trigger: TipTrigger::Earned(earned_system_health),
         surfaces: &[TipSurface::Tui],
     },
     Tip {
@@ -288,6 +307,7 @@ mod tests {
         TipSignals {
             new_session_with_selection_count: count,
             used_new_from_selection: false,
+            ..TipSignals::default()
         }
     }
 
@@ -320,6 +340,7 @@ mod tests {
         let used = TipSignals {
             new_session_with_selection_count: NEW_FROM_SELECTION_TIP_THRESHOLD + 5,
             used_new_from_selection: true,
+            ..TipSignals::default()
         };
         assert!(!tip.is_eligible(TipSurface::Tui, &used));
         // The earned tip drops out, but rotation TUI tips remain.
@@ -371,6 +392,24 @@ mod tests {
             ),
             base
         );
+    }
+
+    #[test]
+    fn system_health_tip_requires_earned_and_undiscovered() {
+        let tip = by_id("system-health").unwrap();
+        let cases = [
+            (false, false, false),
+            (true, false, true),
+            (true, true, false),
+        ];
+        for (earned, used, expected) in cases {
+            let signals = TipSignals {
+                system_health_tip_earned: earned,
+                used_system_health: used,
+                ..TipSignals::default()
+            };
+            assert_eq!(tip.is_eligible(TipSurface::Tui, &signals), expected);
+        }
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -837,6 +837,7 @@ impl App {
         let mut last_refresh_at: Option<std::time::Instant> = None;
         const REFRESH_COOLDOWN: Duration = Duration::from_millis(15);
         let mut last_status_refresh = std::time::Instant::now();
+        let mut last_metrics_sample = std::time::Instant::now();
         #[cfg(feature = "serve")]
         let mut last_daemon_status_refresh = std::time::Instant::now();
         let mut last_disk_refresh = std::time::Instant::now();
@@ -857,6 +858,10 @@ impl App {
         #[cfg(feature = "serve")]
         const DAEMON_STATUS_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
         const DISK_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
+        // Diagnostics-strip sampling. 1s keeps the sparkline responsive to a
+        // fast memory climb; request_metrics_refresh is a no-op unless the strip
+        // is visible, so this costs nothing when the pane is hidden.
+        const METRICS_SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
         // Fastest spinner (breathe) changes every 180ms; 120ms ensures smooth animation
         const SPINNER_REDRAW_INTERVAL: Duration = Duration::from_millis(120);
         const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
@@ -1785,6 +1790,17 @@ impl App {
             if self.home.apply_status_updates() {
                 refresh_needed = true;
                 needs_full_refresh = true;
+            }
+
+            if last_metrics_sample.elapsed() >= METRICS_SAMPLE_INTERVAL {
+                self.home.request_metrics_refresh();
+                last_metrics_sample = std::time::Instant::now();
+            }
+
+            // A new sample only repaints the strip, so a diffed redraw is
+            // enough; no full clear.
+            if self.home.apply_metrics_updates() {
+                refresh_needed = true;
             }
 
             #[cfg(feature = "serve")]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1099,6 +1099,8 @@ impl App {
                                                             // Sidebar collapse/expand toggle; must
                                                             // precede hit_list (button is on the
                                                             // list's top border).
+                                                        } else if self.home.handle_diagnostics_click(mouse.column, mouse.row) {
+                                                            // Compact system-health strip opened the read-only detail view.
                                                         } else if self.home.handle_tips_badge_click(mouse.column, mouse.row) {
                                                             // Footer tips badge opened the overlay;
                                                             // drop any stale preview highlight, like
@@ -1396,6 +1398,13 @@ impl App {
                                     // the collapsed strip toggled the sidebar.
                                     // Runs before hit_list because the button
                                     // lives on the list's top border.
+                                    let _ = self.home.clear_preview_selection();
+                                    self.draw(terminal)?;
+                                    None
+                                } else if self
+                                    .home
+                                    .handle_diagnostics_click(mouse.column, mouse.row)
+                                {
                                     let _ = self.home.clear_preview_selection();
                                     self.draw(terminal)?;
                                     None

--- a/src/tui/components/diagnostics.rs
+++ b/src/tui/components/diagnostics.rs
@@ -34,6 +34,12 @@ pub(crate) fn agent_table_visible_rows(preview_height: u16) -> usize {
         .saturating_sub(AGENT_TABLE_HEADER_ROWS) as usize
 }
 
+fn format_agent_title(title: &str, width: usize) -> String {
+    let title = truncate_to_width(title, width);
+    let padding = width.saturating_sub(title.width());
+    format!("{title}{}", " ".repeat(padding))
+}
+
 /// Memory-pressure severity, worst-of across the available signals. Ordered
 /// ascending so the derived `Ord` lets callers fold inputs with `max`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -357,16 +363,13 @@ pub fn render_system_health(
     let visible = table_area.height.saturating_sub(1) as usize;
     for agent in snapshot.agents.iter().skip(scroll).take(visible) {
         let name_width = table_area.width.saturating_sub(24).max(8) as usize;
-        let title = truncate_to_width(&agent.title, name_width);
+        let title = format_agent_title(&agent.title, name_width);
         let cpu = agent
             .cpu_fraction
             .map(|v| format!("{:.1}%", v * 100.0))
             .unwrap_or_else(|| "?".into());
         table_lines.push(Line::from(vec![
-            Span::styled(
-                format!("{title:<name_width$}"),
-                Style::default().fg(theme.text),
-            ),
+            Span::styled(title, Style::default().fg(theme.text)),
             Span::raw(format!(
                 " {cpu:>6} {:>9} {:>6}",
                 format_bytes(agent.rss_bytes),
@@ -484,9 +487,22 @@ mod tests {
     #[test]
     fn pressure_band_default_sample_is_ok() {
         assert_eq!(pressure_band(&MemorySample::default()), PressureBand::Ok);
-        assert_eq!(agent_table_visible_rows(17), 0);
-        assert_eq!(agent_table_visible_rows(18), 1);
-        assert_eq!(agent_table_visible_rows(24), 7);
+    }
+
+    #[test]
+    fn agent_table_visible_rows_handles_boundaries() {
+        let row_cases = [(17, 0), (18, 1), (24, 7)];
+        for (height, expected) in row_cases {
+            assert_eq!(agent_table_visible_rows(height), expected);
+        }
+    }
+
+    #[test]
+    fn agent_table_title_padding_uses_display_width() {
+        for title in ["agent", "日本語", "aaaaaaaé"] {
+            let formatted = format_agent_title(title, 8);
+            assert_eq!(formatted.width(), 8, "title {title:?}");
+        }
     }
 
     #[test]

--- a/src/tui/components/diagnostics.rs
+++ b/src/tui/components/diagnostics.rs
@@ -3,8 +3,6 @@
 //! The readout row sheds gracefully as width shrinks: the used/total detail
 //! drops before the counts, and below that only the percent remains.
 
-use std::collections::VecDeque;
-
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 use unicode_width::UnicodeWidthStr;
@@ -21,10 +19,7 @@ const HEADROOM_WARN: f64 = 0.70;
 const PSI_CRITICAL: f32 = 20.0;
 /// PSI `some` avg10 percent at or above which a present PSI signal reads Warn.
 const PSI_WARN: f32 = 5.0;
-/// The full 0..=100% scale in per-mille, so the sparkline plots against a fixed
-/// ceiling instead of auto-scaling to whatever the recent peak happened to be.
-const PER_MILLE_MAX: u64 = 1000;
-const HEALTH_FIXED_ROWS: u16 = 14;
+const HEALTH_FIXED_ROWS: u16 = 6;
 const AGENT_TABLE_HEADER_ROWS: u16 = 1;
 
 pub(crate) fn agent_table_visible_rows(preview_height: u16) -> usize {
@@ -220,8 +215,6 @@ pub fn render_system_health(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
-    memory_history: &VecDeque<u64>,
-    cpu_history: &VecDeque<u64>,
     snapshot: &MetricsSnapshot,
     scroll: usize,
 ) {
@@ -268,15 +261,7 @@ pub fn render_system_health(
         "none".into()
     };
 
-    let rows = Layout::vertical([
-        Constraint::Length(6),
-        Constraint::Length(1),
-        Constraint::Length(3),
-        Constraint::Length(1),
-        Constraint::Length(3),
-        Constraint::Min(0),
-    ])
-    .split(inner);
+    let rows = Layout::vertical([Constraint::Length(6), Constraint::Min(0)]).split(inner);
     let band = pressure_band(&snapshot.memory);
     let severity = match band {
         PressureBand::Ok => "OK",
@@ -322,26 +307,7 @@ pub fn render_system_health(
     ];
     frame.render_widget(Paragraph::new(lines), rows[0]);
 
-    render_timeline(
-        frame,
-        rows[1],
-        rows[2],
-        theme,
-        "Memory timeline",
-        memory_history,
-        band_color(theme, band),
-    );
-    render_timeline(
-        frame,
-        rows[3],
-        rows[4],
-        theme,
-        "CPU timeline",
-        cpu_history,
-        theme.running,
-    );
-
-    let table_area = rows[5];
+    let table_area = rows[1];
     if table_area.height == 0 {
         return;
     }
@@ -380,32 +346,6 @@ pub fn render_system_health(
         ]));
     }
     frame.render_widget(Paragraph::new(table_lines), table_area);
-}
-
-fn render_timeline(
-    frame: &mut Frame,
-    label_area: Rect,
-    graph_area: Rect,
-    theme: &Theme,
-    label: &str,
-    history: &VecDeque<u64>,
-    color: Color,
-) {
-    frame.render_widget(
-        Paragraph::new(label).style(Style::default().fg(theme.dimmed)),
-        label_area,
-    );
-    let width = graph_area.width as usize;
-    let start = history.len().saturating_sub(width);
-    let recent: Vec<u64> = history.iter().skip(start).copied().collect();
-    frame.render_widget(
-        Sparkline::default()
-            .data(recent)
-            .max(PER_MILLE_MAX)
-            .direction(RenderDirection::LeftToRight)
-            .style(Style::default().fg(color)),
-        graph_area,
-    );
 }
 
 #[cfg(test)]
@@ -493,7 +433,7 @@ mod tests {
 
     #[test]
     fn agent_table_visible_rows_handles_boundaries() {
-        let row_cases = [(17, 0), (18, 1), (24, 7)];
+        let row_cases = [(9, 0), (10, 1), (16, 7)];
         for (height, expected) in row_cases {
             assert_eq!(agent_table_visible_rows(height), expected);
         }

--- a/src/tui/components/diagnostics.rs
+++ b/src/tui/components/diagnostics.rs
@@ -129,7 +129,13 @@ pub(crate) fn format_bytes(bytes: u64) -> String {
 }
 
 /// Render the single-row current-state strip into `area`.
-pub fn render(frame: &mut Frame, area: Rect, theme: &Theme, snapshot: &MetricsSnapshot) {
+pub fn render(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    snapshot: &MetricsSnapshot,
+    hovered: bool,
+) {
     if area.width == 0 || area.height == 0 {
         return;
     }
@@ -138,6 +144,11 @@ pub fn render(frame: &mut Frame, area: Rect, theme: &Theme, snapshot: &MetricsSn
     let band = pressure_band(mem);
     let color = band_color(theme, band);
 
+    let style = if hovered {
+        Style::default().bg(theme.selection)
+    } else {
+        Style::default()
+    };
     frame.render_widget(
         Paragraph::new(readout_line(
             theme,
@@ -145,71 +156,62 @@ pub fn render(frame: &mut Frame, area: Rect, theme: &Theme, snapshot: &MetricsSn
             mem,
             snapshot,
             area.width as usize,
-        )),
+            hovered,
+        ))
+        .style(style),
         area,
     );
 }
 
-/// Build the readout line under the sparkline, dropping detail as `avail`
-/// (display cells) shrinks. A leading space insets it from the border. Before
-/// the first sample (`total_bytes == 0`) the memory figure is unknown, so only
-/// the counts show rather than a misleading `0%`.
+/// Build the compact CPU and memory readout, adding agent counts when width
+/// permits. A chevron makes the drill-down action visible without consuming a
+/// permanent keybinding.
 fn readout_line<'a>(
     theme: &Theme,
     color: Color,
     mem: &MemorySample,
     snapshot: &MetricsSnapshot,
     avail: usize,
+    hovered: bool,
 ) -> Line<'a> {
     let cpu = snapshot
         .system
         .cpu_fraction
-        .map(|value| format!("CPU {}% · ", (value * 100.0).round() as u32))
-        .unwrap_or_default();
+        .map(|value| format!("CPU {}%", (value * 100.0).round() as u32))
+        .unwrap_or_else(|| "CPU ?".to_string());
+    let memory = if mem.total_bytes > 0 {
+        format!("Mem {}%", (mem.used_fraction() * 100.0).round() as u32)
+    } else {
+        "Mem ?".to_string()
+    };
     let counts = format!(
-        "{cpu}{} agents · {} procs",
+        "{} agents · {} procs",
         snapshot.counts.agents, snapshot.counts.procs
     );
-
-    if mem.total_bytes == 0 {
-        return Line::from(vec![
-            Span::raw(" "),
+    let separator = " · ";
+    let detail_separator = "  │  ";
+    let affordance = "  ›";
+    let primary_width = 1 + cpu.width() + separator.width() + memory.width();
+    let full_width = primary_width + detail_separator.width() + counts.width() + affordance.width();
+    let affordance_color = if hovered { theme.title } else { theme.hint };
+    let mut spans = vec![
+        Span::raw(" "),
+        Span::styled(cpu, Style::default().fg(theme.text).bold()),
+        Span::styled(separator, Style::default().fg(theme.dimmed)),
+        Span::styled(memory, Style::default().fg(color).bold()),
+    ];
+    if full_width <= avail {
+        spans.extend([
+            Span::styled(detail_separator, Style::default().fg(theme.dimmed)),
             Span::styled(counts, Style::default().fg(theme.dimmed)),
         ]);
     }
-
-    let pct = format!("{}%", (mem.used_fraction() * 100.0).round() as u32);
-    let detail = format!(
-        "{}/{}",
-        format_bytes(mem.used_bytes()),
-        format_bytes(mem.total_bytes)
-    );
-    let gap = "  ";
-    let sep = "  │  ";
-
-    let pct_span = Span::styled(pct.clone(), Style::default().fg(color).bold());
-    let full_width = 1 + pct.width() + gap.width() + detail.width() + sep.width() + counts.width();
-    let counts_width = 1 + pct.width() + gap.width() + counts.width();
-
-    let spans = if full_width <= avail {
-        vec![
-            Span::raw(" "),
-            pct_span,
-            Span::raw(gap),
-            Span::styled(detail, Style::default().fg(theme.text)),
-            Span::styled(sep, Style::default().fg(theme.dimmed)),
-            Span::styled(counts, Style::default().fg(theme.dimmed)),
-        ]
-    } else if counts_width <= avail {
-        vec![
-            Span::raw(" "),
-            pct_span,
-            Span::raw(gap),
-            Span::styled(counts, Style::default().fg(theme.dimmed)),
-        ]
-    } else {
-        vec![Span::raw(" "), pct_span]
-    };
+    if primary_width + affordance.width() <= avail {
+        spans.push(Span::styled(
+            affordance,
+            Style::default().fg(affordance_color).bold(),
+        ));
+    }
     Line::from(spans)
 }
 

--- a/src/tui/components/diagnostics.rs
+++ b/src/tui/components/diagnostics.rs
@@ -1,0 +1,337 @@
+//! "memory pressure" strip, docked under the session-list column.
+//!
+//! Two stacked rows: a memory-over-time area sparkline on top, then a readout
+//! row (percent plus used/total, and the agent/process counts). The sparkline
+//! plots memory headroom; its color and the percent share a green/amber/red
+//! band derived by [`pressure_band`] from headroom, PSI, and the macOS pressure
+//! level (worst wins). See [`crate::process::metrics`] for why headroom is the
+//! headline signal.
+//!
+//! The readout row sheds gracefully as width shrinks: the used/total detail
+//! drops before the counts, and below that only the percent remains.
+
+use std::collections::VecDeque;
+
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+use unicode_width::UnicodeWidthStr;
+
+use crate::process::metrics::{MemorySample, MetricsSnapshot};
+use crate::tui::styles::Theme;
+
+/// Fraction used at or above which the strip reads Critical.
+const HEADROOM_CRITICAL: f64 = 0.90;
+/// Fraction used at or above which the strip reads Warn.
+const HEADROOM_WARN: f64 = 0.70;
+/// PSI `some` avg10 percent at or above which a present PSI signal reads Critical.
+const PSI_CRITICAL: f32 = 20.0;
+/// PSI `some` avg10 percent at or above which a present PSI signal reads Warn.
+const PSI_WARN: f32 = 5.0;
+/// The full 0..=100% scale in per-mille, so the sparkline plots against a fixed
+/// ceiling instead of auto-scaling to whatever the recent peak happened to be.
+const PER_MILLE_MAX: u64 = 1000;
+
+/// Memory-pressure severity, worst-of across the available signals. Ordered
+/// ascending so the derived `Ord` lets callers fold inputs with `max`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum PressureBand {
+    Ok,
+    Warn,
+    Critical,
+}
+
+/// Classify a memory sample into a pressure band. Headroom is always an input;
+/// PSI (Linux) and the macOS pressure level contribute only when present, so a
+/// platform that omits a signal never has it read as a false all-clear. The
+/// worst band across the present inputs wins.
+pub(crate) fn pressure_band(mem: &MemorySample) -> PressureBand {
+    let mut band = band_from_headroom(mem.used_fraction());
+    if let Some(v) = mem.psi_mem_some_avg10 {
+        band = band.max(band_from_psi(v));
+    }
+    if let Some(v) = mem.psi_io_some_avg10 {
+        band = band.max(band_from_psi(v));
+    }
+    if let Some(level) = mem.macos_pressure_level {
+        band = band.max(band_from_macos(level));
+    }
+    band
+}
+
+fn band_from_headroom(used_fraction: f64) -> PressureBand {
+    if used_fraction >= HEADROOM_CRITICAL {
+        PressureBand::Critical
+    } else if used_fraction >= HEADROOM_WARN {
+        PressureBand::Warn
+    } else {
+        PressureBand::Ok
+    }
+}
+
+fn band_from_psi(some_avg10: f32) -> PressureBand {
+    if some_avg10 >= PSI_CRITICAL {
+        PressureBand::Critical
+    } else if some_avg10 >= PSI_WARN {
+        PressureBand::Warn
+    } else {
+        PressureBand::Ok
+    }
+}
+
+fn band_from_macos(level: u8) -> PressureBand {
+    match level {
+        4 => PressureBand::Critical,
+        2 => PressureBand::Warn,
+        _ => PressureBand::Ok,
+    }
+}
+
+fn band_color(theme: &Theme, band: PressureBand) -> Color {
+    match band {
+        PressureBand::Ok => theme.running,
+        PressureBand::Warn => theme.waiting,
+        PressureBand::Critical => theme.error,
+    }
+}
+
+/// Compact binary-unit byte string: `22.7G`, `9.9G`, `512M`, `1K`, `512B`.
+/// GiB keeps one decimal but drops a whole `.0`; smaller units round to a whole
+/// number. Integer math throughout so the rounding is exact.
+fn format_bytes(bytes: u64) -> String {
+    const KIB: u64 = 1 << 10;
+    const MIB: u64 = 1 << 20;
+    const GIB: u64 = 1 << 30;
+
+    if bytes >= GIB {
+        // Tenths of a GiB, rounded, so 32 GiB reads "32G" and 22.7 GiB "22.7G".
+        let tenths = (bytes as u128 * 10 + GIB as u128 / 2) / GIB as u128;
+        if tenths % 10 == 0 {
+            format!("{}G", tenths / 10)
+        } else {
+            format!("{}.{}G", tenths / 10, tenths % 10)
+        }
+    } else if bytes >= MIB {
+        format!("{}M", (bytes + MIB / 2) / MIB)
+    } else if bytes >= KIB {
+        format!("{}K", (bytes + KIB / 2) / KIB)
+    } else {
+        format!("{}B", bytes)
+    }
+}
+
+/// Render the memory-pressure strip into `area`.
+///
+/// `history` is the caller-owned ring buffer of headroom samples, newest at the
+/// back, each stored as per-mille of `used_fraction` (`0..=1000`). The sparkline
+/// plots against a fixed `1000` ceiling so the vertical scale is a stable
+/// `0..100%`. When the buffer holds more samples than the sparkline is wide, the
+/// newest `width` are shown (ratatui renders from the front, so the tail is
+/// sliced here to keep the recent window on screen).
+pub fn render(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    history: &VecDeque<u64>,
+    snapshot: &MetricsSnapshot,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    // Stack vertically: sparkline on top, the readout on the bottom row. The
+    // strip sits under the narrow list column, so a side-by-side split would
+    // leave too few columns for the counts.
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(area);
+    let spark_area = chunks[0];
+    let text_area = chunks[1];
+
+    let mem = &snapshot.memory;
+    let band = pressure_band(mem);
+    let color = band_color(theme, band);
+
+    // Show the newest `width` samples: ratatui's Sparkline renders the first N
+    // elements, so a buffer longer than the strip would otherwise drop the most
+    // recent readings.
+    let width = spark_area.width as usize;
+    let start = history.len().saturating_sub(width);
+    let recent: Vec<u64> = history.iter().skip(start).copied().collect();
+    let sparkline = Sparkline::default()
+        .data(recent)
+        .max(PER_MILLE_MAX)
+        .direction(RenderDirection::LeftToRight)
+        .style(Style::default().fg(color));
+    frame.render_widget(sparkline, spark_area);
+
+    frame.render_widget(
+        Paragraph::new(readout_line(
+            theme,
+            color,
+            mem,
+            snapshot,
+            text_area.width as usize,
+        )),
+        text_area,
+    );
+}
+
+/// Build the readout line under the sparkline, dropping detail as `avail`
+/// (display cells) shrinks. A leading space insets it from the border. Before
+/// the first sample (`total_bytes == 0`) the memory figure is unknown, so only
+/// the counts show rather than a misleading `0%`.
+fn readout_line<'a>(
+    theme: &Theme,
+    color: Color,
+    mem: &MemorySample,
+    snapshot: &MetricsSnapshot,
+    avail: usize,
+) -> Line<'a> {
+    let counts = format!(
+        "{} agents · {} procs",
+        snapshot.counts.agents, snapshot.counts.procs
+    );
+
+    if mem.total_bytes == 0 {
+        return Line::from(vec![
+            Span::raw(" "),
+            Span::styled(counts, Style::default().fg(theme.dimmed)),
+        ]);
+    }
+
+    let pct = format!("{}%", (mem.used_fraction() * 100.0).round() as u32);
+    let detail = format!(
+        "{}/{}",
+        format_bytes(mem.used_bytes()),
+        format_bytes(mem.total_bytes)
+    );
+    let gap = "  ";
+    let sep = "  │  ";
+
+    let pct_span = Span::styled(pct.clone(), Style::default().fg(color).bold());
+    let full_width = 1 + pct.width() + gap.width() + detail.width() + sep.width() + counts.width();
+    let counts_width = 1 + pct.width() + gap.width() + counts.width();
+
+    let spans = if full_width <= avail {
+        vec![
+            Span::raw(" "),
+            pct_span,
+            Span::raw(gap),
+            Span::styled(detail, Style::default().fg(theme.text)),
+            Span::styled(sep, Style::default().fg(theme.dimmed)),
+            Span::styled(counts, Style::default().fg(theme.dimmed)),
+        ]
+    } else if counts_width <= avail {
+        vec![
+            Span::raw(" "),
+            pct_span,
+            Span::raw(gap),
+            Span::styled(counts, Style::default().fg(theme.dimmed)),
+        ]
+    } else {
+        vec![Span::raw(" "), pct_span]
+    };
+    Line::from(spans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_with_fraction(used_fraction: f64) -> MemorySample {
+        // total 1000 so available maps cleanly to the target fraction.
+        MemorySample {
+            total_bytes: 1000,
+            available_bytes: (1000.0 * (1.0 - used_fraction)).round() as u64,
+            ..MemorySample::default()
+        }
+    }
+
+    #[test]
+    fn pressure_band_from_headroom_only() {
+        let cases = [
+            (0.0, PressureBand::Ok),
+            (0.69, PressureBand::Ok),
+            (0.70, PressureBand::Warn),
+            (0.89, PressureBand::Warn),
+            (0.90, PressureBand::Critical),
+            (0.99, PressureBand::Critical),
+        ];
+        for (frac, expected) in cases {
+            assert_eq!(
+                pressure_band(&sample_with_fraction(frac)),
+                expected,
+                "headroom fraction {frac}"
+            );
+        }
+    }
+
+    #[test]
+    fn pressure_band_escalates_on_psi_when_headroom_calm() {
+        // Headroom alone is Ok (50% used); PSI drives the band up.
+        let mut mem = sample_with_fraction(0.50);
+        assert_eq!(pressure_band(&mem), PressureBand::Ok);
+
+        mem.psi_mem_some_avg10 = Some(6.0);
+        assert_eq!(pressure_band(&mem), PressureBand::Warn);
+
+        mem.psi_mem_some_avg10 = Some(25.0);
+        assert_eq!(pressure_band(&mem), PressureBand::Critical);
+
+        // io pressure alone (mem PSI absent) still escalates.
+        let mem_io = MemorySample {
+            psi_io_some_avg10: Some(25.0),
+            ..sample_with_fraction(0.50)
+        };
+        assert_eq!(pressure_band(&mem_io), PressureBand::Critical);
+    }
+
+    #[test]
+    fn pressure_band_from_macos_level() {
+        let cases = [
+            (1u8, PressureBand::Ok),
+            (2, PressureBand::Warn),
+            (4, PressureBand::Critical),
+        ];
+        for (level, expected) in cases {
+            let mem = MemorySample {
+                macos_pressure_level: Some(level),
+                ..sample_with_fraction(0.50)
+            };
+            assert_eq!(pressure_band(&mem), expected, "macos level {level}");
+        }
+    }
+
+    #[test]
+    fn pressure_band_takes_worst_of_inputs() {
+        // Critical headroom must not be softened by a calm PSI reading.
+        let mem = MemorySample {
+            psi_mem_some_avg10: Some(1.0),
+            ..sample_with_fraction(0.95)
+        };
+        assert_eq!(pressure_band(&mem), PressureBand::Critical);
+    }
+
+    #[test]
+    fn pressure_band_default_sample_is_ok() {
+        assert_eq!(pressure_band(&MemorySample::default()), PressureBand::Ok);
+    }
+
+    #[test]
+    fn format_bytes_table() {
+        let gib = 1u64 << 30;
+        let cases = [
+            (0u64, "0B"),
+            (512, "512B"),
+            (1024, "1K"),
+            (536_870_912, "512M"), // 512 MiB
+            (32 * gib, "32G"),     // whole GiB drops the .0
+            (22 * gib + 7 * gib / 10, "22.7G"),
+            (9 * gib + 9 * gib / 10, "9.9G"),
+        ];
+        for (bytes, expected) in cases {
+            assert_eq!(format_bytes(bytes), expected, "bytes {bytes}");
+        }
+    }
+}

--- a/src/tui/components/diagnostics.rs
+++ b/src/tui/components/diagnostics.rs
@@ -10,6 +10,7 @@ use ratatui::widgets::*;
 use unicode_width::UnicodeWidthStr;
 
 use crate::process::metrics::{MemorySample, MetricsSnapshot};
+use crate::tui::components::truncate_to_width;
 use crate::tui::styles::Theme;
 
 /// Fraction used at or above which the strip reads Critical.
@@ -23,6 +24,15 @@ const PSI_WARN: f32 = 5.0;
 /// The full 0..=100% scale in per-mille, so the sparkline plots against a fixed
 /// ceiling instead of auto-scaling to whatever the recent peak happened to be.
 const PER_MILLE_MAX: u64 = 1000;
+const HEALTH_FIXED_ROWS: u16 = 14;
+const AGENT_TABLE_HEADER_ROWS: u16 = 1;
+
+pub(crate) fn agent_table_visible_rows(preview_height: u16) -> usize {
+    preview_height
+        .saturating_sub(2)
+        .saturating_sub(HEALTH_FIXED_ROWS)
+        .saturating_sub(AGENT_TABLE_HEADER_ROWS) as usize
+}
 
 /// Memory-pressure severity, worst-of across the available signals. Ordered
 /// ascending so the derived `Ord` lets callers fold inputs with `max`.
@@ -347,8 +357,7 @@ pub fn render_system_health(
     let visible = table_area.height.saturating_sub(1) as usize;
     for agent in snapshot.agents.iter().skip(scroll).take(visible) {
         let name_width = table_area.width.saturating_sub(24).max(8) as usize;
-        let mut title = agent.title.clone();
-        title.truncate(name_width);
+        let title = truncate_to_width(&agent.title, name_width);
         let cpu = agent
             .cpu_fraction
             .map(|v| format!("{:.1}%", v * 100.0))
@@ -475,6 +484,9 @@ mod tests {
     #[test]
     fn pressure_band_default_sample_is_ok() {
         assert_eq!(pressure_band(&MemorySample::default()), PressureBand::Ok);
+        assert_eq!(agent_table_visible_rows(17), 0);
+        assert_eq!(agent_table_visible_rows(18), 1);
+        assert_eq!(agent_table_visible_rows(24), 7);
     }
 
     #[test]

--- a/src/tui/components/diagnostics.rs
+++ b/src/tui/components/diagnostics.rs
@@ -1,11 +1,4 @@
-//! "memory pressure" strip, docked under the session-list column.
-//!
-//! Two stacked rows: a memory-over-time area sparkline on top, then a readout
-//! row (percent plus used/total, and the agent/process counts). The sparkline
-//! plots memory headroom; its color and the percent share a green/amber/red
-//! band derived by [`pressure_band`] from headroom, PSI, and the macOS pressure
-//! level (worst wins). See [`crate::process::metrics`] for why headroom is the
-//! headline signal.
+//! Compact system-health strip and its read-only preview view.
 //!
 //! The readout row sheds gracefully as width shrinks: the used/total detail
 //! drops before the counts, and below that only the percent remains.
@@ -97,7 +90,7 @@ fn band_color(theme: &Theme, band: PressureBand) -> Color {
 /// Compact binary-unit byte string: `22.7G`, `9.9G`, `512M`, `1K`, `512B`.
 /// GiB keeps one decimal but drops a whole `.0`; smaller units round to a whole
 /// number. Integer math throughout so the rounding is exact.
-fn format_bytes(bytes: u64) -> String {
+pub(crate) fn format_bytes(bytes: u64) -> String {
     const KIB: u64 = 1 << 10;
     const MIB: u64 = 1 << 20;
     const GIB: u64 = 1 << 30;
@@ -119,51 +112,15 @@ fn format_bytes(bytes: u64) -> String {
     }
 }
 
-/// Render the memory-pressure strip into `area`.
-///
-/// `history` is the caller-owned ring buffer of headroom samples, newest at the
-/// back, each stored as per-mille of `used_fraction` (`0..=1000`). The sparkline
-/// plots against a fixed `1000` ceiling so the vertical scale is a stable
-/// `0..100%`. When the buffer holds more samples than the sparkline is wide, the
-/// newest `width` are shown (ratatui renders from the front, so the tail is
-/// sliced here to keep the recent window on screen).
-pub fn render(
-    frame: &mut Frame,
-    area: Rect,
-    theme: &Theme,
-    history: &VecDeque<u64>,
-    snapshot: &MetricsSnapshot,
-) {
+/// Render the single-row current-state strip into `area`.
+pub fn render(frame: &mut Frame, area: Rect, theme: &Theme, snapshot: &MetricsSnapshot) {
     if area.width == 0 || area.height == 0 {
         return;
     }
 
-    // Stack vertically: sparkline on top, the readout on the bottom row. The
-    // strip sits under the narrow list column, so a side-by-side split would
-    // leave too few columns for the counts.
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(1)])
-        .split(area);
-    let spark_area = chunks[0];
-    let text_area = chunks[1];
-
     let mem = &snapshot.memory;
     let band = pressure_band(mem);
     let color = band_color(theme, band);
-
-    // Show the newest `width` samples: ratatui's Sparkline renders the first N
-    // elements, so a buffer longer than the strip would otherwise drop the most
-    // recent readings.
-    let width = spark_area.width as usize;
-    let start = history.len().saturating_sub(width);
-    let recent: Vec<u64> = history.iter().skip(start).copied().collect();
-    let sparkline = Sparkline::default()
-        .data(recent)
-        .max(PER_MILLE_MAX)
-        .direction(RenderDirection::LeftToRight)
-        .style(Style::default().fg(color));
-    frame.render_widget(sparkline, spark_area);
 
     frame.render_widget(
         Paragraph::new(readout_line(
@@ -171,9 +128,9 @@ pub fn render(
             color,
             mem,
             snapshot,
-            text_area.width as usize,
+            area.width as usize,
         )),
-        text_area,
+        area,
     );
 }
 
@@ -188,8 +145,13 @@ fn readout_line<'a>(
     snapshot: &MetricsSnapshot,
     avail: usize,
 ) -> Line<'a> {
+    let cpu = snapshot
+        .system
+        .cpu_fraction
+        .map(|value| format!("CPU {}% · ", (value * 100.0).round() as u32))
+        .unwrap_or_default();
     let counts = format!(
-        "{} agents · {} procs",
+        "{cpu}{} agents · {} procs",
         snapshot.counts.agents, snapshot.counts.procs
     );
 
@@ -233,6 +195,203 @@ fn readout_line<'a>(
         vec![Span::raw(" "), pct_span]
     };
     Line::from(spans)
+}
+
+/// Read-only system-health detail rendered in the ordinary preview pane.
+pub fn render_system_health(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    memory_history: &VecDeque<u64>,
+    cpu_history: &VecDeque<u64>,
+    snapshot: &MetricsSnapshot,
+    scroll: usize,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme.border))
+        .title(Span::styled(
+            " System Health ",
+            Style::default().fg(theme.title).bold(),
+        ))
+        .padding(Padding::horizontal(1));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let cpu = snapshot
+        .system
+        .cpu_fraction
+        .map(|v| format!("{:>3}%", (v * 100.0).round() as u32))
+        .unwrap_or_else(|| "  ?%".into());
+    let memory = if snapshot.memory.total_bytes > 0 {
+        format!(
+            "{:>3}%",
+            (snapshot.memory.used_fraction() * 100.0).round() as u32
+        )
+    } else {
+        "  ?%".into()
+    };
+    let load = snapshot
+        .system
+        .load_average
+        .map(|v| format!("{:.2} / {:.2} / {:.2}", v[0], v[1], v[2]))
+        .unwrap_or_else(|| "? / ? / ?".into());
+    let swap = if snapshot.system.swap_total_bytes > 0 {
+        format!(
+            "{} / {}",
+            format_bytes(snapshot.system.swap_used_bytes),
+            format_bytes(snapshot.system.swap_total_bytes)
+        )
+    } else {
+        "none".into()
+    };
+
+    let rows = Layout::vertical([
+        Constraint::Length(6),
+        Constraint::Length(1),
+        Constraint::Length(3),
+        Constraint::Length(1),
+        Constraint::Length(3),
+        Constraint::Min(0),
+    ])
+    .split(inner);
+    let band = pressure_band(&snapshot.memory);
+    let severity = match band {
+        PressureBand::Ok => "OK",
+        PressureBand::Warn => "WARN",
+        PressureBand::Critical => "CRITICAL",
+    };
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("Status  ", Style::default().fg(theme.dimmed)),
+            Span::styled(
+                severity,
+                Style::default().fg(band_color(theme, band)).bold(),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("CPU     ", Style::default().fg(theme.dimmed)),
+            Span::styled(cpu, Style::default().fg(theme.text)),
+        ]),
+        Line::from(vec![
+            Span::styled("Memory  ", Style::default().fg(theme.dimmed)),
+            Span::styled(memory, Style::default().fg(theme.text)),
+            Span::raw(format!(
+                "   {} / {}",
+                format_bytes(snapshot.memory.used_bytes()),
+                format_bytes(snapshot.memory.total_bytes)
+            )),
+        ]),
+        Line::from(vec![
+            Span::styled("Load    ", Style::default().fg(theme.dimmed)),
+            Span::raw(load),
+        ]),
+        Line::from(vec![
+            Span::styled("Swap    ", Style::default().fg(theme.dimmed)),
+            Span::raw(swap),
+        ]),
+        Line::from(vec![
+            Span::styled("Agents  ", Style::default().fg(theme.dimmed)),
+            Span::raw(format!(
+                "{} running · {} processes",
+                snapshot.counts.agents, snapshot.counts.procs
+            )),
+        ]),
+    ];
+    frame.render_widget(Paragraph::new(lines), rows[0]);
+
+    render_timeline(
+        frame,
+        rows[1],
+        rows[2],
+        theme,
+        "Memory timeline",
+        memory_history,
+        band_color(theme, band),
+    );
+    render_timeline(
+        frame,
+        rows[3],
+        rows[4],
+        theme,
+        "CPU timeline",
+        cpu_history,
+        theme.running,
+    );
+
+    let table_area = rows[5];
+    if table_area.height == 0 {
+        return;
+    }
+    if snapshot.agents.is_empty() {
+        frame.render_widget(
+            Paragraph::new("No running AoE agents").style(Style::default().fg(theme.dimmed)),
+            table_area,
+        );
+        return;
+    }
+    let mut table_lines = vec![Line::from(vec![
+        Span::styled(
+            format!("{:<24}", "Agent"),
+            Style::default().fg(theme.hint).bold(),
+        ),
+        Span::styled(
+            format!("{:>7} {:>9} {:>6}", "CPU", "RSS", "Procs"),
+            Style::default().fg(theme.hint).bold(),
+        ),
+    ])];
+    let visible = table_area.height.saturating_sub(1) as usize;
+    for agent in snapshot.agents.iter().skip(scroll).take(visible) {
+        let name_width = table_area.width.saturating_sub(24).max(8) as usize;
+        let mut title = agent.title.clone();
+        title.truncate(name_width);
+        let cpu = agent
+            .cpu_fraction
+            .map(|v| format!("{:.1}%", v * 100.0))
+            .unwrap_or_else(|| "?".into());
+        table_lines.push(Line::from(vec![
+            Span::styled(
+                format!("{title:<name_width$}"),
+                Style::default().fg(theme.text),
+            ),
+            Span::raw(format!(
+                " {cpu:>6} {:>9} {:>6}",
+                format_bytes(agent.rss_bytes),
+                agent.procs
+            )),
+        ]));
+    }
+    frame.render_widget(Paragraph::new(table_lines), table_area);
+}
+
+fn render_timeline(
+    frame: &mut Frame,
+    label_area: Rect,
+    graph_area: Rect,
+    theme: &Theme,
+    label: &str,
+    history: &VecDeque<u64>,
+    color: Color,
+) {
+    frame.render_widget(
+        Paragraph::new(label).style(Style::default().fg(theme.dimmed)),
+        label_area,
+    );
+    let width = graph_area.width as usize;
+    let start = history.len().saturating_sub(width);
+    let recent: Vec<u64> = history.iter().skip(start).copied().collect();
+    frame.render_widget(
+        Sparkline::default()
+            .data(recent)
+            .max(PER_MILLE_MAX)
+            .direction(RenderDirection::LeftToRight)
+            .style(Style::default().fg(color)),
+        graph_area,
+    );
 }
 
 #[cfg(test)]

--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod buttons;
 pub(crate) mod checkbox;
 mod cycler;
+pub(crate) mod diagnostics;
 mod dir_picker;
 mod help;
 pub(crate) mod hover;

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -63,6 +63,10 @@ pub enum ActionId {
     ToggleUnread,
     ToggleContainer,
     TogglePreviewInfo,
+    /// Toggle the memory diagnostics strip (a live memory-pressure sparkline
+    /// plus running agent/process counts). Persisted via
+    /// `session.show_diagnostics_pane` so it survives restarts.
+    ToggleDiagnostics,
     SortPicker,
     GroupBy,
     NextWaiting,
@@ -452,6 +456,22 @@ pub static BINDINGS: &[Binding] = &[
         palette: Some(PaletteMeta {
             title: "Show keyboard shortcuts",
             keywords: &["keys", "shortcuts"],
+            group: PaletteGroup::Settings,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::ToggleDiagnostics,
+        non_strict: &[f(9)],
+        strict: &[f(9)],
+        context: Context::Always,
+        help: Some(HelpMeta {
+            section: HelpSection::Other,
+            desc: "Toggle memory diagnostics",
+        }),
+        palette: Some(PaletteMeta {
+            title: "Toggle memory diagnostics pane",
+            keywords: &["memory", "ram", "diagnostics", "pressure", "procs"],
             group: PaletteGroup::Settings,
             serve_only: false,
         }),
@@ -1015,6 +1035,7 @@ pub fn palette_id(id: ActionId) -> &'static str {
         ActionId::ToggleSnooze => "snooze",
         ActionId::ToggleUnread => "toggle-unread",
         ActionId::TogglePreviewInfo => "toggle-preview-info",
+        ActionId::ToggleDiagnostics => "toggle-diagnostics",
         ActionId::SortPicker => "pick-sort",
         ActionId::GroupBy => "pick-group-by",
         ActionId::Help => "help",
@@ -1376,6 +1397,29 @@ mod tests {
         }
         // Fork has a stable palette id.
         assert_eq!(palette_id(ActionId::Fork), "fork");
+    }
+
+    #[test]
+    fn diagnostics_toggle_is_wired_to_f9_and_palette() {
+        let c = ctx();
+        let f9 = KeyEvent::new(KeyCode::F(9), KeyModifiers::NONE);
+        assert_eq!(
+            resolve(&f9, false, &c),
+            Some(ActionId::ToggleDiagnostics),
+            "F9 toggles the diagnostics strip"
+        );
+        assert_eq!(
+            palette_id(ActionId::ToggleDiagnostics),
+            "toggle-diagnostics"
+        );
+        // The `?` overlay and command palette auto-derive their rows from the
+        // binding, so both must carry metadata for the action to be reachable.
+        let b = BINDINGS
+            .iter()
+            .find(|b| b.id == ActionId::ToggleDiagnostics)
+            .expect("ToggleDiagnostics binding exists");
+        assert!(b.help.is_some(), "help overlay lists the toggle");
+        assert!(b.palette.is_some(), "command palette lists the toggle");
     }
 
     #[test]

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -63,8 +63,8 @@ pub enum ActionId {
     ToggleUnread,
     ToggleContainer,
     TogglePreviewInfo,
-    /// Toggle the memory diagnostics strip (a live memory-pressure sparkline
-    /// plus running agent/process counts). Persisted via
+    /// Toggle the system diagnostics strip (live CPU and memory pressure plus
+    /// running agent/process counts). Persisted via
     /// `session.show_diagnostics_pane` so it survives restarts.
     ToggleDiagnostics,
     /// Open the read-only host and running-agent resource view.

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -67,6 +67,8 @@ pub enum ActionId {
     /// plus running agent/process counts). Persisted via
     /// `session.show_diagnostics_pane` so it survives restarts.
     ToggleDiagnostics,
+    /// Open the read-only host and running-agent resource view.
+    OpenSystemHealth,
     SortPicker,
     GroupBy,
     NextWaiting,
@@ -462,17 +464,27 @@ pub static BINDINGS: &[Binding] = &[
     },
     Binding {
         id: ActionId::ToggleDiagnostics,
-        non_strict: &[f(9)],
-        strict: &[f(9)],
+        non_strict: &[],
+        strict: &[],
         context: Context::Always,
-        help: Some(HelpMeta {
-            section: HelpSection::Other,
-            desc: "Toggle memory diagnostics",
-        }),
+        help: None,
         palette: Some(PaletteMeta {
-            title: "Toggle memory diagnostics pane",
-            keywords: &["memory", "ram", "diagnostics", "pressure", "procs"],
+            title: "Toggle system health strip",
+            keywords: &["system", "health", "memory", "cpu", "pressure"],
             group: PaletteGroup::Settings,
+            serve_only: false,
+        }),
+    },
+    Binding {
+        id: ActionId::OpenSystemHealth,
+        non_strict: &[],
+        strict: &[],
+        context: Context::Always,
+        help: None,
+        palette: Some(PaletteMeta {
+            title: "Open System Health",
+            keywords: &["system", "health", "memory", "cpu", "agents", "processes"],
+            group: PaletteGroup::Views,
             serve_only: false,
         }),
     },
@@ -1036,6 +1048,7 @@ pub fn palette_id(id: ActionId) -> &'static str {
         ActionId::ToggleUnread => "toggle-unread",
         ActionId::TogglePreviewInfo => "toggle-preview-info",
         ActionId::ToggleDiagnostics => "toggle-diagnostics",
+        ActionId::OpenSystemHealth => "open-system-health",
         ActionId::SortPicker => "pick-sort",
         ActionId::GroupBy => "pick-group-by",
         ActionId::Help => "help",
@@ -1400,26 +1413,21 @@ mod tests {
     }
 
     #[test]
-    fn diagnostics_toggle_is_wired_to_f9_and_palette() {
+    fn system_health_actions_are_palette_only() {
         let c = ctx();
         let f9 = KeyEvent::new(KeyCode::F(9), KeyModifiers::NONE);
-        assert_eq!(
-            resolve(&f9, false, &c),
-            Some(ActionId::ToggleDiagnostics),
-            "F9 toggles the diagnostics strip"
-        );
+        assert_ne!(resolve(&f9, false, &c), Some(ActionId::ToggleDiagnostics));
         assert_eq!(
             palette_id(ActionId::ToggleDiagnostics),
             "toggle-diagnostics"
         );
-        // The `?` overlay and command palette auto-derive their rows from the
-        // binding, so both must carry metadata for the action to be reachable.
-        let b = BINDINGS
-            .iter()
-            .find(|b| b.id == ActionId::ToggleDiagnostics)
-            .expect("ToggleDiagnostics binding exists");
-        assert!(b.help.is_some(), "help overlay lists the toggle");
-        assert!(b.palette.is_some(), "command palette lists the toggle");
+        assert_eq!(palette_id(ActionId::OpenSystemHealth), "open-system-health");
+        for action in [ActionId::ToggleDiagnostics, ActionId::OpenSystemHealth] {
+            let binding = BINDINGS.iter().find(|b| b.id == action).unwrap();
+            assert!(binding.non_strict.is_empty() && binding.strict.is_empty());
+            assert!(binding.help.is_none());
+            assert!(binding.palette.is_some());
+        }
     }
 
     #[test]

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -644,6 +644,19 @@ impl HomeView {
         }
     }
 
+    /// Open the read-only System Health view when the compact strip is clicked.
+    pub fn handle_diagnostics_click(&mut self, col: u16, row: u16) -> bool {
+        if self.has_non_live_send_overlay() {
+            return false;
+        }
+        if self.diagnostics_area.contains(Position::from((col, row))) {
+            self.open_system_health();
+            true
+        } else {
+            false
+        }
+    }
+
     /// Click on the footer tips badge: open the tips overlay. Returns true when
     /// the click was on the badge (so the caller stops routing it). Gated on no
     /// overlay being open, the badge rect is captured behind any modal, so this
@@ -2907,6 +2920,7 @@ impl HomeView {
             ActionId::ToggleContainer => self.toggle_container_for_selected(),
             ActionId::TogglePreviewInfo => self.toggle_preview_info(),
             ActionId::ToggleDiagnostics => self.toggle_diagnostics(),
+            ActionId::OpenSystemHealth => self.open_system_health(),
             ActionId::SortPicker => self.show_sort_picker(),
             ActionId::GroupBy => self.show_group_picker(),
             ActionId::ToggleProjectPin => self.toggle_project_pin_at_cursor(),
@@ -4153,6 +4167,8 @@ impl HomeView {
     /// between the `Enter` keybind and double-click activation so the two
     /// paths can't drift.
     pub(super) fn activate_selected_session(&mut self) -> Option<Action> {
+        self.system_health_open = false;
+        self.cpu_history.clear();
         let id = self.selected_session.clone()?;
         if let Some(inst) = self.get_instance(&id) {
             if matches!(inst.status, Status::Deleting | Status::Creating) {
@@ -4275,6 +4291,8 @@ impl HomeView {
             let prev_session = self.selected_session.clone();
             match item {
                 Item::Session { id, .. } => {
+                    self.system_health_open = false;
+                    self.cpu_history.clear();
                     self.selected_session = Some(id.clone());
                     self.selected_group = None;
                     self.selected_group_profile = None;
@@ -4670,6 +4688,10 @@ impl HomeView {
         // the wheel via `has_dialog()`.
         if let Some(view) = &mut self.settings_view {
             return view.handle_wheel_scroll(true);
+        }
+        if self.system_health_open && self.hit_preview(col, row) {
+            self.system_health_scroll = self.system_health_scroll.saturating_sub(3);
+            return true;
         }
         // A preview selection is anchored to absolute scrollback lines,
         // not screen cells, so scrolling no longer invalidates it: the
@@ -5638,6 +5660,8 @@ impl HomeView {
                 None
             }
             Item::Session { id, .. } => {
+                self.system_health_open = false;
+                self.cpu_history.clear();
                 if self.cursor != abs_idx {
                     self.cursor = abs_idx;
                     self.update_selected();
@@ -5880,6 +5904,11 @@ impl HomeView {
         // Settings takeover owns the wheel; see handle_scroll_up.
         if let Some(view) = &mut self.settings_view {
             return view.handle_wheel_scroll(false);
+        }
+        if self.system_health_open && self.hit_preview(col, row) {
+            let max = self.metrics.agents.len().saturating_sub(1);
+            self.system_health_scroll = self.system_health_scroll.saturating_add(3).min(max);
+            return true;
         }
         // Mirror handle_scroll_up: the selection is anchored to scrollback
         // lines, so it survives the scroll and is left in place.

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -4291,8 +4291,6 @@ impl HomeView {
             let prev_session = self.selected_session.clone();
             match item {
                 Item::Session { id, .. } => {
-                    self.system_health_open = false;
-                    self.cpu_history.clear();
                     self.selected_session = Some(id.clone());
                     self.selected_group = None;
                     self.selected_group_profile = None;
@@ -4320,6 +4318,8 @@ impl HomeView {
                 }
             }
             if self.selected_session != prev_session {
+                self.system_health_open = false;
+                self.cpu_history.clear();
                 self.preview_scroll_offset = 0;
                 // A finalized preview selection pins to the previous pane's
                 // cells; carried into a different session it would paint a
@@ -5906,7 +5906,10 @@ impl HomeView {
             return view.handle_wheel_scroll(false);
         }
         if self.system_health_open && self.hit_preview(col, row) {
-            let max = self.metrics.agents.len().saturating_sub(1);
+            let visible_rows = crate::tui::components::diagnostics::agent_table_visible_rows(
+                self.preview_area.height,
+            );
+            let max = self.metrics.agents.len().saturating_sub(visible_rows);
             self.system_health_scroll = self.system_health_scroll.saturating_add(3).min(max);
             return true;
         }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -4168,7 +4168,6 @@ impl HomeView {
     /// paths can't drift.
     pub(super) fn activate_selected_session(&mut self) -> Option<Action> {
         self.system_health_open = false;
-        self.cpu_history.clear();
         let id = self.selected_session.clone()?;
         if let Some(inst) = self.get_instance(&id) {
             if matches!(inst.status, Status::Deleting | Status::Creating) {
@@ -4319,7 +4318,6 @@ impl HomeView {
             }
             if self.selected_session != prev_session {
                 self.system_health_open = false;
-                self.cpu_history.clear();
                 self.preview_scroll_offset = 0;
                 // A finalized preview selection pins to the previous pane's
                 // cells; carried into a different session it would paint a
@@ -5665,7 +5663,6 @@ impl HomeView {
             }
             Item::Session { id, .. } => {
                 self.system_health_open = false;
-                self.cpu_history.clear();
                 if self.cursor != abs_idx {
                     self.cursor = abs_idx;
                     self.update_selected();

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -5146,6 +5146,8 @@ impl HomeView {
         let signals = crate::tips::TipSignals {
             new_session_with_selection_count: config.app_state.new_session_with_selection_count,
             used_new_from_selection: config.app_state.used_new_from_selection,
+            system_health_tip_earned: config.app_state.system_health_tip_earned,
+            used_system_health: config.app_state.used_system_health,
         };
         let eligible = crate::tips::eligible(crate::tips::TipSurface::Tui, &signals);
         self.tips_dialog = Some(TipsDialog::new(
@@ -5242,6 +5244,8 @@ impl HomeView {
         let signals = crate::tips::TipSignals {
             new_session_with_selection_count: config.app_state.new_session_with_selection_count,
             used_new_from_selection: config.app_state.used_new_from_selection,
+            system_health_tip_earned: config.app_state.system_health_tip_earned,
+            used_system_health: config.app_state.used_system_health,
         };
         self.pending_tip_pop = crate::tips::next_earned_pop(
             crate::tips::TipSurface::Tui,
@@ -5875,6 +5879,11 @@ impl HomeView {
             .map(|(_, key)| *key);
         let footer_changed = prev_footer_hover != self.footer_hover;
 
+        let diagnostics_hovered = !self.has_non_live_send_overlay()
+            && self.diagnostics_area.contains(Position::from((col, row)));
+        let diagnostics_changed = diagnostics_hovered != self.diagnostics_hovered;
+        self.diagnostics_hovered = diagnostics_hovered;
+
         // Hover is live over both the scrolling list and the pinned shelf, so
         // a shelf row (Trash / Archived) highlights under the pointer the same
         // way a list row does. `resolve_row_to_index` maps either region.
@@ -5895,7 +5904,11 @@ impl HomeView {
         let badge_changed = badge_hover != self.tips_badge_hovered;
         self.tips_badge_hovered = badge_hover;
 
-        overlay_changed || footer_changed || badge_changed || prev_idx != new_idx
+        overlay_changed
+            || footer_changed
+            || diagnostics_changed
+            || badge_changed
+            || prev_idx != new_idx
     }
 
     /// Route a mouse-wheel-down at (col, row); see handle_scroll_up.

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2906,6 +2906,7 @@ impl HomeView {
             }
             ActionId::ToggleContainer => self.toggle_container_for_selected(),
             ActionId::TogglePreviewInfo => self.toggle_preview_info(),
+            ActionId::ToggleDiagnostics => self.toggle_diagnostics(),
             ActionId::SortPicker => self.show_sort_picker(),
             ActionId::GroupBy => self.show_group_picker(),
             ActionId::ToggleProjectPin => self.toggle_project_pin_at_cursor(),

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2922,11 +2922,15 @@ impl HomeView {
         match self.metrics_poller.try_recv_updates() {
             Ok(snapshot) => {
                 self.metrics = snapshot;
-                let per_mille = (snapshot.memory.used_fraction() * 1000.0).round() as u64;
-                self.metrics_history.push_back(per_mille);
-                // At most one over the cap: exactly one push per apply.
-                if self.metrics_history.len() > METRICS_HISTORY_LEN {
-                    self.metrics_history.pop_front();
+                // A sample requested while visible can arrive after the strip
+                // is hidden. Do not repopulate the history that hiding clears.
+                if self.show_diagnostics {
+                    let per_mille = (snapshot.memory.used_fraction() * 1000.0).round() as u64;
+                    self.metrics_history.push_back(per_mille);
+                    // At most one over the cap: exactly one push per apply.
+                    if self.metrics_history.len() > METRICS_HISTORY_LEN {
+                        self.metrics_history.pop_front();
+                    }
                 }
                 self.pending_metrics_refresh = false;
                 true

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -54,6 +54,11 @@ use super::stop_poller::StopPoller;
 /// has a backing repo must test the repo path, not this string (#3133).
 const SCRATCH_GROUP_LABEL: &str = "scratch";
 
+/// Diagnostics-strip history depth. At the 1s sample cadence this is about two
+/// minutes of headroom samples, over-provisioned past the strip's width (it
+/// docks under the session-list column) so it never runs short.
+const METRICS_HISTORY_LEN: usize = 150;
+
 /// Extract a project group name from a session instance.
 /// Uses `worktree_info.main_repo_path` for worktree sessions (so all branches of the
 /// same repo group together), otherwise uses `project_path`. Returns the last path segment.
@@ -750,6 +755,16 @@ pub struct HomeView {
     // Performance: background status polling
     pub(super) status_poller: StatusPoller,
     pub(super) pending_status_refresh: bool,
+
+    // Memory diagnostics strip (toggled by F9 / `session.show_diagnostics_pane`).
+    // The poller samples memory + agent counts off the UI thread; `metrics`
+    // holds the latest sample and `metrics_history` the headroom ring buffer
+    // (per-mille of used_fraction, newest at the back) feeding the sparkline.
+    pub(super) show_diagnostics: bool,
+    pub(super) metrics_poller: super::metrics_poller::MetricsPoller,
+    pub(super) pending_metrics_refresh: bool,
+    pub(super) metrics: crate::process::metrics::MetricsSnapshot,
+    pub(super) metrics_history: std::collections::VecDeque<u64>,
 
     // Structured (ACP) rows: the tmux poller above bails on them, so their
     // status comes from the daemon instead. See `daemon_status_poller`.
@@ -2275,6 +2290,11 @@ impl HomeView {
             available_tools,
             status_poller: StatusPoller::new(),
             pending_status_refresh: false,
+            show_diagnostics: resolved.session.show_diagnostics_pane,
+            metrics_poller: super::metrics_poller::MetricsPoller::new(),
+            pending_metrics_refresh: false,
+            metrics: crate::process::metrics::MetricsSnapshot::default(),
+            metrics_history: std::collections::VecDeque::new(),
             #[cfg(feature = "serve")]
             daemon_status_poller: super::daemon_status_poller::DaemonStatusPoller::new(),
             #[cfg(feature = "serve")]
@@ -2879,6 +2899,71 @@ impl HomeView {
                 self.reset_status_refresh();
                 true
             }
+        }
+    }
+
+    /// Request a memory + agent-count sample in the background (non-blocking),
+    /// only while the diagnostics strip is visible. Call `apply_metrics_updates`
+    /// to pick up the result.
+    pub fn request_metrics_refresh(&mut self) {
+        if self.show_diagnostics && !self.pending_metrics_refresh {
+            self.metrics_poller
+                .request_refresh(self.pollable_instances());
+            self.pending_metrics_refresh = true;
+        }
+    }
+
+    /// Apply any pending metrics sample, pushing the new headroom point onto
+    /// the sparkline ring buffer. Returns true if a sample was applied (so the
+    /// caller can force a repaint to animate the graph).
+    pub fn apply_metrics_updates(&mut self) -> bool {
+        use std::sync::mpsc::TryRecvError;
+
+        match self.metrics_poller.try_recv_updates() {
+            Ok(snapshot) => {
+                self.metrics = snapshot;
+                let per_mille = (snapshot.memory.used_fraction() * 1000.0).round() as u64;
+                self.metrics_history.push_back(per_mille);
+                // At most one over the cap: exactly one push per apply.
+                if self.metrics_history.len() > METRICS_HISTORY_LEN {
+                    self.metrics_history.pop_front();
+                }
+                self.pending_metrics_refresh = false;
+                true
+            }
+            Err(TryRecvError::Empty) => false,
+            Err(TryRecvError::Disconnected) => {
+                // The sampler thread died (a panic in sample_memory /
+                // count_running_agents). Respawn so pending_metrics_refresh
+                // does not stay stuck and freeze the strip.
+                tracing::error!(
+                    target: "tui.home",
+                    "metrics poller worker gone; respawning a fresh poller",
+                );
+                self.metrics_poller = super::metrics_poller::MetricsPoller::new();
+                self.pending_metrics_refresh = false;
+                false
+            }
+        }
+    }
+
+    /// Toggle the diagnostics strip and persist the new state to
+    /// `session.show_diagnostics_pane` so it survives restarts. Clears the
+    /// history when hiding so a re-open starts fresh rather than showing a
+    /// stale gap.
+    pub fn toggle_diagnostics(&mut self) {
+        self.show_diagnostics = !self.show_diagnostics;
+        if !self.show_diagnostics {
+            self.metrics_history.clear();
+        }
+        let enabled = self.show_diagnostics;
+        if let Err(e) = update_config(|config| {
+            config.session.show_diagnostics_pane = enabled;
+        }) {
+            tracing::warn!(
+                target: "tui.home",
+                "failed to persist show_diagnostics_pane: {e}",
+            );
         }
     }
 
@@ -7373,6 +7458,12 @@ impl HomeView {
         self.strict_hotkeys = config.session.strict_hotkeys;
         self.confirm_before_quit = config.session.confirm_before_quit;
         self.row_tag_mode = config.session.row_tag;
+        // Keep the strip in sync when the Settings UI or a config-file edit
+        // flips the toggle, not just the F9 keybinding.
+        if !self.show_diagnostics && config.session.show_diagnostics_pane {
+            self.metrics_history.clear();
+        }
+        self.show_diagnostics = config.session.show_diagnostics_pane;
         self.agent_clipboard_forward =
             config.tmux.clipboard != crate::session::config::TmuxSettingMode::Disabled;
         self.vt_live_enabled = config.tmux.vt_live;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -769,6 +769,10 @@ pub struct HomeView {
     pub(super) system_health_open: bool,
     pub(super) system_health_scroll: usize,
     pub(super) diagnostics_area: Rect,
+    pub(super) diagnostics_hovered: bool,
+    pub(super) system_health_tip_high_samples: u8,
+    pub(super) system_health_tip_earned: bool,
+    pub(super) system_health_discovered: bool,
 
     // Structured (ACP) rows: the tmux poller above bails on them, so their
     // status comes from the daemon instead. See `daemon_status_poller`.
@@ -1192,6 +1196,8 @@ pub(super) fn tips_unseen_count(config: &crate::session::Config) -> usize {
         &crate::tips::TipSignals {
             new_session_with_selection_count: config.app_state.new_session_with_selection_count,
             used_new_from_selection: config.app_state.used_new_from_selection,
+            system_health_tip_earned: config.app_state.system_health_tip_earned,
+            used_system_health: config.app_state.used_system_health,
         },
     )
 }
@@ -2306,6 +2312,14 @@ impl HomeView {
             system_health_open: false,
             system_health_scroll: 0,
             diagnostics_area: Rect::default(),
+            diagnostics_hovered: false,
+            system_health_tip_high_samples: 0,
+            system_health_tip_earned: user_config
+                .as_ref()
+                .is_some_and(|config| config.app_state.system_health_tip_earned),
+            system_health_discovered: user_config
+                .as_ref()
+                .is_some_and(|config| config.app_state.used_system_health),
             #[cfg(feature = "serve")]
             daemon_status_poller: super::daemon_status_poller::DaemonStatusPoller::new(),
             #[cfg(feature = "serve")]
@@ -2896,9 +2910,14 @@ impl HomeView {
     /// Request a system-health sample in the background while either health
     /// surface is visible. Call `apply_metrics_updates` to pick up the result.
     pub fn request_metrics_refresh(&mut self) {
-        if (self.show_diagnostics || self.system_health_open) && !self.pending_metrics_refresh {
-            self.metrics_poller
-                .request_refresh(self.pollable_instances());
+        let instances = self.pollable_instances();
+        let tip_candidate = !self.system_health_tip_earned
+            && !self.system_health_discovered
+            && instances.len() >= crate::tips::SYSTEM_HEALTH_AGENT_THRESHOLD;
+        if (self.show_diagnostics || self.system_health_open || tip_candidate)
+            && !self.pending_metrics_refresh
+        {
+            self.metrics_poller.request_refresh(instances);
             self.pending_metrics_refresh = true;
         }
     }
@@ -2917,6 +2936,7 @@ impl HomeView {
                     .cpu_fraction
                     .map(|v| (v * 1000.0).round() as u64);
                 self.metrics = snapshot;
+                self.observe_system_health_tip_load();
                 // A sample requested while visible can arrive after the strip
                 // is hidden. Do not repopulate the history that hiding clears.
                 if self.show_diagnostics || self.system_health_open {
@@ -2974,11 +2994,63 @@ impl HomeView {
     }
 
     pub fn open_system_health(&mut self) {
+        self.system_health_discovered = true;
+        if self.pending_tip_pop.map(|tip| tip.id) == Some("system-health") {
+            self.pending_tip_pop = None;
+        }
+        let already_used = load_config()
+            .ok()
+            .flatten()
+            .is_some_and(|config| config.app_state.used_system_health);
+        if !already_used {
+            if let Err(error) = update_app_state(|state| state.used_system_health = true) {
+                tracing::warn!(target: "tui.home", "failed to persist System Health discovery: {error}");
+            } else if let Ok(config) = load_config().map(|config| config.unwrap_or_default()) {
+                self.tips_unseen = tips_unseen_count(&config);
+            }
+        }
         self.system_health_open = true;
         self.system_health_scroll = 0;
         self.diff_view = None;
         self.live_send = None;
         self.request_metrics_refresh();
+    }
+
+    fn observe_system_health_tip_load(&mut self) {
+        if self.system_health_tip_earned || self.system_health_discovered {
+            return;
+        }
+        if self.metrics.counts.agents < crate::tips::SYSTEM_HEALTH_AGENT_THRESHOLD {
+            self.system_health_tip_high_samples = 0;
+            return;
+        }
+        self.system_health_tip_high_samples = self.system_health_tip_high_samples.saturating_add(1);
+        if self.system_health_tip_high_samples < crate::tips::SYSTEM_HEALTH_SAMPLE_THRESHOLD {
+            return;
+        }
+
+        self.system_health_tip_earned = true;
+        if let Err(error) = update_app_state(|state| state.system_health_tip_earned = true) {
+            tracing::warn!(target: "tui.home", "failed to persist System Health tip signal: {error}");
+            return;
+        }
+        let Ok(config) = load_config().map(|config| config.unwrap_or_default()) else {
+            return;
+        };
+        self.tips_unseen = tips_unseen_count(&config);
+        if config.session.show_tips
+            && !config.app_state.used_system_health
+            && !config
+                .app_state
+                .tips_seen
+                .iter()
+                .any(|id| id == "system-health")
+            && self.pending_tip_pop.is_none()
+        {
+            self.pending_tip_pop = crate::tips::catalog()
+                .iter()
+                .find(|tip| tip.id == "system-health");
+        }
     }
 
     /// Request the daemon's view of every structured row's status

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -756,7 +756,7 @@ pub struct HomeView {
     pub(super) status_poller: StatusPoller,
     pub(super) pending_status_refresh: bool,
 
-    // Memory diagnostics strip (toggled by F9 / `session.show_diagnostics_pane`).
+    // Compact system-health strip controlled by `session.show_diagnostics_pane`.
     // The poller samples memory + agent counts off the UI thread; `metrics`
     // holds the latest sample and `metrics_history` the headroom ring buffer
     // (per-mille of used_fraction, newest at the back) feeding the sparkline.
@@ -765,6 +765,10 @@ pub struct HomeView {
     pub(super) pending_metrics_refresh: bool,
     pub(super) metrics: crate::process::metrics::MetricsSnapshot,
     pub(super) metrics_history: std::collections::VecDeque<u64>,
+    pub(super) cpu_history: std::collections::VecDeque<u64>,
+    pub(super) system_health_open: bool,
+    pub(super) system_health_scroll: usize,
+    pub(super) diagnostics_area: Rect,
 
     // Structured (ACP) rows: the tmux poller above bails on them, so their
     // status comes from the daemon instead. See `daemon_status_poller`.
@@ -2295,6 +2299,10 @@ impl HomeView {
             pending_metrics_refresh: false,
             metrics: crate::process::metrics::MetricsSnapshot::default(),
             metrics_history: std::collections::VecDeque::new(),
+            cpu_history: std::collections::VecDeque::new(),
+            system_health_open: false,
+            system_health_scroll: 0,
+            diagnostics_area: Rect::default(),
             #[cfg(feature = "serve")]
             daemon_status_poller: super::daemon_status_poller::DaemonStatusPoller::new(),
             #[cfg(feature = "serve")]
@@ -2902,11 +2910,10 @@ impl HomeView {
         }
     }
 
-    /// Request a memory + agent-count sample in the background (non-blocking),
-    /// only while the diagnostics strip is visible. Call `apply_metrics_updates`
-    /// to pick up the result.
+    /// Request a system-health sample in the background while either health
+    /// surface is visible. Call `apply_metrics_updates` to pick up the result.
     pub fn request_metrics_refresh(&mut self) {
-        if self.show_diagnostics && !self.pending_metrics_refresh {
+        if (self.show_diagnostics || self.system_health_open) && !self.pending_metrics_refresh {
             self.metrics_poller
                 .request_refresh(self.pollable_instances());
             self.pending_metrics_refresh = true;
@@ -2921,15 +2928,27 @@ impl HomeView {
 
         match self.metrics_poller.try_recv_updates() {
             Ok(snapshot) => {
+                let memory_per_mille = (snapshot.memory.used_fraction() * 1000.0).round() as u64;
+                let cpu_per_mille = snapshot
+                    .system
+                    .cpu_fraction
+                    .map(|v| (v * 1000.0).round() as u64);
                 self.metrics = snapshot;
                 // A sample requested while visible can arrive after the strip
                 // is hidden. Do not repopulate the history that hiding clears.
-                if self.show_diagnostics {
-                    let per_mille = (snapshot.memory.used_fraction() * 1000.0).round() as u64;
-                    self.metrics_history.push_back(per_mille);
+                if self.show_diagnostics || self.system_health_open {
+                    self.metrics_history.push_back(memory_per_mille);
                     // At most one over the cap: exactly one push per apply.
                     if self.metrics_history.len() > METRICS_HISTORY_LEN {
                         self.metrics_history.pop_front();
+                    }
+                }
+                if self.system_health_open {
+                    if let Some(value) = cpu_per_mille {
+                        self.cpu_history.push_back(value);
+                    }
+                    if self.cpu_history.len() > METRICS_HISTORY_LEN {
+                        self.cpu_history.pop_front();
                     }
                 }
                 self.pending_metrics_refresh = false;
@@ -2969,6 +2988,14 @@ impl HomeView {
                 "failed to persist show_diagnostics_pane: {e}",
             );
         }
+    }
+
+    pub fn open_system_health(&mut self) {
+        self.system_health_open = true;
+        self.system_health_scroll = 0;
+        self.diff_view = None;
+        self.live_send = None;
+        self.request_metrics_refresh();
     }
 
     /// Request the daemon's view of every structured row's status
@@ -7463,7 +7490,7 @@ impl HomeView {
         self.confirm_before_quit = config.session.confirm_before_quit;
         self.row_tag_mode = config.session.row_tag;
         // Keep the strip in sync when the Settings UI or a config-file edit
-        // flips the toggle, not just the F9 keybinding.
+        // flips the toggle from any settings surface.
         if !self.show_diagnostics && config.session.show_diagnostics_pane {
             self.metrics_history.clear();
         }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -54,11 +54,6 @@ use super::stop_poller::StopPoller;
 /// has a backing repo must test the repo path, not this string (#3133).
 const SCRATCH_GROUP_LABEL: &str = "scratch";
 
-/// Diagnostics-strip history depth. At the 1s sample cadence this is about two
-/// minutes of headroom samples, over-provisioned past the strip's width (it
-/// docks under the session-list column) so it never runs short.
-const METRICS_HISTORY_LEN: usize = 150;
-
 /// Extract a project group name from a session instance.
 /// Uses `worktree_info.main_repo_path` for worktree sessions (so all branches of the
 /// same repo group together), otherwise uses `project_path`. Returns the last path segment.
@@ -757,15 +752,12 @@ pub struct HomeView {
     pub(super) pending_status_refresh: bool,
 
     // Compact system-health strip controlled by `session.show_diagnostics_pane`.
-    // The poller samples memory + agent counts off the UI thread; `metrics`
-    // holds the latest sample and `metrics_history` the headroom ring buffer
-    // (per-mille of used_fraction, newest at the back) feeding the sparkline.
+    // The poller samples host resources and agent counts off the UI thread;
+    // `metrics` holds the latest sample for the strip and detail view.
     pub(super) show_diagnostics: bool,
     pub(super) metrics_poller: super::metrics_poller::MetricsPoller,
     pub(super) pending_metrics_refresh: bool,
     pub(super) metrics: crate::process::metrics::MetricsSnapshot,
-    pub(super) metrics_history: std::collections::VecDeque<u64>,
-    pub(super) cpu_history: std::collections::VecDeque<u64>,
     pub(super) system_health_open: bool,
     pub(super) system_health_scroll: usize,
     pub(super) diagnostics_area: Rect,
@@ -2307,8 +2299,6 @@ impl HomeView {
             metrics_poller: super::metrics_poller::MetricsPoller::new(),
             pending_metrics_refresh: false,
             metrics: crate::process::metrics::MetricsSnapshot::default(),
-            metrics_history: std::collections::VecDeque::new(),
-            cpu_history: std::collections::VecDeque::new(),
             system_health_open: false,
             system_health_scroll: 0,
             diagnostics_area: Rect::default(),
@@ -2922,38 +2912,15 @@ impl HomeView {
         }
     }
 
-    /// Apply any pending metrics sample, pushing the new headroom point onto
-    /// the sparkline ring buffer. Returns true if a sample was applied (so the
-    /// caller can force a repaint to animate the graph).
+    /// Apply any pending metrics sample. Returns true if a sample was applied
+    /// so the caller can repaint the live readouts.
     pub fn apply_metrics_updates(&mut self) -> bool {
         use std::sync::mpsc::TryRecvError;
 
         match self.metrics_poller.try_recv_updates() {
             Ok(snapshot) => {
-                let memory_per_mille = (snapshot.memory.used_fraction() * 1000.0).round() as u64;
-                let cpu_per_mille = snapshot
-                    .system
-                    .cpu_fraction
-                    .map(|v| (v * 1000.0).round() as u64);
                 self.metrics = snapshot;
                 self.observe_system_health_tip_load();
-                // A sample requested while visible can arrive after the strip
-                // is hidden. Do not repopulate the history that hiding clears.
-                if self.show_diagnostics || self.system_health_open {
-                    self.metrics_history.push_back(memory_per_mille);
-                    // At most one over the cap: exactly one push per apply.
-                    if self.metrics_history.len() > METRICS_HISTORY_LEN {
-                        self.metrics_history.pop_front();
-                    }
-                }
-                if self.system_health_open {
-                    if let Some(value) = cpu_per_mille {
-                        self.cpu_history.push_back(value);
-                    }
-                    if self.cpu_history.len() > METRICS_HISTORY_LEN {
-                        self.cpu_history.pop_front();
-                    }
-                }
                 self.pending_metrics_refresh = false;
                 true
             }
@@ -2974,14 +2941,9 @@ impl HomeView {
     }
 
     /// Toggle the diagnostics strip and persist the new state to
-    /// `session.show_diagnostics_pane` so it survives restarts. Clears the
-    /// history when hiding so a re-open starts fresh rather than showing a
-    /// stale gap.
+    /// `session.show_diagnostics_pane` so it survives restarts.
     pub fn toggle_diagnostics(&mut self) {
         self.show_diagnostics = !self.show_diagnostics;
-        if !self.show_diagnostics {
-            self.metrics_history.clear();
-        }
         let enabled = self.show_diagnostics;
         if let Err(e) = update_config(|config| {
             config.session.show_diagnostics_pane = enabled;
@@ -7418,9 +7380,6 @@ impl HomeView {
         self.row_tag_mode = config.session.row_tag;
         // Keep the strip in sync when the Settings UI or a config-file edit
         // flips the toggle from any settings surface.
-        if !self.show_diagnostics && config.session.show_diagnostics_pane {
-            self.metrics_history.clear();
-        }
         self.show_diagnostics = config.session.show_diagnostics_pane;
         self.agent_clipboard_forward =
             config.tmux.clipboard != crate::session::config::TmuxSettingMode::Disabled;

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2470,8 +2470,6 @@ impl HomeView {
                 frame,
                 area,
                 theme,
-                &self.metrics_history,
-                &self.cpu_history,
                 &self.metrics,
                 self.system_health_scroll,
             );

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -104,6 +104,9 @@ impl PaneLayout {
 /// requested scroll.
 const CAPTURE_BUFFER: u16 = 20;
 
+/// Rows the diagnostics strip occupies: a 2-row sparkline plus its readout row.
+const DIAGNOSTICS_STRIP_HEIGHT: u16 = 3;
+
 /// Window captured while the user is off the live edge (reading scrollback):
 /// the full scrollback in one shot, rather than a window that tracks the offset
 /// and re-anchors to the advancing live edge on every capture. Matches tmux's
@@ -761,11 +764,11 @@ impl HomeView {
             .constraints(constraints)
             .split(area);
 
-        // Below STACKED_BREAKPOINT (80 cols), put the list above the preview
-        // instead of side-by-side. At 80 cols a side-by-side preview is only
-        // ~45 cols (with default list_width 35), too cramped for output;
-        // stacking gives the preview the full width.
-        let available_width = main_chunks[0].width;
+        // The diagnostics strip docks under the session-list column (see
+        // `diagnostics_dock`) so it stays narrow and the preview keeps its full
+        // height.
+        let content_area = main_chunks[0];
+        let available_width = content_area.width;
         self.main_area_width = available_width;
         // Collapsed sidebar: the list shrinks to a narrow click-to-expand
         // strip on the left and the preview takes the rest of the width
@@ -778,7 +781,7 @@ impl HomeView {
             let chunks = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Length(strip_width), Constraint::Min(0)])
-                .split(main_chunks[0]);
+                .split(content_area);
             // The full list isn't drawn, so its hit-test rects would
             // otherwise keep last frame's values and a click in the now-
             // preview area could resolve to an invisible list row (and
@@ -788,10 +791,13 @@ impl HomeView {
             self.list_area = Rect::default();
             self.list_inner_area = Rect::default();
             self.shelf_inner_area = Rect::default();
-            self.render_collapsed_strip(frame, chunks[0], theme);
+            // Preview keeps full height; the strip docks under the collapsed
+            // list column.
+            let strip_col = self.diagnostics_dock(frame, chunks[0], theme);
+            self.render_collapsed_strip(frame, strip_col, theme);
             self.render_preview(frame, chunks[1], theme, PaneLayout::Collapsed);
         } else if available_width < responsive::STACKED_BREAKPOINT {
-            let main_height = main_chunks[0].height;
+            let main_height = content_area.height;
             let list_height = responsive::stacked_list_height(main_height);
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
@@ -799,13 +805,17 @@ impl HomeView {
                     Constraint::Length(list_height),
                     Constraint::Min(responsive::STACKED_PREVIEW_MIN),
                 ])
-                .split(main_chunks[0]);
+                .split(content_area);
 
             // Stacked layout has no vertical divider; only the side-by-side
             // path exposes the resize-by-drag affordance.
             self.divider_col = None;
 
-            self.render_list(frame, chunks[0], theme, PaneLayout::Stacked);
+            // Stacked: the list is on top with the preview below, so there is no
+            // list column to dock under; the strip spans the list's width above
+            // the preview.
+            let list_rect = self.diagnostics_dock(frame, chunks[0], theme);
+            self.render_list(frame, list_rect, theme, PaneLayout::Stacked);
             self.render_preview(frame, chunks[1], theme, PaneLayout::Stacked);
         } else {
             // Side-by-side: cap list width so the preview pane keeps its
@@ -820,7 +830,7 @@ impl HomeView {
                     Constraint::Length(effective_list_width),
                     Constraint::Min(responsive::PREVIEW_MIN_WIDTH),
                 ])
-                .split(main_chunks[0]);
+                .split(content_area);
 
             // Layout chunks are contiguous, so chunks[1].x is the first
             // column of the preview block, i.e. the visible left border
@@ -828,7 +838,9 @@ impl HomeView {
             // list's y-range (matches preview's y-range in side-by-side).
             self.divider_col = Some(chunks[1].x);
 
-            self.render_list(frame, chunks[0], theme, PaneLayout::SideBySide);
+            // Strip docks under the list column; the preview keeps full height.
+            let list_rect = self.diagnostics_dock(frame, chunks[0], theme);
+            self.render_list(frame, list_rect, theme, PaneLayout::SideBySide);
             self.render_preview(frame, chunks[1], theme, PaneLayout::SideBySide);
         }
         self.render_status_bar(frame, main_chunks[1], theme);
@@ -917,6 +929,32 @@ impl HomeView {
             // gated rename/delete attempt).
             context_menu,
         );
+    }
+
+    /// Dock the diagnostics strip under the session-list column: carve
+    /// `DIAGNOSTICS_STRIP_HEIGHT` rows off the bottom of `column`, render the
+    /// strip there, and return the reduced rect for the list. Returns `column`
+    /// unchanged when the strip is hidden or the column is too short to spare
+    /// the rows, so the list is never starved below one row.
+    fn diagnostics_dock(&self, frame: &mut Frame, column: Rect, theme: &Theme) -> Rect {
+        if !self.show_diagnostics || column.height <= DIAGNOSTICS_STRIP_HEIGHT {
+            return column;
+        }
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Min(1),
+                Constraint::Length(DIAGNOSTICS_STRIP_HEIGHT),
+            ])
+            .split(column);
+        crate::tui::components::diagnostics::render(
+            frame,
+            rows[1],
+            theme,
+            &self.metrics_history,
+            &self.metrics,
+        );
+        rows[0]
     }
 
     fn active_diff_area(&self, area: Rect) -> Rect {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -948,7 +948,13 @@ impl HomeView {
                 Constraint::Length(DIAGNOSTICS_STRIP_HEIGHT),
             ])
             .split(column);
-        crate::tui::components::diagnostics::render(frame, rows[1], theme, &self.metrics);
+        crate::tui::components::diagnostics::render(
+            frame,
+            rows[1],
+            theme,
+            &self.metrics,
+            self.diagnostics_hovered,
+        );
         self.diagnostics_area = rows[1];
         rows[0]
     }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -104,8 +104,8 @@ impl PaneLayout {
 /// requested scroll.
 const CAPTURE_BUFFER: u16 = 20;
 
-/// Rows the diagnostics strip occupies: a 2-row sparkline plus its readout row.
-const DIAGNOSTICS_STRIP_HEIGHT: u16 = 3;
+/// Rows the compact system-health strip occupies.
+const DIAGNOSTICS_STRIP_HEIGHT: u16 = 1;
 
 /// Window captured while the user is off the live edge (reading scrollback):
 /// the full scrollback in one shot, rather than a window that tracks the offset
@@ -936,7 +936,8 @@ impl HomeView {
     /// strip there, and return the reduced rect for the list. Returns `column`
     /// unchanged when the strip is hidden or the column is too short to spare
     /// the rows, so the list is never starved below one row.
-    fn diagnostics_dock(&self, frame: &mut Frame, column: Rect, theme: &Theme) -> Rect {
+    fn diagnostics_dock(&mut self, frame: &mut Frame, column: Rect, theme: &Theme) -> Rect {
+        self.diagnostics_area = Rect::default();
         if !self.show_diagnostics || column.height <= DIAGNOSTICS_STRIP_HEIGHT {
             return column;
         }
@@ -947,13 +948,8 @@ impl HomeView {
                 Constraint::Length(DIAGNOSTICS_STRIP_HEIGHT),
             ])
             .split(column);
-        crate::tui::components::diagnostics::render(
-            frame,
-            rows[1],
-            theme,
-            &self.metrics_history,
-            &self.metrics,
-        );
+        crate::tui::components::diagnostics::render(frame, rows[1], theme, &self.metrics);
+        self.diagnostics_area = rows[1];
         rows[0]
     }
 
@@ -1228,16 +1224,12 @@ impl HomeView {
         }
         frame.render_widget(Paragraph::new(lines), list_region);
 
-        // --- Divider carrying the sort indicator (between list and shelf) ---
+        // --- Divider between the workspace list and pinned shelf ---
         if let Some(dy) = divider_y {
-            let label = format!(" sort: {} ", self.sort_order.label());
-            let dw = list_region.width as usize;
-            let label_w = label.chars().count().min(dw);
-            let fill = dw.saturating_sub(label_w);
-            let divider = Line::from(vec![
-                Span::styled("─".repeat(fill), Style::default().fg(theme.border)),
-                Span::styled(label, Style::default().fg(theme.dimmed)),
-            ]);
+            let divider = Line::from(Span::styled(
+                "─".repeat(list_region.width as usize),
+                Style::default().fg(theme.border),
+            ));
             frame.render_widget(
                 Paragraph::new(divider),
                 Rect {
@@ -2462,6 +2454,23 @@ impl HomeView {
     }
 
     fn render_preview(&mut self, frame: &mut Frame, area: Rect, theme: &Theme, layout: PaneLayout) {
+        if self.system_health_open {
+            self.preview_outer_area = area;
+            self.preview_area = area;
+            self.preview_pane_area = area;
+            self.preview_visible_rows = area.height as usize;
+            self.sync_preview_capture_worker(None);
+            crate::tui::components::diagnostics::render_system_health(
+                frame,
+                area,
+                theme,
+                &self.metrics_history,
+                &self.cpu_history,
+                &self.metrics,
+                self.system_health_scroll,
+            );
+            return;
+        }
         let compact = area.width < responsive::STACKED_BREAKPOINT;
         let (border_color, title_color) = match self.view_mode {
             ViewMode::Structured => (theme.border, theme.title),

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8202,6 +8202,24 @@ fn hidden_diagnostics_drops_an_inflight_sample_from_history() {
     assert!(!env.view.pending_metrics_refresh);
 }
 
+#[test]
+#[serial]
+fn system_health_survives_refresh_but_closes_on_selection_change() {
+    let mut env = create_test_env_with_sessions(2);
+    env.view.update_selected();
+    env.view.open_system_health();
+    env.view.cpu_history.push_back(500);
+
+    env.view.update_selected();
+    assert!(env.view.system_health_open);
+    assert_eq!(env.view.cpu_history.len(), 1);
+
+    env.view.cursor = 1;
+    env.view.update_selected();
+    assert!(!env.view.system_health_open);
+    assert!(env.view.cpu_history.is_empty());
+}
+
 /// Footer discoverability hints track where each key actually does something.
 /// Archive/Snooze are Attention-only. Fav follows its keybind's own gate
 /// (`Context::FavoritesUsable`): usable in Attention, or in any sort order

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8179,45 +8179,17 @@ fn pollable_instances_recovers_after_inflight_clear() {
 
 #[test]
 #[serial]
-fn hidden_diagnostics_drops_an_inflight_sample_from_history() {
-    use crate::process::metrics::{MemorySample, MetricsSnapshot};
-
-    let mut env = create_test_env_empty();
-    let snapshot = MetricsSnapshot {
-        memory: MemorySample {
-            total_bytes: 100,
-            available_bytes: 25,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-    env.view.show_diagnostics = false;
-    env.view.metrics_poller =
-        super::super::metrics_poller::MetricsPoller::seeded_for_test(snapshot.clone());
-    env.view.pending_metrics_refresh = true;
-
-    assert!(env.view.apply_metrics_updates());
-    assert_eq!(env.view.metrics, snapshot);
-    assert!(env.view.metrics_history.is_empty());
-    assert!(!env.view.pending_metrics_refresh);
-}
-
-#[test]
-#[serial]
 fn system_health_survives_refresh_but_closes_on_selection_change() {
     let mut env = create_test_env_with_sessions(2);
     env.view.update_selected();
     env.view.open_system_health();
-    env.view.cpu_history.push_back(500);
 
     env.view.update_selected();
     assert!(env.view.system_health_open);
-    assert_eq!(env.view.cpu_history.len(), 1);
 
     env.view.cursor = 1;
     env.view.update_selected();
     assert!(!env.view.system_health_open);
-    assert!(env.view.cpu_history.is_empty());
 }
 
 #[test]

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8193,7 +8193,7 @@ fn hidden_diagnostics_drops_an_inflight_sample_from_history() {
     };
     env.view.show_diagnostics = false;
     env.view.metrics_poller =
-        super::super::metrics_poller::MetricsPoller::seeded_for_test(snapshot);
+        super::super::metrics_poller::MetricsPoller::seeded_for_test(snapshot.clone());
     env.view.pending_metrics_refresh = true;
 
     assert!(env.view.apply_metrics_updates());
@@ -8775,8 +8775,8 @@ fn shelf_renders_trash_with_glyph_and_divider_sort() {
         "shelf must show the Trash count"
     );
     assert!(
-        screen.contains("sort:"),
-        "the sort indicator rides the shelf divider"
+        !screen.contains("sort:"),
+        "the shelf divider must not duplicate the header's sort indicator"
     );
     assert!(
         env.view.shelf_inner_area.height > 0,

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8177,6 +8177,31 @@ fn pollable_instances_recovers_after_inflight_clear() {
     assert_eq!(env.view.pollable_instances().len(), 1);
 }
 
+#[test]
+#[serial]
+fn hidden_diagnostics_drops_an_inflight_sample_from_history() {
+    use crate::process::metrics::{MemorySample, MetricsSnapshot};
+
+    let mut env = create_test_env_empty();
+    let snapshot = MetricsSnapshot {
+        memory: MemorySample {
+            total_bytes: 100,
+            available_bytes: 25,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    env.view.show_diagnostics = false;
+    env.view.metrics_poller =
+        super::super::metrics_poller::MetricsPoller::seeded_for_test(snapshot);
+    env.view.pending_metrics_refresh = true;
+
+    assert!(env.view.apply_metrics_updates());
+    assert_eq!(env.view.metrics, snapshot);
+    assert!(env.view.metrics_history.is_empty());
+    assert!(!env.view.pending_metrics_refresh);
+}
+
 /// Footer discoverability hints track where each key actually does something.
 /// Archive/Snooze are Attention-only. Fav follows its keybind's own gate
 /// (`Context::FavoritesUsable`): usable in Attention, or in any sort order

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8220,6 +8220,38 @@ fn system_health_survives_refresh_but_closes_on_selection_change() {
     assert!(env.view.cpu_history.is_empty());
 }
 
+#[test]
+#[serial]
+fn system_health_tip_requires_three_six_agent_samples() {
+    let mut env = create_test_env_empty();
+    env.view.metrics.counts.agents = 6;
+
+    env.view.observe_system_health_tip_load();
+    env.view.observe_system_health_tip_load();
+    assert!(!env.view.system_health_tip_earned);
+    assert!(env.view.pending_tip_pop.is_none());
+
+    env.view.metrics.counts.agents = 5;
+    env.view.observe_system_health_tip_load();
+    assert_eq!(env.view.system_health_tip_high_samples, 0);
+
+    env.view.metrics.counts.agents = 6;
+    for _ in 0..3 {
+        env.view.observe_system_health_tip_load();
+    }
+    assert!(env.view.system_health_tip_earned);
+    assert_eq!(
+        env.view.pending_tip_pop.map(|tip| tip.id),
+        Some("system-health")
+    );
+
+    env.view.open_system_health();
+    assert!(env.view.pending_tip_pop.is_none());
+    let config = crate::session::Config::load().unwrap();
+    assert!(config.app_state.system_health_tip_earned);
+    assert!(config.app_state.used_system_health);
+}
+
 /// Footer discoverability hints track where each key actually does something.
 /// Archive/Snooze are Attention-only. Fav follows its keybind's own gate
 /// (`Context::FavoritesUsable`): usable in Attention, or in any sort order

--- a/src/tui/metrics_poller.rs
+++ b/src/tui/metrics_poller.rs
@@ -1,0 +1,47 @@
+//! Background sampler for the diagnostics strip.
+//!
+//! Reading memory and counting agent process trees forks `ps` / walks `/proc`,
+//! so it must not run on the render loop. This mirrors [`StatusPoller`]: a
+//! [`Worker`] on a named thread samples on request and the main loop drains the
+//! result each frame.
+
+use crate::process::metrics::{count_running_agents, sample_memory, MetricsSnapshot};
+use crate::session::Instance;
+use crate::tui::worker::Worker;
+
+/// Background thread that samples system memory + agent counts without blocking
+/// the UI.
+pub struct MetricsPoller {
+    worker: Worker<Vec<Instance>, MetricsSnapshot>,
+}
+
+impl MetricsPoller {
+    pub fn new() -> Self {
+        Self {
+            worker: Worker::spawn("aoe-metrics-poller", |instances: Vec<Instance>| {
+                MetricsSnapshot {
+                    memory: sample_memory(),
+                    counts: count_running_agents(&instances),
+                }
+            }),
+        }
+    }
+
+    /// Request a sample for the given instances (non-blocking).
+    pub fn request_refresh(&self, instances: Vec<Instance>) {
+        self.worker.request(instances);
+    }
+
+    /// Try to receive a completed sample without blocking. Surfaces
+    /// `Disconnected` (see [`Worker::try_recv`]) so the caller can clear its
+    /// in-flight guard and respawn rather than freeze the strip forever.
+    pub fn try_recv_updates(&self) -> Result<MetricsSnapshot, std::sync::mpsc::TryRecvError> {
+        self.worker.try_recv()
+    }
+}
+
+impl Default for MetricsPoller {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/tui/metrics_poller.rs
+++ b/src/tui/metrics_poller.rs
@@ -5,7 +5,7 @@
 //! [`Worker`] on a named thread samples on request and the main loop drains the
 //! result each frame.
 
-use crate::process::metrics::{count_running_agents, sample_memory, MetricsSnapshot};
+use crate::process::metrics::{MetricsSampler, MetricsSnapshot};
 use crate::session::Instance;
 use crate::tui::worker::Worker;
 
@@ -17,12 +17,10 @@ pub struct MetricsPoller {
 
 impl MetricsPoller {
     pub fn new() -> Self {
+        let mut sampler = MetricsSampler::default();
         Self {
-            worker: Worker::spawn("aoe-metrics-poller", |instances: Vec<Instance>| {
-                MetricsSnapshot {
-                    memory: sample_memory(),
-                    counts: count_running_agents(&instances),
-                }
+            worker: Worker::spawn("aoe-metrics-poller", move |instances: Vec<Instance>| {
+                sampler.sample(&instances)
             }),
         }
     }

--- a/src/tui/metrics_poller.rs
+++ b/src/tui/metrics_poller.rs
@@ -36,13 +36,6 @@ impl MetricsPoller {
     pub fn try_recv_updates(&self) -> Result<MetricsSnapshot, std::sync::mpsc::TryRecvError> {
         self.worker.try_recv()
     }
-
-    #[cfg(test)]
-    pub(crate) fn seeded_for_test(snapshot: MetricsSnapshot) -> Self {
-        Self {
-            worker: Worker::seeded_for_test("aoe-metrics-poller-test", snapshot),
-        }
-    }
 }
 
 impl Default for MetricsPoller {

--- a/src/tui/metrics_poller.rs
+++ b/src/tui/metrics_poller.rs
@@ -38,6 +38,13 @@ impl MetricsPoller {
     pub fn try_recv_updates(&self) -> Result<MetricsSnapshot, std::sync::mpsc::TryRecvError> {
         self.worker.try_recv()
     }
+
+    #[cfg(test)]
+    pub(crate) fn seeded_for_test(snapshot: MetricsSnapshot) -> Self {
+        Self {
+            worker: Worker::seeded_for_test("aoe-metrics-poller-test", snapshot),
+        }
+    }
 }
 
 impl Default for MetricsPoller {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -13,6 +13,7 @@ pub mod dialogs;
 pub mod diff;
 pub(crate) mod home;
 pub(crate) mod markdown;
+mod metrics_poller;
 #[cfg(feature = "serve")]
 pub(crate) mod open_url;
 #[cfg(feature = "serve")]

--- a/tests/e2e/diagnostics_strip.rs
+++ b/tests/e2e/diagnostics_strip.rs
@@ -1,14 +1,11 @@
-use serial_test::parallel;
-use std::time::Duration;
-
 use crate::harness::{require_tmux, TuiTestHarness};
+use serial_test::parallel;
 
-/// F9 toggles the memory diagnostics strip on and off. The strip always shows
-/// the "N agents · N procs" counts (even before the first memory sample), so
-/// "procs" is a stable anchor for its presence.
+/// Both system-health surfaces are reachable independently from the command
+/// palette, without reserving a global function key.
 #[test]
 #[parallel]
-fn test_diagnostics_strip_toggles_with_f9() {
+fn test_system_health_palette_actions() {
     require_tmux!();
 
     let mut h = TuiTestHarness::new("diagnostics_toggle");
@@ -18,9 +15,14 @@ fn test_diagnostics_strip_toggles_with_f9() {
     // Off by default.
     h.assert_screen_not_contains("procs");
 
-    h.send_keys("F9");
+    h.send_keys("C-k");
+    h.type_text("toggle system health strip");
+    h.send_keys("Enter");
     h.wait_for("procs");
 
-    h.send_keys("F9");
-    h.wait_for_absent("procs", Duration::from_secs(5));
+    h.send_keys("C-k");
+    h.type_text("open system health");
+    h.send_keys("Enter");
+    h.wait_for("System Health");
+    h.wait_for("No running AoE agents");
 }

--- a/tests/e2e/diagnostics_strip.rs
+++ b/tests/e2e/diagnostics_strip.rs
@@ -1,0 +1,26 @@
+use serial_test::parallel;
+use std::time::Duration;
+
+use crate::harness::{require_tmux, TuiTestHarness};
+
+/// F9 toggles the memory diagnostics strip on and off. The strip always shows
+/// the "N agents · N procs" counts (even before the first memory sample), so
+/// "procs" is a stable anchor for its presence.
+#[test]
+#[parallel]
+fn test_diagnostics_strip_toggles_with_f9() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("diagnostics_toggle");
+    h.spawn_tui();
+
+    h.wait_for(" aoe ");
+    // Off by default.
+    h.assert_screen_not_contains("procs");
+
+    h.send_keys("F9");
+    h.wait_for("procs");
+
+    h.send_keys("F9");
+    h.wait_for_absent("procs", Duration::from_secs(5));
+}

--- a/tests/e2e/diagnostics_strip.rs
+++ b/tests/e2e/diagnostics_strip.rs
@@ -13,12 +13,13 @@ fn test_system_health_palette_actions() {
 
     h.wait_for(" aoe ");
     // Off by default.
-    h.assert_screen_not_contains("procs");
+    h.assert_screen_not_contains("CPU ");
 
     h.send_keys("C-k");
     h.type_text("toggle system health strip");
     h.send_keys("Enter");
-    h.wait_for("procs");
+    h.wait_for("CPU ");
+    h.wait_for("Mem ");
 
     h.send_keys("C-k");
     h.type_text("open system health");

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -29,6 +29,7 @@ mod claude_shared_project_correlation_e2e;
 mod cli;
 mod cli_session_id_capture;
 mod command_palette;
+mod diagnostics_strip;
 mod errors;
 mod filewatch_config_malformed;
 mod filewatch_config_profile_removal;


### PR DESCRIPTION
## Description

Adds an optional memory-diagnostics strip to the plain TUI so it is possible to see, at a glance, how close the machine is to a memory thrash and how many agents are driving it, before it becomes a problem. This is aimed at the case where several agent sessions run at once on one box (often watched over SSH) and memory quietly fills until things lock up, with nothing in `aoe` surfacing it.

The strip docks under the session-list column, off by default, toggled by F9 and a persisted setting (`session.show_diagnostics_pane`). It shows two stacked rows: a memory-over-time sparkline on top (colored green/amber/red), and a readout row with the current usage (percent plus used/total) and the running agent and process counts.

The pressure line is memory headroom, `1 - MemAvailable/MemTotal` on Linux (`MemAvailable` already excludes unreclaimable tmpfs/shmem, so it is the number that actually moves when a RAM-backed `/tmp` fills), with PSI (`/proc/pressure/{memory,io}`) folded into the color band only, not the plotted line. macOS uses the native memory-pressure level (`kern.memorystatus_vm_pressure_level`). Sampling runs every second on a background worker (modeled on the existing status poller), never on the render thread, into a fixed ring buffer. The agent and process counts reuse the existing session-liveness check and a single process-tree walk, scoped to AoE-managed sessions.

Memory sampling is hand-rolled from `/proc` and `/sys` on Linux and `sysctl`/`vm_stat` on macOS, so the change adds no new dependency. It is TUI-only; there is no web-dashboard surface in this PR. Discussed on #3316 (build it built-in first, then use it to grow a plugin UI-extension mechanism later).

### Screenshot

Real screen capture from the e2e harness with the strip toggled on (empty test environment, so the counts read zero and the sparkline has no samples yet). It docks under the session-list column on the left; the preview keeps full height:

```
╭ aoe ────────────────────────── « ╭ Preview ────────────────────────── hide info with i ╮
│                                  │            Select a session to preview               │
│          No sessions yet         │                                                      │
│      Press 'n' to create one     │                                                      │
│          or 'aoe add .'          │                                                      │
│                    ...           │                    ...                               │
╰──────────────────── sort: Newest │                                                      │
                                   │                                                      │
 0 agents · 0 procs                ╰──────────────────────────────────────────────────────╯
 t View · g Group · n New · / · D Diff · ^K Cmds · ?
```

With live sessions and memory history, the strip's two rows read like this (sparkline on top, readout below), colored green/amber/red by pressure:

```
 ▂▃▄▅▅▆▇▇██▇▆▅▄▃
 64% 22.7/32G · 7 agents · 43 procs
```

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Added `tests/e2e/diagnostics_strip.rs` (F9 toggles the strip on and off through the real binary), plus unit tests for the `/proc` and `vm_stat` parsers, the pressure-band and byte-formatting helpers, and the keybinding wiring. Verified locally: `cargo fmt`, `cargo clippy -- -D warnings` (default and `--features serve`), `cargo test` (default, `--features serve`, and `--no-default-features` bare-core), and the e2e leg all clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus)

**Any Additional AI Details you'd like to share:**
I used it to help with research (the memory-accounting details, how other terminal monitors present this, and the ratatui widget APIs) and to speed up the implementation and tests. The problem, the design decisions (headroom-not-PSI as the plotted line, sampling off the render thread, scoping counts to AoE-managed sessions), and the review are mine, and I have read and understand all of the diff.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added an optional diagnostics strip to the plain TUI.
- Added persistent visibility control through `session.show_diagnostics_pane`.
- Added a System Health view with memory, CPU, pressure, timeline, and agent metrics.
- Added background metric sampling for Linux and macOS.
- Added parser, unit, regression, and end-to-end test coverage.

## Benefits

Users can monitor system health and AoE resource usage without leaving the TUI. Background sampling keeps the interface responsive. The feature remains disabled by default.

## Potential enhancement

The diagnostics strip could become a sidebar tab with detailed health timelines and per-agent metrics. Support for additional platforms could also be added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->