### PR TITLE
fix(plugin): drop aoe-plugin topic results that carry no manifest

### DIFF
--- a/src/plugin/discover.rs
+++ b/src/plugin/discover.rs
@@ -1,20 +1,27 @@
 //! GitHub plugin discovery over the `aoe-plugin` topic.
 //!
 //! Discovery is an explicit action (CLI `aoe plugin discover`, TUI `d`, the
-//! dashboard "Search GitHub" button), never a background task. It is repo-level,
-//! not manifest-level: it runs one GitHub search and badges each result by
-//! matching the repo slug against the featured index and the installed set. It
-//! deliberately does NOT clone or read each repo's `aoe-plugin.toml` (an N+1
-//! network blowup that would burn the unauthenticated search rate limit), so a
-//! result is "a GitHub repository tagged `aoe-plugin`", not "a verified plugin".
-//! Install remains the trust boundary: it fetches the manifest, prompts for
-//! capabilities, and enforces the featured pin (`install::install`).
+//! dashboard "Search GitHub" button), never a background task. It runs one
+//! GitHub search and badges each result by matching the repo slug against the
+//! featured index and the installed set. It deliberately does NOT clone, read,
+//! or parse each repo's `aoe-plugin.toml` (an N+1 that would burn the
+//! unauthenticated API rate limit). The one exception is a best-effort `HEAD`
+//! on the raw CDN for unvetted results: the `aoe-plugin` topic collides with
+//! Age of Empires game projects, so a repo that provably carries no manifest is
+//! dropped rather than offered for install. Existence is not validation, so a
+//! result is still "a GitHub repository tagged `aoe-plugin` that appears to
+//! carry a manifest", not "a verified plugin". Install remains the trust
+//! boundary: it fetches the manifest, prompts for capabilities, and enforces
+//! the featured pin (`install::install`).
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::{bail, Result};
 use aoe_plugin_api::{lucide_icon_name_ok, screenshot_path_ok, MAX_SCREENSHOTS};
+use futures_util::{stream, StreamExt};
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 
 use crate::github::{GitHubClient, GitHubClientConfig, GitHubRepo, DEFAULT_USER_AGENT};
@@ -45,6 +52,19 @@ use super::source::PluginSource;
 
 /// The GitHub topic plugins are published under.
 const PLUGIN_TOPIC: &str = "aoe-plugin";
+
+/// Per-probe timeout. Short on purpose: the manifest probe is a filter, not a
+/// dependency, so a slow CDN must not hold the search hostage.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(4);
+
+/// Wall-clock ceiling for the whole probe phase. Concurrency alone does not
+/// bound it: a full 30-result page at [`PROBE_CONCURRENCY`] is four serial
+/// batches, so uniform timeouts would cost four times [`PROBE_TIMEOUT`].
+/// Probes still in flight when this fires are simply inconclusive.
+const PROBE_PHASE_TIMEOUT: Duration = Duration::from_secs(6);
+
+/// How many manifest probes run at once.
+const PROBE_CONCURRENCY: usize = 8;
 
 /// How a discovered repository relates to what the host already knows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -114,7 +134,131 @@ pub async fn discover(query: Option<&str>) -> Result<Vec<DiscoveryResult>> {
     // discovery and install would disagree about the same trust signal.
     let featured = FeaturedIndex::load()?;
     let installed = installed_slugs();
