### PR TITLE
fix(tui): give the synthetic scratch bucket its own group identity

### DIFF
--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -31,7 +31,12 @@ pub const TRASH_SECTION_NAME: &str = "Trash";
 /// (the way org host-scoped keys are). That keeps a user's own repo named
 /// `scratch` on a distinct identity instead of merging into the bucket (#3237).
 pub const SCRATCH_GROUP_PATH: &str = "__aoe_scratch_group__";
-pub const SCRATCH_GROUP_NAME: &str = "scratch";
+/// Capitalized so the bucket reads as a system group rather than a repo
+/// basename, matching the web sidebar's `Scratch` label. Only safe to differ
+/// from the basename because the identity above no longer rides on the label.
+/// Name sorts lowercase both here and in `sort_by_name`, so the header still
+/// lands at `s`.
+pub const SCRATCH_GROUP_NAME: &str = "Scratch";
 
 #[inline]
 pub fn is_archived_section_path(path: &str) -> bool {

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -1233,10 +1233,18 @@ pub fn append_archived_section_by_project(
 /// uses the min `archived_at` ascending. Attention falls back to
 /// most-recently-archived because archived rows are all tier 99 in the
 /// attention bucket and the tier offers no discriminator inside the shelf.
+///
+/// The bucket key is an identity, not always the label, so AZ/ZA sort on the
+/// display name: the scratch sentinel would otherwise sort under `_` and jump
+/// ahead of every real project instead of landing at `s` (#3237).
 fn sort_archived_project_buckets(buckets: &mut [(String, Vec<&Instance>)], sort_order: SortOrder) {
     match sort_order {
-        SortOrder::AZ => buckets.sort_by_key(|b| b.0.to_lowercase()),
-        SortOrder::ZA => buckets.sort_by_key(|b| Reverse(b.0.to_lowercase())),
+        SortOrder::AZ => {
+            buckets.sort_by_key(|b| project_group_display_name(&b.0).to_lowercase());
+        }
+        SortOrder::ZA => {
+            buckets.sort_by_key(|b| Reverse(project_group_display_name(&b.0).to_lowercase()));
+        }
         SortOrder::Oldest => {
             buckets.sort_by_key(|(_, sessions)| {
                 sessions
@@ -2906,5 +2914,32 @@ mod tests {
         let inst: Instance = serde_json::from_str(legacy).unwrap();
         assert!(!inst.is_archived());
         assert!(inst.archived_at.is_none());
+    }
+
+    /// #3237: the scratch bucket's key is a sentinel, so name-ordering the
+    /// archived sub-folders on the raw key would sort it under `_` and hoist
+    /// it above every real project. It must sort where its label reads.
+    #[test]
+    fn archived_project_buckets_name_sort_uses_display_label() {
+        let myrepo = Instance::new("a", "/repos/myrepo");
+        let throwaway = Instance::new("b", "/app/scratch/x");
+        let zeta = Instance::new("c", "/repos/zeta");
+        let cases = [
+            (SortOrder::AZ, ["myrepo", SCRATCH_GROUP_NAME, "zeta"]),
+            (SortOrder::ZA, ["zeta", SCRATCH_GROUP_NAME, "myrepo"]),
+        ];
+        for (order, expected) in cases {
+            let mut buckets: Vec<(String, Vec<&Instance>)> = vec![
+                ("myrepo".to_string(), vec![&myrepo]),
+                (SCRATCH_GROUP_PATH.to_string(), vec![&throwaway]),
+                ("zeta".to_string(), vec![&zeta]),
+            ];
+            sort_archived_project_buckets(&mut buckets, order);
+            let labels: Vec<&str> = buckets
+                .iter()
+                .map(|b| project_group_display_name(&b.0))
+                .collect();
+            assert_eq!(labels, expected, "{order:?}");
+        }
     }
 }

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -23,6 +23,16 @@ pub const ARCHIVED_SECTION_NAME: &str = "Archived";
 pub const TRASH_SECTION_PATH: &str = "__aoe_trash_section__";
 pub const TRASH_SECTION_NAME: &str = "Trash";
 
+/// Synthetic group identity for the scratch bucket in project mode. Unlike the
+/// Archived/Trash shelves this IS a real in-flow GroupTree node built from live
+/// scratch sessions, so it is keyed on a sentinel PATH whose `__aoe_*_group__`
+/// shape no plausible real repo basename equals (same accepted tradeoff as
+/// `ARCHIVED_/TRASH_SECTION_PATH`), while its display name is seeded separately
+/// (the way org host-scoped keys are). That keeps a user's own repo named
+/// `scratch` on a distinct identity instead of merging into the bucket (#3237).
+pub const SCRATCH_GROUP_PATH: &str = "__aoe_scratch_group__";
+pub const SCRATCH_GROUP_NAME: &str = "scratch";
+
 #[inline]
 pub fn is_archived_section_path(path: &str) -> bool {
     path == ARCHIVED_SECTION_PATH
@@ -31,6 +41,12 @@ pub fn is_archived_section_path(path: &str) -> bool {
 #[inline]
 pub fn is_trash_section_path(path: &str) -> bool {
     path == TRASH_SECTION_PATH
+}
+
+/// Exact match for the synthetic scratch bucket's sentinel identity path.
+#[inline]
+fn is_scratch_group_path(path: &str) -> bool {
+    path == SCRATCH_GROUP_PATH
 }
 
 /// True for the Trash section sentinel or anything nested under it. Mirrors
@@ -58,6 +74,27 @@ pub fn is_within_archived_section(path: &str) -> bool {
 #[inline]
 pub fn archived_project_sub_path(project_name: &str) -> String {
     format!("{}/{}", ARCHIVED_SECTION_PATH, project_name)
+}
+
+/// True for any project-mode header that is synthetic rather than a real,
+/// pinnable repo: the Archived/Trash shelves (and anything nested under them)
+/// and the scratch bucket. Keyed on the path (identity), never the display
+/// label, so a real repo named `scratch` is not caught.
+#[inline]
+pub fn is_synthetic_project_header(path: &str) -> bool {
+    is_within_archived_section(path) || is_within_trash_section(path) || is_scratch_group_path(path)
+}
+
+/// Map a project-mode group identity key to its human display label, for the
+/// sites that render a raw `group_path` to the user. Only the scratch sentinel
+/// differs from its key; every real repo key already IS its label.
+#[inline]
+pub fn project_group_display_name(key: &str) -> &str {
+    if is_scratch_group_path(key) {
+        SCRATCH_GROUP_NAME
+    } else {
+        key
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1169,7 +1206,7 @@ pub fn append_archived_section_by_project(
         let sub_collapsed = project_collapsed.get(&sub_path).copied().unwrap_or(false);
         items.push(Item::Group {
             path: sub_path,
-            name: project_name,
+            name: project_group_display_name(&project_name).to_string(),
             depth: 1,
             collapsed: sub_collapsed,
             session_count: sessions.len(),

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -65,9 +65,11 @@ pub(crate) use groups::is_live_favorite;
 pub use groups::{
     append_archived_section, append_archived_section_by_project, append_trash_section,
     archived_project_sub_path, flatten_sessions_by_attention, flatten_tree,
-    flatten_tree_all_profiles, is_archived_section_path, is_trash_section_path,
-    is_within_archived_section, is_within_trash_section, Group, GroupTree, Item,
-    ARCHIVED_SECTION_NAME, ARCHIVED_SECTION_PATH, TRASH_SECTION_NAME, TRASH_SECTION_PATH,
+    flatten_tree_all_profiles, is_archived_section_path, is_synthetic_project_header,
+    is_trash_section_path, is_within_archived_section, is_within_trash_section,
+    project_group_display_name, Group, GroupTree, Item, ARCHIVED_SECTION_NAME,
+    ARCHIVED_SECTION_PATH, SCRATCH_GROUP_NAME, SCRATCH_GROUP_PATH, TRASH_SECTION_NAME,
+    TRASH_SECTION_PATH,
 };
 #[cfg(feature = "serve")]
 pub(crate) use instance::ResumeAttemptPolicy;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3324,7 +3324,7 @@ impl HomeView {
     /// Pick a representative repo path for a selected group so "New Session"
     /// from a project/group can prefill the working directory. In project
     /// mode the group label is a derived repo basename, so match members by
-    /// `project_group_name`; in manual mode match by the stored
+    /// `project_group_key`; in manual mode match by the stored
     /// `group_path`, including nested subgroups. In org mode there is no
     /// single unambiguous repo to prefill (unlike Project, an org spans many
     /// repos by design), so this always returns `None` there, mirroring the
@@ -3336,7 +3336,7 @@ impl HomeView {
         self.instances
             .values()
             .find(|inst| match self.group_by {
-                GroupByMode::Project => super::project_group_name(inst) == group_path,
+                GroupByMode::Project => super::project_group_key(inst) == group_path,
                 GroupByMode::Org => false,
                 GroupByMode::Manual => {
                     inst.group_path == group_path

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1270,7 +1270,10 @@ impl HomeView {
         self.confirm_dialog = Some(
             ConfirmDialog::new(
                 title,
-                &format!("Archive all {count} {noun} in {scope} \"{group_path}\"?"),
+                &format!(
+                    "Archive all {count} {noun} in {scope} \"{}\"?",
+                    crate::session::project_group_display_name(&group_path)
+                ),
                 "archive_group",
             )
             .neutral(),
@@ -2958,7 +2961,13 @@ impl HomeView {
                     Some(inst.group_path.clone())
                 }
             })
-            .or_else(|| self.selected_group.clone());
+            .or_else(|| {
+                // The scratch bucket's group_path is an internal sentinel; show
+                // its display label in the Group field, not the raw sentinel (#3237).
+                self.selected_group
+                    .as_deref()
+                    .map(|g| crate::session::project_group_display_name(g).to_string())
+            });
 
         if prefill_path.is_some() || prefill_group.is_some() {
             let existing_groups: Vec<String> =
@@ -3331,8 +3340,14 @@ impl HomeView {
     /// web org header, which routes "New Session" through the generic
     /// create flow instead of a specific repo path. Also returns `None` for
     /// an empty group (no member to borrow a path from), leaving the dialog
-    /// on the default cwd.
+    /// on the default cwd. The synthetic scratch bucket lends no path either:
+    /// a session under it would return its throwaway `<app_dir>/scratch/<id>`
+    /// as the prefill, and creating a new session rooted there ties its cwd
+    /// to another scratch session's lifetime (#3237).
     pub(super) fn group_repo_path(&self, group_path: &str) -> Option<String> {
+        if crate::session::is_synthetic_project_header(group_path) {
+            return None;
+        }
         self.instances
             .values()
             .find(|inst| match self.group_by {
@@ -3866,10 +3881,14 @@ impl HomeView {
                     {
                         continue;
                     }
-                    let label = if name == path {
+                    // The parenthetical disambiguates org keys (owner vs
+                    // owner@host); route it through the display mapper so a
+                    // synthetic bucket's sentinel path never leaks (#3237).
+                    let disambiguator = crate::session::project_group_display_name(path);
+                    let label = if name.as_str() == disambiguator {
                         format!("Jump to group: {}", name)
                     } else {
-                        format!("Jump to group: {} ({})", name, path)
+                        format!("Jump to group: {} ({})", name, disambiguator)
                     };
                     entries.push(PaletteCommand {
                         id: "jump-group",

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -48,31 +48,25 @@ use super::settings::SettingsView;
 use super::status_poller::{StatusPoller, StatusUpdate};
 use super::stop_poller::StopPoller;
 
-/// Header label the synthetic scratch bucket renders under in project view.
-/// Not an identity: a user's own repo whose basename happens to be `scratch`
-/// derives the same label from its path, so anything deciding whether a header
-/// has a backing repo must test the repo path, not this string (#3133).
-const SCRATCH_GROUP_LABEL: &str = "scratch";
-
-/// Extract a project group name from a session instance.
-/// Uses `worktree_info.main_repo_path` for worktree sessions (so all branches of the
-/// same repo group together), otherwise uses `project_path`. Returns the last path segment.
+/// The GroupTree identity key for a session in project mode. Worktree sessions
+/// key on `main_repo_path` (so all branches of a repo group together); other
+/// sessions key on the last segment of `project_path`. Scratch sessions key on
+/// the `SCRATCH_GROUP_PATH` sentinel, which no real repo basename can equal, so
+/// a user's own repo named `scratch` keeps a distinct identity (#3237); the
+/// bucket's display name is seeded separately in `build_flat_items_by_project`.
 fn project_group_key(inst: &Instance) -> String {
-    // Scratch sessions live under `<app_dir>/scratch/<instance-id>/`, so the last
-    // path segment is the opaque instance id. Group them under a readable label.
     if inst.scratch {
-        return SCRATCH_GROUP_LABEL.to_string();
+        return crate::session::SCRATCH_GROUP_PATH.to_string();
     }
 
     crate::session::projects::repo_label(inst.repo_path())
 }
 
 /// Header label the synthetic "no resolvable owner" bucket renders under in
-/// org view. Not an identity, same caveat as `SCRATCH_GROUP_LABEL`: a hosted
-/// remote whose owner happens to literally be named "No organization" would
-/// share this header, but that collision is vanishingly unlikely in practice
-/// (unlike `scratch`, a plausible real repo basename) so it is not guarded
-/// against the way `is_synthetic_scratch_header` guards the scratch label.
+/// org view. This is a display label; a hosted remote whose owner is literally
+/// "No organization" would share it, but that collision is vanishingly unlikely
+/// (unlike `scratch`, a plausible real repo basename), so org does not give it a
+/// sentinel identity the way project mode does for scratch (#3237).
 const NO_ORG_GROUP_LABEL: &str = "No organization";
 
 /// Kinds of in-progress mouse drags. Today only the list/preview divider
@@ -5119,7 +5113,7 @@ impl HomeView {
             .map(|i| i.group_path.clone())
             .filter(|p| !p.is_empty())
             .collect();
-        let empty_pinned: Vec<crate::session::Group> =
+        let mut seed_groups: Vec<crate::session::Group> =
             crate::session::projects::unpopulated_projects(
                 &populated_labels,
                 &self.registered_projects,
@@ -5127,7 +5121,18 @@ impl HomeView {
             .into_iter()
             .map(|p| crate::session::Group::new(&p.label, &p.label))
             .collect();
-        let mut tree = GroupTree::new_with_groups(&tree_seed, &empty_pinned);
+        // The synthetic scratch bucket keys on a sentinel path so a real repo
+        // named `scratch` keeps its own identity (#3237); seed its display name
+        // the way org seeds host-scoped keys, but only when a live scratch
+        // session populates it (an archived-only scratch group would otherwise
+        // render an undeletable empty header, per the phantom-header note above).
+        if populated_labels.contains(crate::session::SCRATCH_GROUP_PATH) {
+            seed_groups.push(crate::session::Group::new(
+                crate::session::SCRATCH_GROUP_NAME,
+                crate::session::SCRATCH_GROUP_PATH,
+            ));
+        }
+        let mut tree = GroupTree::new_with_groups(&tree_seed, &seed_groups);
         for (path, &collapsed) in &self.project_group_collapsed {
             if collapsed {
                 tree.set_collapsed(path, true);
@@ -7090,15 +7095,13 @@ impl HomeView {
     /// strings) render an unpinnable phantom header: pinned by label, judged
     /// by path.
     ///
-    /// Scratch sessions are excluded for the same reason: their `repo_path()` is
-    /// the throwaway `<app_dir>/scratch/<id>` directory, not a repo anyone can
-    /// register. They share the `scratch` header with a user repo of that
-    /// basename (#3133), so letting one lend the header its path would both hide
-    /// the real repo and offer an app-internal directory up for pinning.
+    /// A scratch session never matches here: its `project_group_key` is the
+    /// `SCRATCH_GROUP_PATH` sentinel, which no display label equals, so the
+    /// synthetic bucket has no backing repo path to lend (#3237).
     pub(super) fn project_header_repo_path(&self, label: &str) -> Option<String> {
         self.instances
             .values()
-            .find(|i| !i.is_archived() && !i.scratch && project_group_key(i) == label)
+            .find(|i| !i.is_archived() && project_group_key(i) == label)
             .map(|i| crate::session::projects::canonical_key(i.repo_path()))
     }
 
@@ -7124,38 +7127,17 @@ impl HomeView {
         }
     }
 
-    /// True when project header `label` is nothing but the synthetic scratch
-    /// bucket, so there is no repo behind it to register or pin. Judged by
-    /// backing identity rather than by the label: scratch sessions and a user's
-    /// own repo named `scratch` derive the same header label, and that header is
-    /// a real project (#3133). A PINNED registry entry carrying the label also
-    /// counts as backing, so an empty pinned `scratch` project stays reachable to
-    /// unpin. The pin flag is required because it is what `unpopulated_projects`
-    /// and `is_project_label_pinned`'s label branch key on: a saved-but-unpinned
-    /// entry never surfaces a header of its own, so counting it as backing would
-    /// open the gate on a header the toggle has no path to act on, and `p` would
-    /// silently do nothing instead of keeping its global meaning. With no
-    /// backing repo path, `is_project_label_pinned` IS that pinned-label
-    /// lookup, so it is reused here rather than restating the predicate.
-    fn is_synthetic_scratch_header(&self, label: &str) -> bool {
-        label == SCRATCH_GROUP_LABEL
-            && self.project_header_repo_path(label).is_none()
-            && !self.is_project_label_pinned(label)
-    }
-
     /// The project-view header label under the cursor when it is a real,
     /// pinnable project: project grouping is active, the cursor is on a group
-    /// header, and that header is neither the synthetic Archived section nor the
-    /// synthetic `scratch` bucket (scratch sessions have no backing repo to pin).
+    /// header, and that header is not a synthetic one (the Archived/Trash
+    /// shelves or the scratch bucket, none of which have a backing repo to pin).
     pub(super) fn project_group_at_cursor(&self) -> Option<String> {
         if self.group_by != GroupByMode::Project {
             return None;
         }
         match self.flat_items.get(self.cursor) {
             Some(Item::Group { path, name, .. })
-                if !crate::session::is_within_archived_section(path)
-                    && !crate::session::is_within_trash_section(path)
-                    && !self.is_synthetic_scratch_header(name) =>
+                if !crate::session::is_synthetic_project_header(path) =>
             {
                 Some(name.clone())
             }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -57,7 +57,7 @@ const SCRATCH_GROUP_LABEL: &str = "scratch";
 /// Extract a project group name from a session instance.
 /// Uses `worktree_info.main_repo_path` for worktree sessions (so all branches of the
 /// same repo group together), otherwise uses `project_path`. Returns the last path segment.
-fn project_group_name(inst: &Instance) -> String {
+fn project_group_key(inst: &Instance) -> String {
     // Scratch sessions live under `<app_dir>/scratch/<instance-id>/`, so the last
     // path segment is the opaque instance id. Group them under a readable label.
     if inst.scratch {
@@ -4758,7 +4758,7 @@ impl HomeView {
     fn known_project_group_paths(&self) -> std::collections::HashSet<String> {
         let mut paths = std::collections::HashSet::new();
         for inst in self.instances.values() {
-            let group = project_group_name(inst);
+            let group = project_group_key(inst);
             if group.is_empty() {
                 continue;
             }
@@ -5089,7 +5089,7 @@ impl HomeView {
         let grouped: Vec<Instance> = base_instances
             .into_iter()
             .map(|mut inst| {
-                inst.group_path = project_group_name(&inst);
+                inst.group_path = project_group_key(&inst);
                 inst
             })
             .collect();
@@ -7098,7 +7098,7 @@ impl HomeView {
     pub(super) fn project_header_repo_path(&self, label: &str) -> Option<String> {
         self.instances
             .values()
-            .find(|i| !i.is_archived() && !i.scratch && project_group_name(i) == label)
+            .find(|i| !i.is_archived() && !i.scratch && project_group_key(i) == label)
             .map(|i| crate::session::projects::canonical_key(i.repo_path()))
     }
 
@@ -7271,7 +7271,7 @@ impl HomeView {
             return;
         };
         let group_path = match self.group_by {
-            GroupByMode::Project => Some(project_group_name(inst)),
+            GroupByMode::Project => Some(project_group_key(inst)),
             GroupByMode::Org => Some(self.org_group_key(inst)),
             GroupByMode::Manual => {
                 let p = inst.group_path.clone();

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1987,7 +1987,7 @@ impl HomeView {
                         .as_ref()
                         .is_none_or(|p| &i.source_profile == p)
                 })
-                .filter(|i| super::project_group_name(i) == group_path)
+                .filter(|i| super::project_group_key(i) == group_path)
                 .map(|i| i.id.clone())
                 .collect(),
             // Org headers are derived from each session's resolved remote

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1407,8 +1407,7 @@ impl HomeView {
                 // rather than stale. Project view only; the registry lookup is
                 // keyed by the header label.
                 let pinned = self.group_by == GroupByMode::Project
-                    && !crate::session::is_within_archived_section(path)
-                    && !crate::session::is_within_trash_section(path)
+                    && !crate::session::is_synthetic_project_header(path)
                     && self.is_project_label_pinned(name);
                 // The top-level shelf section headers get a leading type glyph
                 // so they read as system shelves, not user groups. Project

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7229,15 +7229,19 @@ fn test_project_group_key_handles_trailing_slash() {
 }
 
 #[test]
-fn test_project_group_key_groups_scratch_under_scratch() {
+fn test_project_group_key_scratch_uses_sentinel_not_label() {
     use super::project_group_key;
+    use crate::session::{project_group_display_name, SCRATCH_GROUP_PATH};
 
     let mut inst = Instance::new(
         "test",
         "/home/user/.config/agent-of-empires/scratch/a4535853054b4096",
     );
     inst.scratch = true;
-    assert_eq!(project_group_key(&inst), "scratch");
+    // Scratch keys on the sentinel identity, not the display label, so a real
+    // repo named `scratch` keeps a distinct identity (#3237).
+    assert_eq!(project_group_key(&inst), SCRATCH_GROUP_PATH);
+    assert_eq!(project_group_display_name(SCRATCH_GROUP_PATH), "scratch");
 }
 
 #[test]
@@ -10500,58 +10504,72 @@ fn p_key_opens_projects_dialog_off_project_header() {
 /// synthetic scratch bucket (sessions with no repo, living under
 /// `<app_dir>/scratch/<id>`) stays excluded. The gate used to reject the header
 /// by its display LABEL, which collapsed both cases together and left `p` on a
-/// real `~/scratch` repo falling through to the Projects dialog. See #3133.
+/// real `~/scratch` repo falling through to the Projects dialog. See #3133; #3237
+/// then gave the synthetic bucket its own sentinel identity, so the real repo
+/// and the bucket render as two separate headers, keyed here by path.
 #[test]
 #[serial]
 fn scratch_label_pin_gate_keys_on_backing_repo_not_label() {
     use crate::session::config::GroupByMode;
     use crate::session::projects::canonical_key;
+    use crate::session::SCRATCH_GROUP_PATH;
 
     // (case, has a real repo named `scratch`, has a synthetic scratch session,
     //  a pre-existing registry entry for `/repos/scratch` and its pin flag,
-    //  the pin gate opens on the header, the header is pinned after `p`)
+    //  the path of the header this case targets, the pin gate opens on it, and
+    //  whether it is pinned after `p`)
     let cases = [
         // The reporter's setup: a plain repo at `~/scratch`, no scratch sessions.
-        ("real repo only", true, false, None, true, true),
+        ("real repo only", true, false, None, "scratch", true, true),
         // Nothing but the synthetic bucket: no repo exists to register.
-        ("synthetic bucket only", false, true, None, false, false),
-        // Both derive the same label and so share one header today. The real
-        // repo backs it, so the header is pinnable and the pin must resolve to
-        // that repo rather than the app-internal scratch directory.
+        (
+            "synthetic bucket only",
+            false,
+            true,
+            None,
+            SCRATCH_GROUP_PATH,
+            false,
+            false,
+        ),
+        // The real repo and the synthetic bucket now render as two separate
+        // headers (#3237). This case targets the real repo header, which backs a
+        // pinnable project; the bucket's own header is covered by
+        // `synthetic_scratch_bucket_is_distinct_from_real_repo`.
         (
             "real repo plus scratch session",
             true,
             true,
             None,
+            "scratch",
             true,
             true,
         ),
         // A saved-but-unpinned repo named `scratch` surfaces no header of its
-        // own, so the synthetic bucket is the only thing rendering this one and
-        // the toggle has no path to act on. `p` must keep its global meaning
-        // rather than resolve to a pin that silently does nothing.
+        // own (only pinned empties do), so the synthetic bucket is the only
+        // `scratch` header and `p` must keep its global meaning.
         (
             "saved unpinned repo plus scratch session",
             false,
             true,
             Some(false),
+            SCRATCH_GROUP_PATH,
             false,
             false,
         ),
-        // A pinned registry entry backs the header even with no live session of
-        // its own, so `p` must reach the unpin path instead of being swallowed
-        // as the synthetic bucket.
+        // A pinned registry entry surfaces its own empty header even with no live
+        // session, so `p` must reach the unpin path on that header.
         (
             "pinned empty repo plus scratch session",
             false,
             true,
             Some(true),
+            "scratch",
             true,
             false,
         ),
     ];
 
-    for (case, has_repo, has_scratch, saved, gate_open, pinned_after) in cases {
+    for (case, has_repo, has_scratch, saved, target_path, gate_open, pinned_after) in cases {
         let temp = TempDir::new().unwrap();
         let _guard = setup_test_home(&temp);
         let storage = Storage::new_unwatched("test").unwrap();
@@ -10600,8 +10618,8 @@ fn scratch_label_pin_gate_keys_on_backing_repo_not_label() {
         let idx = view
             .flat_items
             .iter()
-            .position(|i| matches!(i, Item::Group { name, .. } if name == "scratch"))
-            .unwrap_or_else(|| panic!("{case}: scratch header must be present"));
+            .position(|i| matches!(i, Item::Group { path, .. } if path == target_path))
+            .unwrap_or_else(|| panic!("{case}: header at path {target_path} must be present"));
         view.cursor = idx;
         view.update_selected();
 
@@ -10646,6 +10664,177 @@ fn scratch_label_pin_gate_keys_on_backing_repo_not_label() {
             );
         }
     }
+}
+
+/// #3237: a real repo named `scratch` and the synthetic scratch bucket must
+/// render as two separate project headers with distinct identity paths, one
+/// session each (not a pooled count), and independent pin/scope state. Mirrors
+/// the org same-owner-two-hosts separation test above.
+#[test]
+#[serial]
+fn synthetic_scratch_bucket_is_distinct_from_real_repo() {
+    use crate::session::config::GroupByMode;
+    use crate::session::SCRATCH_GROUP_PATH;
+
+    let temp = TempDir::new().unwrap();
+    let _guard = setup_test_home(&temp);
+    let storage = Storage::new_unwatched("test").unwrap();
+
+    let real = Instance::new("work", "/repos/scratch");
+    let mut throwaway = Instance::new("throwaway", "/app-dir/scratch/abc123");
+    throwaway.scratch = true;
+    let scratch_id = throwaway.id.clone();
+    let instances = vec![real, throwaway];
+    storage
+        .update(|i, g| {
+            *i = instances.clone();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let mut view = HomeView::new(
+        Some("test".to_string()),
+        AvailableTools::with_tools(&["claude"]),
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+    view.group_by = GroupByMode::Project;
+    view.flat_items = view.build_flat_items();
+
+    // Two headers, both displayed "scratch", distinct identity paths, one
+    // session each rather than a pooled count of two.
+    let scratch_headers: Vec<(&str, usize)> = view
+        .flat_items
+        .iter()
+        .filter_map(|i| match i {
+            Item::Group {
+                path,
+                name,
+                session_count,
+                ..
+            } if name == "scratch" => Some((path.as_str(), *session_count)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        scratch_headers.len(),
+        2,
+        "real repo and synthetic bucket must be two headers, got {scratch_headers:?}"
+    );
+    assert!(scratch_headers.contains(&("scratch", 1)));
+    assert!(scratch_headers.contains(&(SCRATCH_GROUP_PATH, 1)));
+
+    // The synthetic bucket is not a pinnable project; the real repo is.
+    let real_idx = view
+        .flat_items
+        .iter()
+        .position(|i| matches!(i, Item::Group { path, .. } if path == "scratch"))
+        .unwrap();
+    view.cursor = real_idx;
+    assert_eq!(view.project_group_at_cursor().as_deref(), Some("scratch"));
+    let bucket_idx = view
+        .flat_items
+        .iter()
+        .position(|i| matches!(i, Item::Group { path, .. } if path == SCRATCH_GROUP_PATH))
+        .unwrap();
+    view.cursor = bucket_idx;
+    assert_eq!(view.project_group_at_cursor(), None);
+
+    // Bulk-archive scope on the synthetic bucket touches only the scratch
+    // session, never the real repo's session.
+    view.selected_group = Some(SCRATCH_GROUP_PATH.to_string());
+    assert_eq!(view.active_sessions_in_selected_group(), vec![scratch_id]);
+}
+
+/// #3237: New Session from the synthetic scratch bucket must not prefill
+/// another scratch session's throwaway `<app_dir>/scratch/<id>` directory as
+/// the working cwd; the dialog should fall through to the default cwd instead
+/// of tying the new session's lifetime to an unrelated scratch dir. Mirrors
+/// the same invariant `project_header_repo_path` enforces for the pin action.
+#[test]
+#[serial]
+fn scratch_bucket_lends_no_repo_path_for_new_session_prefill() {
+    use crate::session::config::GroupByMode;
+    use crate::session::SCRATCH_GROUP_PATH;
+
+    let temp = TempDir::new().unwrap();
+    let _guard = setup_test_home(&temp);
+    let storage = Storage::new_unwatched("test").unwrap();
+
+    let mut throwaway = Instance::new("throwaway", "/app-dir/scratch/abc123");
+    throwaway.scratch = true;
+    let instances = vec![throwaway];
+    storage
+        .update(|i, g| {
+            *i = instances.clone();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let view = HomeView::new(
+        Some("test".to_string()),
+        AvailableTools::with_tools(&["claude"]),
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+    assert_eq!(view.group_by, GroupByMode::Project);
+    assert_eq!(view.group_repo_path(SCRATCH_GROUP_PATH), None);
+}
+
+/// #3237 pitfall guard: when the only scratch session is archived, the seed
+/// must not create a phantom empty `scratch` header in the main flow (an
+/// archived-only project header is undeletable in project mode). The bucket
+/// appears only nested under the Archived section.
+#[test]
+#[serial]
+fn scratch_bucket_absent_from_main_flow_when_only_scratch_is_archived() {
+    use crate::session::config::GroupByMode;
+    use crate::session::{is_within_archived_section, SCRATCH_GROUP_PATH};
+
+    let temp = TempDir::new().unwrap();
+    let _guard = setup_test_home(&temp);
+    let storage = Storage::new_unwatched("test").unwrap();
+
+    let mut throwaway = Instance::new("throwaway", "/app-dir/scratch/abc123");
+    throwaway.scratch = true;
+    throwaway.archive();
+    let instances = vec![throwaway];
+    storage
+        .update(|i, g| {
+            *i = instances.clone();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let mut view = HomeView::new(
+        Some("test".to_string()),
+        AvailableTools::with_tools(&["claude"]),
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+    view.group_by = GroupByMode::Project;
+    // Expand the Archived shelf so its per-project sub-headers are emitted.
+    view.archived_section_collapsed = false;
+    view.flat_items = view.build_flat_items();
+
+    assert!(
+        !view
+            .flat_items
+            .iter()
+            .any(|i| matches!(i, Item::Group { path, .. } if path == SCRATCH_GROUP_PATH)),
+        "an archived-only scratch session must not seed a phantom main-flow bucket"
+    );
+    assert!(
+        view.flat_items.iter().any(|i| matches!(
+            i,
+            Item::Group { path, name, .. }
+                if is_within_archived_section(path) && name == "scratch"
+        )),
+        "the archived scratch session should still render under the Archived section"
+    );
 }
 
 /// Pin a project, archive its only session, then unpin: the empty header must

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7196,16 +7196,16 @@ fn test_apply_creation_results_returns_session_id() {
 }
 
 #[test]
-fn test_project_group_name_uses_last_path_segment() {
-    use super::project_group_name;
+fn test_project_group_key_uses_last_path_segment() {
+    use super::project_group_key;
 
     let inst = Instance::new("test", "/home/user/my-project");
-    assert_eq!(project_group_name(&inst), "my-project");
+    assert_eq!(project_group_key(&inst), "my-project");
 }
 
 #[test]
-fn test_project_group_name_uses_main_repo_for_worktree() {
-    use super::project_group_name;
+fn test_project_group_key_uses_main_repo_for_worktree() {
+    use super::project_group_key;
     use crate::session::WorktreeInfo;
     use chrono::Utc;
 
@@ -7217,27 +7217,27 @@ fn test_project_group_name_uses_main_repo_for_worktree() {
         created_at: Utc::now(),
         base_branch: None,
     });
-    assert_eq!(project_group_name(&inst), "my-project");
+    assert_eq!(project_group_key(&inst), "my-project");
 }
 
 #[test]
-fn test_project_group_name_handles_trailing_slash() {
-    use super::project_group_name;
+fn test_project_group_key_handles_trailing_slash() {
+    use super::project_group_key;
 
     let inst = Instance::new("test", "/home/user/my-project/");
-    assert_eq!(project_group_name(&inst), "my-project");
+    assert_eq!(project_group_key(&inst), "my-project");
 }
 
 #[test]
-fn test_project_group_name_groups_scratch_under_scratch() {
-    use super::project_group_name;
+fn test_project_group_key_groups_scratch_under_scratch() {
+    use super::project_group_key;
 
     let mut inst = Instance::new(
         "test",
         "/home/user/.config/agent-of-empires/scratch/a4535853054b4096",
     );
     inst.scratch = true;
-    assert_eq!(project_group_name(&inst), "scratch");
+    assert_eq!(project_group_key(&inst), "scratch");
 }
 
 #[test]
@@ -10356,7 +10356,7 @@ fn project_attention_archive_selected_group_removes_empty_main_header() {
         env.view
             .instances
             .values()
-            .filter(|i| super::project_group_name(i) == "beta")
+            .filter(|i| super::project_group_key(i) == "beta")
             .all(|i| i.is_archived()),
         "all beta sessions must be archived"
     );
@@ -10676,7 +10676,7 @@ fn unpin_archived_only_project_leaves_main_flow() {
         .view
         .instances
         .values()
-        .filter(|i| super::project_group_name(i) == "beta")
+        .filter(|i| super::project_group_key(i) == "beta")
         .map(|i| i.id.clone())
         .collect();
     for id in &beta_ids {
@@ -10856,7 +10856,7 @@ fn pinned_project_survives_losing_last_session() {
     // entry keeps the header alive even with zero members.
     env.view
         .instances
-        .retain(|_, i| super::project_group_name(i) != "alpha");
+        .retain(|_, i| super::project_group_key(i) != "alpha");
     env.view.flat_items = env.view.build_flat_items();
 
     let alpha_header = env.view.flat_items.iter().find_map(|i| match i {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7241,7 +7241,7 @@ fn test_project_group_key_scratch_uses_sentinel_not_label() {
     // Scratch keys on the sentinel identity, not the display label, so a real
     // repo named `scratch` keeps a distinct identity (#3237).
     assert_eq!(project_group_key(&inst), SCRATCH_GROUP_PATH);
-    assert_eq!(project_group_display_name(SCRATCH_GROUP_PATH), "scratch");
+    assert_eq!(project_group_display_name(SCRATCH_GROUP_PATH), "Scratch");
 }
 
 #[test]
@@ -10707,7 +10707,7 @@ fn scratch_label_pin_gate_keys_on_backing_repo_not_label() {
 #[serial]
 fn synthetic_scratch_bucket_is_distinct_from_real_repo() {
     use crate::session::config::GroupByMode;
-    use crate::session::SCRATCH_GROUP_PATH;
+    use crate::session::{SCRATCH_GROUP_NAME, SCRATCH_GROUP_PATH};
 
     let temp = TempDir::new().unwrap();
     let _guard = setup_test_home(&temp);
@@ -10735,9 +10735,10 @@ fn synthetic_scratch_bucket_is_distinct_from_real_repo() {
     view.group_by = GroupByMode::Project;
     view.flat_items = view.build_flat_items();
 
-    // Two headers, both displayed "scratch", distinct identity paths, one
-    // session each rather than a pooled count of two.
-    let scratch_headers: Vec<(&str, usize)> = view
+    // Two headers on distinct identity paths, one session each rather than a
+    // pooled count of two. The repo header keeps its basename; the bucket
+    // renders the capitalized system label.
+    let scratch_headers: Vec<(&str, &str, usize)> = view
         .flat_items
         .iter()
         .filter_map(|i| match i {
@@ -10746,7 +10747,9 @@ fn synthetic_scratch_bucket_is_distinct_from_real_repo() {
                 name,
                 session_count,
                 ..
-            } if name == "scratch" => Some((path.as_str(), *session_count)),
+            } if name.eq_ignore_ascii_case("scratch") => {
+                Some((path.as_str(), name.as_str(), *session_count))
+            }
             _ => None,
         })
         .collect();
@@ -10755,8 +10758,8 @@ fn synthetic_scratch_bucket_is_distinct_from_real_repo() {
         2,
         "real repo and synthetic bucket must be two headers, got {scratch_headers:?}"
     );
-    assert!(scratch_headers.contains(&("scratch", 1)));
-    assert!(scratch_headers.contains(&(SCRATCH_GROUP_PATH, 1)));
+    assert!(scratch_headers.contains(&("scratch", "scratch", 1)));
+    assert!(scratch_headers.contains(&(SCRATCH_GROUP_PATH, SCRATCH_GROUP_NAME, 1)));
 
     // The synthetic bucket is not a pinnable project; the real repo is.
     let real_idx = view
@@ -10824,7 +10827,7 @@ fn scratch_bucket_lends_no_repo_path_for_new_session_prefill() {
 #[serial]
 fn scratch_bucket_absent_from_main_flow_when_only_scratch_is_archived() {
     use crate::session::config::GroupByMode;
-    use crate::session::{is_within_archived_section, SCRATCH_GROUP_PATH};
+    use crate::session::{is_within_archived_section, SCRATCH_GROUP_NAME, SCRATCH_GROUP_PATH};
 
     let temp = TempDir::new().unwrap();
     let _guard = setup_test_home(&temp);
@@ -10864,7 +10867,7 @@ fn scratch_bucket_absent_from_main_flow_when_only_scratch_is_archived() {
         view.flat_items.iter().any(|i| matches!(
             i,
             Item::Group { path, name, .. }
-                if is_within_archived_section(path) && name == "scratch"
+                if is_within_archived_section(path) && name == SCRATCH_GROUP_NAME
         )),
         "the archived scratch session should still render under the Archived section"
     );


### PR DESCRIPTION
## Description

Closes #3237.

In the TUI's project view a group's identity IS its display-label string: `project_group_key` (formerly `project_group_name`) returned the literal `"scratch"` for every synthetic scratch session, and `GroupTree` keys nodes by that path. A user's own repository whose basename happens to be `scratch` produced the same key, so the two collapsed into one header with a pooled session count and a shared collapse / sort / pin state. The interim `is_synthetic_scratch_header` heuristic from #3222 (label + backing-repo + pin lookup) masked the pin gate but could not fix the merge.

This fix mirrors what org mode already does for `owner@host` keys (#3284): a sentinel identity path plus a seeded `Group` carrying the display name.

- `SCRATCH_GROUP_PATH = "__aoe_scratch_group__"` (identity, no real repo basename can equal it) and `SCRATCH_GROUP_NAME = "scratch"` (display) live beside the existing `ARCHIVED_/TRASH_SECTION_*` constants in `src/session/groups.rs`.
- `project_group_key` returns the sentinel for `inst.scratch`, so a real `scratch` repo keeps a distinct identity and `GroupTree` renders two separate headers.
- `build_flat_items_by_project` seeds `Group::new(SCRATCH_GROUP_NAME, SCRATCH_GROUP_PATH)` only when a live scratch session populates the sentinel (an archived-only scratch group would otherwise create an undeletable phantom header, the same trap the surrounding phantom-header guard already prevents for regular projects).
- A shared `is_synthetic_project_header(path)` predicate (archived || trash || scratch) gates the pin glyph in the header renderer and `project_group_at_cursor`, so those actions never target a header with no backing repo. Keyed strictly on path; a real repo named `scratch` is never caught.
- `project_group_display_name(key)` maps the sentinel back to `"scratch"` at the four sites that render a raw group key to the user: the archived sub-header (`append_archived_section_by_project`), the archive-group prompt (`prompt_archive_selected_group`), the New Session group-field prefill (`open_new_from_selection`), and the command-palette "Jump to group" disambiguator. Real-repo and org keys pass through unchanged.
- `group_repo_path` short-circuits to `None` for any synthetic project header, so "New Session" from the scratch bucket lands on the default cwd rather than another scratch session's throwaway `<app_dir>/scratch/<id>` directory (which would tie the new session's cwd to an unrelated scratch session's lifetime). This matches the "no backing repo to lend" invariant `project_header_repo_path` already documents for the pin action.

`is_synthetic_scratch_header` and the now-dead `!i.scratch` guard in `project_header_repo_path` are removed.

### One-time behavior on upgrade (no migration)

The `project_group_collapsed` map is keyed by group path. Before this change a collapsed synthetic bucket saved key `"scratch"`; after, it saves the sentinel. Two consequences, both self-healing on the first toggle and neither worse than today's shared-key behavior, so no migration is needed:

1. A user who had the synthetic bucket collapsed will see that state land on a real `scratch` repo header once (if one exists); the synthetic bucket starts expanded.
2. The archived-scratch sub-folder collapse key changes from `__aoe_archived_section__/scratch` to `__aoe_archived_section__/__aoe_scratch_group__` once.

### Known limitation left in place

Org mode's `owner@host` key still renders verbatim in the archive-group prompt and archived sub-header (pre-existing, shared with this PR's changed sites). Fixing it needs `&self` and the git-remote cache and is out of scope for #3237.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

TUI grouping change; no visual redesign, no new screen. Screenshot/recording skipped.

## Test Coverage Analysis

Web dashboard / structured view (Playwright user story)
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The web dashboard already handles this correctly: `useRepoGroups.ts` keys the scratch bucket on `SCRATCH_GROUP_ID = "__scratch__"` with its own display label. Group identity is computed client-side from the `scratch: bool` flag on each session; no group-path string crosses the wire.

TUI / CLI (e2e test)
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

The change is entirely in the flat-items build for project mode, which is covered by unit tests (see below). Nothing about how the TUI renders, subcommand behavior, or session lifecycle changed.

Tests added / migrated in `src/tui/home/tests.rs`:

- `test_project_group_key_scratch_uses_sentinel_not_label`: asserts `project_group_key` returns the sentinel and `project_group_display_name` maps it back.
- `synthetic_scratch_bucket_is_distinct_from_real_repo`: regression. A real `/repos/scratch` session and a synthetic scratch session render as two headers with distinct paths, `session_count == 1` each (not pooled), the synthetic one is not pinnable, and `selected_group = sentinel` scopes bulk archive to only the scratch session. Models on `build_flat_items_by_org_scopes_same_named_owners_by_host`.
- `scratch_bucket_absent_from_main_flow_when_only_scratch_is_archived`: pitfall guard. When the only scratch session is archived, the seed must not create a phantom `scratch` header in the main flow; the bucket appears only under Archived, and its sub-header displays `"scratch"` (not the sentinel).
- `scratch_bucket_lends_no_repo_path_for_new_session_prefill`: asserts `group_repo_path(SCRATCH_GROUP_PATH)` returns `None`.
- `scratch_label_pin_gate_keys_on_backing_repo_not_label`: rewritten to locate headers by path (the two `"scratch"`-named headers now coexist); each of the five cases still exercises the pin gate on the intended header.

Verified locally: `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo test` (default), `cargo test --features serve`, `cargo test --no-default-features` all clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

AI Model/Tool used: Claude Code (Opus 4.8)

Any Additional AI Details you'd like to share:

I used it to speed up mapping the touch points and drafting the tests, and had subagents adversarially review the design and the diff (correctness, altitude, blast-radius, senior review, then simplification). The identity/display split was the design decision; the sentinel-path direction came from #3237's own description. I reviewed the whole diff, understand it, and answered reviewer feedback in my own words.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Separated the synthetic Scratch bucket from real repositories named `scratch` with a distinct internal identity and shared display name.
- Updated grouping, sorting, collapse state, pinning, selection, archive actions, and session handling to use the correct group identity.
- Created the synthetic group only when live scratch sessions exist.
- Prevented synthetic groups from supplying repository paths for new sessions.
- Replaced the scratch-header heuristic with centralized synthetic-header detection.
- Added tests for group separation, archived-only sessions, pinning, selection, sorting, and new-session path handling.

## Benefits

This prevents session counts and group state from mixing between real and synthetic groups. Real `scratch` repositories can now be managed normally, while synthetic groups remain excluded from repository-specific actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->