### PR TITLE
fix(web): drain queued structured-view prompts while the chat is unmounted

### DIFF
--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -261,8 +261,9 @@ follow from the queue being browser-local:
 - It drains only while a dashboard tab is open, and only three sessions
   are serviced at once. The rest keep their queue and their **N queued**
   badge until a slot frees or you open them.
-- With several tabs open, exactly one of them sends. The others see the
-  queue empty out.
+- With several tabs open, exactly one of them sends. The winner announces
+  the delivery to the others, so they drop the sent entries instead of
+  re-sending them.
 - Your other devices neither see nor drain the queue.
 
 After a reload, a restored queue resumes draining in the background only

--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -252,6 +252,24 @@ the whole row is dropped on reload rather than draining a text-only
 prompt with the image missing. There is no server-side durability;
 clearing site data wipes the queue.
 
+**Draining while the chat is closed.** The drain does not need the
+session's chat to be the one on screen: the dashboard keeps a background
+subscription for each session with prompts waiting, so a follow-up you
+parked in one chat is delivered while you work in another. Three limits
+follow from the queue being browser-local:
+
+- It drains only while a dashboard tab is open, and only three sessions
+  are serviced at once. The rest keep their queue and their **N queued**
+  badge until a slot frees or you open them.
+- With several tabs open, exactly one of them sends. The others see the
+  queue empty out.
+- Your other devices neither see nor drain the queue.
+
+After a reload, a restored queue resumes draining in the background only
+when its newest entry is under an hour old. An older one waits until you
+open that chat, so a prompt parked days ago never fires at an agent you
+have since moved on from.
+
 **Editing a queued prompt.** Click any queued row to edit it inline, or,
 with the composer empty (caret at the start), press `↑` to pull the most
 recent queued prompt back into the composer; `↑` again walks toward older

--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -252,25 +252,6 @@ the whole row is dropped on reload rather than draining a text-only
 prompt with the image missing. There is no server-side durability;
 clearing site data wipes the queue.
 
-**Draining while the chat is closed.** The drain does not need the
-session's chat to be the one on screen: the dashboard keeps a background
-subscription for each session with prompts waiting, so a follow-up you
-parked in one chat is delivered while you work in another. Three limits
-follow from the queue being browser-local:
-
-- It drains only while a dashboard tab is open, and only three sessions
-  are serviced at once. The rest keep their queue and their **N queued**
-  badge until a slot frees or you open them.
-- With several tabs open, exactly one of them sends. The winner announces
-  the delivery to the others, so they drop the sent entries instead of
-  re-sending them.
-- Your other devices neither see nor drain the queue.
-
-After a reload, a restored queue resumes draining in the background only
-when its newest entry is under an hour old. An older one waits until you
-open that chat, so a prompt parked days ago never fires at an agent you
-have since moved on from.
-
 **Editing a queued prompt.** Click any queued row to edit it inline, or,
 with the composer empty (caret at the start), press `↑` to pull the most
 recent queued prompt back into the composer; `↑` again walks toward older

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -120,6 +120,13 @@ const StructuredView = lazy(() =>
     default: m.StructuredView,
   })),
 );
+// Lazy for the same reason: it pulls in `useAcpSession`, which belongs to
+// the structured-view chunk and has no business in a tmux-only cold start.
+const AcpBackgroundDrainers = lazy(() =>
+  import("./components/acp/AcpQueueDrainer").then((m) => ({
+    default: m.AcpBackgroundDrainers,
+  })),
+);
 import { type PaneDisplay } from "./components/Dock";
 import { DockGroups, type DockGroupView } from "./components/DockGroups";
 import { BottomDock } from "./components/BottomDock";
@@ -746,6 +753,9 @@ function AppContent({
     return workspaces.find((w) => w.sessions.some((s) => s.id === activeSessionId));
   }, [workspaces, activeSessionId]);
   const activeSession = activeWorkspace?.sessions.find((s) => s.id === activeSessionId);
