### PR TITLE
fix(config): surface config load errors and unrecognized keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "rust-embed",
  "semver",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serde_yaml",
  "serial_test",
@@ -3915,6 +3916,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ aoe-plugin-api = { path = "aoe-plugin-api" }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
+serde_ignored = "0.1"
 serde_json = "1.0"
 serde_yaml = "0.9"
 toml = "1.1"

--- a/src/cli/settings.rs
+++ b/src/cli/settings.rs
@@ -34,6 +34,24 @@ fn source_label(source: &SettingSource) -> String {
 }
 
 fn run_explain(key: &str) -> Result<()> {
+    // Surface parse failures / unrecognized keys BEFORE the per-key output.
+    // On a parse failure `resolve` sees `Config::default()`, so every source
+    // legitimately reports `schema default`; without the banner that reads as
+    // "your file is honored and matches the defaults," which was the exact
+    // trap the #3207 reporter fell into (#3228).
+    let probe = crate::session::probe_global_config();
+    if let Some(err) = probe.load_err.as_deref() {
+        eprintln!(
+            "warning: config.toml failed to parse; every value below is a built-in default.\n  file: {}\n  reason: {err}\n",
+            crate::session::config_path_display()
+        );
+    } else if !probe.ignored_keys.is_empty() {
+        eprintln!(
+            "note: some keys in config.toml were not recognized and were ignored: {}\n",
+            probe.ignored_keys.join(", ")
+        );
+    }
+
     let Some(resolved) = resolve(key) else {
         bail!("'{key}' is not a known setting. Use a core `section.field` or a `plugin:<id>.<field>` key.");
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,19 +424,30 @@ async fn run(
         migrations::run_migrations()?;
     }
 
-    // Surface config parse errors and unrecognized keys on stderr for the
-    // one-shot CLI commands that reach this point (add/list/ps/status/session/
-    // remove/send/killall/group/serve-foreground). Skipped when a tracing
-    // subscriber is already running (`should_init`) so the `_or_warn` helpers'
-    // `tracing::warn!` handle it without a duplicate. Gated on
-    // `cli::command_name` so hidden machine-spawned subcommands (`__acp-runner`
-    // etc.) never eprintln into a detached worker's redirected stderr. The TUI
-    // path skips this: `collect_startup_config_warnings` already runs there and
-    // is rendered as a startup dialog by `App::show_startup_warning` (#3228).
-    if !should_init && cli.command.as_ref().and_then(cli::command_name).is_some() {
-        if let Some(warning) = agent_of_empires::session::collect_startup_config_warnings(&profile)
-        {
-            eprintln!("{warning}");
+    // Surface config diagnostics on stderr for user-visible CLI commands
+    // (`add`/`list`/`ps`/`status`/`session`/`remove`/`send`/`killall`/`group`/
+    // `serve` foreground). Two classes with different subscriber overlap:
+    //
+    // - Unrecognized keys: collected only by `serde_ignored` inside the
+    //   startup probe; no other surface reports them. Always emit when a user
+    //   is watching, even when a tracing subscriber is running (`should_init`
+    //   true), because the `_or_warn` helpers cover only parse failures.
+    // - Parse failures: reported by `Config::load_or_warn`'s `tracing::warn!`
+    //   when a subscriber is up. Emit here only when it isn't, so a foreground
+    //   run doesn't duplicate the tracing line.
+    //
+    // Gated on `cli::command_name` so hidden machine-spawned subcommands
+    // (`__acp-runner` etc.) never eprintln into a detached worker's redirected
+    // stderr. The TUI path skips this: `collect_startup_config_warnings`
+    // already runs there and is rendered by `App::show_startup_warning` (#3228).
+    if cli.command.as_ref().and_then(cli::command_name).is_some() {
+        let warning = if should_init {
+            agent_of_empires::session::collect_startup_ignored_key_warnings(&profile)
+        } else {
+            agent_of_empires::session::collect_startup_config_warnings(&profile)
+        };
+        if let Some(w) = warning {
+            eprintln!("{w}");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,6 +313,7 @@ async fn main() -> Result<()> {
     if let Err(e) = run(
         cli,
         is_daemon_child,
+        should_init,
         debug_namespace_drift,
         debug_log_warning,
     )
@@ -335,6 +336,7 @@ async fn main() -> Result<()> {
 async fn run(
     cli: Cli,
     is_daemon_child: bool,
+    should_init: bool,
     debug_namespace_drift: Option<(std::path::PathBuf, std::path::PathBuf)>,
     debug_log_warning: Option<String>,
 ) -> Result<()> {
@@ -420,6 +422,22 @@ async fn run(
     // TUI mode handles migrations with a spinner; CLI runs them silently
     if cli.command.is_some() {
         migrations::run_migrations()?;
+    }
+
+    // Surface config parse errors and unrecognized keys on stderr for the
+    // one-shot CLI commands that reach this point (add/list/ps/status/session/
+    // remove/send/killall/group/serve-foreground). Skipped when a tracing
+    // subscriber is already running (`should_init`) so the `_or_warn` helpers'
+    // `tracing::warn!` handle it without a duplicate. Gated on
+    // `cli::command_name` so hidden machine-spawned subcommands (`__acp-runner`
+    // etc.) never eprintln into a detached worker's redirected stderr. The TUI
+    // path skips this: `collect_startup_config_warnings` already runs there and
+    // is rendered as a startup dialog by `App::show_startup_warning` (#3228).
+    if !should_init && cli.command.as_ref().and_then(cli::command_name).is_some() {
+        if let Some(warning) = agent_of_empires::session::collect_startup_config_warnings(&profile)
+        {
+            eprintln!("{warning}");
+        }
     }
 
     let result = match cli.command {

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -2820,7 +2820,12 @@ fn config_save_lock() -> &'static Mutex<()> {
 }
 
 impl Config {
-    pub fn load() -> Result<Self> {
+    /// Read and parse `config.toml` into a raw `toml::Table`, with the
+    /// stale `app_state` section stripped. Shared prelude for [`Config::load`]
+    /// and [`Config::config_ignored_keys`]; keeping the read + strip in one
+    /// place stops the ignored-key probe from ever flagging a section `load`
+    /// silently drops.
+    fn load_raw_table() -> Result<toml::Table> {
         let path = config_path()?;
         let mut table: toml::Table = if path.exists() {
             toml::from_str(&fs::read_to_string(&path)?)?
@@ -2831,9 +2836,35 @@ impl Config {
         // from before the split (or written by an out-of-date peer) so it
         // never shadows the authoritative source below.
         table.remove("app_state");
+        Ok(table)
+    }
+
+    pub fn load() -> Result<Self> {
+        let table = Self::load_raw_table()?;
         let mut config: Config = table.try_into()?;
         config.app_state = AppStateConfig::load()?;
         Ok(config)
+    }
+
+    /// Dotted paths of keys in the on-disk `config.toml` that `Config` does not
+    /// recognize (unknown struct fields at any depth), so a typo like
+    /// `[sandbox] privildged = true` surfaces instead of being silently
+    /// dropped. Only called on the Ok path: `Config::load` errored out already
+    /// carries the load-error text, and the two failure classes are per-file
+    /// mutually exclusive (no `deny_unknown_fields`, so an unknown key never
+    /// fails the load). Map-keyed sections (`agents`, `tools`, `plugins`,
+    /// `session.custom_agents`, `acp.acp_defaults`, ...) never flag because
+    /// their keys are entries, not struct fields; nested struct-field typos
+    /// inside them still do.
+    pub(crate) fn config_ignored_keys() -> Vec<String> {
+        let Ok(table) = Self::load_raw_table() else {
+            return Vec::new();
+        };
+        let mut ignored = Vec::new();
+        let _ = serde_ignored::deserialize::<_, _, Config>(toml::Value::Table(table), |path| {
+            ignored.push(path.to_string());
+        });
+        ignored
     }
 
     /// Like [`Config::load`], but logs a warning on failure and returns defaults

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -707,14 +707,30 @@ pub(crate) fn config_path_display() -> String {
         .unwrap_or_else(|_| "config.toml".to_string())
 }
 
+/// Which classes of probe finding a caller wants surfaced.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum WarningClass {
+    /// Parse failures and unrecognized keys.
+    All,
+    /// Unrecognized keys only. For paths where a tracing subscriber is already
+    /// running: a parse failure reaches the operator through that sink, but
+    /// ignored keys are collected nowhere else.
+    IgnoredKeysOnly,
+}
+
 /// Format one probe result as a user-visible line, or `None` when the file is
-/// clean. `scope_label` is prefixed to both the parse-failure and the
-/// unrecognized-keys message (e.g. `"global config"`, `"profile config 'foo'"`).
-fn format_probe(probe: &ConfigProbe, scope_label: &str, path_display: &str) -> Option<String> {
+/// clean (or failed to parse under [`WarningClass::IgnoredKeysOnly`], which
+/// carries no ignored-key information anyway). `scope_label` is prefixed to
+/// both messages (e.g. `"global config"`, `"profile config 'foo'"`).
+fn format_probe(
+    probe: &ConfigProbe,
+    scope_label: &str,
+    path_display: &str,
+    class: WarningClass,
+) -> Option<String> {
     if let Some(e) = probe.load_err.as_deref() {
-        Some(format!(
-            "Failed to load {scope_label} ({path_display}); using defaults.\n{e}"
-        ))
+        (class == WarningClass::All)
+            .then(|| format!("Failed to load {scope_label} ({path_display}); using defaults.\n{e}"))
     } else if !probe.ignored_keys.is_empty() {
         Some(format!(
             "Unrecognized keys in {scope_label} ({path_display}) were ignored: {}",
@@ -725,22 +741,42 @@ fn format_probe(probe: &ConfigProbe, scope_label: &str, path_display: &str) -> O
     }
 }
 
-/// Format only the unrecognized-keys half of a probe result. Returns `None`
-/// when the file is clean OR failed to parse: a parse failure would have
-/// been reported by `Config::load_or_warn`'s `tracing::warn!` (assuming a
-/// subscriber is running), and it does not carry ignored-key information.
-fn format_probe_ignored_keys_only(
-    probe: &ConfigProbe,
-    scope_label: &str,
-    path_display: &str,
-) -> Option<String> {
-    if probe.load_err.is_some() || probe.ignored_keys.is_empty() {
+/// Probe the global config and the active profile's config, formatting the
+/// requested classes into one blank-line-separated message.
+fn collect_startup_warnings(profile: &str, class: WarningClass) -> Option<String> {
+    let mut messages: Vec<String> = Vec::new();
+
+    if let Some(msg) = format_probe(
+        &probe_global_config(),
+        "global config",
+        &config_path_display(),
+        class,
+    ) {
+        messages.push(msg);
+    }
+
+    let effective = if profile.is_empty() {
+        config::resolve_default_profile()
+    } else {
+        profile.to_string()
+    };
+    let profile_path_display = profile_config::get_profile_config_path(&effective)
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| format!("profiles/{effective}/config.toml"));
+    let profile_scope = format!("profile config '{effective}'");
+    if let Some(msg) = format_probe(
+        &probe_profile_config(&effective),
+        &profile_scope,
+        &profile_path_display,
+        class,
+    ) {
+        messages.push(msg);
+    }
+
+    if messages.is_empty() {
         None
     } else {
-        Some(format!(
-            "Unrecognized keys in {scope_label} ({path_display}) were ignored: {}",
-            probe.ignored_keys.join(", ")
-        ))
+        Some(messages.join("\n\n"))
     }
 }
 
@@ -751,38 +787,7 @@ fn format_probe_ignored_keys_only(
 /// gives users a chance to see that their settings have been ignored without
 /// needing `AGENT_OF_EMPIRES_DEBUG=1`.
 pub fn collect_startup_config_warnings(profile: &str) -> Option<String> {
-    let mut messages: Vec<String> = Vec::new();
-
-    if let Some(msg) = format_probe(
-        &probe_global_config(),
-        "global config",
-        &config_path_display(),
-    ) {
-        messages.push(msg);
-    }
-
-    let effective = if profile.is_empty() {
-        config::resolve_default_profile()
-    } else {
-        profile.to_string()
-    };
-    let profile_path_display = profile_config::get_profile_config_path(&effective)
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|_| format!("profiles/{effective}/config.toml"));
-    let profile_scope = format!("profile config '{effective}'");
-    if let Some(msg) = format_probe(
-        &probe_profile_config(&effective),
-        &profile_scope,
-        &profile_path_display,
-    ) {
-        messages.push(msg);
-    }
-
-    if messages.is_empty() {
-        None
-    } else {
-        Some(messages.join("\n\n"))
-    }
+    collect_startup_warnings(profile, WarningClass::All)
 }
 
 /// Like [`collect_startup_config_warnings`], but only the unrecognized-keys
@@ -792,38 +797,7 @@ pub fn collect_startup_config_warnings(profile: &str) -> Option<String> {
 /// helpers, but ignored keys are collected only by this probe, so they must
 /// still be surfaced on stderr even when tracing is up (#3228 CodeRabbit).
 pub fn collect_startup_ignored_key_warnings(profile: &str) -> Option<String> {
-    let mut messages: Vec<String> = Vec::new();
-
-    if let Some(msg) = format_probe_ignored_keys_only(
-        &probe_global_config(),
-        "global config",
-        &config_path_display(),
-    ) {
-        messages.push(msg);
-    }
-
-    let effective = if profile.is_empty() {
-        config::resolve_default_profile()
-    } else {
-        profile.to_string()
-    };
-    let profile_path_display = profile_config::get_profile_config_path(&effective)
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|_| format!("profiles/{effective}/config.toml"));
-    let profile_scope = format!("profile config '{effective}'");
-    if let Some(msg) = format_probe_ignored_keys_only(
-        &probe_profile_config(&effective),
-        &profile_scope,
-        &profile_path_display,
-    ) {
-        messages.push(msg);
-    }
-
-    if messages.is_empty() {
-        None
-    } else {
-        Some(messages.join("\n\n"))
-    }
+    collect_startup_warnings(profile, WarningClass::IgnoredKeysOnly)
 }
 
 // ── TUI presence ────────────────────────────────────────────────────────────
@@ -1081,9 +1055,33 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_collect_startup_config_warnings_clean() {
-        let _temp = isolate_app_dir();
+        let temp = isolate_app_dir();
         // No config files written = defaults everywhere = no warning.
         assert!(collect_startup_config_warnings("").is_none());
+
+        // A config.toml written by our own serializer must probe clean too.
+        // The ignored-key probe deserializes the file (and, for profiles, a
+        // serialized `Config::default()` with the overrides merged onto it),
+        // so any Serialize/Deserialize asymmetry in the schema would warn
+        // every user on every startup rather than only on a real typo.
+        let dir = app_dir(&temp);
+        fs::write(
+            dir.join("config.toml"),
+            toml::to_string_pretty(&config::Config::default()).unwrap(),
+        )
+        .unwrap();
+        let profile_dir = dir.join("profiles").join("default");
+        fs::create_dir_all(&profile_dir).unwrap();
+        fs::write(
+            profile_dir.join("config.toml"),
+            "description = \"work\"\n[sandbox]\nenabled_by_default = true\n",
+        )
+        .unwrap();
+        let warning = collect_startup_config_warnings("default");
+        assert!(
+            warning.is_none(),
+            "round-tripped config must not warn, got: {warning:?}"
+        );
     }
 
     #[test]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -654,22 +654,90 @@ pub fn set_default_profile(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// One file's probe result: either the parse errored out (per-key values fall
+/// back to defaults), or it loaded but some keys were unrecognized and
+/// silently dropped. The two are mutually exclusive per file: without
+/// `deny_unknown_fields`, an unknown key never fails the load.
+pub struct ConfigProbe {
+    pub load_err: Option<String>,
+    pub ignored_keys: Vec<String>,
+}
+
+/// Try to load a config file, and on success enumerate its unrecognized keys.
+/// The two arms of `ConfigProbe` are always populated the same way; this
+/// helper keeps the global and profile probes from drifting apart.
+fn probe<T, E: std::fmt::Display>(
+    load: impl FnOnce() -> Result<T, E>,
+    ignored: impl FnOnce(&T) -> Vec<String>,
+) -> ConfigProbe {
+    match load() {
+        Ok(cfg) => ConfigProbe {
+            load_err: None,
+            ignored_keys: ignored(&cfg),
+        },
+        Err(e) => ConfigProbe {
+            load_err: Some(e.to_string()),
+            ignored_keys: Vec::new(),
+        },
+    }
+}
+
+/// Probe the global `config.toml`: run the real `Config::load` and, if it
+/// succeeded, run `serde_ignored` to enumerate any unknown struct fields at
+/// any depth.
+pub fn probe_global_config() -> ConfigProbe {
+    probe(Config::load, |_| Config::config_ignored_keys())
+}
+
+/// Same shape as [`probe_global_config`] but for a profile's `config.toml`.
+pub fn probe_profile_config(profile: &str) -> ConfigProbe {
+    probe(
+        || profile_config::load_profile_config(profile),
+        profile_config::profile_config_ignored_keys,
+    )
+}
+
+/// Human-readable path of the global `config.toml`, with a stable fallback so
+/// the message reads sensibly when the app dir can't even be resolved.
+pub(crate) fn config_path_display() -> String {
+    config::config_path()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "config.toml".to_string())
+}
+
+/// Format one probe result as a user-visible line, or `None` when the file is
+/// clean. `scope_label` is prefixed to both the parse-failure and the
+/// unrecognized-keys message (e.g. `"global config"`, `"profile config 'foo'"`).
+fn format_probe(probe: &ConfigProbe, scope_label: &str, path_display: &str) -> Option<String> {
+    if let Some(e) = probe.load_err.as_deref() {
+        Some(format!(
+            "Failed to load {scope_label} ({path_display}); using defaults.\n{e}"
+        ))
+    } else if !probe.ignored_keys.is_empty() {
+        Some(format!(
+            "Unrecognized keys in {scope_label} ({path_display}) were ignored: {}",
+            probe.ignored_keys.join(", ")
+        ))
+    } else {
+        None
+    }
+}
+
 /// Probe the global config and the active profile's config at startup so the
-/// TUI can show a single user-visible warning when either fails to parse.
-/// `tracing::warn!` calls inside the `_or_warn` helpers are silently dropped
-/// in default TUI mode (no subscriber), so this gives users a chance to see
-/// that their settings have been ignored without needing `AGENT_OF_EMPIRES_DEBUG=1`.
+/// TUI can show a single user-visible warning when either fails to parse OR
+/// contains unrecognized keys. `tracing::warn!` calls inside the `_or_warn`
+/// helpers are silently dropped in default TUI mode (no subscriber), so this
+/// gives users a chance to see that their settings have been ignored without
+/// needing `AGENT_OF_EMPIRES_DEBUG=1`.
 pub fn collect_startup_config_warnings(profile: &str) -> Option<String> {
     let mut messages: Vec<String> = Vec::new();
 
-    let global_path_display = config::config_path()
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|_| "config.toml".to_string());
-
-    if let Err(e) = Config::load() {
-        messages.push(format!(
-            "Failed to load global config ({global_path_display}); using defaults.\n{e}"
-        ));
+    if let Some(msg) = format_probe(
+        &probe_global_config(),
+        "global config",
+        &config_path_display(),
+    ) {
+        messages.push(msg);
     }
 
     let effective = if profile.is_empty() {
@@ -677,15 +745,16 @@ pub fn collect_startup_config_warnings(profile: &str) -> Option<String> {
     } else {
         profile.to_string()
     };
-
     let profile_path_display = profile_config::get_profile_config_path(&effective)
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| format!("profiles/{effective}/config.toml"));
-
-    if let Err(e) = profile_config::load_profile_config(&effective) {
-        messages.push(format!(
-            "Failed to load profile config '{effective}' ({profile_path_display}); using defaults.\n{e}"
-        ));
+    let profile_scope = format!("profile config '{effective}'");
+    if let Some(msg) = format_probe(
+        &probe_profile_config(&effective),
+        &profile_scope,
+        &profile_path_display,
+    ) {
+        messages.push(msg);
     }
 
     if messages.is_empty() {
@@ -986,6 +1055,111 @@ mod tests {
 
         let warning = collect_startup_config_warnings("default").expect("expected a warning");
         assert!(warning.contains("Failed to load profile config 'default'"));
+    }
+
+    /// #3228: a nested typo inside a known section is silently dropped by
+    /// serde today (no `deny_unknown_fields`). The startup probe surfaces it.
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_startup_config_warnings_flags_nested_unknown_key() {
+        let temp = isolate_app_dir();
+        let dir = app_dir(&temp);
+        // The exact typo shape from #3218: an unknown key nested inside a
+        // known section. Must show up as `sandbox.privildged` in the warning.
+        fs::write(
+            dir.join("config.toml"),
+            "[sandbox]\nenabled_by_default = true\nprivildged = true\n",
+        )
+        .unwrap();
+
+        let warning = collect_startup_config_warnings("").expect("expected a warning");
+        assert!(
+            warning.contains("Unrecognized keys in global config"),
+            "warning should announce unrecognized keys, got: {warning}"
+        );
+        assert!(
+            warning.contains("sandbox.privildged"),
+            "warning should name the dotted path, got: {warning}"
+        );
+    }
+
+    /// #3228: user-defined map-key sections must never false-positive. These
+    /// are all documented in `docs/guides/configuration.md`.
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_startup_config_warnings_allows_documented_map_sections() {
+        let temp = isolate_app_dir();
+        let dir = app_dir(&temp);
+        // `session.custom_agents` is a `HashMap<String,String>` (name -> shell
+        // command), so it must be an inline table, not a section. The other
+        // three are the real map-key-plus-struct shapes (`agents.<name>`,
+        // `tools.<name>`, `plugins.<id>`) that exercise the "user-defined
+        // section with typed contents" pattern.
+        fs::write(
+            dir.join("config.toml"),
+            "[session]\n\
+             custom_agents = { myagent = \"true\" }\n\
+             [agents.claude.status_map]\n\
+             SessionStart = \"running\"\n\
+             [tools.lazygit]\n\
+             command = \"lazygit\"\n\
+             [plugins.\"aoe.web\"]\n\
+             enabled = true\n",
+        )
+        .unwrap();
+
+        // These are all valid map-key entries, not struct fields, so
+        // serde_ignored produces zero paths and the probe is clean.
+        let warning = collect_startup_config_warnings("");
+        assert!(
+            warning.is_none(),
+            "documented map-key sections must not produce a warning, got: {warning:?}"
+        );
+    }
+
+    /// #3228: even inside a user-defined map entry, a struct-field typo does
+    /// flag. This guards against a future "just skip everything under
+    /// `agents.*`" regression that would swallow the intended catch.
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_startup_config_warnings_flags_typo_inside_map_entry() {
+        let temp = isolate_app_dir();
+        let dir = app_dir(&temp);
+        // `agents.<name>.status_map` is a real field; the typo below is not.
+        fs::write(
+            dir.join("config.toml"),
+            "[agents.claude]\nstatus_maap = { foo = \"bar\" }\n",
+        )
+        .unwrap();
+
+        let warning = collect_startup_config_warnings("").expect("expected a warning");
+        assert!(
+            warning.contains("agents.claude.status_maap"),
+            "typo inside a map entry should still flag, got: {warning}"
+        );
+    }
+
+    /// #3228: unrecognized keys in a profile config are reported the same way.
+    /// The probe merges overrides onto a default `Config` to sidestep the
+    /// `#[serde(flatten)]` catch-all on `ProfileConfig` (which would otherwise
+    /// swallow every unknown key as valid JSON).
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_startup_config_warnings_flags_unknown_key_in_profile() {
+        let temp = isolate_app_dir();
+        let dir = app_dir(&temp);
+        let profile_dir = dir.join("profiles").join("default");
+        fs::create_dir_all(&profile_dir).unwrap();
+        fs::write(
+            profile_dir.join("config.toml"),
+            "[sandbox]\nprivildged = true\n",
+        )
+        .unwrap();
+
+        let warning =
+            collect_startup_config_warnings("default").expect("expected a profile warning");
+        assert!(warning.contains("Unrecognized keys in profile config 'default'"));
+        assert!(warning.contains("sandbox.privildged"));
     }
 
     fn release_dir_in(root: impl AsRef<Path>) -> PathBuf {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -760,8 +760,13 @@ fn collect_startup_warnings(profile: &str, class: WarningClass) -> Option<String
     } else {
         profile.to_string()
     };
-    let profile_path_display = profile_config::get_profile_config_path(&effective)
-        .map(|p| p.display().to_string())
+    // Non-creating resolver: `get_profile_config_path` goes through the
+    // creating `get_profile_dir`, so naming an unknown profile (`aoe list -p
+    // ghost`) would birth `profiles/ghost/` here, before the command's own
+    // `resolve_existing_profile` gets to reject it. See
+    // `tests/e2e/profile_lazy_creation.rs`.
+    let profile_path_display = get_profile_dir_path(&effective)
+        .map(|p| p.join("config.toml").display().to_string())
         .unwrap_or_else(|_| format!("profiles/{effective}/config.toml"));
     let profile_scope = format!("profile config '{effective}'");
     if let Some(msg) = format_probe(

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -725,6 +725,25 @@ fn format_probe(probe: &ConfigProbe, scope_label: &str, path_display: &str) -> O
     }
 }
 
+/// Format only the unrecognized-keys half of a probe result. Returns `None`
+/// when the file is clean OR failed to parse: a parse failure would have
+/// been reported by `Config::load_or_warn`'s `tracing::warn!` (assuming a
+/// subscriber is running), and it does not carry ignored-key information.
+fn format_probe_ignored_keys_only(
+    probe: &ConfigProbe,
+    scope_label: &str,
+    path_display: &str,
+) -> Option<String> {
+    if probe.load_err.is_some() || probe.ignored_keys.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "Unrecognized keys in {scope_label} ({path_display}) were ignored: {}",
+            probe.ignored_keys.join(", ")
+        ))
+    }
+}
+
 /// Probe the global config and the active profile's config at startup so the
 /// TUI can show a single user-visible warning when either fails to parse OR
 /// contains unrecognized keys. `tracing::warn!` calls inside the `_or_warn`
@@ -752,6 +771,47 @@ pub fn collect_startup_config_warnings(profile: &str) -> Option<String> {
         .unwrap_or_else(|_| format!("profiles/{effective}/config.toml"));
     let profile_scope = format!("profile config '{effective}'");
     if let Some(msg) = format_probe(
+        &probe_profile_config(&effective),
+        &profile_scope,
+        &profile_path_display,
+    ) {
+        messages.push(msg);
+    }
+
+    if messages.is_empty() {
+        None
+    } else {
+        Some(messages.join("\n\n"))
+    }
+}
+
+/// Like [`collect_startup_config_warnings`], but only the unrecognized-keys
+/// class. Used on paths where a tracing subscriber is already running
+/// (`should_init` true, e.g. TUI startup or `serve --daemon-child`): parse
+/// failures reach the operator through `tracing::warn!` from `_or_warn`
+/// helpers, but ignored keys are collected only by this probe, so they must
+/// still be surfaced on stderr even when tracing is up (#3228 CodeRabbit).
+pub fn collect_startup_ignored_key_warnings(profile: &str) -> Option<String> {
+    let mut messages: Vec<String> = Vec::new();
+
+    if let Some(msg) = format_probe_ignored_keys_only(
+        &probe_global_config(),
+        "global config",
+        &config_path_display(),
+    ) {
+        messages.push(msg);
+    }
+
+    let effective = if profile.is_empty() {
+        config::resolve_default_profile()
+    } else {
+        profile.to_string()
+    };
+    let profile_path_display = profile_config::get_profile_config_path(&effective)
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| format!("profiles/{effective}/config.toml"));
+    let profile_scope = format!("profile config '{effective}'");
+    if let Some(msg) = format_probe_ignored_keys_only(
         &probe_profile_config(&effective),
         &profile_scope,
         &profile_path_display,
@@ -1057,6 +1117,45 @@ mod tests {
 
         let warning = collect_startup_config_warnings("default").expect("expected a warning");
         assert!(warning.contains("Failed to load profile config 'default'"));
+    }
+
+    /// #3228 CodeRabbit follow-up: the ignored-keys-only variant is the
+    /// path a subscribed run (TUI, foreground serve, or `AOE_LOG_LEVEL`
+    /// set) uses so ignored keys are still surfaced without duplicating
+    /// the parse-error line that `tracing::warn!` already reports. It
+    /// must report unrecognized keys but NOT parse failures.
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_startup_ignored_key_warnings_reports_ignored_only() {
+        let temp = isolate_app_dir();
+        let dir = app_dir(&temp);
+        fs::write(
+            dir.join("config.toml"),
+            "[sandbox]\nenabled_by_default = true\nprivildged = true\n",
+        )
+        .unwrap();
+
+        let warning =
+            collect_startup_ignored_key_warnings("").expect("ignored key must be reported");
+        assert!(warning.contains("sandbox.privildged"));
+        assert!(!warning.contains("Failed to load"));
+    }
+
+    /// #3228 CodeRabbit follow-up: a parse failure alone is *not* reported
+    /// by the ignored-keys-only variant. `tracing::warn!` from
+    /// `Config::load_or_warn` covers that class when a subscriber is up.
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_startup_ignored_key_warnings_silent_on_parse_failure() {
+        let temp = isolate_app_dir();
+        let dir = app_dir(&temp);
+        fs::write(
+            dir.join("config.toml"),
+            "[sandbox]\nenabled_by_default = \"not-a-bool\"\n",
+        )
+        .unwrap();
+
+        assert!(collect_startup_ignored_key_warnings("").is_none());
     }
 
     /// #3228: a nested typo inside a known section is silently dropped by

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -64,15 +64,48 @@ pub fn load_profile_config(profile: &str) -> Result<ProfileConfig> {
     Ok(config)
 }
 
+/// Merge a sparse override object onto a full serialized `Config::default()`,
+/// yielding the resolved JSON that would land in memory if this profile were
+/// applied. Shared prelude for [`validate_overrides_typecheck`] (which
+/// re-deserializes it into `Config` to type-check) and
+/// [`profile_config_ignored_keys`] (which runs `serde_ignored` to enumerate
+/// unknown keys).
+fn merged_onto_default(overrides: &serde_json::Value) -> Result<serde_json::Value> {
+    let mut base = serde_json::to_value(Config::default())?;
+    crate::session::settings_schema::merge_json(&mut base, overrides);
+    Ok(base)
+}
+
 /// Confirm a sparse override object deserializes back into a [`Config`] when
 /// merged onto the defaults. Used at load time so a malformed override file is
 /// a graceful error rather than a merge-time panic.
 pub(super) fn validate_overrides_typecheck(overrides: &serde_json::Value) -> Result<()> {
-    let mut base = serde_json::to_value(Config::default())?;
-    crate::session::settings_schema::merge_json(&mut base, overrides);
+    let base = merged_onto_default(overrides)?;
     serde_json::from_value::<Config>(base)
         .map_err(|e| anyhow::anyhow!("invalid override value: {e}"))?;
     Ok(())
+}
+
+/// Dotted paths of keys in this profile that `Config` does not recognize
+/// (unknown struct fields at any depth), so a typo like `[sandbox] privildged
+/// = true` surfaces instead of being silently dropped. Runs `serde_ignored`
+/// against the profile's overrides merged onto a default `Config`; a raw
+/// `serde_ignored::deserialize::<ProfileConfig>` would report nothing, since
+/// `#[serde(flatten)] overrides` absorbs every unknown key as valid JSON.
+/// Map-keyed sections (`agents`, `tools`, `plugins`, `session.custom_agents`,
+/// `acp.acp_defaults`, ...) never flag because their keys are entries, not
+/// struct fields; nested struct-field typos inside them still do. Takes the
+/// already-loaded `ProfileConfig` so the caller does not read+parse the
+/// profile file a second time.
+pub(crate) fn profile_config_ignored_keys(cfg: &ProfileConfig) -> Vec<String> {
+    let Ok(base) = merged_onto_default(&cfg.overrides_value()) else {
+        return Vec::new();
+    };
+    let mut ignored = Vec::new();
+    let _ = serde_ignored::deserialize::<_, _, Config>(base, |path| {
+        ignored.push(path.to_string());
+    });
+    ignored
 }
 
 /// Save profile-specific config


### PR DESCRIPTION
## Description

Closes #3228.

A bad value or a typo in `config.toml` or a profile config used to revert the entire file to built-in defaults with no visible message. `Config::load_or_warn`'s `tracing::warn!` is dropped in one-shot CLI mode (no subscriber), and unknown keys are dropped by serde entirely because `Config` has no `#[serde(deny_unknown_fields)]` (and cannot, without breaking forward-compatibility with older or newer config files).

The extended startup probe `collect_startup_config_warnings` now reports both classes for global config and the active profile:

- The existing parse-failure class (wording unchanged; the two existing tests keep passing).
- Unrecognized keys at any depth via `serde_ignored`, so a nested typo like `[sandbox] privildged = true` prints its dotted path instead of being silently dropped. Map-keyed sections (`agents`, `tools`, `plugins`, `session.custom_agents`, `acp.acp_defaults`, ...) never false-positive because their keys are entries, not struct fields; struct-field typos inside those maps still do.

Two new surfaces route the warning where users watch:

- One-shot CLI (`main.rs::run`): `eprintln!` for user-visible commands (`add`, `list`, `ps`, `status`, `session`, `serve` foreground). Gated on `!should_init` so a subscribed run doesn't duplicate the tracing sink's line, and on `cli::command_name(&cmd).is_some()` so hidden machine-spawned subcommands (`__acp-runner`, `__vt-pipe`, ...) never eprintln into a detached worker's redirected stderr.
- `aoe settings explain`: a top banner when the config failed to parse (in that case every value below is a real schema default; the previous output read as "your file is honored and matches the defaults" — the exact trap the #3207 reporter fell into). A different note lists unrecognized keys when the file parsed cleanly but keys were dropped.

`SettingSource` is untouched: provenance is per-key, parse-failure is per-file. The banner solves the misleading `source: schema default` at the file level without stamping a whole-file condition onto every key.

Adds `serde_ignored = "0.1"` (MIT/Apache; no new transitive deps beyond `serde`, already in the tree). `cargo deny check` on CI covers the license/supply-chain gate.

The profile probe merges overrides onto a default `Config` before running `serde_ignored`, mirroring `validate_overrides_typecheck`. A raw `serde_ignored::deserialize::<ProfileConfig>` would return nothing because `#[serde(flatten)] overrides: serde_json::Map` absorbs every unknown key as valid JSON.

Explicitly not doing:

- Adding `#[serde(deny_unknown_fields)]` to `Config`. Would break forward-compat and removed-feature drift; the issue itself lands on "warn is safer than reject."
- Making `load_or_warn` fatal. Would break repair paths like `aoe settings explain` on a broken file.
- Fixing profile write clobbering (server profile PATCH does `unwrap_or_default` then `save_profile_config`, so editing one field overwrites the rest of a broken profile file). Different defect class (write-path data loss vs read-path visibility). Split into a companion PR.
- Fixing the remote-standalone TUI's dropped startup warning. `remote_home::run_standalone` has no `InfoDialog` analog; needs a real display surface, not a one-liner. Deferred.
- Fixing the same misleading label on `/api/settings/resolved`. Deferred to keep the coverage-matrix mandate off this PR; a companion "add a `parseError` field on the endpoint envelope" PR is the right shape.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

CLI + startup-probe change; no visual redesign, no new screen. Screenshot/recording skipped.

## Test Coverage Analysis

Web dashboard / structured view (Playwright user story)
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The change surfaces messages via a startup probe. `/api/settings/resolved` and the web dashboard are intentionally out of scope (see the "Explicitly not doing" list above); a companion PR will land the endpoint envelope + Playwright coverage.

TUI / CLI (e2e test)
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

`main.rs::run` gained one `eprintln!` after migrations; no new subcommand, no new TUI screen, no session-lifecycle change. The startup probe path is fully unit-tested (see below), which is a stronger signal than an e2e assertion on a formatted line.

Tests added in `src/session/mod.rs` (all `#[serial_test::serial]` + `isolate_app_dir()`, alongside the pre-existing bad-global / bad-profile / clean tests):

- `test_collect_startup_config_warnings_flags_nested_unknown_key`: `[sandbox] privildged = true` produces a warning containing the dotted path.
- `test_collect_startup_config_warnings_allows_documented_map_sections`: documented map-key sections (`session.custom_agents`, `agents.<name>`, `tools.<name>`, `plugins."<id>"`) produce zero warnings.
- `test_collect_startup_config_warnings_flags_typo_inside_map_entry`: a struct-field typo INSIDE a map entry (`[agents.claude] status_maap = ...`) still flags. Guards against a reintroduced allow-list that would swallow the nested typos the feature exists to catch.
- `test_collect_startup_config_warnings_flags_unknown_key_in_profile`: profile probe reports unknown keys the same way. Guards the flatten trap (a raw `serde_ignored::deserialize::<ProfileConfig>` would return nothing because `#[serde(flatten)] overrides` absorbs everything).

Verified locally: `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo test --lib` (4494 pass), `cargo test --no-default-features --lib` (4494 pass), `cargo test --features serve --lib` (all scratch/config tests pass).

## AI Usage

- [ ] No AI was used
- [x] AI was used

AI Model/Tool used: Claude Code (Opus 4.8)

Any Additional AI Details you'd like to share:

I used subagents to map the ~35 `load_or_warn` call sites and every user-facing surface where a config error could reach the user, then to adversarially review the design (correctness / altitude / blast-radius / senior), and finally to review the diff (reuse / simplification / efficiency / altitude). The design decisions (surface-not-fatal, `serde_ignored` for nested detection, banner-not-enum-variant for `settings explain`, splitting the profile-write fix into a companion PR) are mine. I reviewed the whole diff, understand it, and answered reviewer feedback in my own words.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added diagnostics for invalid and unrecognized settings in global and profile `config.toml` files.
- Displayed warnings for applicable CLI commands and notes in `aoe settings explain`.
- Preserved compatibility by ignoring unknown settings.
- Added shared configuration probing and warning helpers.
- Prevented profile checks from creating directories for nonexistent profiles.
- Added tests for nested keys, map sections, typos, parse failures, profile settings, and serialization round-trips.

## Benefits

Users can identify configuration errors instead of silently using built-in defaults. Newer or removed configuration fields remain supported. Nonexistent profiles continue to fail validation without creating directories.

## Technical changes

- Added `serde_ignored` for unknown-key detection.
- Reported ignored keys with nested paths while excluding valid map-entry keys.
- Reused configuration loading and profile override helpers.
- Kept `SettingSource` and valid setting behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->