### PR TITLE
fix(tui): truncate settings custom-instruction preview on a char boundary

### DIFF
--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -872,10 +872,12 @@ impl SettingsView {
                             .chars()
                             .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
                             .collect();
-                        if collapsed.len() > 47 {
-                            format!("{}...", &collapsed[..47])
-                        } else {
-                            collapsed
+                        // Truncate on a char boundary: `&collapsed[..47]`
+                        // panics when a multi-byte char spans byte 47 of a
+                        // long custom instruction.
+                        match collapsed.char_indices().nth(47) {
+                            Some((cut, _)) => format!("{}...", &collapsed[..cut]),
+                            None => collapsed,
                         }
                     }
                     Some(text) => text.to_string(),


### PR DESCRIPTION
## Description
The settings screen's custom-instruction preview truncates long values with a literal byte slice, `&collapsed[..47]`. When a multi-byte character (e.g. an accented letter, CJK, or an emoji) spans byte 47, the slice panics with "byte index 47 is not a char boundary" and takes down the TUI as soon as the settings row renders. Found by auditing for literal byte slices on arbitrary strings.

Fix: cut at `collapsed.char_indices().nth(47)` instead, which always lands on a char boundary. Behavior for ASCII values is unchanged (47 chars + `...`); shorter values still render whole.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the change is a two-line boundary-safe cut inside an inline render closure; extracting it into a testable helper would grow the diff more than the fix itself, and an e2e that drives the settings screen with a multi-byte custom instruction costs ~2s on the serial e2e path forever (per the test-cost guidance in AGENTS.md) for a panic class the type of cut now makes unrepresentable.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude Fable 5 (Claude Code)

**Any Additional AI Details you'd like to share:**
Fix authored and verified with `cargo check` against current main; the same change has been running in a downstream build where the full unit suite passes.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevents a TUI panic when custom-instruction previews contain multi-byte characters.
- Preserves the existing 47-character preview behavior for ASCII text.
- Displays shorter instructions in full.
- Improves rendering reliability without changing public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->