### PR TITLE
test: make absolute_shell resolution independent of $PATH

### DIFF
--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -72,11 +72,23 @@ fn host_pane_inputs(
 ///
 /// tmux's `default-shell` rejects a bare name ("not a suitable shell: bash"),
 /// and [`user_shell`] falls back to a bare `bash` when `$SHELL` is unset (e.g.
-/// an `aoe serve` daemon started from launchd/systemd). `which` returns an
-/// already absolute, existing path unchanged, and `None` when the shell is not
-/// found so the caller can skip `default-shell` rather than fail creation.
+/// an `aoe serve` daemon started from launchd/systemd). Returns an already
+/// absolute, existing path unchanged, and `None` when the shell is not found
+/// so the caller can skip `default-shell` rather than fail creation.
 fn absolute_shell(shell: &str) -> Option<String> {
-    which::which(shell)
+    absolute_shell_in(shell, std::env::var_os("PATH").as_deref())
+}
+
+/// [`absolute_shell`] with an explicit PATH-style lookup list, split out so the
+/// unit test can resolve against a controlled directory instead of the
+/// process `$PATH`. `paths` is a `$PATH`-style joined string; when it is `None`
+/// no directories are searched, so a bare name will not resolve (an absolute
+/// path still does).
+fn absolute_shell_in(shell: &str, paths: Option<&std::ffi::OsStr>) -> Option<String> {
+    // `which_in` requires a cwd; it is only used to resolve a relative shell
+    // path, which bare names and absolute paths ignore.
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    which::which_in(shell, paths, cwd)
         .ok()
         .map(|p| p.to_string_lossy().into_owned())
 }
@@ -686,12 +698,25 @@ mod tests {
 
     #[test]
     fn absolute_shell_resolves_bare_name_and_rejects_missing() {
-        // tmux's `default-shell` needs an absolute path: a bare name resolves
-        // via PATH, and an unknown shell yields None so create_with_size skips
+        // Hermetic: resolve against a controlled directory rather than the
+        // process `$PATH`, so the result does not depend on which shells the
+        // host happens to have installed. tmux's `default-shell` needs an
+        // absolute path; an unknown name yields None so create_with_size skips
         // the option instead of failing `new-session`.
-        let resolved = absolute_shell("sh").expect("sh must resolve on a unix host");
-        assert!(std::path::Path::new(&resolved).is_absolute(), "{resolved}");
-        assert_eq!(absolute_shell("aoe-not-a-real-shell-xyzzy"), None);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = dir.path().join("aoe-test-shell");
+        std::fs::write(&bin, b"#!/bin/sh\n").expect("write shim");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        }
+        let paths = Some(dir.path().as_os_str());
+        // `which_in` returns the search dir joined with the name verbatim, so
+        // the resolved path equals the planted shim exactly.
+        let resolved = absolute_shell_in("aoe-test-shell", paths).expect("shim must resolve");
+        assert_eq!(std::path::Path::new(&resolved), bin);
+        assert_eq!(absolute_shell_in("aoe-not-a-real-shell-xyzzy", paths), None);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Follow-up to #3344 (raised in the #3341 review). `absolute_shell`'s unit test resolved `"sh"` and a sentinel name through the process `$PATH`, so it was deterministic on the hosts that run this suite (Unix, since the crate needs `tmux`) but not hermetic.

This splits the PATH lookup into `absolute_shell_in(shell, paths)` backed by `which::which_in`. `absolute_shell` keeps its signature and passes the process `$PATH`, so production behavior is unchanged. The test now plants a temp executable in a controlled lookup dir and resolves against it, with no dependency on the ambient `$PATH` and no env mutation (so no `#[serial]` needed).

Test-only hardening; no behavior change to shell resolution in production.

Closes #3344.

## PR Type

- [x] Refactor

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: no TUI/CLI/session-lifecycle behavior change. This only rewrites the existing `absolute_shell_resolves_bare_name_and_rejects_missing` unit test to resolve against a controlled directory instead of the process `$PATH`; production shell resolution is unchanged.

Gates run locally (all green):
- `cargo fmt --all --check`
- `cargo clippy --features serve --lib --bins -- -D warnings`
- `cargo test --features serve --lib 'tmux::terminal_session::tests::absolute_shell'`

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (Opus) via the omp coding harness.

**Any Additional AI Details you'd like to share:** Follow-up implementation from the #3341 review discussion; wording reviewed by a human.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Made shell-resolution tests independent of the process `$PATH`.
- Added controlled-path lookup with `which::which_in`.
- Added coverage for successful resolution, canonicalization, and missing-shell rejection.
- Preserved production behavior and `create_with_size` behavior.

## Benefits

- Tests behave consistently across environments.
- Tests avoid changing global environment state.
- The existing production API remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->