### PR TITLE
docs: add Otari telemetry guide

### DIFF
--- a/docs/guides/otari-telemetry.md
+++ b/docs/guides/otari-telemetry.md
@@ -17,6 +17,8 @@ The examples use these placeholders:
 
 Claude Code appends `/v1/logs` to the root URL. The `api_request` events on the logs signal contain the usage Otari imports. Traces are not required. The optional metrics exporter adds content-free outcome counters such as commits and lines changed, but it does not import usage by itself.
 
+“Content-free” does not mean anonymous. Claude Code telemetry can carry `user.email`, `user.account_uuid`, `user.account_id`, `organization.id`, the installation-scoped `user.id`, and `session.id`. Restrict access to the Otari deployment accordingly. Prompt, response, and tool content are redacted by default; do not enable `OTEL_LOG_USER_PROMPTS`, `OTEL_LOG_ASSISTANT_RESPONSES`, `OTEL_LOG_TOOL_DETAILS`, `OTEL_LOG_TOOL_CONTENT`, or `OTEL_LOG_RAW_API_BODIES` unless you intend to export the corresponding sensitive content.
+
 ## Host Claude Code sessions
 
 Add an `env` block to `~/.claude/settings.json`, merging it with any settings already present:
@@ -48,7 +50,7 @@ export AOE_OTARI_OTEL_HEADERS='Authorization=Bearer gw-your-exempt-key'
 
 Use `~/.zshenv`, not `~/.zshrc`, when zsh launches AoE. `.zshrc` is only read by interactive shells and can be skipped by a non-interactive launch context. Open a new zsh after editing the file, or run `source ~/.zshenv`, before restarting AoE. If a service manager launches AoE, define the variable in that service's environment instead.
 
