### PR TITLE
fix(tui): keep held keys out of paste bursts

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -357,6 +357,20 @@ impl App {
         }
     }
 
+    /// Holding a key produces a stream of indistinguishable Press events on
+    /// terminals that do not report key-event types. That stream has the same
+    /// timing as Mosh's paste fallback, but it is navigation, not pasted text.
+    /// Keep it on the normal input path so held `j`/`k` continue scrolling the
+    /// session list instead of opening the message composer.
+    fn is_auto_repeat_burst(keys: &[KeyEvent]) -> bool {
+        let Some(first) = keys.first() else {
+            return false;
+        };
+        keys.iter().skip(1).all(|key| {
+            key.code == first.code && key.modifiers == first.modifiers && key.kind == first.kind
+        })
+    }
+
     /// Peel a trailing Enter off a paste burst so plain-Enter Submit
     /// semantics survive when the user types or dictates fast enough to
     /// pump everything through the burst path.
@@ -996,7 +1010,9 @@ impl App {
                                         _ => break,
                                     }
                                 }
-                                if burst_keys.len() >= PASTE_BURST_MIN_LEN {
+                                if burst_keys.len() >= PASTE_BURST_MIN_LEN
+                                    && !Self::is_auto_repeat_burst(&burst_keys)
+                                {
                                     // Peel a trailing Enter so the dialog's
                                     // plain-Enter Submit branch still fires.
                                     // Embedded mid-burst Enters stay as '\n'
@@ -4766,6 +4782,41 @@ mod tests {
             KeyCode::Backspace,
             KeyModifiers::NONE
         )));
+    }
+
+    #[test]
+    fn auto_repeat_burst_rejects_held_navigation_but_not_pasted_text() {
+        let cases = [
+            (
+                vec![
+                    key(KeyCode::Char('j'), KeyModifiers::NONE),
+                    key(KeyCode::Char('j'), KeyModifiers::NONE),
+                    key(KeyCode::Char('j'), KeyModifiers::NONE),
+                ],
+                true,
+            ),
+            (
+                vec![
+                    key(KeyCode::Char('k'), KeyModifiers::NONE),
+                    key(KeyCode::Char('k'), KeyModifiers::NONE),
+                    key(KeyCode::Char('k'), KeyModifiers::NONE),
+                ],
+                true,
+            ),
+            (
+                vec![
+                    key(KeyCode::Char('p'), KeyModifiers::NONE),
+                    key(KeyCode::Char('a'), KeyModifiers::NONE),
+                    key(KeyCode::Char('s'), KeyModifiers::NONE),
+                    key(KeyCode::Char('t'), KeyModifiers::NONE),
+                    key(KeyCode::Char('e'), KeyModifiers::NONE),
+                ],
+                false,
+            ),
+        ];
+        for (keys, expected) in cases {
+            assert_eq!(App::is_auto_repeat_burst(&keys), expected, "{keys:?}");
+        }
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -357,18 +357,19 @@ impl App {
         }
     }
 
-    /// Holding a key produces a stream of indistinguishable Press events on
-    /// terminals that do not report key-event types. That stream has the same
-    /// timing as Mosh's paste fallback, but it is navigation, not pasted text.
-    /// Keep it on the normal input path so held `j`/`k` continue scrolling the
-    /// session list instead of opening the message composer.
+    /// Holding a key produces a stream of Press events on terminals that do not
+    /// report key-event types, or an initial Press followed by Repeat events on
+    /// terminals that do. That stream has the same timing as Mosh's paste
+    /// fallback, but it is navigation, not pasted text. Keep it on the normal
+    /// input path so held `j`/`k` continue scrolling the session list instead of
+    /// opening the message composer.
     fn is_auto_repeat_burst(keys: &[KeyEvent]) -> bool {
         let Some(first) = keys.first() else {
             return false;
         };
-        keys.iter().skip(1).all(|key| {
-            key.code == first.code && key.modifiers == first.modifiers && key.kind == first.kind
-        })
+        keys.iter()
+            .skip(1)
+            .all(|key| key.code == first.code && key.modifiers == first.modifiers)
     }
 
     /// Peel a trailing Enter off a paste burst so plain-Enter Submit
@@ -4800,6 +4801,26 @@ mod tests {
                     key(KeyCode::Char('k'), KeyModifiers::NONE),
                     key(KeyCode::Char('k'), KeyModifiers::NONE),
                     key(KeyCode::Char('k'), KeyModifiers::NONE),
+                ],
+                true,
+            ),
+            (
+                vec![
+                    KeyEvent::new_with_kind(
+                        KeyCode::Char('j'),
+                        KeyModifiers::NONE,
+                        KeyEventKind::Press,
+                    ),
+                    KeyEvent::new_with_kind(
+                        KeyCode::Char('j'),
+                        KeyModifiers::NONE,
+                        KeyEventKind::Repeat,
+                    ),
+                    KeyEvent::new_with_kind(
+                        KeyCode::Char('j'),
+                        KeyModifiers::NONE,
+                        KeyEventKind::Repeat,
+                    ),
                 ],
                 true,
             ),


### PR DESCRIPTION
## Description
<!-- Describe your changes and the problem they solve -->


## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [ ] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [ ] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**


**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved TUI input handling to distinguish held navigation keys from pasted text.
- Updated auto-repeat burst detection to support mixed press and repeat events.
- Added tests for repeated navigation keys, mixed event types, and normal pasted text.

## Benefits

- Held `j` and `k` keys continue to navigate correctly.
- Valid pasted text still uses paste handling.
- The change prevents key holds from being misread as pasted input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->