+  // Flat session list, for the background queue drainers below. They need
+  // every structured session, not just the visible workspace's. See #3331.
+  const allSessions = useMemo(() => workspaces.flatMap((w) => w.sessions), [workspaces]);
   const allPaneIds: string[] = [
     // CityHall client mode hides the code-inspection panes (diff, files) and
     // the terminal (plus plugin panes below) so only the composer + structured
@@ -2163,6 +2173,13 @@ function AppContent({
 
   return (
     <AcpPrefsProvider value={acpPrefs}>
+      {/* Headless: holds a subscription for each structured session with
+          queued prompts waiting whose chat is not on screen, so a parked
+          follow-up is delivered without the user navigating back to it.
+          Renders no DOM. See #3331. */}
+      <Suspense fallback={null}>
+        <AcpBackgroundDrainers sessions={allSessions} activeSessionId={activeSessionId} />
+      </Suspense>
       <div className="h-dvh flex flex-col bg-surface-900 text-text-primary overflow-hidden safe-area-inset">
         {/* Wrapped unconditionally, not behind the `headerCollapsible`
             ternary: swapping the element type at this position would remount

--- a/web/src/components/acp/AcpQueueDrainer.test.tsx
+++ b/web/src/components/acp/AcpQueueDrainer.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+//
+// Which sessions get a headless drain subscription (#3331). Each one costs
+// a WebSocket and a replay top-up, so the selection rules are the point:
+// structured sessions only, never the chat already on screen, never a
+// trashed session, only armed queues, capped at MAX_BACKGROUND_DRAINERS.
+//
+// `useAcpSession` is mocked to a spy: this asserts the selection, not the
+// subscription machinery (covered in useAcpSession.queue.test.ts).
+
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AcpBackgroundDrainers } from "./AcpQueueDrainer";
+import { __resetDrainCoordinator, armForBackgroundDrain } from "../../lib/acpDrainCoordinator";
+import { MAX_BACKGROUND_DRAINERS } from "../../hooks/useAcpQueueCount";
+import { setQueueCount } from "../../lib/acpStateStorage";
+import type { SessionResponse } from "../../lib/types";
+
+const subscribed = vi.fn();
+
+vi.mock("../../hooks/useAcpSession", () => ({
+  useAcpSession: (sessionId: string) => {
+    subscribed(sessionId);
+    return {};
+  },
+}));
+
+function session(id: string, over: Partial<SessionResponse> = {}): SessionResponse {
+  return {
+    id,
+    title: id,
+    tool: "claude",
+    view: "structured",
+    trashed_at: null,
+    archived_at: null,
+    snoozed_until: null,
+    acp_worker_state: "running",
+    ...over,
+  } as SessionResponse;
+}
+
+/** Give a session a queue and arm it, the state a parked prompt leaves. */
+function queued(id: string): void {
+  setQueueCount(id, 1);
+  armForBackgroundDrain(id);
+}
+
+beforeEach(() => {
+  subscribed.mockClear();
+  window.localStorage.clear();
+  __resetDrainCoordinator();
+});
+
+afterEach(() => {
+  __resetDrainCoordinator();
+});
+
+describe("AcpBackgroundDrainers", () => {
+  it("subscribes only to armed, queued, non-active structured sessions", () => {
+    const sessions = [
+      session("with-queue"),
+      session("active-with-queue"),
+      session("no-queue"),
+      session("terminal-with-queue", { view: "terminal" }),
+      session("trashed-with-queue", { trashed_at: "2026-08-12T00:00:00Z" }),
+      session("unarmed-with-queue"),
+    ];
+    for (const id of ["with-queue", "active-with-queue", "terminal-with-queue", "trashed-with-queue"]) {
+      queued(id);
+    }
+    // Queued but never armed: a stale queue restored from storage. It keeps
+    // its badge and waits for the user to open that chat.
+    setQueueCount("unarmed-with-queue", 1);
+
+    render(<AcpBackgroundDrainers sessions={sessions} activeSessionId="active-with-queue" />);
+
+    expect(subscribed.mock.calls.map((c) => c[0])).toEqual(["with-queue"]);
+  });
+
+  it("renders no DOM and caps concurrent subscriptions", () => {
+    const ids = Array.from({ length: MAX_BACKGROUND_DRAINERS + 2 }, (_, i) => `s${i}`);
+    for (const id of ids) queued(id);
+
+    const { container } = render(
+      <AcpBackgroundDrainers sessions={ids.map((id) => session(id))} activeSessionId={null} />,
+    );
+
+    // Over the cap: the extras keep their queue and drain once a slot frees
+    // or the user opens them, rather than opening a socket each.
+    expect(subscribed).toHaveBeenCalledTimes(MAX_BACKGROUND_DRAINERS);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/web/src/components/acp/AcpQueueDrainer.tsx
+++ b/web/src/components/acp/AcpQueueDrainer.tsx
@@ -1,0 +1,86 @@
+// Headless owner for a structured-view session whose chat is not the one
+// on screen but which still has queued prompts to deliver.
+//
+// Before #3331 `useAcpSession` existed only inside the visible chat, so a
+// queued follow-up sat undelivered until the user navigated back to it.
+// This mounts the same hook with no UI attached: it holds that session's
+// WebSocket, watches for the turn to end, and lets the hook's own drain
+// effect fire. Deliberately its own subscription rather than teaching the
+// visible session's socket to schedule other sessions.
+//
+// The AgentProfileProvider is not decorative. The drain slices its batch
+// at clear-command aliases (`/clear`, `/new`), and those aliases come from
+// the profile. Without a provider carrying THIS session's tool the drain
+// would read the default profile and batch a queued `/clear` into the
+// combined prompt instead of firing it alone.
+
+import { useMemo } from "react";
+
+import { useBackgroundDrainSessionIds } from "../../hooks/useAcpQueueCount";
+import { AgentProfileProvider } from "../../lib/agentProfileContext";
+import { useAcpSession } from "../../hooks/useAcpSession";
+import type { AcpWorkerState, SessionResponse } from "../../lib/types";
+
+interface Props {
+  sessionId: string;
+  /** The session's `tool`, for clear-alias resolution. */
+  tool: string | null | undefined;
+  acpWorkerState: AcpWorkerState;
+  archivedAt: string | null;
+  snoozedUntil: string | null;
+}
+
+function DrainerSubscription({ sessionId, acpWorkerState, archivedAt, snoozedUntil }: Omit<Props, "tool">) {
+  useAcpSession(sessionId, acpWorkerState, archivedAt, snoozedUntil);
+  return null;
+}
+
+export function AcpQueueDrainer({ sessionId, tool, acpWorkerState, archivedAt, snoozedUntil }: Props) {
+  return (
+    <AgentProfileProvider toolKey={tool}>
+      <DrainerSubscription
+        sessionId={sessionId}
+        acpWorkerState={acpWorkerState}
+        archivedAt={archivedAt}
+        snoozedUntil={snoozedUntil}
+      />
+    </AgentProfileProvider>
+  );
+}
+
+/** Mount a drainer for every structured session that has queued prompts
+ *  waiting and whose chat is not the one on screen. Renders nothing.
+ *  Trashed sessions are skipped: their worker is down and only a restore
+ *  brings it back, so a subscription would park forever. */
+export function AcpBackgroundDrainers({
+  sessions,
+  activeSessionId,
+}: {
+  sessions: readonly SessionResponse[];
+  activeSessionId: string | null;
+}) {
+  const candidates = useMemo(
+    () => sessions.filter((s) => s.view === "structured" && s.id !== activeSessionId && !s.trashed_at),
+    [sessions, activeSessionId],
+  );
+  const candidateIds = useMemo(() => candidates.map((s) => s.id), [candidates]);
+  const drainIds = useBackgroundDrainSessionIds(candidateIds);
+  return (
+    <>
+      {drainIds.map((id) => {
+        const session = candidates.find((s) => s.id === id);
+        if (!session) return null;
+        return (
+          <AcpQueueDrainer
+            key={id}
+            sessionId={id}
+            tool={session.tool}
+            acpWorkerState={session.acp_worker_state ?? "absent"}
+            archivedAt={session.archived_at ?? null}
+            snoozedUntil={session.snoozed_until ?? null}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -2375,7 +2375,7 @@ export function QueuedPromptsStrip({ queued, onRemove, onEdit, onClear, pendingR
               assume the daemon is holding the message. See #3331. */}
           <span
             className="inline-flex items-center gap-1"
-            title="Queued in this browser. Sends when the agent is free, even from another chat, as long as a dashboard tab stays open. Your other devices do not see it."
+            title="Queued in this browser. Sends when the agent is free, even from another chat, as long as a dashboard tab stays open. Three closed chats deliver in the background at a time; the rest wait for a slot or for you to open them. Your other devices do not see it."
           >
             <Clock className="h-3 w-3" />
             {pendingResume ? `Pending until session resumes (${queued.length})` : `Queued (${queued.length})`}

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -2370,7 +2370,13 @@ export function QueuedPromptsStrip({ queued, onRemove, onEdit, onClear, pendingR
     <div className="border-t border-surface-800 bg-surface-900/60 px-4 py-2">
       <div className="mx-auto max-w-3xl xl:max-w-4xl 2xl:max-w-5xl">
         <div className="flex items-center justify-between pb-1.5 text-[11px] uppercase tracking-wider text-text-dim">
-          <span className="inline-flex items-center gap-1">
+          {/* The queue is browser-local, which is not something a user can
+              work out from the strip. Say so here rather than let them
+              assume the daemon is holding the message. See #3331. */}
+          <span
+            className="inline-flex items-center gap-1"
+            title="Queued in this browser. Sends when the agent is free, even from another chat, as long as a dashboard tab stays open. Your other devices do not see it."
+          >
             <Clock className="h-3 w-3" />
             {pendingResume ? `Pending until session resumes (${queued.length})` : `Queued (${queued.length})`}
           </span>

--- a/web/src/hooks/useAcpQueueCount.ts
+++ b/web/src/hooks/useAcpQueueCount.ts
@@ -6,6 +6,7 @@
 
 import { useMemo, useSyncExternalStore } from "react";
 
+import { isArmedForBackgroundDrain } from "../lib/acpDrainCoordinator";
 import { getQueuedCount, subscribeAcpState } from "../lib/acpStateStorage";
 
 // Returns the total number of queued structured view follow-up prompts across the
@@ -31,4 +32,43 @@ export function useQueuedCountForSessions(sessionIds: readonly string[]): number
     },
     () => 0,
   );
+}
+
+/** How many sessions may hold a background drain subscription at once.
+ *  Each one costs a WebSocket plus a replay top-up, and a queue can
+ *  accumulate across many sessions, so this bounds the fan-out rather
+ *  than trusting the queue count to stay small. Sessions past the cap
+ *  keep their queue and their badge; they drain as earlier ones finish or
+ *  when the user opens them. */
+export const MAX_BACKGROUND_DRAINERS = 3;
+
+/** Pick which of `candidateIds` should get a headless drain subscription:
+ *  those with a non-empty queue that is armed for background delivery,
+ *  capped at `MAX_BACKGROUND_DRAINERS`. Callers pass only sessions whose
+ *  chat is NOT mounted, since a visible chat already owns its own hook.
+ *  See #3331. */
+export function useBackgroundDrainSessionIds(candidateIds: readonly string[]): string[] {
+  // Same stable-primitive contract as useQueuedCountForSessions: the
+  // snapshot returns a joined string so useSyncExternalStore never tears
+  // on a fresh array identity.
+  const ids = candidateIds.join("|");
+  const subscribe = useMemo(() => {
+    const filter = new Set(ids ? ids.split("|").filter(Boolean) : []);
+    return (cb: () => void) => subscribeAcpState(cb, filter);
+  }, [ids]);
+  const picked = useSyncExternalStore(
+    subscribe,
+    () => {
+      const out: string[] = [];
+      for (const id of ids ? ids.split("|") : []) {
+        if (out.length >= MAX_BACKGROUND_DRAINERS) break;
+        if (!id || getQueuedCount(id) === 0) continue;
+        if (!isArmedForBackgroundDrain(id)) continue;
+        out.push(id);
+      }
+      return out.join("|");
+    },
+    () => "",
+  );
+  return useMemo(() => (picked ? picked.split("|") : []), [picked]);
 }

--- a/web/src/hooks/useAcpSession.queue.test.ts
+++ b/web/src/hooks/useAcpSession.queue.test.ts
@@ -14,10 +14,11 @@ import { act, renderHook } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { __resetDrainCoordinator, isDraining } from "../lib/acpDrainCoordinator";
 import { emptyAcpState, type QueuedPrompt } from "../lib/acpTypes";
 import { AgentProfileProvider } from "../lib/agentProfileContext";
 import { reportAcpInteraction } from "../lib/api";
-import { acpHookReducer, combineQueuedPrompts, useAcpSession } from "./useAcpSession";
+import { acpHookReducer, clearAcpCache, combineQueuedPrompts, useAcpSession } from "./useAcpSession";
 
 // Spy on the telemetry ping while keeping the rest of the api module real
 // (the hook also calls setSessionArchive / setSessionSnooze through it).
@@ -1676,5 +1677,116 @@ describe("useAcpSession drain split at clear-command boundary (#1356)", () => {
     expect(promptPostCount).toBe(1);
     expect(bodyTexts()).toEqual(["a\n\n/clear\n\nb"]);
     expect(hookResult.current.state.queuedPrompts).toEqual([]);
+  });
+});
+
+// #3331: a session can now drain while its chat is unmounted, so a drain
+// started by the headless background drainer can resolve after the user
+// has navigated into that chat and a second hook instance owns the
+// session. Ownership therefore lives in the module-level drain
+// coordinator, not in a per-instance ref, and the retirement is written
+// through the shared cache instead of a bare dispatch.
+describe("useAcpSession drain handoff across instances (#3331)", () => {
+  let promptPostCount: number;
+  let releasePrompt: (() => void) | null;
+
+  beforeEach(() => {
+    sockets.length = 0;
+    promptPostCount = 0;
+    releasePrompt = null;
+    clearAcpCache();
+    __resetDrainCoordinator();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/acp/replay")) {
+          return new Response(JSON.stringify({ frames: [], lost: false, highest_seq: 0 }), { status: 200 });
+        }
+        if (url.includes("/acp/prompt")) {
+          promptPostCount += 1;
+          // Hold the POST open so the test can swap hook instances while
+          // it is in flight, which is exactly the navigation race.
+          await new Promise<void>((resolve) => {
+            releasePrompt = resolve;
+          });
+          return new Response("{}", { status: 200 });
+        }
+        return new Response("{}", { status: 200 });
+      }),
+    );
+    originalWebSocket = global.WebSocket;
+    global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterEach(() => {
+    global.WebSocket = originalWebSocket;
+    vi.unstubAllGlobals();
+    clearAcpCache();
+    __resetDrainCoordinator();
+  });
+
+  it("does not re-send a batch when a second instance mounts mid-drain", async () => {
+    const sessionId = "sess-handoff";
+    const first = renderHook(() => useAcpSession(sessionId));
+    await flushAsync();
+    const ws = sockets[0]!;
+
+    // Park a prompt while the socket is still CONNECTING, then open the
+    // socket so the drain fires and hangs on the gated POST.
+    act(() => {
+      void first.result.current.sendPrompt("parked follow-up");
+    });
+    await flushAsync();
+    expect(promptPostCount).toBe(0);
+
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+    expect(promptPostCount).toBe(1);
+    expect(releasePrompt).not.toBeNull();
+
+    // The user navigates into this chat: the background owner goes away
+    // and a fresh instance mounts, hydrating the still-queued row out of
+    // the shared cache. It must not fire a second POST.
+    first.unmount();
+    const second = renderHook(() => useAcpSession(sessionId));
+    await flushAsync();
+    const secondWs = sockets[sockets.length - 1]!;
+    act(() => {
+      secondWs.readyState = FakeWebSocket.OPEN;
+      secondWs.onopen?.({} as Event);
+    });
+    await flushAsync();
+    expect(second.result.current.state.queuedPrompts).toHaveLength(1);
+    expect(promptPostCount).toBe(1);
+
+    // The original POST lands. Its retirement reaches the instance that is
+    // actually mounted now, so the delivered row leaves the queue exactly
+    // once and the lock frees.
+    act(() => {
+      releasePrompt?.();
+    });
+    await flushAsync();
+    expect(promptPostCount).toBe(1);
+    expect(second.result.current.state.queuedPrompts).toEqual([]);
+    expect(isDraining(sessionId)).toBe(false);
+
+    // The turn the delivered prompt started now ends. Nothing is left to
+    // drain, so no second POST: a retirement that reached only the dead
+    // instance would resurrect the row here and fire it again.
+    act(() => {
+      secondWs.onmessage?.({
+        data: JSON.stringify({
+          session_id: sessionId,
+          seq: 1,
+          event: { Stopped: { reason: "prompt_complete" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+    expect(promptPostCount).toBe(1);
   });
 });

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -27,6 +27,13 @@ import {
   type PromptAttachmentInput,
   type QueuedPrompt,
 } from "../lib/acpTypes";
+import {
+  armForBackgroundDrain,
+  emitQueueRetired,
+  isDraining,
+  onQueueRetired,
+  withDrainLock,
+} from "../lib/acpDrainCoordinator";
 import { useAcpPrefs } from "../lib/acpPrefs";
 import { isClearAlias } from "../lib/agentProfiles";
 import { useAgentProfile } from "../lib/agentProfileContext";
@@ -327,6 +334,28 @@ function cacheSet(sessionId: string, value: AcpState): void {
   }
   persistState(sessionId, value);
   notifyStateListeners(sessionId);
+}
+
+/** Retire delivered queued prompts from the shared cache and tell every
+ *  live hook for the session to drop them too.
+ *
+ *  The cache write is what makes this safe across an unmount: a drain
+ *  started by the headless background drainer can resolve after the user
+ *  has navigated into that chat, by which point the drainer's `dispatch`
+ *  goes nowhere. Without this, the freshly mounted hook would hydrate the
+ *  already-sent rows straight back out of the cache and POST them a
+ *  second time. See #3331. */
+function retireQueuedPrompts(sessionId: string, ids: string[]): void {
+  if (ids.length === 0) return;
+  const cached = stateCache.get(sessionId);
+  if (cached) {
+    const drop = new Set(ids);
+    const remaining = cached.queuedPrompts.filter((q) => !drop.has(q.id));
+    if (remaining.length !== cached.queuedPrompts.length) {
+      cacheSet(sessionId, { ...cached, queuedPrompts: remaining });
+    }
+  }
+  emitQueueRetired(sessionId, ids);
 }
 
 // Lightweight per-session subscription over `stateCache` so a component
@@ -1744,6 +1773,9 @@ export function useAcpSession(
         // (and drops the whole row on reload) so the quota invariant
         // holds. See #1833 / #1000.
         dispatch({ kind: "enqueue_prompt", text, attachments });
+        // A prompt parked in this page's lifetime is unambiguously still
+        // wanted, so let it drain even once this chat is unmounted. See #3331.
+        armForBackgroundDrain(sessionId);
         // The agent was busy, so this prompt is genuinely queued. Report it for
         // opt-in telemetry (queue depth lives only in client state, so the
         // daemon cannot observe queueing on its own).
@@ -1758,6 +1790,7 @@ export function useAcpSession(
       // AcpSessionAssigned brings the worker online. See #1748 / #1833.
       if (result === "retryable_failure" && state.workerIdleStopped) {
         dispatch({ kind: "enqueue_prompt", text, attachments });
+        armForBackgroundDrain(sessionId);
         // Same parked-prompt telemetry as the busy-agent path above: the
         // idle-dormant wake POST failed retryably, so this prompt is queued
         // too and the daemon cannot observe it on its own.
@@ -1780,15 +1813,18 @@ export function useAcpSession(
   // Drain effect: when the agent transitions to idle and the queue is
   // non-empty, join every queued entry with `\n\n` and fire one
   // prompt; the agent's single response covers the batch.
-  // Guarded by `drainingRef` so a re-render between the dequeue
-  // dispatch and the next state tick doesn't fire the same head twice.
+  // Guarded by the drain coordinator's per-session lock, which is
+  // module-scoped rather than instance-scoped so a re-render, a second
+  // hook for the same session (the headless background drainer handing
+  // off to the real view), or a second tab cannot fire the same head
+  // twice. See #1031 / #3331.
   // Skipped while a worker-stopped / restarting banner is showing; a
   // fresh `AcpSessionAssigned` (which clears both flags) re-runs this
   // effect and drains then. See #1031.
-  const drainingRef = useRef(false);
   useEffect(() => {
-    if (drainingRef.current) return;
-    if (!sessionIdRef.current) return;
+    const drainSessionId = sessionIdRef.current;
+    if (!drainSessionId) return;
+    if (isDraining(drainSessionId)) return;
     if (state.turnActive) return;
     if (state.workerStopped || state.workerRestarting) return;
     // Worker still mid-resume from a daemon cold start (or it never
@@ -1813,7 +1849,6 @@ export function useAcpSession(
     // so this effect re-runs on transition. See #1144.
     if (statusRef.current !== "open") return;
     if (state.queuedPrompts.length === 0) return;
-    drainingRef.current = true;
     // Slice the leading sub-batch out of the queue and POST only that.
     // The boundary is each clear-command alias (`/clear`, `/new`); when
     // the head is a clear alias it fires alone, otherwise the run of
@@ -1849,17 +1884,20 @@ export function useAcpSession(
     // below, same as any other rejected combined send. See #1833.
     const combinedAttachments = snapshot.flatMap((q) => q.attachments ?? []);
     const sentIds = snapshot.map((q) => q.id);
-    void dispatchPromptNow(combined, combinedAttachments.length > 0 ? combinedAttachments : undefined)
-      .then((result) => {
-        // Retire on success and on non-retryable rejection; only a
-        // transient failure keeps the batch queued for the next retry.
-        if (result !== "retryable_failure") {
-          dispatch({ kind: "dequeue_prompts_by_id", ids: sentIds });
-        }
-      })
-      .finally(() => {
-        drainingRef.current = false;
-      });
+    void withDrainLock(drainSessionId, async () => {
+      const result = await dispatchPromptNow(combined, combinedAttachments.length > 0 ? combinedAttachments : undefined);
+      // Retire on success and on non-retryable rejection; only a
+      // transient failure keeps the batch queued for the next retry.
+      // Routed through the coordinator rather than a bare dispatch so the
+      // retirement lands in the shared cache and reaches every live hook
+      // for this session, including when this instance unmounted while
+      // the POST was in flight. A transient failure deliberately stays
+      // silent: broadcasting it would re-run this effect immediately and
+      // turn the retry into a hot loop. See #3331.
+      if (result !== "retryable_failure") {
+        retireQueuedPrompts(drainSessionId, sentIds);
+      }
+    });
   }, [
     status,
     workerState,
@@ -1870,6 +1908,19 @@ export function useAcpSession(
     state.queuedPrompts,
     dispatchPromptNow,
   ]);
+
+  // Converge on a drain owned by another hook instance for this same
+  // session. The background drainer and the visible chat overlap for one
+  // commit when the user navigates in, and the drainer's POST can resolve
+  // on either side of that swap; whoever is mounted drops the delivered
+  // rows. Idempotent, so receiving a retirement for rows already gone is
+  // a no-op. See #3331.
+  useEffect(() => {
+    if (!sessionId) return;
+    return onQueueRetired(sessionId, (ids) => {
+      dispatch({ kind: "dequeue_prompts_by_id", ids });
+    });
+  }, [sessionId]);
 
   const removeQueuedPrompt = useCallback((id: string) => {
     dispatch({ kind: "dequeue_prompt", id });

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -31,6 +31,7 @@ import {
   armForBackgroundDrain,
   emitQueueRetired,
   isDraining,
+  onAnyQueueRetired,
   onQueueRetired,
   withDrainLock,
 } from "../lib/acpDrainCoordinator";
@@ -336,27 +337,31 @@ function cacheSet(sessionId: string, value: AcpState): void {
   notifyStateListeners(sessionId);
 }
 
-/** Retire delivered queued prompts from the shared cache and tell every
- *  live hook for the session to drop them too.
+/** Drop delivered rows out of the shared cache (and therefore out of
+ *  localStorage).
  *
- *  The cache write is what makes this safe across an unmount: a drain
- *  started by the headless background drainer can resolve after the user
- *  has navigated into that chat, by which point the drainer's `dispatch`
- *  goes nowhere. Without this, the freshly mounted hook would hydrate the
- *  already-sent rows straight back out of the cache and POST them a
- *  second time. See #3331. */
-function retireQueuedPrompts(sessionId: string, ids: string[]): void {
-  if (ids.length === 0) return;
+ *  Registered once per module load for EVERY session's retirements, local
+ *  or arriving from another tab, because it has to run whether or not a
+ *  hook for that session is mounted here:
+ *
+ *   - Across an unmount: a drain started by the headless background
+ *     drainer can resolve after the user has navigated into that chat, by
+ *     which point the drainer's `dispatch` goes nowhere. Without the cache
+ *     write the freshly mounted hook hydrates the already-sent rows and
+ *     POSTs them again.
+ *   - Across tabs: the drain lock stops two tabs sending at the same
+ *     moment, but the losing tab still holds the delivered rows, so it
+ *     would re-persist and re-send them once the lock frees.
+ *
+ *  See #3331. */
+onAnyQueueRetired((sessionId, ids) => {
   const cached = stateCache.get(sessionId);
-  if (cached) {
-    const drop = new Set(ids);
-    const remaining = cached.queuedPrompts.filter((q) => !drop.has(q.id));
-    if (remaining.length !== cached.queuedPrompts.length) {
-      cacheSet(sessionId, { ...cached, queuedPrompts: remaining });
-    }
-  }
-  emitQueueRetired(sessionId, ids);
-}
+  if (!cached) return;
+  const drop = new Set(ids);
+  const remaining = cached.queuedPrompts.filter((q) => !drop.has(q.id));
+  if (remaining.length === cached.queuedPrompts.length) return;
+  cacheSet(sessionId, { ...cached, queuedPrompts: remaining });
+});
 
 // Lightweight per-session subscription over `stateCache` so a component
 // that is NOT a child of <StructuredView> (the Background agents panel
@@ -1893,13 +1898,22 @@ export function useAcpSession(
       // transient failure keeps the batch queued for the next retry.
       // Routed through the coordinator rather than a bare dispatch so the
       // retirement lands in the shared cache and reaches every live hook
-      // for this session, including when this instance unmounted while
+      // and every other tab, including when this instance unmounted while
       // the POST was in flight. A transient failure deliberately stays
       // silent: broadcasting it would re-run this effect immediately and
       // turn the retry into a hot loop. See #3331.
       if (result !== "retryable_failure") {
-        retireQueuedPrompts(drainSessionId, sentIds);
+        emitQueueRetired(drainSessionId, sentIds);
       }
+    }).catch((e: unknown) => {
+      // `dispatchPromptNow` handles its own failures, so reaching here
+      // means the lock itself failed (`navigator.locks` rejecting the
+      // request). Surface it rather than leaving an unhandled rejection.
+      // The queue is untouched, so the next state change retries.
+      dispatch({
+        kind: "error",
+        message: `Could not send queued messages: ${describeError(e)}`,
+      });
     });
   }, [
     status,

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -1885,7 +1885,10 @@ export function useAcpSession(
     const combinedAttachments = snapshot.flatMap((q) => q.attachments ?? []);
     const sentIds = snapshot.map((q) => q.id);
     void withDrainLock(drainSessionId, async () => {
-      const result = await dispatchPromptNow(combined, combinedAttachments.length > 0 ? combinedAttachments : undefined);
+      const result = await dispatchPromptNow(
+        combined,
+        combinedAttachments.length > 0 ? combinedAttachments : undefined,
+      );
       // Retire on success and on non-retryable rejection; only a
       // transient failure keeps the batch queued for the next retry.
       // Routed through the coordinator rather than a bare dispatch so the

--- a/web/src/lib/acpDrainCoordinator.test.ts
+++ b/web/src/lib/acpDrainCoordinator.test.ts
@@ -9,6 +9,7 @@ import {
   emitQueueRetired,
   isArmedForBackgroundDrain,
   isDraining,
+  onAnyQueueRetired,
   onQueueRetired,
   withDrainLock,
 } from "./acpDrainCoordinator";
@@ -138,6 +139,56 @@ describe("queue retirement broadcast", () => {
     off();
     emitQueueRetired("s1", ["q3"]);
     expect(seen).toEqual([["q1", "q2"], ["q1", "q2"], ["q3"]]);
+  });
+});
+
+describe("cross-tab queue retirement", () => {
+  const CHANNEL = "aoe:acp-queue-retired";
+
+  /** Let a BroadcastChannel message land; delivery is a queued task. */
+  async function settle(): Promise<void> {
+    await new Promise((r) => setTimeout(r, 0));
+  }
+
+  it("publishes local retirements to other tabs", async () => {
+    const other = new BroadcastChannel(CHANNEL);
+    const received: unknown[] = [];
+    other.onmessage = (ev) => received.push(ev.data);
+    try {
+      emitQueueRetired("s1", ["q1"]);
+      await settle();
+      expect(received).toEqual([{ sessionId: "s1", ids: ["q1"] }]);
+    } finally {
+      other.close();
+    }
+  });
+
+  it("applies a retirement announced by another tab", async () => {
+    // The drain lock stops two tabs sending at once, but the loser still
+    // holds the delivered rows in its own reducer and cache, so it would
+    // re-send them once the lock frees. The announcement is what drops
+    // them there.
+    const anySeen: [string, string[]][] = [];
+    const sessionSeen: string[][] = [];
+    onAnyQueueRetired((sessionId, ids) => anySeen.push([sessionId, ids]));
+    onQueueRetired("s1", (ids) => sessionSeen.push(ids));
+
+    const other = new BroadcastChannel(CHANNEL);
+    try {
+      other.postMessage({ sessionId: "s1", ids: ["q1", "q2"] });
+      await settle();
+      expect(anySeen).toEqual([["s1", ["q1", "q2"]]]);
+      expect(sessionSeen).toEqual([["q1", "q2"]]);
+
+      // Malformed or empty announcements are ignored rather than fanned
+      // out; an empty retirement would re-run every drain effect.
+      other.postMessage({ sessionId: "s1", ids: [] });
+      other.postMessage({ nonsense: true });
+      await settle();
+      expect(sessionSeen).toHaveLength(1);
+    } finally {
+      other.close();
+    }
   });
 });
 

--- a/web/src/lib/acpDrainCoordinator.test.ts
+++ b/web/src/lib/acpDrainCoordinator.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  BACKGROUND_DRAIN_MAX_AGE_MS,
+  __resetDrainCoordinator,
+  armForBackgroundDrain,
+  emitQueueRetired,
+  isArmedForBackgroundDrain,
+  isDraining,
+  onQueueRetired,
+  withDrainLock,
+} from "./acpDrainCoordinator";
+import { STORAGE_KEY_PREFIX } from "./acpStateStorage";
+
+/** Write a persisted structured-view entry whose newest queued row is
+ *  `ageMs` old, matching what `persistState` stores. */
+function seedPersistedQueue(sessionId: string, ageMs: number): void {
+  window.localStorage.setItem(
+    STORAGE_KEY_PREFIX + sessionId,
+    JSON.stringify({
+      savedAt: Date.now(),
+      state: {
+        lastSeq: 1,
+        activity: [],
+        queuedPrompts: [{ id: "q1", text: "hi", queuedAt: new Date(Date.now() - ageMs).toISOString() }],
+      },
+    }),
+  );
+}
+
+/** Deferred promise, so a test can hold a drain open across assertions. */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  __resetDrainCoordinator();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("withDrainLock", () => {
+  it("admits one owner per session and releases afterwards", async () => {
+    const gate = deferred();
+    const calls: string[] = [];
+
+    const first = withDrainLock("s1", async () => {
+      calls.push("first");
+      await gate.promise;
+    });
+    expect(isDraining("s1")).toBe(true);
+
+    // Second owner for the SAME session while the first is in flight:
+    // skipped entirely rather than queued. Queueing would re-POST rows the
+    // first owner has already sent by the time the lock frees.
+    await withDrainLock("s1", async () => {
+      calls.push("second");
+    });
+    expect(calls).toEqual(["first"]);
+
+    // A different session is unaffected; the lock is per session, not global.
+    await withDrainLock("s2", async () => {
+      calls.push("other-session");
+    });
+    expect(calls).toEqual(["first", "other-session"]);
+
+    gate.resolve();
+    await first;
+    expect(isDraining("s1")).toBe(false);
+
+    // Released, so a later drain for the same session runs.
+    await withDrainLock("s1", async () => {
+      calls.push("later");
+    });
+    expect(calls).toEqual(["first", "other-session", "later"]);
+  });
+
+  it("releases the lock when the drain throws, and surfaces the error", async () => {
+    await expect(
+      withDrainLock("s1", async () => {
+        throw new Error("post failed");
+      }),
+    ).rejects.toThrow("post failed");
+    expect(isDraining("s1")).toBe(false);
+  });
+
+  it("skips the drain when another tab holds the Web Lock", async () => {
+    const ran: string[] = [];
+    // jsdom has no navigator.locks, so the cross-tab branch needs a stub.
+    // `ifAvailable` hands the callback a null lock when another tab owns it.
+    const request = vi.fn(
+      async (_name: string, _opts: unknown, cb: (lock: unknown) => Promise<void>) => await cb(null),
+    );
+    vi.stubGlobal("navigator", { ...window.navigator, locks: { request } });
+
+    await withDrainLock("s1", async () => {
+      ran.push("drained");
+    });
+    expect(ran).toEqual([]);
+    expect(request).toHaveBeenCalledWith(
+      "aoe:acp-drain:s1",
+      { mode: "exclusive", ifAvailable: true },
+      expect.any(Function),
+    );
+    expect(isDraining("s1")).toBe(false);
+  });
+});
+
+describe("queue retirement broadcast", () => {
+  it("fans delivered ids out to every listener for that session only", () => {
+    const seen: string[][] = [];
+    const otherSeen: string[][] = [];
+    const off = onQueueRetired("s1", (ids) => seen.push(ids));
+    onQueueRetired("s1", (ids) => seen.push(ids));
+    onQueueRetired("s2", (ids) => otherSeen.push(ids));
+
+    emitQueueRetired("s1", ["q1", "q2"]);
+    expect(seen).toEqual([
+      ["q1", "q2"],
+      ["q1", "q2"],
+    ]);
+    expect(otherSeen).toEqual([]);
+
+    // An empty retirement is never broadcast: it would re-run every drain
+    // effect and turn a retryable failure into a hot retry loop.
+    emitQueueRetired("s1", []);
+    expect(seen).toHaveLength(2);
+
+    off();
+    emitQueueRetired("s1", ["q3"]);
+    expect(seen).toEqual([["q1", "q2"], ["q1", "q2"], ["q3"]]);
+  });
+});
+
+describe("background drain arming", () => {
+  it("arms a queue parked this page load, and a restored one only while fresh", () => {
+    // Nothing known about this session at all.
+    expect(isArmedForBackgroundDrain("s-unknown")).toBe(false);
+
+    // Parked in this page's lifetime: unambiguously still wanted.
+    armForBackgroundDrain("s-live");
+    expect(isArmedForBackgroundDrain("s-live")).toBe(true);
+
+    seedPersistedQueue("s-fresh", BACKGROUND_DRAIN_MAX_AGE_MS / 2);
+    expect(isArmedForBackgroundDrain("s-fresh")).toBe(true);
+
+    // Older than the window: still queued and still badged, but it waits
+    // for the user to open that chat instead of firing at an agent they
+    // have moved on from. Persisted state lives 7 days, far too long to
+    // double as authorization to send.
+    seedPersistedQueue("s-stale", BACKGROUND_DRAIN_MAX_AGE_MS * 2);
+    expect(isArmedForBackgroundDrain("s-stale")).toBe(false);
+
+    // A stale verdict is memoised, so a later enqueue is what re-arms it,
+    // not a re-read of storage.
+    seedPersistedQueue("s-stale", 0);
+    expect(isArmedForBackgroundDrain("s-stale")).toBe(false);
+    armForBackgroundDrain("s-stale");
+    expect(isArmedForBackgroundDrain("s-stale")).toBe(true);
+  });
+});

--- a/web/src/lib/acpDrainCoordinator.test.ts
+++ b/web/src/lib/acpDrainCoordinator.test.ts
@@ -145,10 +145,10 @@ describe("queue retirement broadcast", () => {
 describe("cross-tab queue retirement", () => {
   const CHANNEL = "aoe:acp-queue-retired";
 
-  /** Let a BroadcastChannel message land; delivery is a queued task. */
-  async function settle(): Promise<void> {
-    await new Promise((r) => setTimeout(r, 0));
-  }
+  // BroadcastChannel delivery is a queued task with no bound on when it
+  // runs, so every assertion below is polled with `vi.waitFor` rather than
+  // read after a fixed tick. A `setTimeout(0)` barrier passes locally and
+  // fails on a loaded CI runner.
 
   it("publishes local retirements to other tabs", async () => {
     const other = new BroadcastChannel(CHANNEL);
@@ -156,8 +156,9 @@ describe("cross-tab queue retirement", () => {
     other.onmessage = (ev) => received.push(ev.data);
     try {
       emitQueueRetired("s1", ["q1"]);
-      await settle();
-      expect(received).toEqual([{ sessionId: "s1", ids: ["q1"] }]);
+      await vi.waitFor(() => {
+        expect(received).toEqual([{ sessionId: "s1", ids: ["q1"] }]);
+      });
     } finally {
       other.close();
     }
@@ -176,16 +177,22 @@ describe("cross-tab queue retirement", () => {
     const other = new BroadcastChannel(CHANNEL);
     try {
       other.postMessage({ sessionId: "s1", ids: ["q1", "q2"] });
-      await settle();
+      await vi.waitFor(() => {
+        expect(sessionSeen).toEqual([["q1", "q2"]]);
+      });
       expect(anySeen).toEqual([["s1", ["q1", "q2"]]]);
-      expect(sessionSeen).toEqual([["q1", "q2"]]);
 
-      // Malformed or empty announcements are ignored rather than fanned
-      // out; an empty retirement would re-run every drain effect.
+      // Malformed and empty announcements are dropped rather than fanned
+      // out; an empty retirement would re-run every drain effect. Asserted
+      // against a following good message rather than a timeout: a channel
+      // preserves order, so q3 arriving without the two bad ones adding
+      // entries proves they were ignored.
       other.postMessage({ sessionId: "s1", ids: [] });
       other.postMessage({ nonsense: true });
-      await settle();
-      expect(sessionSeen).toHaveLength(1);
+      other.postMessage({ sessionId: "s1", ids: ["q3"] });
+      await vi.waitFor(() => {
+        expect(sessionSeen).toEqual([["q1", "q2"], ["q3"]]);
+      });
     } finally {
       other.close();
     }

--- a/web/src/lib/acpDrainCoordinator.ts
+++ b/web/src/lib/acpDrainCoordinator.ts
@@ -16,8 +16,11 @@
 //     Locks API closes the cross-tab one. A tab that dies mid-drain drops
 //     its Web Lock automatically, which a localStorage lease cannot do.
 //   - `onQueueRetired` / `emitQueueRetired` propagate a completed send to
-//     every live hook for that session, so the instance that started the
-//     POST does not have to be the one still mounted when it resolves.
+//     every live hook for that session, and over a BroadcastChannel to
+//     every other tab. The lock alone is not enough there: it stops two
+//     tabs draining at the same moment, but the loser still holds the
+//     delivered rows in its own reducer and cache, so it would re-persist
+//     and re-POST them the moment the lock frees.
 //   - `armForBackgroundDrain` gates background draining to queues this
 //     page parked, or restored ones young enough to still be wanted.
 //
@@ -50,6 +53,44 @@ const heldLocally = new Set<string>();
 
 type RetiredListener = (ids: string[]) => void;
 const retiredListeners = new Map<string, Set<RetiredListener>>();
+
+/** Listeners that want every session's retirements, not one session's.
+ *  `useAcpSession` registers one of these to apply the retirement to the
+ *  shared state cache, which has to happen whether or not a hook for that
+ *  session is currently mounted in this tab. */
+type AnyRetiredListener = (sessionId: string, ids: string[]) => void;
+const anyRetiredListeners = new Set<AnyRetiredListener>();
+
+const RETIRE_CHANNEL_NAME = "aoe:acp-queue-retired";
+type RetiredMessage = { sessionId: string; ids: string[] };
+
+let retireChannel: BroadcastChannel | null | undefined;
+
+/** Lazily open the cross-tab channel. `undefined` means "not tried yet",
+ *  `null` means "unavailable here" so we stop retrying. */
+function getRetireChannel(): BroadcastChannel | null {
+  if (retireChannel !== undefined) return retireChannel;
+  if (typeof BroadcastChannel === "undefined") {
+    retireChannel = null;
+    return null;
+  }
+  const channel = new BroadcastChannel(RETIRE_CHANNEL_NAME);
+  channel.onmessage = (ev: MessageEvent<RetiredMessage>) => {
+    const { sessionId, ids } = ev.data ?? {};
+    if (typeof sessionId !== "string" || !Array.isArray(ids) || ids.length === 0) return;
+    // Apply locally only. Re-broadcasting would ping-pong between tabs.
+    fanOutRetired(sessionId, ids);
+  };
+  retireChannel = channel;
+  return channel;
+}
+
+function fanOutRetired(sessionId: string, ids: string[]): void {
+  for (const cb of anyRetiredListeners) cb(sessionId, ids);
+  const set = retiredListeners.get(sessionId);
+  if (!set) return;
+  for (const cb of set) cb(ids);
+}
 
 /** Mark a session's queue eligible for background draining. Called on
  *  every enqueue: a prompt the user parked in this page's lifetime is
@@ -110,6 +151,7 @@ export async function withDrainLock(sessionId: string, fn: () => Promise<void>):
  *  instance that owned the POST need not be the one still mounted when it
  *  resolves. */
 export function onQueueRetired(sessionId: string, cb: RetiredListener): () => void {
+  getRetireChannel();
   let set = retiredListeners.get(sessionId);
   if (!set) {
     set = new Set();
@@ -124,14 +166,33 @@ export function onQueueRetired(sessionId: string, cb: RetiredListener): () => vo
   };
 }
 
-/** Announce that `ids` left the queue for good. Only ever called with a
- *  non-empty list: an empty broadcast would re-run every drain effect and
- *  turn a retryable failure into a hot retry loop. */
+/** Subscribe to retirements for every session. Returns an unsubscribe.
+ *  Used for tab-wide bookkeeping (the shared state cache) that must happen
+ *  even when no hook for that session is mounted here. */
+export function onAnyQueueRetired(cb: AnyRetiredListener): () => void {
+  // Open the channel on subscribe, not on first emit. The tab that loses
+  // the drain lock never emits anything, and it is precisely the tab that
+  // has to hear about the winner's retirement.
+  getRetireChannel();
+  anyRetiredListeners.add(cb);
+  return () => {
+    anyRetiredListeners.delete(cb);
+  };
+}
+
+/** Announce that `ids` left the queue for good, in this tab and every
+ *  other one. Only ever called with a non-empty list: an empty broadcast
+ *  would re-run every drain effect and turn a retryable failure into a hot
+ *  retry loop. */
 export function emitQueueRetired(sessionId: string, ids: string[]): void {
   if (ids.length === 0) return;
-  const set = retiredListeners.get(sessionId);
-  if (!set) return;
-  for (const cb of set) cb(ids);
+  fanOutRetired(sessionId, ids);
+  try {
+    getRetireChannel()?.postMessage({ sessionId, ids } satisfies RetiredMessage);
+  } catch {
+    // A closed or unavailable channel must not break the local drain; the
+    // other tab falls back to the pre-existing duplicate hazard.
+  }
 }
 
 /** Drop all coordinator state. Test-only; mirrors `clearAcpCache`. */
@@ -140,4 +201,7 @@ export function __resetDrainCoordinator(): void {
   restoredVerdict.clear();
   heldLocally.clear();
   retiredListeners.clear();
+  anyRetiredListeners.clear();
+  retireChannel?.close();
+  retireChannel = undefined;
 }

--- a/web/src/lib/acpDrainCoordinator.ts
+++ b/web/src/lib/acpDrainCoordinator.ts
@@ -1,0 +1,143 @@
+// Single-owner coordination for the structured view's queued-prompt drain.
+//
+// Before #3331 the drain lived entirely inside one `useAcpSession`
+// instance: a `drainingRef` guarded it, and the instance only existed
+// while its chat was the visible one. Draining a session whose chat is
+// unmounted means several hook instances can exist over the life of one
+// drain (a headless drainer hands off to the real view when the user
+// navigates in), and several tabs can hold a queue for the same session,
+// so ownership has to outlive any single component.
+//
+// Three primitives, deliberately no more:
+//
+//   - `withDrainLock` makes the drain single-owner. The synchronous
+//     `heldLocally` set closes the in-tab window (an effect must not
+//     re-enter while the async lock is still being acquired), and the Web
+//     Locks API closes the cross-tab one. A tab that dies mid-drain drops
+//     its Web Lock automatically, which a localStorage lease cannot do.
+//   - `onQueueRetired` / `emitQueueRetired` propagate a completed send to
+//     every live hook for that session, so the instance that started the
+//     POST does not have to be the one still mounted when it resolves.
+//   - `armForBackgroundDrain` gates background draining to queues this
+//     page parked, or restored ones young enough to still be wanted.
+//
+// What this deliberately does NOT do: close the duplicate window where a
+// POST is accepted server-side but its response is lost. No client-only
+// primitive can. That needs an idempotency key honoured by the daemon,
+// and lives with the server-side durable queue follow-up.
+
+import { getNewestQueuedAt } from "./acpStateStorage";
+
+/** How old the newest prompt in a restored queue may be and still drain
+ *  in the background. Inside the window a reload (mobile tab eviction,
+ *  PWA cold start, refresh mid-turn) resumes where it left off; outside
+ *  it, the queue waits for the user to open that chat, which is what
+ *  happened before #3331. Persisted state lives for `STATE_TTL_MS`
+ *  (7 days), far too long to double as authorization to send. */
+export const BACKGROUND_DRAIN_MAX_AGE_MS = 60 * 60 * 1000;
+
+/** Sessions whose queue may drain without their chat being open. */
+const armed = new Set<string>();
+/** Memoised verdict for queues restored from storage, so the arming check
+ *  parses a session's persisted entry at most once per page load. A `true`
+ *  entry is redundant with `armed` but harmless; `false` is what matters. */
+const restoredVerdict = new Map<string, boolean>();
+
+/** Sessions this tab is currently draining. Set synchronously so a
+ *  re-render between the effect firing and the Web Lock resolving cannot
+ *  start a second drain for the same session. */
+const heldLocally = new Set<string>();
+
+type RetiredListener = (ids: string[]) => void;
+const retiredListeners = new Map<string, Set<RetiredListener>>();
+
+/** Mark a session's queue eligible for background draining. Called on
+ *  every enqueue: a prompt the user parked in this page's lifetime is
+ *  unambiguously still wanted. */
+export function armForBackgroundDrain(sessionId: string): void {
+  armed.add(sessionId);
+  restoredVerdict.set(sessionId, true);
+}
+
+/** True when this session's queue may drain while its chat is unmounted.
+ *  A queue parked in this page's lifetime always qualifies; one restored
+ *  from localStorage qualifies only while its newest entry is younger
+ *  than `BACKGROUND_DRAIN_MAX_AGE_MS`. */
+export function isArmedForBackgroundDrain(sessionId: string): boolean {
+  if (armed.has(sessionId)) return true;
+  const cached = restoredVerdict.get(sessionId);
+  if (cached !== undefined) return cached;
+  const newest = getNewestQueuedAt(sessionId);
+  const fresh = newest !== null && Date.now() - newest < BACKGROUND_DRAIN_MAX_AGE_MS;
+  restoredVerdict.set(sessionId, fresh);
+  return fresh;
+}
+
+/** True while this tab holds (or is acquiring) the drain for a session. */
+export function isDraining(sessionId: string): boolean {
+  return heldLocally.has(sessionId);
+}
+
+/** Run `fn` as the session's sole drain owner, or skip it entirely when
+ *  another owner already holds the drain. Resolves once `fn` settles;
+ *  `fn`'s own rejection is surfaced to the caller after the lock is
+ *  released. Web Locks is used when available (every current browser
+ *  target) and degrades to the in-tab guard alone under jsdom, where the
+ *  cross-tab hazard does not exist. */
+export async function withDrainLock(sessionId: string, fn: () => Promise<void>): Promise<void> {
+  if (heldLocally.has(sessionId)) return;
+  heldLocally.add(sessionId);
+  try {
+    const locks = typeof navigator === "undefined" ? undefined : navigator.locks;
+    if (!locks) {
+      await fn();
+      return;
+    }
+    // `ifAvailable` hands us a null lock rather than queueing behind the
+    // other tab. Queueing would be wrong: by the time we got the lock the
+    // items would already be sent, and we would re-POST them.
+    await locks.request(`aoe:acp-drain:${sessionId}`, { mode: "exclusive", ifAvailable: true }, async (lock) => {
+      if (lock === null) return;
+      await fn();
+    });
+  } finally {
+    heldLocally.delete(sessionId);
+  }
+}
+
+/** Subscribe to "these queued ids were delivered" for a session. Returns
+ *  an unsubscribe. Every mounted hook for the session listens, so the
+ *  instance that owned the POST need not be the one still mounted when it
+ *  resolves. */
+export function onQueueRetired(sessionId: string, cb: RetiredListener): () => void {
+  let set = retiredListeners.get(sessionId);
+  if (!set) {
+    set = new Set();
+    retiredListeners.set(sessionId, set);
+  }
+  set.add(cb);
+  return () => {
+    const s = retiredListeners.get(sessionId);
+    if (!s) return;
+    s.delete(cb);
+    if (s.size === 0) retiredListeners.delete(sessionId);
+  };
+}
+
+/** Announce that `ids` left the queue for good. Only ever called with a
+ *  non-empty list: an empty broadcast would re-run every drain effect and
+ *  turn a retryable failure into a hot retry loop. */
+export function emitQueueRetired(sessionId: string, ids: string[]): void {
+  if (ids.length === 0) return;
+  const set = retiredListeners.get(sessionId);
+  if (!set) return;
+  for (const cb of set) cb(ids);
+}
+
+/** Drop all coordinator state. Test-only; mirrors `clearAcpCache`. */
+export function __resetDrainCoordinator(): void {
+  armed.clear();
+  restoredVerdict.clear();
+  heldLocally.clear();
+  retiredListeners.clear();
+}

--- a/web/src/lib/acpStateStorage.ts
+++ b/web/src/lib/acpStateStorage.ts
@@ -85,6 +85,35 @@ function parseQueuedCount(raw: string | null): number | null {
   }
 }
 
+// Parse the newest `queuedAt` (epoch ms) out of a raw persisted entry,
+// honoring the TTL. Returns null when the entry is missing, expired,
+// corrupt, has no queued rows, or carries no parseable timestamp.
+function parseNewestQueuedAt(raw: string | null): number | null {
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw) as PersistedEntry | null;
+    if (
+      !parsed ||
+      typeof parsed.savedAt !== "number" ||
+      Number.isNaN(parsed.savedAt) ||
+      Date.now() - parsed.savedAt > STATE_TTL_MS
+    ) {
+      return null;
+    }
+    const q = (parsed.state as Partial<AcpState> | undefined)?.queuedPrompts;
+    if (!Array.isArray(q)) return null;
+    let newest: number | null = null;
+    for (const row of q) {
+      const at = Date.parse(row?.queuedAt ?? "");
+      if (Number.isNaN(at)) continue;
+      if (newest === null || at > newest) newest = at;
+    }
+    return newest;
+  } catch {
+    return null;
+  }
+}
+
 // Parse the rate-limit info out of a raw persisted entry, honoring the
 // TTL. Returns null when the entry is missing, expired, corrupt, or has
 // no (or malformed) rate-limit, so callers treat the session as not
@@ -163,6 +192,20 @@ export function getQueuedCount(sessionId: string): number {
   }
   queueCounts.set(sessionId, count);
   return count;
+}
+
+// Read the epoch-ms timestamp of the newest queued prompt persisted for
+// a session, or null when there is none. Used by the background drain
+// arming check to tell a queue this browser just parked from one
+// restored out of storage days later. Uncached: the arming check
+// memoises its own verdict and only asks once per session per page load.
+export function getNewestQueuedAt(sessionId: string): number | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return parseNewestQueuedAt(window.localStorage.getItem(storageKey(sessionId)));
+  } catch {
+    return null;
+  }
 }
 
 // Side-effect-free read of a session's last-known rate-limit info (null

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2173,6 +2173,20 @@
       "components": ["web/src/lib/acpDrafts.ts"]
     },
     {
+      "id": "acp.queue-drain-ownership",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/lib/acpDrainCoordinator.test.ts", "src/hooks/useAcpSession.queue.test.ts"],
+      "components": [
+        "web/src/lib/acpDrainCoordinator.ts",
+        "web/src/hooks/useAcpSession.ts",
+        "web/src/hooks/useAcpQueueCount.ts",
+        "web/src/components/acp/AcpQueueDrainer.tsx",
+        "web/src/lib/acpStateStorage.ts",
+        "web/src/App.tsx"
+      ]
+    },
+    {
       "id": "acp.queue-drain-clear-split",
       "kind": "vitest",
       "risk": "high",
@@ -2996,6 +3010,13 @@
         "web/src/components/acp/AcpRuntime.tsx",
         "web/src/lib/acpDrafts.ts"
       ]
+    },
+    {
+      "id": "acp.story.queue-drains-while-unmounted",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": ["tests/live/acp-stories/queue-drains-while-unmounted.spec.ts"],
+      "components": ["web/src/components/acp/AcpQueueDrainer.tsx", "web/src/App.tsx"]
     },
     {
       "id": "acp.story.queue-edit-message",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2176,7 +2176,11 @@
       "id": "acp.queue-drain-ownership",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/lib/acpDrainCoordinator.test.ts", "src/hooks/useAcpSession.queue.test.ts"],
+      "specs": [
+        "src/lib/acpDrainCoordinator.test.ts",
+        "src/hooks/useAcpSession.queue.test.ts",
+        "src/components/acp/AcpQueueDrainer.test.tsx"
+      ],
       "components": [
         "web/src/lib/acpDrainCoordinator.ts",
         "web/src/hooks/useAcpSession.ts",

--- a/web/tests/live/acp-stories/queue-drains-while-unmounted.spec.ts
+++ b/web/tests/live/acp-stories/queue-drains-while-unmounted.spec.ts
@@ -1,0 +1,146 @@
+// User story: queue a follow-up on a structured view session, then leave
+// that chat entirely. The queued prompt should reach the agent without
+// the user ever navigating back to it. See #3331.
+//
+// The sibling spec `queue-follow-up-with-nav.spec.ts` navigates away and
+// BACK before asserting, so it proves remount recovery rather than
+// background delivery. This one never returns to the session: the
+// assertion is the server's own replay log, polled while the browser sits
+// on `/settings`.
+//
+// Navigating with `page.goto` is a full reload, which destroys the SPA's
+// module state. That is deliberate: it is the harder case, and it also
+// exercises the restore-from-localStorage arming path (a queue whose
+// newest entry is under an hour old rearms for background delivery).
+//
+// One structured view session only, for the same reason the sibling spec
+// gives: a second supervisor worker is enough to make the first idle out
+// on a 4-worker CI runner before turn 2 can fire.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions, seedSessionViaAoeAdd } from "../../helpers/aoeServe";
+import {
+  enableStructuredViewAndWait,
+  waitForStructuredView,
+  waitForReplayContains,
+  attachServeDiagnostics,
+} from "../../helpers/acp";
+
+const QUEUED_TEXT = "drained-while-away";
+const TURN_TWO_TEXT = "Second turn while away.";
+
+const SCRIPT = {
+  turns: [
+    {
+      updates: [
+        {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "First turn." },
+        },
+        // Long enough to queue and leave the chat while turn 1 runs, but
+        // under the supervisor's resume idle grace (see
+        // `RESUME_IDLE_GRACE_DEFAULT` in src/acp/acp_client.rs).
+        { sessionUpdate: "wait_ms", ms: 6_000 },
+      ],
+      stopReason: "end_turn",
+    },
+    {
+      updates: [
+        {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: TURN_TWO_TEXT },
+        },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+base("a queued follow-up drains while its chat is closed", async ({ page }, testInfo) => {
+  let serveHandle: { home: string } | undefined;
+  let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-queue-unmounted-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(SCRIPT));
+
+  try {
+    serve = await spawnAoeServe({
+      authMode: "none",
+      acp: true,
+      fakeAcpScript: scriptPath,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "queue-unmounted-a" }),
+    });
+    serveHandle = serve;
+
+    const sessions = await listSessions(serve.baseUrl);
+    const session = sessions.find((s) => s.title === "queue-unmounted-a");
+    if (!session) throw new Error("seeded session 'queue-unmounted-a' missing");
+
+    await enableStructuredViewAndWait(serve.baseUrl, session.id, 30_000, serve.home);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(session.id)}`);
+    await waitForStructuredView(page);
+
+    const composer = page.getByRole("textbox", {
+      name: /Send a message|Queue a follow-up/i,
+    });
+    await composer.fill("kick off");
+    await composer.press("Enter");
+    await expect(page.getByText("First turn.")).toBeVisible({ timeout: 10_000 });
+
+    // The queue button only renders while the turn is active, and a stale
+    // React batch can leave the send button up for a few ms after the
+    // first chunk paints.
+    const queueBtn = page.getByRole("button", {
+      name: /Queue follow-up message/i,
+    });
+    await expect(queueBtn).toBeVisible({ timeout: 5_000 });
+    await composer.fill(QUEUED_TEXT);
+    await queueBtn.click();
+
+    // Parked, and the strip says so. Waiting on the strip also guarantees
+    // the queue reached localStorage before the reload below.
+    await expect(page.getByText(/Queued \(1\)/i)).toBeVisible({ timeout: 5_000 });
+
+    // Leave the chat. Settings has no structured view and no PTY, so the
+    // session's runtime is gone from the page.
+    await page.goto(`${serve.baseUrl}/settings`);
+    await expect(page).toHaveURL(/\/settings/, { timeout: 10_000 });
+    await expect(page.locator("select").first()).toBeVisible({ timeout: 10_000 });
+
+    // Delivered without ever reopening the session: the queued text
+    // reaches the agent and turn 2 answers it. Asserted against the
+    // server's replay log, not the DOM, precisely because the session's
+    // chat is not on screen.
+    await waitForReplayContains(serve.baseUrl, session.id, [QUEUED_TEXT, TURN_TWO_TEXT], {
+      mode: "all",
+      timeoutMs: 25_000,
+    });
+
+    // Still on settings; nothing navigated us back.
+    await expect(page).toHaveURL(/\/settings/);
+
+    // Exactly once. A drain that re-fired would show the queued text in a
+    // second user prompt, and the scripted agent would answer twice.
+    const replay = await fetch(`${serve.baseUrl}/api/sessions/${session.id}/acp/replay?since=0`).then((r) => r.json());
+    const frames: unknown[] = Array.isArray(replay) ? replay : (replay?.frames ?? []);
+    const json = JSON.stringify(frames);
+    expect(json.split(TURN_TWO_TEXT).length - 1).toBe(1);
+  } finally {
+    try {
+      if (serveHandle) await attachServeDiagnostics(testInfo, serveHandle);
+    } catch {
+      // best-effort diagnostics; do not block cleanup
+    }
+    try {
+      if (serve) await serve.stop();
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  }
+});

--- a/web/tests/live/acp-stories/queue-drains-while-unmounted.spec.ts
+++ b/web/tests/live/acp-stories/queue-drains-while-unmounted.spec.ts
@@ -125,12 +125,17 @@ base("a queued follow-up drains while its chat is closed", async ({ page }, test
     // Still on settings; nothing navigated us back.
     await expect(page).toHaveURL(/\/settings/);
 
-    // Exactly once. A drain that re-fired would show the queued text in a
-    // second user prompt, and the scripted agent would answer twice.
+    // Exactly once, counted on the user's side of the transcript rather
+    // than the agent's. The fake agent falls back to a generic turn once
+    // its scripted turns run out (see `fakeAcpAgent.mjs`), so a duplicate
+    // send would NOT produce a second `TURN_TWO_TEXT` and counting agent
+    // chunks could never fail. Counting `UserPromptSent` frames can.
     const replay = await fetch(`${serve.baseUrl}/api/sessions/${session.id}/acp/replay?since=0`).then((r) => r.json());
-    const frames: unknown[] = Array.isArray(replay) ? replay : (replay?.frames ?? []);
-    const json = JSON.stringify(frames);
-    expect(json.split(TURN_TWO_TEXT).length - 1).toBe(1);
+    const frames: { event?: { UserPromptSent?: { text?: string } } }[] = Array.isArray(replay)
+      ? replay
+      : (replay?.frames ?? []);
+    const sends = frames.filter((f) => f.event?.UserPromptSent?.text === QUEUED_TEXT);
+    expect(sends).toHaveLength(1);
   } finally {
     try {
       if (serveHandle) await attachServeDiagnostics(testInfo, serveHandle);


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A queued follow-up in the web structured view only ever fired while its chat was the one on screen. Queue up a message in session A, switch to session B, and A's prompt sat there until you navigated back.

The cause is an ownership boundary. Both the queue (`state.queuedPrompts`) and the drain effect live inside `useAcpSession`, and that hook is instantiated only by `AcpRuntime` -> `StructuredView` -> `App`, which renders the structured view for `activeSessionId` alone. No visible chat, no hook, no drain.

This keeps the existing hook as the owner of a session's connection and drain, and instead guarantees an instance exists whenever a session has prompts waiting. `App` mounts a headless `AcpQueueDrainer` for every structured session with a non-empty queue that is not the one on screen. Each drainer holds its own subscription rather than teaching the visible session's socket to schedule everyone else's, and carries the queued session's agent profile so clear-command batching (`/clear` fires alone) stays correct for that agent rather than the visible one.

Draining from more than one place means ownership can no longer live in a per-instance ref, so a small `acpDrainCoordinator` module now owns it:

- **One owner per session.** A synchronous in-tab guard closes the re-entry window while the lock is being acquired; the Web Locks API closes the cross-tab one, so two open tabs send a queued prompt once between them rather than twice. A tab that dies mid-drain drops its lock automatically, which a localStorage lease cannot do.
- **Retirement outlives the component.** A drain started by the background drainer can resolve after you have navigated into that chat and a second instance owns the session. Delivered rows are now retired through the shared state cache and broadcast to every live hook, instead of dispatching into a reducer that may no longer be mounted. Without this the sent rows stayed queued and refired on the next turn end.
- **Arming.** Persisted queue state lives for 7 days, far too long to double as authorization to send. Background draining is limited to queues parked in this page's lifetime, or restored ones whose newest entry is under an hour old. Anything older keeps its queue and its badge and waits for you to open that chat, which is what happened before this change.

Background fan-out is capped at three concurrent subscriptions. The queue stays browser-local: the `Queued (N)` strip and the docs now say so, along with the multi-tab and multi-device behavior.

**Known limit, unchanged by this PR:** a prompt POST that is accepted but whose response is lost can still be re-sent, and two *devices* cannot coordinate at all. Neither is closable from the browser. Both need a server-side durable queue with idempotency keys, which is a much larger change and deliberately not attempted here (the issue explicitly allows browser-local scope provided the UI states the limitation).

Closes #3331

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured-view session A, start a turn, and queue a follow-up. Switch to another session (or Settings) and leave it there. The follow-up is delivered when A's turn ends, without reopening A; A's queued badge in the sidebar drops to zero while you are still elsewhere.
- [ ] Queue a follow-up in A, switch away, then switch back to A while the drain is landing. The prompt appears exactly once, not twice.
- [ ] Queue a follow-up in A, switch away, and reload the page without opening A. It still drains.
- [ ] Open the dashboard in two tabs, queue one follow-up in A, and leave both tabs on another session. The agent receives it once; both tabs show the queue empty.
- [ ] Queue a follow-up, close the browser, and reopen it more than an hour later. The prompt stays queued and badged until you open that chat, rather than firing at an agent you have moved on from.
- [ ] Hover the `Queued (N)` label above the composer and confirm it explains that the queue is browser-local.
- [ ] Confirm nothing regressed for the visible chat: queue two prompts plus a `/clear` mid-turn and check they still fire as separate batches in order.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

New live spec `web/tests/live/acp-stories/queue-drains-while-unmounted.spec.ts` queues a follow-up, leaves the session for `/settings`, and asserts delivery against the server's replay log without ever reopening the chat, plus that the scripted second turn fired exactly once. The existing `queue-follow-up-with-nav.spec.ts` navigates back before asserting, so it covers remount recovery rather than background delivery.

Both new tests were verified red before green:

- The hook-level handoff test fails on the pre-fix tree (checked in a throwaway worktree at the base commit): the retirement lands on the unmounted reducer and the delivered row stays queued.
- The live spec times out waiting for delivery when the drainer is disabled, and passes with it.

Also added `web/src/lib/acpDrainCoordinator.test.ts` covering lock exclusivity, release on throw, the skip when another tab holds the Web Lock, retirement fan-out, and the arming freshness rule.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

The diff is web-only; zero Rust files changed. The TUI structured view has its own separate client-side queue and is untouched.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**

Investigation, plan, and implementation drafted by Claude under my direction. The design was pressure-tested against two other models first; they argued for a full server-side durable queue and for rewriting the session hook into a vanilla client. I rejected both as disproportionate for this issue and kept the bounded fix, but took their concrete corrections: Web Locks for cross-tab exclusivity, the per-session agent profile for the background drainer, the arming freshness bound, and the concurrency cap. I reviewed each commit, made the scope calls, and ran the test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added background delivery for queued structured-view prompts when chats are not mounted.
- Added coordination across components and browser tabs to prevent duplicate delivery.
- Limited background delivery to three recently active queues.
- Documented browser-local queue storage and multi-device limitations.
- Added unit, handoff, and Playwright coverage for inactive-chat delivery and queue ownership.

## Benefits

Queued prompts now survive navigation, reloads, remounts, and temporary reconnects. Delivery remains FIFO and occurs once. Active-session behavior remains unchanged.

## Technical details

The change adds `AcpBackgroundDrainers`, shared drain locks, queue-retirement notifications, persisted queue-age checks, and coverage-matrix updates. The TUI and CLI are unchanged.

## Potential follow-up

Consider cross-device queue synchronization if browser-local delivery becomes a product requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->