### PR TITLE
feat(tui): add codex quick permission responses

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -806,7 +806,11 @@ pub const AGENTS: &[AgentDef] = &[
         // swallowed as newlines instead of triggering submit. 150ms > 120ms.
         send_keys_enter_delay_ms: 150,
         install_hint: "npm install -g @openai/codex",
-        permission_response: None,
+        permission_response: Some(PermissionResponse {
+            allow: &[KeyToken::Literal("y")],
+            allow_always: Some(&[KeyToken::Literal("a")]),
+            deny: &[KeyToken::Literal("d")],
+        }),
     },
     AgentDef {
         name: "gemini",

--- a/tests/e2e/permission_response_e2e.rs
+++ b/tests/e2e/permission_response_e2e.rs
@@ -6,24 +6,22 @@ use serial_test::parallel;
 
 use crate::harness::{require_tmux, TuiTestHarness};
 
-/// Write a fake "claude" script that prints a static permission-prompt
-/// block, then blocks reading exactly one byte from stdin via `dd` (not
-/// `read -r`, which would wait for a newline the app never sends; the
-/// real Claude Code CLI selects a numbered menu option on a bare digit
-/// with no Enter, and `send_key_tokens` deliberately sends no implicit
-/// trailing key). Once a byte arrives, it echoes it in a recognizable,
-/// greppable form and sleeps so the pane stays alive for the assertion.
+/// Write a fake agent script that prints a static permission-prompt block,
+/// then blocks reading exactly one byte from stdin via `dd` (not `read -r`,
+/// which would wait for a newline the app never sends). Once a byte arrives,
+/// it echoes it in a recognizable, greppable form and sleeps so the pane
+/// stays alive for the assertion.
 ///
-/// Returns the script's absolute path, for use with `--cmd-override`
-/// rather than relying on `$PATH`: the tmux pane that runs the agent
-/// launches it through a login shell (so version-manager PATHs like
-/// NVM load), and that shell's own rc files can reorder `$PATH` ahead of
-/// a `$PATH`-installed stub, letting a real `claude` on the host shadow
-/// it. An absolute `--cmd-override` path sidesteps PATH lookup entirely.
-fn install_fake_claude_prompt(h: &TuiTestHarness) -> std::path::PathBuf {
+/// Returns the script's absolute path, for use with `--cmd-override` rather
+/// than relying on `$PATH`: the tmux pane that runs the agent launches it
+/// through a login shell (so version-manager PATHs like NVM load), and that
+/// shell's own rc files can reorder `$PATH` ahead of a `$PATH`-installed stub,
+/// letting a real agent on the host shadow it. An absolute `--cmd-override`
+/// path sidesteps PATH lookup entirely.
+fn install_fake_prompt(h: &TuiTestHarness, tool: &str) -> std::path::PathBuf {
     let dir = h.home_path().join("fake-bin");
     std::fs::create_dir_all(&dir).expect("create fake-bin dir");
-    let claude = dir.join("fake-claude");
+    let prompt = dir.join(format!("fake-{tool}"));
     // The pane's tty starts in canonical line-buffered mode, so a bare
     // digit with no trailing Enter (exactly what `send_key_tokens` sends)
     // sits in the kernel tty driver's line buffer forever; `dd` would
@@ -40,14 +38,14 @@ char=$(dd bs=1 count=1 2>/dev/null)\n\
 stty icanon echo 2>/dev/null\n\
 echo \"GOT:[$char]\"\n\
 sleep 60\n";
-    std::fs::write(&claude, script).expect("write fake claude prompt script");
+    std::fs::write(&prompt, script).expect("write fake prompt script");
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&claude, std::fs::Permissions::from_mode(0o755))
-            .expect("chmod fake claude");
+        std::fs::set_permissions(&prompt, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake prompt script");
     }
-    claude
+    prompt
 }
 
 #[test]
@@ -56,7 +54,7 @@ fn test_respond_to_permission_allow_sends_bare_digit() {
     require_tmux!();
 
     let mut h = TuiTestHarness::new("perm_resp_allow");
-    let fake_claude = install_fake_claude_prompt(&h);
+    let fake_claude = install_fake_prompt(&h, "claude");
 
     let project = h.project_path();
     // `--launch` starts the tmux session (spawning the fake claude script)
@@ -104,7 +102,7 @@ fn test_respond_to_permission_deny_sends_bare_digit() {
     require_tmux!();
 
     let mut h = TuiTestHarness::new("perm_resp_deny");
-    let fake_claude = install_fake_claude_prompt(&h);
+    let fake_claude = install_fake_prompt(&h, "claude");
 
     let project = h.project_path();
     // See the allow test above for why the add-launch output isn't asserted.
@@ -130,4 +128,38 @@ fn test_respond_to_permission_deny_sends_bare_digit() {
     h.send_keys("d");
 
     h.wait_for("GOT:[3]");
+}
+
+#[test]
+#[parallel]
+fn test_respond_to_codex_permission_allow_always_sends_a() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("perm_resp_codex_allow_always");
+    h.install_path_command("codex");
+    let fake_codex = install_fake_prompt(&h, "codex");
+
+    let project = h.project_path();
+    h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-t",
+        "CodexPermResp",
+        "--tool",
+        "codex",
+        "--cmd-override",
+        fake_codex.to_str().unwrap(),
+        "--launch",
+    ]);
+
+    h.spawn_tui();
+    h.wait_for(" aoe ");
+    h.wait_for("CodexPermResp");
+    h.wait_for("Do you want to proceed?");
+
+    h.send_keys("a");
+    h.wait_for("Respond to Permission Prompt");
+    h.send_keys("A");
+
+    h.wait_for("GOT:[a]");
 }


### PR DESCRIPTION
## Description

Adds sidebar quick permission-response mappings for Codex. The `a` sidebar action can now send `y`, `a`, or `d` for allow, allow-for-session, and deny; an E2E test covers the session-scoped path.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
openai-codex/gpt-5.6-terra via Oh My Pi

**Any Additional AI Details you'd like to share:**
AI implemented the Codex mappings and E2E coverage; the contributor requested this PR.

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds Codex sidebar shortcuts for allowing, allowing for the session, and denying permission requests.
- Generalizes permission-prompt test helpers for multiple tools.
- Adds an end-to-end test for the session-scoped Codex response.

## Benefits

Users can respond to Codex permission requests directly from the sidebar. The tests also improve coverage and make future tool-specific permission tests easier to add.

## Potential enhancement

Add coverage for the Codex allow and deny shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->