-    Ok(rank(badge_repos(repos, &featured, &installed)))
+    let badged = badge_repos(repos, &featured, &installed);
+    let probes = probe_unvetted(&badged).await;
+    Ok(rank(drop_missing(badged, &probes)))
+}
+
+/// The outcome of one `aoe-plugin.toml` existence probe. Tri-state on purpose:
+/// a bool would conflate "this repo has no manifest" with "we could not
+/// check", and only the former may drop a result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ManifestProbe {
+    Present,
+    Missing,
+    Unknown,
+}
+
+/// Map a probe response to an outcome; `None` is a transport error or timeout.
+/// Only a definitive 404 is `Missing`: a 403/429 (CDN throttling) or a 5xx says
+/// nothing about the repo, so everything else fails open.
+fn classify(status: Option<StatusCode>) -> ManifestProbe {
+    match status {
+        Some(s) if s.is_success() => ManifestProbe::Present,
+        Some(StatusCode::NOT_FOUND) => ManifestProbe::Missing,
+        _ => ManifestProbe::Unknown,
+    }
+}
+
+/// Split a `gh:owner/repo` slug. [`badge_repos`] already validated the shape.
+fn owner_repo(slug: &str) -> Option<(&str, &str)> {
+    slug.strip_prefix("gh:")?.split_once('/')
+}
+
+/// `HEAD` the repo's default-branch `aoe-plugin.toml` on the raw CDN. Not the
+/// contents API [`GitHubClient::get_repo_file`] uses: that draws on the 60/hr
+/// unauthenticated core budget, which one 30-result page would half exhaust,
+/// while the CDN is not on that budget. `HEAD` is enough because the question
+/// is existence, and it downloads no body.
+async fn probe_manifest(http: &reqwest::Client, owner: &str, repo: &str) -> ManifestProbe {
+    let url = raw_url(owner, repo, None, "aoe-plugin.toml");
+    classify(http.head(url).send().await.ok().map(|r| r.status()))
+}
+
+/// Probe every unvetted result concurrently, keyed by slug. Installed and
+/// featured sources are deliberately never probed: both install from a pinned
+/// ref, so a manifest missing from the default branch today does not make them
+/// uninstallable, and acting on that would be a false alarm on a working
+/// plugin. Curation drift belongs in featured-index maintenance, not here.
+async fn probe_unvetted(results: &[DiscoveryResult]) -> HashMap<String, ManifestProbe> {
+    let targets: Vec<(String, String, String)> = results
+        .iter()
+        .filter(|r| r.badge == DiscoveryBadge::Unvetted)
+        .filter_map(|r| {
+            owner_repo(&r.slug)
+                .map(|(owner, repo)| (r.slug.clone(), owner.to_string(), repo.to_string()))
+        })
+        .collect();
+    let attempted = targets.len();
+    if attempted == 0 {
+        return HashMap::new();
+    }
+    let http = match reqwest::Client::builder()
+        .user_agent(DEFAULT_USER_AGENT)
+        .timeout(PROBE_TIMEOUT)
+        .build()
+    {
+        Ok(http) => http,
+        // No client means no evidence, so every result stays.
+        Err(_) => return HashMap::new(),
+    };
+
+    let mut probes = stream::iter(targets.into_iter().map(|(slug, owner, repo)| {
+        let http = &http;
+        async move { (slug, probe_manifest(http, &owner, &repo).await) }
+    }))
+    .buffer_unordered(PROBE_CONCURRENCY);
+
+    // Drain under a phase deadline rather than wrapping the collect: a single
+    // timeout around the whole thing would throw away the probes that already
+    // came back, so one hung repo would unfilter the entire page.
+    let deadline = tokio::time::Instant::now() + PROBE_PHASE_TIMEOUT;
+    let mut out = HashMap::new();
+    while let Ok(Some((slug, probe))) = tokio::time::timeout_at(deadline, probes.next()).await {
+        out.insert(slug, probe);
+    }
+    log_probes(attempted, &out);
+    out
+}
+
+/// Report probe outcomes in aggregate. A page where nothing came back
+/// conclusive means the filter did not run at all (a network that reaches
+/// `api.github.com` but blocks `raw.githubusercontent.com` does this), which is
+/// worth saying out loud since the topic-collision results are then unfiltered.
+fn log_probes(attempted: usize, probes: &HashMap<String, ManifestProbe>) {
+    let count = |want: ManifestProbe| probes.values().filter(|p| **p == want).count();
+    let present = count(ManifestProbe::Present);
+    let missing = count(ManifestProbe::Missing);
+    // Probes that never completed before the deadline are inconclusive too.
+    let unknown = attempted - present - missing;
+    if present == 0 && missing == 0 {
+        tracing::warn!(
+            target: "plugin.discover",
+            unknown,
+            "every manifest probe was inconclusive; raw.githubusercontent.com may be unreachable, so topic-collision results are not filtered"
+        );
+    } else {
+        tracing::debug!(
+            target: "plugin.discover",
+            present,
+            missing,
+            unknown,
+            "manifest probes"
+        );
+    }
+}
+
+/// Drop the results a probe proved carry no manifest. A slug absent from
+/// `probes` (never probed, or still in flight when the phase deadline fired) is
+/// retained, so the filter always fails open.
+fn drop_missing(
+    results: Vec<DiscoveryResult>,
+    probes: &HashMap<String, ManifestProbe>,
+) -> Vec<DiscoveryResult> {
+    results
+        .into_iter()
+        .filter(|r| probes.get(&r.slug) != Some(&ManifestProbe::Missing))
+        .collect()
 }
 
 /// The normalized `gh:owner/repo` slugs of every installed external GitHub
