### PR TITLE
test(session): make OMP mtime fixtures portable

### DIFF
--- a/src/session/capture/omp.rs
+++ b/src/session/capture/omp.rs
@@ -3078,7 +3078,9 @@ mod tests {
             )
             .unwrap();
             let breadcrumb = write_breadcrumb(&meta, "pts-7", Path::new(cwd), &session, false);
-            set_mtime_ms(&breadcrumb, 100_001);
+            // BSD `test -nt` only compares timestamps at whole-second precision.
+            // Keep the fixture fresh on the macOS CI host as well as in Linux containers.
+            set_mtime_ms(&breadcrumb, 101_000);
             let marker = tmp.path().join("launch-marker");
             std::fs::write(&marker, launch_marker(&meta, "pts-7", "/pending")).unwrap();
             set_mtime_ms(&marker, 100_000);
@@ -3143,7 +3145,9 @@ mod tests {
         )
         .unwrap();
         let breadcrumb = write_breadcrumb(&meta, "pts-7", Path::new(cwd), &session, false);
-        set_mtime_ms(&breadcrumb, 100_001);
+        // The container script is exercised by the host shell in this test, whose
+        // BSD `test -nt` comparison needs a whole-second timestamp difference.
+        set_mtime_ms(&breadcrumb, 101_000);
         let marker = tmp.path().join("launch-marker");
         std::fs::write(&marker, launch_marker(&meta, "pts-7", "/pending")).unwrap();
         set_mtime_ms(&marker, 100_000);


### PR DESCRIPTION
## Description

Fixes the macOS CI failure in the OMP container-capture tests. The fixtures previously placed the breadcrumb only 1 ms after the launch marker. macOS's BSD `test -nt` comparison uses whole-second precision, so it rejected the breadcrumb while the Rust host check accepted it.

The fixtures now use a one-second timestamp gap. Production capture behavior is unchanged.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** OpenAI Codex

**Any Additional AI Details you'd like to share:** Diagnosed the failing GitHub Actions job and updated the existing regression fixtures. No new production code paths were added.

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated two OMP capture test fixtures to use a one-second timestamp gap.
- Added comments that document BSD `test -nt` precision and macOS CI compatibility.
- Production capture behavior remains unchanged.

## Benefits

- Prevents macOS CI failures caused by whole-second timestamp comparison.
- Keeps fixture behavior consistent with the Rust host check.

## Further enhancement

- Consider adding a regression test for timestamp precision across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->