### PR TITLE
fix: classify absent tmux socket as no-server, not error

### DIFF
--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -246,11 +246,16 @@ const FIELD_SEP: char = '|';
 
 /// tmux exits non-zero with `no server running on <socket>` on stderr when
 /// there are simply zero sessions, the normal state for a structured-view
-/// user who never opens a terminal. That is the empty case, not an error:
-/// callers log it at trace and treat the result as empty, reserving warn for
-/// a genuinely unexpected non-zero exit.
+/// user who never opens a terminal. It also exits non-zero with
+/// `error connecting to <socket> (No such file or directory)` when the socket
+/// file itself is absent (issue #3337), which is likewise the empty case, not
+/// an error. Both are treated as empty: callers log at trace and return an
+/// empty result, reserving warn for a genuinely unexpected non-zero exit. A
+/// transient glitch on an existing socket stays on the error path.
 fn tmux_no_server_running(stderr: &[u8]) -> bool {
-    String::from_utf8_lossy(stderr).contains("no server running")
+    let s = String::from_utf8_lossy(stderr);
+    s.contains("no server running")
+        || (s.contains("error connecting to") && s.contains("No such file or directory"))
 }
 
 pub fn refresh_session_cache() {
@@ -1502,6 +1507,10 @@ mod tests {
             b"no server running on /tmp/tmux-501/default\n"
         ));
         assert!(tmux_no_server_running(b"no server running on /path.sock"));
+        // The socket file itself is absent (issue #3337): also the empty case.
+        assert!(tmux_no_server_running(
+            b"error connecting to /path.sock (No such file or directory)"
+        ));
     }
 
     #[test]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -193,6 +193,21 @@ pub(crate) fn tmux_command() -> Command {
     cmd
 }
 
+/// Like [`tmux_command`], but pins `LC_ALL=C` for read-only status queries
+/// whose non-zero stderr we classify with [`tmux_no_server_running`]. tmux's
+/// `client.c` prints `error connecting to <socket> (strerror(errno))` for a
+/// non-`ECONNREFUSED` connect failure, and glibc localizes `strerror` by
+/// `LC_MESSAGES`, so on a non-English host the `(No such file or directory)`
+/// ENOENT marker for an absent socket (#3337) would not match and the empty
+/// case would be misclassified as an error. NOT folded into [`tmux_command`]:
+/// the interactive attach/switch-client/capture-pane paths must keep the
+/// user's locale for UTF-8 and status-bar rendering.
+pub(crate) fn tmux_query_command() -> Command {
+    let mut cmd = tmux_command();
+    cmd.env("LC_ALL", "C");
+    cmd
+}
+
 // Debug builds use `aoe_dev_*` prefixes so `cargo run` and an installed
 // release `aoe` never mistake each other's sessions. Debug builds also run on
 // their own tmux socket (see `tmux_socket`), so the two builds no longer