-Add the OTel settings to the `sandbox.environment` list for the profile that launches the session. On macOS and Windows, profile overrides normally live at `~/.agent-of-empires/profiles/<profile>/config.toml`. On Linux, they live under `$XDG_CONFIG_HOME/agent-of-empires/profiles/<profile>/config.toml`, with `~/.config` as the default XDG config home. See the [configuration reference](configuration.md#file-locations) if your app directory differs.
+Add the OTel settings to the `sandbox.environment` list for the profile that launches the session. On Linux, profiles live under `$XDG_CONFIG_HOME/agent-of-empires/profiles/<profile>/config.toml`, with `~/.config` as the default XDG config home. On Windows, use `~/.agent-of-empires/profiles/<profile>/config.toml`. On macOS, use the profile under the active app directory: AoE prefers `$XDG_CONFIG_HOME/agent-of-empires/` when that directory exists, but otherwise keeps using an existing `~/.agent-of-empires/` even if `XDG_CONFIG_HOME` is set. If neither directory exists, setting `XDG_CONFIG_HOME` selects the XDG path; otherwise AoE uses `~/.agent-of-empires/`. See the [configuration reference](configuration.md#file-locations).
 
 ```toml
 [sandbox]
@@ -68,7 +70,7 @@ To include optional outcome counters, add `"OTEL_METRICS_EXPORTER=otlp"` to the 
 
 ### Profile precedence
 
-AoE resolves global configuration first, then the active profile, then repository configuration. A profile's `sandbox.environment` list replaces the global list rather than extending it. If you use a named profile, edit that profile's `config.toml` and preserve its existing entries. Add the OTel entries separately to every profile that should export telemetry.
+AoE resolves global configuration first, then the active profile, then repository configuration. Arrays replace rather than extend the earlier layer: a profile's `sandbox.environment` replaces the global list, and a repository-level `.agent-of-empires/config.toml` list replaces the profile list. Preserve or add the OTel entries in every applicable profile and in each repository-level list that overrides it.
 
 ## Apply and verify
 
@@ -86,7 +88,8 @@ AoE resolves global configuration first, then the active profile, then repositor
 
    ```sh
    AOE_SANDBOX_NAME=aoe-sandbox-xxxxxxxx
-   docker exec "$AOE_SANDBOX_NAME" sh -c '
+   AOE_CONTAINER_CLI=docker  # use podman for Podman, or container for Apple Container
+   "$AOE_CONTAINER_CLI" exec "$AOE_SANDBOX_NAME" sh -c '
      for name in \
        CLAUDE_CODE_ENABLE_TELEMETRY \
        OTEL_LOGS_EXPORTER \
@@ -109,7 +112,7 @@ AoE resolves global configuration first, then the active profile, then repositor
 ## Troubleshooting
 
 - **The header is missing in the container:** confirm the variable is set in the exact shell or service environment that launched AoE, then restart AoE and create a new sandbox session.
-- **Other sandbox variables disappeared:** restore the prior entries in the active profile's `sandbox.environment` list. The profile list replaces the global list.
+- **Other sandbox variables disappeared:** restore the prior entries in the last `sandbox.environment` list AoE applies. Profile lists replace the global list, and repository-level lists replace profile lists.
 - **Otari returns 403:** confirm the key is active, belongs to the intended user, and is budget-exempt.
 - **Otari returns 404 for `/v1/logs`:** telemetry import requires a standalone Otari gateway, not a hybrid gateway.
 - **A manual `curl` or Python probe is blocked while Claude Code works:** a reverse proxy or WAF can classify clients differently. Check its rules and Otari logs before changing the OTel configuration.

--- a/docs/guides/otari-telemetry.md
+++ b/docs/guides/otari-telemetry.md
@@ -1,0 +1,118 @@
+# Export Claude Code Usage to Otari
+
+[Claude Code](https://code.claude.com/docs/en/monitoring-usage) can export usage events over OpenTelemetry (OTel). This guide sends those events from both host and Agent of Empires sandbox sessions to a self-hosted [Otari](https://github.com/mozilla-ai/otari) gateway.
+
+This setup imports subscription-backed Claude Code usage for analytics. It does not route model requests through Otari or enforce an Otari budget. If a Claude Code session already routes requests through Otari with `ANTHROPIC_BASE_URL`, do not also export that session's telemetry to Otari. Doing both records the same traffic twice in cost analytics.
+
+## Before you start
+
+Create a dedicated, budget-exempt importer key in your standalone Otari deployment. Otari rejects budgeted keys for retrospective imports, and hybrid gateways do not serve the local OTLP ingest endpoints. Follow Otari's [Claude Code import guide](https://github.com/mozilla-ai/otari/blob/main/docs/use-with-claude-code.md#import-subscription-usage-without-routing-through-otari) for current key creation and deployment requirements.
+
+Treat the importer key as a secret. Because it is budget-exempt, do not reuse it for live gateway traffic.
+
+The examples use these placeholders:
+
+- `https://otari.example.com`: the Otari root URL, without `/v1`
+- `gw-your-exempt-key`: the dedicated importer key
+
+Claude Code appends `/v1/logs` to the root URL. The `api_request` events on the logs signal contain the usage Otari imports. Traces are not required. The optional metrics exporter adds content-free outcome counters such as commits and lines changed, but it does not import usage by itself.
+
+## Host Claude Code sessions
+
+Add an `env` block to `~/.claude/settings.json`, merging it with any settings already present:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "https://otari.example.com",
+    "OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer gw-your-exempt-key"
+  }
+}
+```
+
+This file now contains the importer key. Keep it private and do not commit or share it. To include Otari's optional outcome counters, also set `"OTEL_METRICS_EXPORTER": "otlp"` in the same `env` object.
+
+Restart Claude Code after changing the settings. New host sessions will export usage to Otari.
+
+## AoE sandbox sessions
+
+For sandbox sessions, keep the importer key out of the AoE configuration. Store the complete header in an environment variable on the host:
+
+```sh
+# ~/.zshenv
+export AOE_OTARI_OTEL_HEADERS='Authorization=Bearer gw-your-exempt-key'
+```
+
+Use `~/.zshenv`, not `~/.zshrc`, when zsh launches AoE. `.zshrc` is only read by interactive shells and can be skipped by a non-interactive launch context. Open a new zsh after editing the file, or run `source ~/.zshenv`, before restarting AoE. If a service manager launches AoE, define the variable in that service's environment instead.
+
+Add the OTel settings to the `sandbox.environment` list for the profile that launches the session. On macOS and Windows, profile overrides normally live at `~/.agent-of-empires/profiles/<profile>/config.toml`. On Linux, they live under `$XDG_CONFIG_HOME/agent-of-empires/profiles/<profile>/config.toml`, with `~/.config` as the default XDG config home. See the [configuration reference](configuration.md#file-locations) if your app directory differs.
+
+```toml
+[sandbox]
+environment = [
+    # Keep any existing entries in this list.
+    "CLAUDE_CODE_ENABLE_TELEMETRY=1",
+    "OTEL_LOGS_EXPORTER=otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf",
+    "OTEL_EXPORTER_OTLP_ENDPOINT=https://otari.example.com",
+    "OTEL_EXPORTER_OTLP_HEADERS=$AOE_OTARI_OTEL_HEADERS",
+]
+```
+
+The `KEY=$HOST_VAR` form makes AoE read the value from its host environment and inject it into the container as `KEY`. The secret therefore never appears in `config.toml`.
+
+To include optional outcome counters, add `"OTEL_METRICS_EXPORTER=otlp"` to the same list.
+
+### Profile precedence
+
+AoE resolves global configuration first, then the active profile, then repository configuration. A profile's `sandbox.environment` list replaces the global list rather than extending it. If you use a named profile, edit that profile's `config.toml` and preserve its existing entries. Add the OTel entries separately to every profile that should export telemetry.
+
+## Apply and verify
+
+1. Make sure `AOE_OTARI_OTEL_HEADERS` is present in the environment that launches AoE.
+2. If AoE was started with `aoe serve --daemon`, reload its configuration and environment:
+
+   ```sh
+   aoe serve --restart
+   ```
+
+   If the TUI creates your sessions, quit and relaunch it from the updated shell. A foreground, systemd, or launchd process must be restarted through the shell or service manager that launched it.
+3. Start a fresh sandbox session. Existing containers keep the environment from the time they were created.
+4. Find the container name in the AoE status bar. It follows the pattern `aoe-sandbox-<session-id-prefix>`.
+5. Verify that each required variable is non-empty without printing the secret header:
+
+   ```sh
+   AOE_SANDBOX_NAME=aoe-sandbox-xxxxxxxx
+   docker exec "$AOE_SANDBOX_NAME" sh -c '
+     for name in \
+       CLAUDE_CODE_ENABLE_TELEMETRY \
+       OTEL_LOGS_EXPORTER \
+       OTEL_EXPORTER_OTLP_PROTOCOL \
+       OTEL_EXPORTER_OTLP_ENDPOINT \
+       OTEL_EXPORTER_OTLP_HEADERS
+     do
+       if [ -n "$(printenv "$name")" ]; then
+         printf "%s: set\n" "$name"
+       else
+         printf "%s: MISSING\n" "$name"
+       fi
+     done
+   '
+   ```
+
+6. Run a prompt in the fresh Claude Code session. The logs exporter normally flushes within a few seconds.
+7. Confirm that a `source = claude_code` row appears in Otari's Activity page for the importer key. If it does not, check the Otari gateway logs for requests to `/v1/logs`.
+
+## Troubleshooting
+
+- **The header is missing in the container:** confirm the variable is set in the exact shell or service environment that launched AoE, then restart AoE and create a new sandbox session.
+- **Other sandbox variables disappeared:** restore the prior entries in the active profile's `sandbox.environment` list. The profile list replaces the global list.
+- **Otari returns 403:** confirm the key is active, belongs to the intended user, and is budget-exempt.
+- **Otari returns 404 for `/v1/logs`:** telemetry import requires a standalone Otari gateway, not a hybrid gateway.
+- **A manual `curl` or Python probe is blocked while Claude Code works:** a reverse proxy or WAF can classify clients differently. Check its rules and Otari logs before changing the OTel configuration.
+- **No row appears immediately:** wait for the logs export interval, which defaults to a few seconds, then generate another Claude Code request.
+
+Historical backfills and Otari-side deployment setup are outside the scope of this guide. See Otari's [external usage documentation](https://github.com/mozilla-ai/otari/blob/main/docs/external-usage.md) for those workflows.

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -55,6 +55,13 @@ const PAGES = [
       "Run AI coding agents in isolated Docker containers with Agent of Empires.",
   },
   {
+    source: "docs/guides/otari-telemetry.md",
+    dest: "guides/otari-telemetry.md",
+    title: "Claude Code Telemetry to Otari",
+    description:
+      "Export Claude Code usage from host and AoE sandbox sessions to a self-hosted Otari gateway.",
+  },
+  {
     source: "docs/guides/tmux-status-bar.md",
     dest: "guides/tmux-status-bar.md",
     title: "tmux Status Bar",
@@ -424,6 +431,7 @@ const URL_MAP = {
   "docs/guides/repo-config.md": "/guides/repo-config/",
   "docs/guides/mcp-servers.md": "/guides/mcp-servers/",
   "docs/guides/sandbox.md": "/guides/sandbox/",
+  "docs/guides/otari-telemetry.md": "/guides/otari-telemetry/",
   "docs/guides/tmux-status-bar.md": "/guides/tmux-status-bar/",
   "docs/guides/web-dashboard.md": "/guides/web-dashboard/",
   "docs/guides/web/dashboard.md": "/guides/web/dashboard/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -24,6 +24,7 @@ export const docsNav: NavSection[] = [
     title: "Guides",
     items: [
       { title: "Docker Sandbox", href: "/guides/sandbox/", description: "Run AI coding agents in isolated Docker containers." },
+      { title: "Claude Code Telemetry to Otari", href: "/guides/otari-telemetry/", description: "Export Claude Code usage from host and sandbox sessions to Otari." },
       { title: "Podman", href: "/guides/podman/", description: "Use Podman as a rootless alternative to Docker for sandboxing." },
       { title: "Apple Containers", href: "/guides/apple-containers/", description: "Sandbox agents with Apple's native container framework on macOS." },
       { title: "Live Mode", href: "/guides/live-mode/", description: "Watch a session stream live and type into it from the TUI." },


### PR DESCRIPTION
## Description

Adds a guide for exporting Claude Code usage from both host and AoE sandbox sessions to a self-hosted Otari gateway.

The guide covers:

- the current budget-exempt Otari importer-key requirement
- host `settings.json` configuration
- secret-safe `sandbox.environment` forwarding through `KEY=$HOST_VAR`
- profile precedence and non-interactive zsh environment loading
- daemon, TUI, and service-manager restart behavior
- fresh-container verification without printing the bearer key
- the current signal split: logs import usage, while metrics add optional outcome counters

The canonical page is wired into the website sync map and Guides navigation.

Closes #3102

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A: documentation-only change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Additional verification:

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --quiet`
- `cd website && npm run build`
- `git diff --check`
- shell syntax check for the container verification example

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex

**Any Additional AI Details you'd like to share:** Drafted and verified the guide against the current AoE source, Claude Code monitoring documentation, and Otari documentation. No user secrets were used.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a guide for sending Claude Code telemetry from host and sandbox sessions to a self-hosted Otari gateway.
- Documented secure key handling, profile settings, daemon restarts, verification, troubleshooting, and telemetry limits.
- Added the guide to website synchronization and Guides navigation.

## Benefits

- Provides one clear setup path for Claude Code usage imports.
- Reduces the risk of exposing gateway keys.
- Clarifies supported telemetry and out-of-scope features, including historical backfill.

## Further enhancement

- Add screenshots or example verification output for additional user guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->