### PR TITLE
fix(tui): preserve trailing bg fills in preview captures

### DIFF
--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -2955,12 +2955,12 @@ mod tests {
         );
         wait_for_pane_text(&session, "ALPHA");
 
-        let fill = "\u{1b}[44m    ";
+        let fill = format!("\u{1b}[44m{}", " ".repeat(40));
         let (with_cursor, _) = session
             .capture_pane_with_cursor(10)
             .expect("capture_pane_with_cursor");
         assert!(
-            with_cursor.contains(fill),
+            with_cursor.contains(fill.as_str()),
             "capture_pane_with_cursor dropped the styled fill:\n{with_cursor:?}"
         );
 
@@ -2968,14 +2968,14 @@ mod tests {
             .capture_window_composited(10)
             .expect("capture_window_composited");
         assert!(
-            composited.contains(fill),
+            composited.contains(fill.as_str()),
             "capture_window_composited dropped the styled fill:\n{composited:?}"
         );
 
         let layout = session.capture_window_layout(1).expect("layout");
         let rows = layout.panes[0].rows.join("\n");
         assert!(
-            rows.contains(fill),
+            rows.contains(fill.as_str()),
             "capture_window_layout dropped the styled fill:\n{rows:?}"
         );
     }

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -779,6 +779,9 @@ impl Session {
                 &pane0,
                 "-p",
                 "-e",
+                // Trailing bg fills stay, matching the VT path (#3336); see
+                // `capture_pane_with_cursor`.
+                "-N",
                 "-S",
                 &format!("-{}", lines),
                 ";",
@@ -944,6 +947,9 @@ impl Session {
                 target,
                 "-p".to_string(),
                 "-e".to_string(),
+                // Trailing bg fills stay, matching the VT path (#3336); see
+                // `capture_pane_with_cursor`.
+                "-N".to_string(),
             ]);
         }
 
@@ -1047,6 +1053,11 @@ impl Session {
                 &target,
                 "-p",
                 "-e",
+                // Preserve trailing spaces: a bg-styled fill running to the
+                // right edge is content the VT path keeps (`row_last_col`),
+                // and dropping it here makes the preview flicker whenever the
+                // two capture sources alternate (#3336).
+                "-N",
                 "-S",
                 &start,
                 ";",
@@ -2845,7 +2856,8 @@ mod tests {
         );
     }
 
-    /// An unsplit window must composite to exactly what `capture_pane`
+    /// An unsplit window must composite to exactly what the single-pane
+    /// preview capture (`capture_pane_with_cursor`, the other `-N` transport)
     /// returns, so the overwhelmingly common case is provably unchanged.
     #[test]
     #[serial_test::serial]
@@ -2859,7 +2871,10 @@ mod tests {
         let session = start_composite_session(guard.name(), 80, 24, "sh -c 'echo ALPHA; sleep 30'");
         wait_for_pane_text(&session, "ALPHA");
 
-        let plain = session.capture_pane(10).expect("capture_pane");
+        let plain = session
+            .capture_pane_with_cursor(10)
+            .expect("capture_pane_with_cursor")
+            .0;
         let composited = session
             .capture_window_composited(10)
             .expect("capture_window_composited");
@@ -2913,6 +2928,58 @@ mod tests {
         );
     }
 
+    /// A full-screen TUI (opencode's dimmed modal backdrop, its empty home
+    /// screen) paints its background as full-width runs of bg-styled spaces.
+    /// `capture-pane` trims trailing spaces by default, styled or not, while
+    /// the VT path keeps styled trailing blanks as content (`row_last_col`).
+    /// The preview alternates between the two sources, so a fill dropped by
+    /// one and kept by the other flickers at the idle-poll cadence (#3336).
+    /// Every preview-feeding capture must therefore preserve the fill.
+    #[test]
+    #[serial_test::serial]
+    fn preview_captures_preserve_trailing_bg_fill() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let guard = TmuxTestSession::new("aoe_test_bg_fill");
+        // Row 0: a 40-column run of bg-styled spaces, opencode's backdrop
+        // pattern. Row 1: text so the wait helper has a needle that survives
+        // the trim either way.
+        let session = start_composite_session(
+            guard.name(),
+            40,
+            8,
+            "sh -c 'printf \"\\033[44m%40s\\033[0m\\nALPHA\\n\" \"\"; sleep 30'",
+        );
+        wait_for_pane_text(&session, "ALPHA");
+
+        let fill = "\u{1b}[44m    ";
+        let (with_cursor, _) = session
+            .capture_pane_with_cursor(10)
+            .expect("capture_pane_with_cursor");
+        assert!(
+            with_cursor.contains(fill),
+            "capture_pane_with_cursor dropped the styled fill:\n{with_cursor:?}"
+        );
+
+        let composited = session
+            .capture_window_composited(10)
+            .expect("capture_window_composited");
+        assert!(
+            composited.contains(fill),
+            "capture_window_composited dropped the styled fill:\n{composited:?}"
+        );
+
+        let layout = session.capture_window_layout(1).expect("layout");
+        let rows = layout.panes[0].rows.join("\n");
+        assert!(
+            rows.contains(fill),
+            "capture_window_layout dropped the styled fill:\n{rows:?}"
+        );
+    }
+
     /// `C-b z` keeps `window_panes` at its real count while reporting every pane
     /// at the window's FULL rectangle, so the rectangles overlap and the
     /// compositor's tiling assumption breaks. Compositing that painted pane 0 at
