### PR TITLE
fix(send): claude Enter swallowed by paste-burst window leaves unsubmitted [Pasted text]

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -723,7 +723,14 @@ pub const AGENTS: &[AgentDef] = &[
         },
         fork_strategy: ForkStrategy::ClaudeFork,
         host_only: false,
-        send_keys_enter_delay_ms: 0,
+        // Claude Code has paste-burst suppression like Codex. Its input handler
+        // (usePasteHandler.ts) sets PASTE_COMPLETION_TIMEOUT_MS = 100 and, while a
+        // bracketed paste is still pending, appends any incoming Enter to the paste
+        // buffer instead of submitting it. When we send the message via
+        // send_via_paste_buffer and fire Enter immediately (0ms), that Enter lands
+        // inside the 100ms window and is swallowed, leaving an unsubmitted
+        // "[Pasted text]" placeholder. 150ms > 100ms lets the window expire first.
+        send_keys_enter_delay_ms: 150,
         ready_marker: None,
         install_hint: "npm install -g @anthropic-ai/claude-code",
         permission_response: Some(PermissionResponse {
@@ -2211,8 +2218,13 @@ mod tests {
     fn test_send_keys_enter_delay() {
         // Codex needs a delay to outlast its 120ms paste-burst suppression window
         assert!(send_keys_enter_delay("codex") >= 150);
-        // Other agents should not delay
-        assert_eq!(send_keys_enter_delay("claude"), 0);
+        // Claude Code also has paste-burst suppression: usePasteHandler.ts sets
+        // PASTE_COMPLETION_TIMEOUT_MS = 100 and, while a paste is pending, routes
+        // an incoming Enter into the paste buffer instead of submitting it (the
+        // `[Pasted text]` sits unsubmitted). The Enter must arrive after that
+        // 100ms window expires, so claude needs a delay > 100ms.
+        assert!(send_keys_enter_delay("claude") > 100);
+        // Other agents have no paste-burst suppression and should not delay
         assert_eq!(send_keys_enter_delay("opencode"), 0);
         assert_eq!(send_keys_enter_delay("hermes"), 0);
         assert_eq!(send_keys_enter_delay("kiro"), 0);


### PR DESCRIPTION
## Description
A multi-line message delivered to a Claude Code pane through the paste-buffer send path frequently lands as an **unsubmitted** `[Pasted text #1 +N lines]` placeholder: the paste arrives, but the trailing Enter never registers, so the message sits in the composer until a human notices.

Root cause is in Claude Code's own input handling (`src/hooks/usePasteHandler.ts`): `PASTE_COMPLETION_TIMEOUT_MS = 100`. A bracketed paste starts a 100ms quiet-timer and only commits when it fires; while the paste is still pending, an incoming Enter is appended to the paste chunks instead of submitting. Our send path (`send_via_paste_buffer`, then Enter after `send_keys_enter_delay_ms`) fired the Enter at 0ms for claude, landing inside that window and getting swallowed. Codex was already protected with a 150ms delay for the same class of suppression; claude was left at 0.

Fix: set claude's `send_keys_enter_delay_ms` from 0 to 150 (past the 100ms window), so `tmux/session.rs` sleeps out the paste-completion window before sending Enter. The regression test now asserts `send_keys_enter_delay("claude") > 100`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the behavioral contract is covered by updating the existing unit regression `test_send_keys_enter_delay` (asserts claude's delay clears the 100ms paste window, mirroring the existing codex assertion); an e2e reproduction would need a real Claude Code binary at a prompt to demonstrate the swallowed Enter, which the harness's fake agents can't exhibit.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude Fable 5 (Claude Code)

**Any Additional AI Details you'd like to share:**
Diagnosed against Claude Code's published source; the fix has been running in a downstream build where multi-line injected sends to claude panes stopped stranding unsubmitted paste buffers.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Increased Claude Code’s Enter delay to 150 ms.
- Updated the regression test to confirm the delay exceeds Claude’s 100 ms paste window.
- Prevents multi-line messages from leaving an unsubmitted paste placeholder.

## Benefit

Claude Code now submits multi-line messages reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->