### PR TITLE
fix: preserve statuses when tmux probe fails

### DIFF
--- a/src/cli/ps.rs
+++ b/src/cli/ps.rs
@@ -605,7 +605,13 @@ fn collect_tmux_states(instances: &mut [Instance]) -> Vec<TmuxState> {
     }
 
     crate::tmux::refresh_session_cache();
-    let meta = crate::tmux::batch_pane_metadata().unwrap_or_default();
+    let meta = match crate::tmux::batch_pane_metadata() {
+        Ok(meta) => meta,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to collect tmux pane metadata");
+            return Vec::new();
+        }
+    };
 
     let mut states = Vec::new();
     let mut known: HashSet<String> = HashSet::new();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3006,7 +3006,7 @@ fn apply_tick_status_decisions(
     instances: &mut [Instance],
     prev: &std::collections::HashMap<String, crate::session::Status>,
     suppressed_ids: &std::collections::HashSet<String>,
-    pane_metadata: &std::collections::HashMap<String, crate::tmux::PaneMetadata>,
+    pane_metadata: Option<&std::collections::HashMap<String, crate::tmux::PaneMetadata>>,
 ) {
     for inst in instances.iter_mut() {
         if suppressed_ids.contains(&inst.id) {
@@ -3027,6 +3027,15 @@ fn apply_tick_status_decisions(
         if skip_tmux_decision_for_structured(inst) {
             continue;
         }
+        let Some(pane_metadata) = pane_metadata else {
+            // A failed batch probe says nothing about any individual pane.
+            // Keep the last live status instead of treating an empty metadata
+            // map as proof that every pane disappeared.
+            if let Some(live) = inst.live_status_baseline {
+                inst.status = live;
+            }
+            continue;
+        };
         let session_name = crate::tmux::resolve_agent_session_name_in(
             pane_metadata,
             &inst.id,
@@ -4371,12 +4380,19 @@ async fn status_poll_loop(state: Arc<AppState>) {
             let mut instances = load_all_instances(&file_watch_for_poll).unwrap_or_default();
             seed_unknown_tracking(&mut instances, &prev_unknown_tracking);
             crate::tmux::refresh_session_cache();
-            let pane_metadata = crate::tmux::batch_pane_metadata().unwrap_or_default();
+            let pane_metadata = crate::tmux::batch_pane_metadata();
+            if let Err(error) = &pane_metadata {
+                tracing::warn!(
+                    target: "server.status",
+                    %error,
+                    "holding tmux-backed statuses because pane metadata is unavailable",
+                );
+            }
             apply_tick_status_decisions(
                 &mut instances,
                 &prev_for_poll,
                 &suppressed_ids,
-                &pane_metadata,
+                pane_metadata.as_ref().ok(),
             );
             (instances, live_structured_worker_records())
         })
@@ -7217,7 +7233,7 @@ mod tests {
             &mut instances,
             &prev,
             &std::collections::HashSet::new(),
-            &std::collections::HashMap::new(),
+            Some(&std::collections::HashMap::new()),
         );
 
         assert_eq!(
@@ -7247,7 +7263,7 @@ mod tests {
             &mut instances,
             &prev,
             &std::collections::HashSet::new(),
-            &std::collections::HashMap::new(),
+            Some(&std::collections::HashMap::new()),
         );
 
         assert_eq!(instances[0].status, Status::Idle, "disk status stands");
@@ -7273,7 +7289,7 @@ mod tests {
             &mut instances,
             &prev,
             &std::collections::HashSet::from([id]),
-            &std::collections::HashMap::new(),
+            Some(&std::collections::HashMap::new()),
         );
 
         assert_eq!(instances[0].status, Status::Starting);
@@ -7282,6 +7298,30 @@ mod tests {
             vec![(0, Status::Error)],
             "a transition the tick does own must still be reported"
         );
+    }
+
+    #[test]
+    fn tick_holds_tmux_statuses_when_the_batch_probe_fails() {
+        for (disk, live) in [
+            (Status::Idle, Status::Running),
+            (Status::Unknown, Status::Error),
+        ] {
+            let mut inst = Instance::new("tmux-session", "/tmp/test");
+            inst.status = disk;
+            let id = inst.id.clone();
+            let prev = std::collections::HashMap::from([(id, live)]);
+            let mut instances = vec![inst];
+
+            apply_tick_status_decisions(
+                &mut instances,
+                &prev,
+                &std::collections::HashSet::new(),
+                None,
+            );
+
+            assert_eq!(instances[0].status, live, "disk status was {disk:?}");
+            assert_eq!(observed_transitions(&instances, &prev), vec![]);
+        }
     }
 
     #[test]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -597,9 +597,9 @@ pub fn stop_all_sessions() -> anyhow::Result<usize> {
 /// Returns `Err` when the underlying `tmux list-panes` call fails to spawn or
 /// exits non-zero. Callers MUST distinguish this from `Ok(map)` where a missing
 /// key means the session is genuinely absent: `Err` means we don't know.
-/// Startup recovery treats `Err` as "skip this pass" to avoid killing a
-/// possibly-live pane on a transient tmux glitch; status pollers treat it as
-/// `unwrap_or_default()` because their semantics are unchanged by an empty map.
+/// Startup recovery and status pollers treat `Err` as "skip this pass" to
+/// avoid acting on a possibly-live pane during a transient tmux glitch. A
+/// successful empty map is authoritative and means there are no panes.
 pub fn batch_pane_metadata() -> anyhow::Result<HashMap<String, PaneMetadata>> {
     let start = Instant::now();
     let output = tmux_command()

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -143,7 +143,17 @@ pub(super) fn poll_statuses_once(
 
     let pane_metadata = if any_pollable {
         crate::tmux::refresh_session_cache();
-        crate::tmux::batch_pane_metadata().unwrap_or_default()
+        match crate::tmux::batch_pane_metadata() {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                tracing::warn!(
+                    target: "session.status",
+                    %error,
+                    "skipping status refresh because tmux pane metadata is unavailable",
+                );
+                return Vec::new();
+            }
+        }
     } else {
         HashMap::new()
     };


### PR DESCRIPTION
## Description

Preserve the last authoritative status of tmux-backed sessions when the shared pane-metadata probe fails. Previously both status pollers collapsed a failed list-panes call into an empty metadata map. That made live renamed panes appear absent and discarded the pane_dead signal for known dead panes.

The daemon now carries the previous live status across a failed probe, while the standalone TUI skips that refresh. Successful empty snapshots remain authoritative.

Fixes #3327
Fixes #3328

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

The new regression test and 6,116 existing serve tests pass. Two unrelated existing permission-fixture tests fail in this root-owned sandbox. No documentation change was necessary because this restores the existing status contract. This is not a visual UI change.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR does not change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under web/tests/ and updated web/tests/coverage-matrix.json
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under tests/e2e/
- [x] Skipped a test, because: the failure is an injected batch-probe result covered deterministically at the Rust unit-test tier; an e2e test cannot force this internal tmux subprocess failure without nondeterministic load or a test-only binary seam.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Codex

**Any Additional AI Details you would like to share:** Root-cause tracing, implementation, and verification.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Preserve tmux-backed session statuses when pane-metadata probes fail.
- Skip status refreshes when metadata is unavailable.
- Keep successful empty metadata results authoritative.
- Add regression coverage for live and dead session states.
- Clarify probe failure handling across status pollers.

## Benefits

This prevents temporary tmux failures from marking healthy sessions as missing or `Error`. It also preserves `pane_dead` information and supports existing recovery and auto-resume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->