@@ -2922,7 +2989,7 @@ mod tests {
     /// so, since nothing self-heals a zoom.
     ///
     /// Zoomed must therefore be treated as unsplit, byte-for-byte identical to
-    /// the plain capture.
+    /// the single-pane preview capture.
     #[test]
     #[serial_test::serial]
     fn a_zoomed_pane_falls_back_to_the_plain_capture() {
@@ -2980,7 +3047,10 @@ mod tests {
         );
         assert_eq!(
             zoomed,
-            session.capture_pane(10).expect("plain capture"),
+            session
+                .capture_pane_with_cursor(10)
+                .expect("capture_pane_with_cursor")
+                .0,
             "zoomed must be byte-identical to the pane-0 capture"
         );
 
@@ -3137,7 +3207,10 @@ mod tests {
         let (content, cursor) = session
             .capture_window_composited_with_cursor(20)
             .expect("composited capture");
-        let plain = session.capture_pane(20).expect("capture_pane");
+        let plain = session
+            .capture_pane_with_cursor(20)
+            .expect("capture_pane_with_cursor")
+            .0;
         assert_eq!(
             content, plain,
             "unsplit window must still pass pane bytes through untouched"

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -1076,8 +1076,8 @@ impl Session {
 
         let raw = String::from_utf8_lossy(&output.stdout);
         // First line: pre-capture cursor header. Last line: post-capture
-        // header. Everything between is the verbatim `capture-pane` output
-        // (same bytes the plain `capture_pane` path returns).
+        // header. Everything between is the verbatim cursor-aware preview
+        // capture output.
         let mut parts = raw.splitn(2, '\n');
         let cursor_line = parts.next().unwrap_or("");
         let rest = parts.next().unwrap_or("");

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -626,7 +626,10 @@ fn capture_seed_snapshot(target: &str) -> Option<(Vec<u8>, PaneSeedState)> {
         };
         // The alternate screen has no scrollback, so only the normal buffer
         // pulls history (`-S`); the pane keeps that history across re-arms.
-        let mut args = vec!["capture-pane", "-t", target, "-p", "-e"];
+        // `-N` keeps trailing bg-styled fills (a modal backdrop painted as
+        // full-width styled spaces) so the seeded grid renders them the same
+        // way live chunks do (#3336).
+        let mut args = vec!["capture-pane", "-t", target, "-p", "-e", "-N"];
         if !pre.alt {
             args.extend_from_slice(&["-S", &seed_start]);
         }


### PR DESCRIPTION
## Description

Fixes #3336.

The live preview flickered every ~250-500ms on opencode's empty home screen and while its modals (model picker, command palette) were open: the background fill blinked in and out.

Root cause: the preview's two capture sources disagree on trailing background fills. The VT grid path keeps styled trailing blanks as content (`row_last_col` counts a bg fill running to the edge as drawn cells), while `tmux capture-pane` trims trailing spaces regardless of styling. A TUI that paints its backdrop as full-width runs of bg-styled spaces (opencode's dimmed modal backdrop, its empty home screen) therefore renders with the fill on VT frames and without it on fork frames. opencode also repaints intermittently while idle (its in-widget caret blink), so worker VT frames alternated with the 250ms idle fork's `capture-pane` frames, and the fill blinked at that cadence.

The fix passes `-N` (preserve trailing spaces) to every preview-feeding capture so both sources agree:

- `Session::capture_pane_with_cursor` (single-pane preview fallback)
- `Session::capture_window_composited_with_cursor` (composited fallback)
- `Session::capture_window_layout` (VT composite fork)
- `capture_seed_snapshot` (VT grid seed)

Deliberately unchanged: `capture_pane` (status detection consumes it for pattern matching; trailing-space changes there are all risk and no benefit, since it never renders) and `capture_pane_full` (smart rename). `-N` needs tmux 2.9; aoe already assumes 3.2+.

The unsplit/zoomed pass-through tests now compare the composite against `capture_pane_with_cursor`, the single-pane transport that shares the `-N` encoding, instead of `capture_pane`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

Before (flicker on the empty home screen / model picker; recording from #3336):

https://github.com/user-attachments/assets/f683a3f5-8b61-49f6-b274-a2eac3823078

After the fix the preview is stable (validated manually against a live opencode session).

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the regression is pinned at the capture layer by a new tmux-gated unit test (`preview_captures_preserve_trailing_bg_fill`), which reproduces opencode's backdrop pattern (a full-width row of bg-styled spaces) and failed before the fix with exactly the reported symptom (fill trimmed to a dangling SGR). An e2e test would need a real full-screen agent repainting on a timer plus visual frame comparison across the VT/fork alternation, which is timing-dependent and adds serial e2e wall time for strictly less precision than the unit test.

## Testing

- `cargo fmt`, `cargo clippy` clean on touched files.
- New test: `tmux::session::tests::preview_captures_preserve_trailing_bg_fill` (TDD: written first, failed with the fill trimmed, passes after).
- `cargo test`: identical pass/fail profile to `main` on my machine (the few failing tmux-gated tests fail on unmodified `main` too; they depend on `#{pane_current_command}`, which reports the user's default shell `fish` instead of the spawned command).
- Manual: rebuilt with the fix, opened a fresh opencode session and its model picker in the preview; flicker is gone.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (OpenCode agent)

**Any Additional AI Details you'd like to share:**
The investigation (frame-by-frame recording analysis, tmux capture experiments), the fix, and this PR text were produced by an AI agent working under my direction. I reproduced the bug, reviewed the code, and validated the fix manually against a live opencode session.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated preview captures to preserve trailing spaces and background fills.
- Added regression coverage for full-width background rendering.
- Updated pass-through tests to use consistent capture behavior.
- Kept status detection and smart-rename captures unchanged.

This prevents preview flicker and keeps background fills stable during idle repaints and fallback captures.

## Technical details

`capture-pane -N` is now used by `capture_pane_with_cursor`, `capture_window_composited_with_cursor`, `capture_window_layout`, and `capture_seed_snapshot`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->