@@ -245,22 +260,35 @@ struct SessionCache {
 const FIELD_SEP: char = '|';
 
 /// tmux exits non-zero with `no server running on <socket>` on stderr when
-/// there are simply zero sessions, the normal state for a structured-view
-/// user who never opens a terminal. It also exits non-zero with
+/// there is no server on the resolved socket (zero sessions, or the socket's
+/// server has died): the normal state for a structured-view user who never
+/// opens a terminal. It also exits non-zero with
 /// `error connecting to <socket> (No such file or directory)` when the socket
 /// file itself is absent (issue #3337), which is likewise the empty case, not
 /// an error. Both are treated as empty: callers log at trace and return an
-/// empty result, reserving warn for a genuinely unexpected non-zero exit. A
-/// transient glitch on an existing socket stays on the error path.
+/// empty result, reserving warn for a genuinely unexpected non-zero exit.
+///
+/// A transient glitch on an existing socket stays on the error path: tmux
+/// (`client.c`) emits `error connecting to <socket> (<strerror>)` for a
+/// non-`ECONNREFUSED` connect failure, so `(Permission denied)` (EACCES) and
+/// `(Socket operation on non-socket)` (ENOTSOCK) do NOT match. The ENOENT
+/// marker is matched anchored to the end of its own line, so a socket path
+/// that happens to contain the phrase cannot fake the empty case on a
+/// different errno. Callers MUST use [`tmux_query_command`] so the `strerror`
+/// text is stable English (see #3327/#3328).
 fn tmux_no_server_running(stderr: &[u8]) -> bool {
     let s = String::from_utf8_lossy(stderr);
     s.contains("no server running")
-        || (s.contains("error connecting to") && s.contains("No such file or directory"))
+        || s.lines().any(|line| {
+            let line = line.trim();
+            line.starts_with("error connecting to ")
+                && line.ends_with("(No such file or directory)")
+        })
 }
 
 pub fn refresh_session_cache() {
     let start = Instant::now();
-    let output = tmux_command()
+    let output = tmux_query_command()
         .args(["list-sessions", "-F", "#{session_name}|#{session_activity}"])
         .output();
 
@@ -607,7 +635,7 @@ pub fn stop_all_sessions() -> anyhow::Result<usize> {
 /// successful empty map is authoritative and means there are no panes.
 pub fn batch_pane_metadata() -> anyhow::Result<HashMap<String, PaneMetadata>> {
     let start = Instant::now();
-    let output = tmux_command()
+    let output = tmux_query_command()
         .args([
             "list-panes",
             "-a",
@@ -665,7 +693,7 @@ pub fn batch_pane_metadata() -> anyhow::Result<HashMap<String, PaneMetadata>> {
 /// pass" rather than "nothing attached", so a transient tmux glitch cannot
 /// kill a pane the user is sitting in.
 pub fn attached_session_names() -> anyhow::Result<HashSet<String>> {
-    let output = tmux_command()
+    let output = tmux_query_command()
         .args(["list-sessions", "-F", "#{session_name}|#{session_attached}"])
         .output();
 
@@ -1511,6 +1539,11 @@ mod tests {
         assert!(tmux_no_server_running(
             b"error connecting to /path.sock (No such file or directory)"
         ));
+        // The ENOENT marker is anchored to the line end, so it is still
+        // detected when the socket path itself contains the phrase (#3337 F4).
+        assert!(tmux_no_server_running(
+            b"error connecting to /tmp/No such file or directory.sock (No such file or directory)"
+        ));
     }
 
     #[test]
@@ -1519,6 +1552,21 @@ mod tests {
         assert!(!tmux_no_server_running(b"can't find session: aoe_foo"));
         assert!(!tmux_no_server_running(b"usage: list-sessions"));
         assert!(!tmux_no_server_running(b""));
+        // Transient strerrors reaching the error-connecting branch (tmux
+        // client.c, non-ECONNREFUSED) must stay on the error path (#3327/#3328).
+        // ECONNREFUSED is NOT here: tmux emits `no server running` for a dead
+        // server, which is the empty case above.
+        assert!(!tmux_no_server_running(
+            b"error connecting to /path.sock (Permission denied)"
+        ));
+        assert!(!tmux_no_server_running(
+            b"error connecting to /path.sock (Socket operation on non-socket)"
+        ));
+        // A socket path containing the ENOENT phrase must not fake the empty
+        // case on a different errno (#3337 F4).
+        assert!(!tmux_no_server_running(
+            b"error connecting to /tmp/No such file or directory.sock (Permission denied)"
+        ));
     }
 
     #[test]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -193,15 +193,16 @@ pub(crate) fn tmux_command() -> Command {
     cmd
 }
 
-/// Like [`tmux_command`], but pins `LC_ALL=C` for read-only status queries
-/// whose non-zero stderr we classify with [`tmux_no_server_running`]. tmux's
+/// Like [`tmux_command`], but pins `LC_ALL=C` so tmux's connection-failure
+/// messages on stderr stay stable English for callers that match them. tmux's
 /// `client.c` prints `error connecting to <socket> (strerror(errno))` for a
 /// non-`ECONNREFUSED` connect failure, and glibc localizes `strerror` by
 /// `LC_MESSAGES`, so on a non-English host the `(No such file or directory)`
-/// ENOENT marker for an absent socket (#3337) would not match and the empty
-/// case would be misclassified as an error. NOT folded into [`tmux_command`]:
-/// the interactive attach/switch-client/capture-pane paths must keep the
-/// user's locale for UTF-8 and status-bar rendering.
+/// ENOENT marker for an absent socket (#3337) would not match. Used by the
+/// status-query callers (which classify via [`tmux_no_server_running`]) and by
+/// `kill_session_if_present`. NOT folded into [`tmux_command`]: the
+/// interactive attach/switch-client/capture-pane paths must keep the user's
+/// locale for UTF-8 and status-bar rendering.
 pub(crate) fn tmux_query_command() -> Command {
     let mut cmd = tmux_command();
     cmd.env("LC_ALL", "C");
@@ -272,18 +273,22 @@ const FIELD_SEP: char = '|';
 /// (`client.c`) emits `error connecting to <socket> (<strerror>)` for a
 /// non-`ECONNREFUSED` connect failure, so `(Permission denied)` (EACCES) and
 /// `(Socket operation on non-socket)` (ENOTSOCK) do NOT match. The ENOENT
-/// marker is matched anchored to the end of its own line, so a socket path
-/// that happens to contain the phrase cannot fake the empty case on a
-/// different errno. Callers MUST use [`tmux_query_command`] so the `strerror`
-/// text is stable English (see #3327/#3328).
+/// marker (and the `no server running` marker) is matched anchored per line,
+/// so a socket path that happens to contain either phrase cannot fake the
+/// empty case on a different errno. Callers MUST use [`tmux_query_command`] so
+/// the `strerror` text is stable English (see #3327/#3328).
 fn tmux_no_server_running(stderr: &[u8]) -> bool {
     let s = String::from_utf8_lossy(stderr);
-    s.contains("no server running")
-        || s.lines().any(|line| {
-            let line = line.trim();
-            line.starts_with("error connecting to ")
-                && line.ends_with("(No such file or directory)")
-        })
+    // tmux (`client.c`) prints both markers at the start of their own line
+    // (`no server running on <socket>` / `error connecting to <socket>
+    // (<strerror>)`), so anchor to the line rather than scanning the whole
+    // buffer, where an arbitrary socket path could otherwise spoof a match.
+    s.lines().any(|line| {
+        let line = line.trim();
+        line.starts_with("no server running")
+            || (line.starts_with("error connecting to ")
+                && line.ends_with("(No such file or directory)"))
+    })
 }
 
 pub fn refresh_session_cache() {
@@ -1562,10 +1567,13 @@ mod tests {
         assert!(!tmux_no_server_running(
             b"error connecting to /path.sock (Socket operation on non-socket)"
         ));
-        // A socket path containing the ENOENT phrase must not fake the empty
-        // case on a different errno (#3337 F4).
+        // A socket path containing either marker phrase must not fake the empty
+        // case on a different errno; both markers are anchored per line.
         assert!(!tmux_no_server_running(
             b"error connecting to /tmp/No such file or directory.sock (Permission denied)"
+        ));
+        assert!(!tmux_no_server_running(
+            b"error connecting to /tmp/no server running.sock (Permission denied)"
         ));
     }
 

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -1857,7 +1857,10 @@ mod tests {
         let name = guard.name().to_string();
         // A short, static "booting" line appears immediately and would
         // satisfy the generic settle heuristic well under 700ms; the real
-        // marker text only appears after the sleep.
+        // marker text only appears after the sleep. The trailing `set-option
+        // pane-base-index 0` chain mirrors `append_pane_base_index_args` so the
+        // `^.0` capture target resolves on hosts with `pane-base-index 1` set
+        // globally (#488, #2231).
         let status = crate::tmux::tmux_command()
             .args([
                 "new-session",
@@ -1871,6 +1874,12 @@ mod tests {
                 "sh",
                 "-c",
                 "echo booting; sleep 0.7; echo 'ask anything...'; sleep 30",
+                ";",
+                "set-option",
+                "-t",
+                &name,
+                "pane-base-index",
+                "0",
             ])
             .status()
             .expect("tmux new-session");

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -68,6 +68,19 @@ fn host_pane_inputs(
     (pairs, cmd)
 }
 
+/// Resolve a shell name or path to an absolute path via a PATH lookup.
+///
+/// tmux's `default-shell` rejects a bare name ("not a suitable shell: bash"),
+/// and [`user_shell`] falls back to a bare `bash` when `$SHELL` is unset (e.g.
+/// an `aoe serve` daemon started from launchd/systemd). `which` returns an
+/// already absolute, existing path unchanged, and `None` when the shell is not
+/// found so the caller can skip `default-shell` rather than fail creation.
+fn absolute_shell(shell: &str) -> Option<String> {
+    which::which(shell)
+        .ok()
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
 /// Shared implementation of the paired-terminal lifecycle. Not exposed; the
 /// public [`TerminalSession`] and [`ContainerTerminalSession`] wrap one of
 /// these with a fixed [`TerminalKind`].
@@ -156,7 +169,13 @@ impl PairedTerminal {
         // server and poison `default-shell` + base env for every session,
         // including release ones (#2608). Container terminals are excluded;
         // their HOME/shell belong to the container, not the host.
-        let host_shell = matches!(self.kind, TerminalKind::Host).then(user_shell);
+        // `user_shell` yields a bare `bash` when `$SHELL` is unset (a daemon
+        // launched from launchd/systemd) and tmux's `default-shell` rejects a
+        // bare name ("not a suitable shell: bash"), so resolve it to an absolute
+        // path. Pinning SHELL to the resolved path also keeps #2608 consistent.
+        let host_shell = matches!(self.kind, TerminalKind::Host)
+            .then(user_shell)
+            .map(|shell| absolute_shell(&shell).unwrap_or(shell));
         let home = std::env::var("HOME").unwrap_or_default();
         let path = std::env::var("PATH").unwrap_or_default();
         let (pinned_pairs, effective_cmd) =
@@ -191,7 +210,12 @@ impl PairedTerminal {
         append_remain_on_exit_args(&mut args, &self.name);
         append_pane_base_index_args(&mut args, &self.name);
         append_window_size_args(&mut args, &self.name);
-        if let Some(shell) = &host_shell {
+        // Only pin `default-shell` when the shell resolved to an absolute path;
+        // tmux rejects a bare name and would fail the whole `new-session`.
+        if let Some(shell) = host_shell
+            .as_deref()
+            .filter(|s| std::path::Path::new(s).is_absolute())
+        {
             append_default_shell_args(&mut args, &self.name, shell);
         }
         append_tmux_setting_args(&mut args, &self.name, &config);
@@ -658,6 +682,16 @@ mod tests {
     fn test_host_pane_inputs_drops_empty_home_path() {
         let (env, _) = host_pane_inputs(Some("/bin/bash"), None, "", "");
         assert_eq!(env, vec![("SHELL".to_string(), "/bin/bash".to_string())]);
+    }
+
+    #[test]
+    fn absolute_shell_resolves_bare_name_and_rejects_missing() {
+        // tmux's `default-shell` needs an absolute path: a bare name resolves
+        // via PATH, and an unknown shell yields None so create_with_size skips
+        // the option instead of failing `new-session`.
+        let resolved = absolute_shell("sh").expect("sh must resolve on a unix host");
+        assert!(std::path::Path::new(&resolved).is_absolute(), "{resolved}");
+        assert_eq!(absolute_shell("aoe-not-a-real-shell-xyzzy"), None);
     }
 
     #[test]

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -170,16 +170,19 @@ impl PairedTerminal {
         // including release ones (#2608). Container terminals are excluded;
         // their HOME/shell belong to the container, not the host.
         // `user_shell` yields a bare `bash` when `$SHELL` is unset (a daemon
-        // launched from launchd/systemd) and tmux's `default-shell` rejects a
-        // bare name ("not a suitable shell: bash"), so resolve it to an absolute
-        // path. Pinning SHELL to the resolved path also keeps #2608 consistent.
-        let host_shell = matches!(self.kind, TerminalKind::Host)
-            .then(user_shell)
-            .map(|shell| absolute_shell(&shell).unwrap_or(shell));
+        // launched from launchd/systemd), and tmux's `default-shell` rejects
+        // anything that is not an absolute path to an existing executable
+        // ("not a suitable shell: bash"). Resolve it once: `default_shell` is
+        // `Some` only when `which` finds an executable, and pins `default-shell`
+        // only then so tmux never fails `new-session` on an unusable shell. The
+        // pane's SHELL env and login command prefer that resolved path but fall
+        // back to the raw name so a pane still launches when it cannot resolve.
+        let host_shell = matches!(self.kind, TerminalKind::Host).then(user_shell);
+        let default_shell = host_shell.as_deref().and_then(absolute_shell);
+        let shell_for_pane = default_shell.as_deref().or(host_shell.as_deref());
         let home = std::env::var("HOME").unwrap_or_default();
         let path = std::env::var("PATH").unwrap_or_default();
-        let (pinned_pairs, effective_cmd) =
-            host_pane_inputs(host_shell.as_deref(), command, &home, &path);
+        let (pinned_pairs, effective_cmd) = host_pane_inputs(shell_for_pane, command, &home, &path);
         // Host terminals also forward the inherited host env (DISPLAY, XDG_*,
         // DBUS, ... plus every other var under `session.inherit_host_environment`)
         // so a browser opened from the pane reaches the user's desktop;
@@ -210,12 +213,9 @@ impl PairedTerminal {
         append_remain_on_exit_args(&mut args, &self.name);
         append_pane_base_index_args(&mut args, &self.name);
         append_window_size_args(&mut args, &self.name);
-        // Only pin `default-shell` when the shell resolved to an absolute path;
-        // tmux rejects a bare name and would fail the whole `new-session`.
-        if let Some(shell) = host_shell
-            .as_deref()
-            .filter(|s| std::path::Path::new(s).is_absolute())
-        {
+        // `default_shell` is `Some` only when `which` resolved an existing
+        // executable, so pinning it can never fail `new-session`.
+        if let Some(shell) = default_shell.as_deref() {
             append_default_shell_args(&mut args, &self.name, shell);
         }
         append_tmux_setting_args(&mut args, &self.name, &config);

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -319,6 +319,11 @@ pub(crate) fn kill_session_if_present(name: &str) -> Result<()> {
         .output()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        // Deliberately broader than `tmux_no_server_running`: for a kill, ANY
+        // connect failure (`error connecting`, any errno) means there is no
+        // server and thus no session to remove, so it is success. The status
+        // pollers need the narrower ENOENT-only test to keep transient glitches
+        // on the error path; here a false "absent" cannot act on a live pane.
         let absent = stderr.contains("can't find session")
             || stderr.contains("no server running")
             || stderr.contains("error connecting");

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -314,8 +314,7 @@ pub fn tmux_prefix_display() -> &'static str {
 /// `Err`. Caller is responsible for `refresh_session_cache` after a
 /// successful kill.
 pub(crate) fn kill_session_if_present(name: &str) -> Result<()> {
-    let output = crate::tmux::tmux_command()
-        .env("LC_ALL", "C")
+    let output = crate::tmux::tmux_query_command()
         .args(["kill-session", "-t", name])
         .output()?;
     if !output.status.success() {


### PR DESCRIPTION
## Description

`tmux_no_server_running()` only matched the substring `no server running`, but when the resolved tmux socket file is **absent**, tmux exits non-zero with `error connecting to <path> (No such file or directory)` (tmux `client.c`; verified for both `-S` and `-L`, exit 1). So `batch_pane_metadata()` returned `Err` instead of `Ok(empty)`. Since #3335 made `poll_statuses_once()` return an empty `Vec` on `Err`, every status froze on any checkout with no tmux server on the resolved socket.

Fix: classify the socket-absent case (ENOENT) as the empty case, while keeping genuinely transient failures on the error path so #3327/#3328 do not regress. tmux emits `no server running` for `ECONNREFUSED` (a dead server), so that already maps to the empty case; only ENOENT reaches the `error connecting to (strerror)` branch as an empty case, while EACCES/ENOTSOCK stay errors.

The ENOENT marker is `strerror(errno)`, which glibc localizes by `LC_MESSAGES`, so the three status-query callers (and `kill_session_if_present`) now go through a new `tmux_query_command()` that pins `LC_ALL=C`; it is deliberately kept out of `tmux_command()` so interactive attach/capture-pane paths keep the user's locale for UTF-8. The marker is matched anchored to its own line so a socket path that contains the phrase cannot fake the empty case on a different errno.

Two latent, pre-existing failures were also root-caused and fixed while making the suites green on hosts that differ from CI:

- **`create_with_size` pinned tmux `default-shell` to a bare shell name.** `user_shell()` falls back to a bare `bash` when `$SHELL` is unset (an `aoe serve` daemon started from launchd/systemd), and tmux rejects a non-absolute `default-shell` (`not a suitable shell`), failing the whole host-terminal `new-session`. The host shell is now resolved once via `which`; `default-shell` is pinned **only when the shell resolves to an existing executable**, and an unresolvable shell is skipped so tmux never fails `new-session`. The raw name is still pinned as `SHELL` and used for the pane login command as a fallback.
- **`wait_until_ready`'s test session did not pin `pane-base-index 0`.** Production pins it via `append_pane_base_index_args`, so the `^.0` capture target resolves under a `pane-base-index 1` user config; the test's raw `new-session` omitted it, so its pane landed at index 1 and the capture never matched (`can't find pane: 0`). The test now chains the same option, mirroring the existing convention (#488, #2231).

Commits: `fix: classify absent tmux socket as no-server, not error` (the core fix) and `fix: harden tmux no-server classification (review)` (locale/anchoring/default-shell-resolution hardening from review).

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: no TUI/CLI/session-lifecycle behavior change. The fix is in unit-tested pure logic: the `tmux_no_server_running` table covers the ENOENT empty case, the anchoring cases, and the transient strerrors (EACCES/ENOTSOCK) that must stay errors; an `absolute_shell` unit test defends the resolve/skip contract; and the two originally-failing `tmux::`/`status_poller` unit tests pass deterministically without a tmux server.

Gates run locally (all green):
- `cargo fmt --all --check`
- `cargo clippy --features serve --lib --bins -- -D warnings`
- `cargo test --features serve --lib 'tmux::'` (381 passed)
- `cargo test --features serve --lib status_poller` (17 passed)

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (Opus) via the omp coding harness.

**Any Additional AI Details you'd like to share:** AI assisted with root-cause analysis (verified empirically against real `tmux 3.7b` and against the tmux `client.c` source) and the patch; a human is reviewing before merge.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Treats a missing tmux socket as “no server running” instead of an error.
- Keeps transient socket failures visible.
- Forces a stable locale for status queries while preserving the user’s locale for interactive commands.
- Resolves and validates the shell before configuring tmux.
- Makes readiness tests independent of the host’s pane index settings.
- Adds coverage for socket errors, locale handling, marker anchoring, shell resolution, and pane indexing.

These changes prevent status polling from freezing when no tmux server exists and improve test reliability across environments.

## Technical details

- Added `tmux_query_command()`.
- Anchored no-server markers to their own lines.
- Applied conditional `default-shell` configuration.
- Updated `kill_session_if_present` to handle absent tmux servers safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->