@@ -506,6 +650,85 @@ mod tests {
         let repos = vec![repo("not-a-slug", 1), repo("a/b/c", 1)];
         let out = badge_repos(repos, &FeaturedIndex::default(), &[]);
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn classify_maps_only_404_to_missing() {
+        let cases = [
+            (Some(StatusCode::OK), ManifestProbe::Present),
+            (Some(StatusCode::NOT_FOUND), ManifestProbe::Missing),
+            // CDN throttling and server errors say nothing about the repo, so
+            // they must never drop a result.
+            (Some(StatusCode::FORBIDDEN), ManifestProbe::Unknown),
+            (Some(StatusCode::TOO_MANY_REQUESTS), ManifestProbe::Unknown),
+            (
+                Some(StatusCode::INTERNAL_SERVER_ERROR),
+                ManifestProbe::Unknown,
+            ),
+            // A transport error or a timeout.
+            (None, ManifestProbe::Unknown),
+        ];
+        for (status, expected) in cases {
+            assert_eq!(classify(status), expected, "{status:?}");
+        }
+    }
+
+    #[test]
+    fn drops_only_the_results_a_probe_proved_missing() {
+        let repos = vec![
+            repo("acme/missing", 1),
+            repo("acme/present", 1),
+            repo("acme/unknown", 1),
+            repo("acme/unprobed", 1),
+            repo("acme/installed", 1),
+            repo("acme/vetted", 1),
+        ];
+        let index = featured("gh:acme/vetted");
+        let installed = vec!["gh:acme/installed".to_string()];
+        let badged = badge_repos(repos, &index, &installed);
+        // Installed and featured slugs are never probed, so they are absent
+        // from the map even when their default branch lost its manifest;
+        // `unprobed` stands in for a probe that missed the phase deadline.
+        let probes = HashMap::from([
+            ("gh:acme/missing".to_string(), ManifestProbe::Missing),
+            ("gh:acme/present".to_string(), ManifestProbe::Present),
+            ("gh:acme/unknown".to_string(), ManifestProbe::Unknown),
+        ]);
+        let kept: Vec<String> = drop_missing(badged, &probes)
+            .into_iter()
+            .map(|r| r.slug)
+            .collect();
+        assert!(
+            !kept.contains(&"gh:acme/missing".to_string()),
+            "a confirmed-missing manifest must drop the result: {kept:?}"
+        );
+        assert_eq!(kept.len(), 5, "everything else fails open: {kept:?}");
+    }
+
+    #[test]
+    fn a_page_of_missing_manifests_yields_the_empty_state() {
+        let badged = badge_repos(
+            vec![repo("acme/a", 1), repo("acme/b", 1)],
+            &FeaturedIndex::default(),
+            &[],
+        );
+        let probes = HashMap::from([
+            ("gh:acme/a".to_string(), ManifestProbe::Missing),
+            ("gh:acme/b".to_string(), ManifestProbe::Missing),
+        ]);
+        assert!(drop_missing(badged, &probes).is_empty());
+    }
+
+    #[test]
+    fn the_manifest_probe_targets_the_raw_cdn_not_the_api() {
+        // The probe must not draw on the 60/hr unauthenticated core API budget,
+        // which is the whole reason discovery avoided per-repo manifest reads.
+        let url = raw_url("acme", "widget", None, "aoe-plugin.toml");
+        assert_eq!(
+            url,
+            "https://raw.githubusercontent.com/acme/widget/HEAD/aoe-plugin.toml"
+        );
+        assert!(!url.starts_with(&api_base()), "{url}");
     }
 
     #[test]

--- a/src/plugin/fetch.rs
+++ b/src/plugin/fetch.rs
@@ -139,8 +139,16 @@ pub async fn fetch(source: &PluginSource) -> Result<FetchedPlugin> {
 
 fn read_manifest(tree: &Path) -> Result<(PluginManifest, Vec<u8>)> {
     let path = tree.join("aoe-plugin.toml");
-    let bytes = std::fs::read(&path)
-        .with_context(|| format!("no aoe-plugin.toml at {}", path.display()))?;
+    // Discovery filters most of these out, but it fails open when the raw CDN
+    // is unreachable, so this stays the authoritative answer and leads with the
+    // likely cause rather than a staging path.
+    let bytes = std::fs::read(&path).with_context(|| {
+        format!(
+            "no aoe-plugin.toml at {}; this repository is not an installable plugin. \
+             The GitHub `aoe-plugin` topic is also used by unrelated Age of Empires projects.",
+            path.display()
+        )
+    })?;
     let text = std::str::from_utf8(&bytes).context("aoe-plugin.toml is not valid UTF-8")?;
     let manifest = PluginManifest::from_toml_str(text).map_err(|e| anyhow!("{e}"))?;
     Ok((manifest, bytes))

--- a/src/plugin/fetch.rs
+++ b/src/plugin/fetch.rs
@@ -139,16 +139,20 @@ pub async fn fetch(source: &PluginSource) -> Result<FetchedPlugin> {
 
 fn read_manifest(tree: &Path) -> Result<(PluginManifest, Vec<u8>)> {
     let path = tree.join("aoe-plugin.toml");
-    // Discovery filters most of these out, but it fails open when the raw CDN
-    // is unreachable, so this stays the authoritative answer and leads with the
-    // likely cause rather than a staging path.
-    let bytes = std::fs::read(&path).with_context(|| {
-        format!(
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        // Discovery filters most of these out, but it fails open when the raw
+        // CDN is unreachable, so this stays the authoritative answer and leads
+        // with the likely cause rather than a staging path. Scoped to a real
+        // absence: a permission error or a directory at that path is an I/O
+        // problem, not a repo that turned out to be an Age of Empires mod.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => bail!(
             "no aoe-plugin.toml at {}; this repository is not an installable plugin. \
              The GitHub `aoe-plugin` topic is also used by unrelated Age of Empires projects.",
             path.display()
-        )
-    })?;
+        ),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", path.display())),
+    };
     let text = std::str::from_utf8(&bytes).context("aoe-plugin.toml is not valid UTF-8")?;
     let manifest = PluginManifest::from_toml_str(text).map_err(|e| anyhow!("{e}"))?;
     Ok((manifest, bytes))

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4081,6 +4081,13 @@ async fn purge_session_artifacts(
         let mut instances = state.instances.write().await;
         instances.retain(|i| i.id != id);
     }
+    // The row is now gone from both disk and memory. Bump last, so any
+    // reloader still carrying a `sessions.json` snapshot that predates either
+    // removal drops it instead of folding the deleted row back into
+    // `state.instances`. See invariant 8 on `reload_state_instances_from_disk`.
+    state
+        .delete_epoch
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     state.instance_locks.write().await.remove(id);
     if let Some(entry) = recent_entry {
         if let Err(e) = crate::session::record_recent_project(entry) {

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4080,14 +4080,17 @@ async fn purge_session_artifacts(
     {
         let mut instances = state.instances.write().await;
         instances.retain(|i| i.id != id);
+        // The row is now gone from both disk and memory, so any reloader still
+        // carrying a `sessions.json` snapshot that predates either removal must
+        // drop it rather than fold the deleted row back in. Bump while still
+        // holding the `instances` write lock: a reloader checks the epoch under
+        // that same lock, so the removal and the bump land as one step and a
+        // reload cannot slip between them. See invariant 8 on
+        // `reload_state_instances_from_disk`.
+        state
+            .delete_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     }
-    // The row is now gone from both disk and memory. Bump last, so any
-    // reloader still carrying a `sessions.json` snapshot that predates either
-    // removal drops it instead of folding the deleted row back into
-    // `state.instances`. See invariant 8 on `reload_state_instances_from_disk`.
-    state
-        .delete_epoch
-        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     state.instance_locks.write().await.remove(id);
     if let Some(entry) = recent_entry {
         if let Err(e) = crate::session::record_recent_project(entry) {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3161,7 +3161,10 @@ fn skip_tmux_decision_for_structured(inst: &mut Instance) -> bool {
 //    a reload rather than resurrecting the row. Dropping ids missing from
 //    `prior_by_id` is NOT an alternative; that is also how a session
 //    created by another process (the CLI, a peer daemon) legitimately
-//    enters `state.instances`.
+//    enters `state.instances`. The comparison happens under the
+//    `state.instances` write lock, and the delete bumps under that same
+//    lock, so the two are ordered against each other; comparing before
+//    taking the lock reopens the race one lock acquisition later.
 
 /// Reload `state.instances` by merging caller-supplied `fresh` against the
 /// prior in-memory snapshot per id, then reapplying the acp overlay.
@@ -3200,10 +3203,30 @@ pub(crate) async fn reload_state_instances_from_disk(
     status_source: StatusSource,
     read_epoch: u64,
 ) {
+    // Snapshot suppression here so a worker that unmarks between the
+    // caller's input build and the per-id decision cannot combine a
+    // cleared mark with a stale row to re-emit the phantom Error
+    // transition the suppression exists to prevent. Idempotent on the
+    // poll path, where the caller already applied the same override
+    // inside `spawn_blocking`.
+    let suppressed_ids =
+        crate::session::recovery::snapshot_recently_restarted(&state.recently_restarted);
+
+    let mut current = state.instances.write().await;
+
     // Invariant 8: `fresh` predates a committed delete, so folding it in would
     // put the removed row back. Drop the whole reload rather than filter it:
     // the next poll tick re-reads disk 2s from now and converges, and a delete
     // is rare enough that losing one tick of status updates costs nothing.
+    //
+    // Read under the `instances` write lock, and before `drain_from` empties
+    // `current`, so this is atomic against the delete. Checking before taking
+    // the lock leaves a hole: a reload could pass the check, park on the lock,
+    // let a delete take the lock, remove the row and bump, then wake and write
+    // its stale snapshot over the removal. The delete bumps inside the same
+    // lock scope for the same reason. No memory ordering closes that gap; it
+    // is a check-then-act race, so the check has to happen under the lock that
+    // orders the two writers.
     let current_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
     if current_epoch != read_epoch {
         tracing::debug!(
@@ -3215,16 +3238,6 @@ pub(crate) async fn reload_state_instances_from_disk(
         return;
     }
 
-    // Snapshot suppression here so a worker that unmarks between the
-    // caller's input build and the per-id decision cannot combine a
-    // cleared mark with a stale row to re-emit the phantom Error
-    // transition the suppression exists to prevent. Idempotent on the
-    // poll path, where the caller already applied the same override
-    // inside `spawn_blocking`.
-    let suppressed_ids =
-        crate::session::recovery::snapshot_recently_restarted(&state.recently_restarted);
-
-    let mut current = state.instances.write().await;
     let prior_by_id = PriorById::drain_from(&mut current);
 
     let mut merged: Vec<Instance> = Vec::with_capacity(fresh.len());
@@ -8420,6 +8433,9 @@ mod tests {
         .await
         .expect("bootstrap wake must fire after init returns");
 
+        // Invariant 8: capture the epoch BEFORE the disk read, the order every
+        // production caller uses.
+        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
         let file_watch = state.file_watch.clone();
         let fresh = tokio::task::spawn_blocking(move || load_all_instances(&file_watch))
             .await
@@ -8430,7 +8446,7 @@ mod tests {
             fresh,
             Vec::new(),
             StatusSource::DiskOnly,
-            state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst),
+            read_epoch,
         )
         .await;
 
@@ -8492,6 +8508,66 @@ mod tests {
             "a deleted session must not come back from a pre-delete snapshot: {titles:?}"
         );
         assert_eq!(titles, vec!["survivor".to_string()]);
+    }
+
+    // The epoch comparison has to be atomic against the delete, not merely
+    // ordered by `SeqCst`. Comparing before taking the `instances` write lock
+    // leaves a check-then-act race: a reload passes the check, parks on the
+    // lock, a delete takes the lock and removes the row, and the reload then
+    // wakes and writes its stale snapshot over the removal.
+    //
+    // This drives that exact interleaving. The test holds the write lock so
+    // the spawned reload is guaranteed to be parked on it, bumps the epoch
+    // while it waits (standing in for the delete), then releases. On a
+    // current-thread runtime the ordering is deterministic, not timing
+    // dependent.
+    #[tokio::test]
+    async fn a_reload_parked_on_the_instances_lock_still_sees_a_delete_that_won_the_race() {
+        let doomed = Instance::new("doomed", "/tmp/doomed");
+        let survivor = Instance::new("survivor", "/tmp/survivor");
+        let stale_snapshot = vec![doomed.clone(), survivor.clone()];
+
+        let state = test_support::build_test_app_state(vec![survivor.clone()]);
+        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
+
+        // Hold the lock the reload needs, so it cannot get past it.
+        let guard = state.instances.write().await;
+
+        let reload_state = Arc::clone(&state);
+        let reload = tokio::spawn(async move {
+            reload_state_instances_from_disk(
+                &reload_state,
+                stale_snapshot,
+                Vec::new(),
+                StatusSource::DiskOnly,
+                read_epoch,
+            )
+            .await;
+        });
+
+        // Let the spawned task run until it parks on the write lock.
+        tokio::task::yield_now().await;
+
+        // The delete commits while the reload is parked: row out, epoch up.
+        // Both happen before the lock is released, mirroring the real purge.
+        state
+            .delete_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        drop(guard);
+
+        reload.await.expect("reload task");
+
+        let titles: Vec<String> = state
+            .instances
+            .read()
+            .await
+            .iter()
+            .map(|i| i.title.clone())
+            .collect();
+        assert!(
+            !titles.contains(&"doomed".to_string()),
+            "a reload that was already waiting on the lock when the delete landed must still drop: {titles:?}"
+        );
     }
 
     // The guard must not be implemented by dropping ids missing from the prior
@@ -8566,6 +8642,9 @@ mod tests {
         .await
         .expect("bootstrap wake must fire after init returns");
 
+        // Invariant 8: capture the epoch BEFORE the disk read, the order every
+        // production caller uses.
+        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
         let file_watch = state.file_watch.clone();
         let fresh = tokio::task::spawn_blocking(move || load_all_instances(&file_watch))
             .await
@@ -8576,7 +8655,7 @@ mod tests {
             fresh,
             Vec::new(),
             StatusSource::DiskOnly,
-            state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst),
+            read_epoch,
         )
         .await;
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -395,9 +395,10 @@ pub struct AppState {
     /// Bumped once per committed session removal, after the row is gone from
     /// both `sessions.json` and `instances`. A reloader reads it before its
     /// disk read and hands the value back to
-    /// [`reload_state_instances_from_disk`], which drops the reload when the
+    /// `reload_state_instances_from_disk`, which drops the reload when the
     /// value moved: the disk snapshot it is carrying predates a delete, so
-    /// folding it in would resurrect the removed row. See invariant 8.
+    /// folding it in would resurrect the removed row. See invariant 8 on that
+    /// function.
     pub delete_epoch: std::sync::atomic::AtomicU64,
     /// Ids whose startup-recovery cascade is scheduled but not yet complete.
     /// Phase A seeds it; each Phase B worker drains its id on completion. The

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -392,6 +392,13 @@ pub struct AppState {
     /// transitions to `Status::Error` for up to 8 seconds while the agent
     /// is still settling. Periodically GC'd by a background task.
     pub recently_restarted: crate::session::recovery::RecentlyRestarted,
+    /// Bumped once per committed session removal, after the row is gone from
+    /// both `sessions.json` and `instances`. A reloader reads it before its
+    /// disk read and hands the value back to
+    /// [`reload_state_instances_from_disk`], which drops the reload when the
+    /// value moved: the disk snapshot it is carrying predates a delete, so
+    /// folding it in would resurrect the removed row. See invariant 8.
+    pub delete_epoch: std::sync::atomic::AtomicU64,
     /// Ids whose startup-recovery cascade is scheduled but not yet complete.
     /// Phase A seeds it; each Phase B worker drains its id on completion. The
     /// background refresher walks it to keep queued candidates' marks in
@@ -1201,6 +1208,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             crate::session::conversation_summary::MAX_CONCURRENT,
         ),
         recently_restarted: crate::session::recovery::new_recently_restarted(),
+        delete_epoch: std::sync::atomic::AtomicU64::new(0),
         recovery_pending: crate::session::recovery::new_recovery_pending(),
         cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {
             // Seed with an already-stale timestamp so the first request
@@ -3143,6 +3151,16 @@ fn skip_tmux_decision_for_structured(inst: &mut Instance) -> bool {
 //    scrape can briefly carry the prior status; it self-corrects on
 //    the next 2s tick. Polling is canonical (invariant 6) so this is
 //    acceptable.
+// 8. Every caller must read `state.delete_epoch` BEFORE its disk read and
+//    pass that value as `read_epoch`. `fresh` is a snapshot of
+//    `sessions.json`, and `*current = merged` below replaces
+//    `state.instances` wholesale, so a delete that commits between the
+//    read and this call would otherwise be undone: the deleted row is
+//    still in `fresh` and comes straight back. The epoch check drops such
+//    a reload rather than resurrecting the row. Dropping ids missing from
+//    `prior_by_id` is NOT an alternative; that is also how a session
+//    created by another process (the CLI, a peer daemon) legitimately
+//    enters `state.instances`.
 
 /// Reload `state.instances` by merging caller-supplied `fresh` against the
 /// prior in-memory snapshot per id, then reapplying the acp overlay.
@@ -3179,7 +3197,23 @@ pub(crate) async fn reload_state_instances_from_disk(
     fresh: Vec<Instance>,
     #[cfg(feature = "serve")] live_worker_records: Vec<LiveStructuredWorkerRecord>,
     status_source: StatusSource,
+    read_epoch: u64,
 ) {
+    // Invariant 8: `fresh` predates a committed delete, so folding it in would
+    // put the removed row back. Drop the whole reload rather than filter it:
+    // the next poll tick re-reads disk 2s from now and converges, and a delete
+    // is rare enough that losing one tick of status updates costs nothing.
+    let current_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
+    if current_epoch != read_epoch {
+        tracing::debug!(
+            target: "server.file_watch",
+            read_epoch,
+            current_epoch,
+            "dropping a disk reload whose snapshot predates a session delete"
+        );
+        return;
+    }
+
     // Snapshot suppression here so a worker that unmarks between the
     // caller's input build and the per-id decision cannot combine a
     // cleared mark with a stale row to re-emit the phantom Error
@@ -3716,6 +3750,9 @@ async fn disk_watcher_consumer(state: Arc<AppState>) {
             _ = state.disk_changed.notified() => {}
         }
         let started = std::time::Instant::now();
+        // Invariant 8: read before the disk read, so a delete committing
+        // during it invalidates this snapshot.
+        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
         let file_watch_for_load = state.file_watch.clone();
         let loaded = match tokio::task::spawn_blocking(move || {
             load_all_instances(&file_watch_for_load)
@@ -3748,6 +3785,7 @@ async fn disk_watcher_consumer(state: Arc<AppState>) {
             fresh,
             live_worker_records,
             StatusSource::DiskOnly,
+            read_epoch,
         )
         .await;
         tracing::trace!(
@@ -4367,6 +4405,11 @@ async fn status_poll_loop(state: Arc<AppState>) {
         // lands) misreads that mismatch as a brand new transition and
         // restamps idle_entered_at/last_accessed_at. See #2690.
         let prev_for_poll = prev.clone();
+        // Invariant 8: read before `load_all_instances()` below. The tmux
+        // scrape that follows it can block for seconds when the tmux server is
+        // unreachable, which is exactly when a concurrent delete has time to
+        // land and this tick's snapshot goes stale.
+        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
         let updated = tokio::task::spawn_blocking(move || {
             let mut instances = load_all_instances(&file_watch_for_poll).unwrap_or_default();
             seed_unknown_tracking(&mut instances, &prev_unknown_tracking);
@@ -4440,6 +4483,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
                 instances,
                 live_worker_records,
                 StatusSource::TmuxApplied,
+                read_epoch,
             )
             .await;
 
@@ -5917,6 +5961,7 @@ pub mod test_support {
                 crate::session::conversation_summary::MAX_CONCURRENT,
             ),
             recently_restarted: crate::session::recovery::new_recently_restarted(),
+            delete_epoch: std::sync::atomic::AtomicU64::new(0),
             recovery_pending: crate::session::recovery::new_recovery_pending(),
             cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {
                 refreshed_at: std::time::Instant::now(),
@@ -6022,11 +6067,13 @@ pub mod test_support {
         fresh: Vec<Instance>,
         live_worker_records: Vec<(crate::process::worker_registry::WorkerRecord, String)>,
     ) {
+        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
         super::reload_state_instances_from_disk(
             state,
             fresh,
             live_worker_records,
             super::StatusSource::DiskOnly,
+            read_epoch,
         )
         .await
     }
@@ -6036,11 +6083,13 @@ pub mod test_support {
         fresh: Vec<Instance>,
         live_worker_records: Vec<(crate::process::worker_registry::WorkerRecord, String)>,
     ) {
+        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
         super::reload_state_instances_from_disk(
             state,
             fresh,
             live_worker_records,
             super::StatusSource::TmuxApplied,
+            read_epoch,
         )
         .await
     }
@@ -8375,7 +8424,14 @@ mod tests {
             .await
             .expect("join")
             .expect("load");
-        reload_state_instances_from_disk(&state, fresh, Vec::new(), StatusSource::DiskOnly).await;
+        reload_state_instances_from_disk(
+            &state,
+            fresh,
+            Vec::new(),
+            StatusSource::DiskOnly,
+            state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst),
+        )
+        .await;
 
         let instances = state.instances.read().await;
         let titles: Vec<&str> = instances.iter().map(|i| i.title.as_str()).collect();
@@ -8388,6 +8444,85 @@ mod tests {
             titles.contains(&"p2-mid-init"),
             "writes DURING init's iteration (the gap window) must be reconciled by the bootstrap wake; titles: {:?}",
             titles
+        );
+    }
+
+    // A reloader reads `sessions.json`, then does slow work (the poll loop's
+    // tmux scrape, which blocks for seconds when the tmux server is
+    // unreachable) before folding the snapshot into `state.instances`. A
+    // delete committing inside that window used to come straight back, because
+    // the merge rebuilds `state.instances` wholesale from the stale snapshot.
+    // Observed as a live Playwright failure: DELETE returned 200, the sidebar
+    // row went away, and the very next `GET /api/sessions` listed the session
+    // again with its pre-delete status. See invariant 8.
+    #[tokio::test]
+    async fn a_reload_predating_a_delete_does_not_resurrect_the_removed_row() {
+        let doomed = Instance::new("doomed", "/tmp/doomed");
+        let survivor = Instance::new("survivor", "/tmp/survivor");
+        // What a reloader read from disk before the delete landed.
+        let stale_snapshot = vec![doomed.clone(), survivor.clone()];
+        let read_epoch = 0;
+
+        let state = test_support::build_test_app_state(vec![survivor.clone()]);
+        // The delete already committed: `doomed` is gone from memory, and the
+        // epoch moved to say so.
+        state
+            .delete_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        reload_state_instances_from_disk(
+            &state,
+            stale_snapshot,
+            Vec::new(),
+            StatusSource::DiskOnly,
+            read_epoch,
+        )
+        .await;
+
+        let titles: Vec<String> = state
+            .instances
+            .read()
+            .await
+            .iter()
+            .map(|i| i.title.clone())
+            .collect();
+        assert!(
+            !titles.contains(&"doomed".to_string()),
+            "a deleted session must not come back from a pre-delete snapshot: {titles:?}"
+        );
+        assert_eq!(titles, vec!["survivor".to_string()]);
+    }
+
+    // The guard must not be implemented by dropping ids missing from the prior
+    // in-memory map: that is also how a session created by another process
+    // (the CLI, a peer daemon) legitimately arrives. Only a moved epoch means
+    // "this snapshot predates a delete".
+    #[tokio::test]
+    async fn a_reload_at_the_current_epoch_still_adopts_externally_created_rows() {
+        let known = Instance::new("known", "/tmp/known");
+        let created_elsewhere = Instance::new("created-elsewhere", "/tmp/elsewhere");
+        let state = test_support::build_test_app_state(vec![known.clone()]);
+        let read_epoch = state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst);
+
+        reload_state_instances_from_disk(
+            &state,
+            vec![known, created_elsewhere],
+            Vec::new(),
+            StatusSource::DiskOnly,
+            read_epoch,
+        )
+        .await;
+
+        let titles: Vec<String> = state
+            .instances
+            .read()
+            .await
+            .iter()
+            .map(|i| i.title.clone())
+            .collect();
+        assert!(
+            titles.contains(&"created-elsewhere".to_string()),
+            "a row this daemon has never seen must still be adopted: {titles:?}"
         );
     }
 
@@ -8435,7 +8570,14 @@ mod tests {
             .await
             .expect("join")
             .expect("load");
-        reload_state_instances_from_disk(&state, fresh, Vec::new(), StatusSource::DiskOnly).await;
+        reload_state_instances_from_disk(
+            &state,
+            fresh,
+            Vec::new(),
+            StatusSource::DiskOnly,
+            state.delete_epoch.load(std::sync::atomic::Ordering::SeqCst),
+        )
+        .await;
 
         let instances = state.instances.read().await;
         assert!(


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The `aoe-plugin` GitHub topic collides with the Age of Empires modding namespace, so the plugin marketplace listed repos that are not plugins at all. At the time of writing the topic held 5 repos and one of them, `FedericoBoccaccioPersonale/AoE2DE-Pixel-Monitor` (an Age of Empires 2 Definitive Edition pixel-monitoring tool), had no `aoe-plugin.toml`. It rendered as a normal `unvetted` result with a live Install button in the dashboard and an `aoe plugin install gh:...` command in the CLI. The user only found out after the install path cloned the repo and failed to read a manifest.

Discovery now probes each unvetted result with a `HEAD` on `raw.githubusercontent.com` for `aoe-plugin.toml` at the default branch, and drops the ones that answer 404. The raw CDN is deliberately not the contents API `details()` uses: that draws on the 60/hr unauthenticated core budget, which a single 30-result page would half exhaust, and avoiding exactly that cost is why discovery skipped per-repo manifest reads in the first place. `HEAD` answers the only question the list needs and downloads no body.

The probe outcome is tri-state internally (`Present` / `Missing` / `Unknown`) so "this repo has no manifest" is never conflated with "we could not check". Only a definitive 404 drops a result. A 403 or 429 (CDN throttling), a 5xx, a transport error, a timeout, or a probe still in flight when the phase deadline fires all fail open and keep the row. Installed and featured sources are never probed at all: both install from a pinned ref, so a manifest missing from the default branch today does not make them uninstallable, and acting on that would be a false alarm on a working plugin.

Nothing is added to the serialized `DiscoveryResult` and no surface renders probe state. Whether the check ran is a property of one request from one client at one moment, not a property of the plugin, and a row-level "unverified" marker would explain a degraded run without preventing it. The diagnostic need is met with aggregate logging on the `plugin.discover` target instead, including a `warn!` for the case where nothing came back conclusive (a network that reaches `api.github.com` but blocks `raw.githubusercontent.com` does this, and the filter then provides none of its value).

Because the filter fails open, install stays the authoritative answer, so its error now leads with the likely cause instead of a staging path.

Latency is bounded by both a 4s per-request timeout and a 6s ceiling on the whole probe phase. Concurrency alone does not bound it: a full 30-result page at concurrency 8 is four serial batches. The phase drains under a deadline rather than wrapping the collect in one timeout, so one hung repo cannot discard the probes that already came back and unfilter the entire page.

Closes #3323

### Unrelated fix carried here: a stale disk reload could resurrect a deleted session

CI on this PR hit a failure in `web/tests/live/golden-path.spec.ts` that turned out to be a real backend race rather than test flakiness, so it is fixed here rather than rerun. It is unrelated to plugin discovery; I am carrying it in this PR at the maintainer's direction, and it is isolated in its own commit (`317e3d0e4`) for review.

A reloader reads `sessions.json`, then does slow work before folding the snapshot into `state.instances`. In `status_poll_loop` that slow work is `refresh_session_cache()` plus `batch_pane_metadata()`, which shell out to tmux and block for seconds when the tmux server is unreachable. `reload_state_instances_from_disk` then rebuilds `state.instances` wholesale from the snapshot, so a delete committing inside that window came straight back, carrying its pre-delete status.

That is exactly what the CI artifact showed: `DELETE` returned 200, the sidebar row went away, and the next `GET /api/sessions` listed the session again with `status: "Error"` and `last_error: "tmux server could not be reached"`. The gap between the row's `created_at` and `last_accessed_at` was 4.24s, matching `UNKNOWN_ERROR_WINDOW_NEVER_PRESENT`, so the poller had latched `Error` before the delete and that stale row is what returned. It self-heals on the next tick, so the user-visible window is up to one poll period, but for that window the API contradicts a delete it just reported as successful.

Fix: a `delete_epoch` on `AppState`, bumped once the row is gone from both disk and memory. Both reloaders read it before their disk read and pass it back; the merge drops the reload when the value moved. Dropping the whole tick rather than filtering the single row keeps the guard trivial, and the next tick converges 2s later.

Filtering ids missing from the prior in-memory map would have been the wrong fix: that is also how a session created by another process (the CLI, a peer daemon) legitimately enters `state.instances`. The second regression test pins that case so the guard cannot be "simplified" into breaking it.

Both tests were verified red before green by neutering the guard: the resurrection test then fails with `["doomed", "survivor"]`, the exact symptom, while the external-creation test still passes.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe plugin discover`. `gh:FedericoBoccaccioPersonale/AoE2DE-Pixel-Monitor` is absent; the four real plugins (`plugin-github`, `plugin-cron`, `Talador12/agent-of-agent-of-empires`, `amanzainal/aoe-voice-input`) are all still listed. Compare against `https://api.github.com/search/repositories?q=topic:aoe-plugin+fork:false+archived:false`, which still returns 5.
- [ ] Confirm the search is not noticeably slower: the full `aoe plugin discover` round trip stays around 2 to 3 seconds.
- [ ] Run `AOE_LOG_LEVEL=debug aoe plugin discover`, then check the log for `plugin.discover: manifest probes`. It should read `present=2 missing=1 unknown=0`, showing the two featured sources were skipped rather than probed.
- [ ] Open the dashboard Plugins page, click "Search GitHub", and confirm the same four results with no Install button on a non-plugin.
- [ ] Open the TUI plugin manager, press `d`, and confirm the same list.
- [ ] Simulate the CDN being unreachable (block `raw.githubusercontent.com` in `/etc/hosts` or on the network) and search again. All 5 results come back rather than an empty list, and the log carries the `every manifest probe was inconclusive` warning.
- [ ] With the CDN still blocked, run `aoe plugin install gh:FedericoBoccaccioPersonale/AoE2DE-Pixel-Monitor`. It fails with "this repository is not an installable plugin" and the note about the Age of Empires topic collision, rather than a bare path.
- [ ] Session delete race: with `aoe serve` running and a session open in the dashboard, delete it, then immediately reload the page a few times. The session stays gone; it never reappears with an `Error` status for a second or two before vanishing again.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

No web file changes. The dashboard renders whatever `GET /api/plugins/discover` returns, and the response shape is unchanged.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the session-delete race is covered by two new Rust unit tests on `reload_state_instances_from_disk`, verified red before green. Reproducing it through the live suite would mean racing a 2s poll tick against a delete, which is what made it an intermittent CI failure in the first place; the unit tests pin the mechanism deterministically instead. For the discovery change, the behavior an e2e test would assert depends on live GitHub search plus live CDN responses, which is neither deterministic nor offline-safe. The layer that can actually regress is the filter policy, and that is covered by pure unit tests in `src/plugin/discover.rs`: the status-to-outcome mapping table (200, 404, 403, 429, 5xx, transport error), the drop rule across probed-missing, probed-present, probed-unknown, unprobed, installed, and featured rows, the all-missing case that yields the empty state, and an assertion that the probe URL targets the raw CDN rather than `api_base()`. No TUI rendering, CLI flag, or help text changed.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**

Investigation, plan, and implementation drafted by Claude under my direction. The plan went through a multi-model debate before any code was written, which cut the original scope: I had approved a user-visible "unverified" badge on all three surfaces, and the debate argued it down to internal-only state, which is why the diff is 2 files instead of 6. I made the design calls, reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Checks unvetted GitHub repositories for `aoe-plugin.toml` before listing them.
- Removes repositories only after a confirmed 404 response.
- Keeps installed and featured plugins visible.
- Uses bounded, fail-open checks for network errors and throttling.
- Adds diagnostics and regression tests for discovery and manifest validation.
- Improves installation errors for repositories without a manifest.
- Prevents deleted sessions from returning during concurrent reloads.
- Preserves sessions created by other processes.
- Adds tests for both session scenarios.

## Benefits

Users see fewer invalid plugin listings and receive clearer installation errors. Discovery remains resilient during network problems. Deleted sessions remain deleted after reloads.

## Further enhancement

Future work could show an unverified status or adjust ranking for inconclusive results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->