### PR TITLE
fix(tui): keep poller repair off the render loop

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -5719,7 +5719,11 @@ impl Instance {
     /// OMP pollers reload pane metadata on every tick, so a replacement binds
     /// to the durable generation that won any concurrent restart race.
     pub(crate) fn repair_session_id_poller_if_needed(&mut self) -> bool {
-        if !self.supports_session_poller()
+        // Structured sessions have ACP workers rather than tmux panes. Their
+        // lifecycle is reconciled by the daemon, so probing tmux here can only
+        // fail and is especially costly from the native TUI's refresh loop.
+        if self.is_structured()
+            || !self.supports_session_poller()
             || self.session_id_poller_is_running()
             || !self.has_live_tmux_pane()
         {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1779,6 +1779,7 @@ impl App {
 
             if last_status_refresh.elapsed() >= STATUS_REFRESH_INTERVAL {
                 self.home.request_status_refresh();
+                self.home.repair_session_id_pollers();
                 last_status_refresh = std::time::Instant::now();
             }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3453,14 +3453,17 @@ impl HomeView {
             }
         }
 
-        // A concurrent restart can publish a newer OMP generation while the
-        // poller from this process exits in the pane-replacement gap. Repair
-        // stopped workers on the recurring tick, after draining their final
-        // observation.
-        for inst in self.instances.values_mut() {
-            inst.repair_session_id_poller_if_needed();
-        }
         changed
+    }
+
+    /// Recreate stopped terminal session-id pollers after a status-refresh
+    /// cadence has refreshed tmux state. This is deliberately separate from
+    /// [`Self::apply_session_id_updates`], which runs on every input/render
+    /// wake while live views are open.
+    pub fn repair_session_id_pollers(&mut self) {
+        for instance in self.instances.values_mut() {
+            instance.repair_session_id_poller_if_needed();
+        }
     }
 
     /// Drain the startup-recovery channel and apply each `RecoveryUpdate`

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -18098,7 +18098,7 @@ mod apply_session_id_updates {
 
     use super::*;
     use crate::session::poller::SessionPoller;
-    use crate::session::ResumeIntent;
+    use crate::session::{ResumeIntent, View};
     use std::sync::{Arc, Mutex};
 
     const NEW_SID: &str = "019342ab-1111-7aaa-8bbb-cccdddeeefff";
@@ -18411,7 +18411,7 @@ mod apply_session_id_updates {
 
     #[test]
     #[serial]
-    fn apply_session_id_updates_repairs_stopped_poller_on_live_pane() {
+    fn repair_session_id_pollers_skips_structured_and_repairs_live_terminal() {
         if skip_if_no_tmux() {
             return;
         }
@@ -18419,23 +18419,46 @@ mod apply_session_id_updates {
         let _guard = setup_test_home(&temp);
 
         let profile = "apply-poller-repair";
-        let inst = fresh_instance(profile, "repair");
-        let mut view = build_view_with_inst(profile, &inst);
-        let stopped = Arc::new(Mutex::new(SessionPoller::new("stopped".to_string())));
-        view.instances.get_mut(&inst.id).unwrap().session_id_poller = Some(stopped.clone());
-        let _tmux = TmuxSession::create(&inst.id, &inst.title);
+        let terminal = fresh_instance(profile, "repair-terminal");
+        let mut structured = fresh_instance(profile, "repair-structured");
+        structured.view = View::Structured;
+        let mut view = build_view_with_inst(profile, &terminal);
+        view.instances
+            .insert(structured.id.clone(), structured.clone());
+        let terminal_stopped = Arc::new(Mutex::new(SessionPoller::new("stopped".to_string())));
+        let structured_stopped = Arc::new(Mutex::new(SessionPoller::new("stopped".to_string())));
+        view.instances
+            .get_mut(&terminal.id)
+            .unwrap()
+            .session_id_poller = Some(terminal_stopped.clone());
+        view.instances
+            .get_mut(&structured.id)
+            .unwrap()
+            .session_id_poller = Some(structured_stopped.clone());
+        let _tmux = TmuxSession::create(&terminal.id, &terminal.title);
 
-        assert!(!view.apply_session_id_updates());
+        view.repair_session_id_pollers();
         let repaired = view
             .instances
-            .get(&inst.id)
+            .get(&terminal.id)
             .and_then(|i| i.session_id_poller.clone())
             .expect("live pane should receive a replacement poller");
-        assert!(!Arc::ptr_eq(&repaired, &stopped));
+        assert!(!Arc::ptr_eq(&repaired, &terminal_stopped));
         assert!(repaired
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .is_running());
+        assert!(
+            Arc::ptr_eq(
+                &view
+                    .instances
+                    .get(&structured.id)
+                    .and_then(|i| i.session_id_poller.clone())
+                    .expect("structured poller should be untouched"),
+                &structured_stopped,
+            ),
+            "structured sessions must not probe tmux or start terminal pollers"
+        );
         repaired
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -18437,6 +18437,19 @@ mod apply_session_id_updates {
             .session_id_poller = Some(structured_stopped.clone());
         let _tmux = TmuxSession::create(&terminal.id, &terminal.title);
 
+        assert!(!view.apply_session_id_updates());
+        assert!(
+            Arc::ptr_eq(
+                &view
+                    .instances
+                    .get(&terminal.id)
+                    .and_then(|i| i.session_id_poller.clone())
+                    .expect("drain should retain the stopped poller"),
+                &terminal_stopped,
+            ),
+            "the hot drain path must not repair pollers"
+        );
+
         view.repair_session_id_pollers();
         let repaired = view
             .instances


### PR DESCRIPTION
## Description

Fix native TUI lag caused by session-ID poller repair running on every 33 ms input/render wake. Structured ACP sessions now skip terminal poller repair entirely, and terminal poller repair runs only on the existing 500 ms status-refresh cadence.

The regression test verifies that a live terminal session still receives a replacement poller while a structured session is left untouched.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Skipped a test, because: the regression is Rust lifecycle scheduling with a deterministic unit test, not a browser interaction.

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the regression is covered at the cheapest deterministic layer by asserting structured rows do not enter tmux poller repair and live terminal rows still heal.

## AI Usage

- [x] AI was used
- [x] I am an AI Agent filling out this form

**AI Model/Tool used:** OpenAI Codex

**Any Additional AI Details you'd like to share:** Root cause investigation identified the unthrottled repair sweep introduced in #3230.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevented native TUI lag by skipping poller repair for structured sessions during frequent updates.
- Moved terminal poller repair to the existing 500 ms status-refresh cycle.
- Added regression coverage for terminal poller replacement and structured-session preservation.

## Benefits

- Reduces unnecessary work during TUI updates.
- Preserves terminal-session recovery.
- Leaves structured sessions unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->