### PR TITLE
fix(config): stop advertising inert repo [tmux] and [sound] overrides

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -503,6 +503,6 @@ Profile overrides go in `~/.agent-of-empires/profiles/<name>/config.toml` and us
 
 Per-repo settings go in `.agent-of-empires/config.toml` at your project root. Run `aoe init` to generate a template.
 
-Repo config supports: `[hooks]`, `[session]`, `[sandbox]`, and `[worktree]` sections. It does not support `[tmux]`, `[updates]`, `[claude]`, or `[diff]` (those are personal settings).
+Repo config supports: `[hooks]`, `[session]`, `[sandbox]`, and `[worktree]` sections. It does not support `[tmux]`, `[sound]`, `[updates]`, `[claude]`, or `[diff]` (those are personal settings).
 
 See [Repo Config & Hooks](repo-config.md) for details.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -503,6 +503,6 @@ Profile overrides go in `~/.agent-of-empires/profiles/<name>/config.toml` and us
 
 Per-repo settings go in `.agent-of-empires/config.toml` at your project root. Run `aoe init` to generate a template.
 
-Repo config supports: `[hooks]`, `[session]`, `[sandbox]`, `[worktree]`, and `[updates]` sections. It does not support `[tmux]`, `[sound]`, `[claude]`, or `[diff]` (those are personal settings).
+Repo config supports: `[hooks]`, `[session]`, `[sandbox]`, and `[worktree]` sections. It does not support `[tmux]`, `[sound]`, `[updates]`, `[claude]`, or `[diff]` (those are personal settings).
 
 See [Repo Config & Hooks](repo-config.md) for details.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -503,6 +503,6 @@ Profile overrides go in `~/.agent-of-empires/profiles/<name>/config.toml` and us
 
 Per-repo settings go in `.agent-of-empires/config.toml` at your project root. Run `aoe init` to generate a template.
 
-Repo config supports: `[hooks]`, `[session]`, `[sandbox]`, and `[worktree]` sections. It does not support `[tmux]`, `[sound]`, `[updates]`, `[claude]`, or `[diff]` (those are personal settings).
+Repo config supports: `[hooks]`, `[session]`, `[sandbox]`, `[worktree]`, and `[updates]` sections. It does not support `[tmux]`, `[sound]`, `[claude]`, or `[diff]` (those are personal settings).
 
 See [Repo Config & Hooks](repo-config.md) for details.

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -57,9 +57,13 @@ use super::project_mcp::ProjectMcpServer;
 /// [`HostHooksConfig`]), so honoring it from a repo would let a checked-out
 /// repository execute arbitrary host commands. Host hooks are profile/global
 /// only.
-const REPO_OVERRIDABLE_SECTIONS: &[&str] = &[
-    "hooks", "session", "sandbox", "worktree", "updates", "tmux", "sound",
-];
+///
+/// `tmux` and `sound` are deliberately absent (#3229): every consumer
+/// resolves them through profile/global-only paths (`resolve_config_or_warn`
+/// or `Config::load*`), never a repo-aware resolver, so a repo entry here
+/// could never take effect. Wire those resolvers before making either
+/// section repo-overridable.
+const REPO_OVERRIDABLE_SECTIONS: &[&str] = &["hooks", "session", "sandbox", "worktree", "updates"];
 
 /// What a repo may set inside one overridable section (#3154).
 enum SectionPolicy {
@@ -1622,13 +1626,6 @@ pub const INIT_TEMPLATE: &str = r#"# Agent of Empires - Repository Configuration
 
 # [updates]
 # update_check_mode = "off"
-
-# [tmux]
-# status_bar = "auto"
-# mouse = "auto"
-
-# [sound]
-# enabled = false
 "#;
 
 #[cfg(test)]
@@ -2040,13 +2037,69 @@ mod tests {
 
     #[test]
     fn test_repo_may_override_field() {
-        assert!(repo_may_override_field("session", "default_tool"));
-        assert!(repo_may_override_field("session", "agent_detect_as"));
-        assert!(repo_may_override_field("sandbox", "memory_limit"));
-        assert!(repo_may_override_field("worktree", "path_template"));
-        assert!(!repo_may_override_field("session", "custom_agents"));
-        assert!(!repo_may_override_field("sandbox", "default_image"));
-        assert!(!repo_may_override_field("acp", "auto_approve"));
+        // (section, field, expected) — the whitelist and denylist behavior
+        // across every scope the sanitizer / TUI query at runtime. tmux and
+        // sound rows guard #3229: their sections are not repo-overridable, so
+        // every field on them must answer false.
+        let cases = [
+            ("session", "default_tool", true),
+            ("session", "agent_detect_as", true),
+            ("sandbox", "memory_limit", true),
+            ("worktree", "path_template", true),
+            ("session", "custom_agents", false),
+            ("sandbox", "default_image", false),
+            ("acp", "auto_approve", false),
+            ("tmux", "status_bar", false),
+            ("tmux", "mouse", false),
+            ("tmux", "clipboard", false),
+            ("tmux", "socket_name", false),
+            ("tmux", "vt_live", false),
+            ("sound", "enabled", false),
+            ("sound", "on_start", false),
+        ];
+        for (section, field, expected) in cases {
+            assert_eq!(
+                repo_may_override_field(section, field),
+                expected,
+                "{section}.{field}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_merge_repo_config_strips_tmux_and_sound() {
+        // #3229: a repo config that sets `[tmux]` or `[sound]` merges to a
+        // no-op and the blocks are stripped from the allowed-override view
+        // used for save/edit.
+        // Every override must differ from the section's default value, or
+        // the "merge is a no-op" assertion below is a false-green (it would
+        // hold whether or not the sanitizer strips the block).
+        let repo: RepoConfig = toml::from_str(
+            r#"
+            [tmux]
+            status_bar = "enabled"
+            mouse = "enabled"
+            [sound]
+            enabled = true
+        "#,
+        )
+        .unwrap();
+        let base = Config::default();
+        let merged = merge_repo_config(base.clone(), &repo);
+        // Compare via serde_json since TmuxConfig/SoundConfig do not derive
+        // PartialEq; the JSON round-trip is the same shape the merge uses.
+        let merged_json = serde_json::to_value(&merged).unwrap();
+        let base_json = serde_json::to_value(&base).unwrap();
+        assert_eq!(
+            merged_json["tmux"], base_json["tmux"],
+            "repo-declared tmux must be dropped on merge"
+        );
+        assert_eq!(
+            merged_json["sound"], base_json["sound"],
+            "repo-declared sound must be dropped on merge"
+        );
+        assert!(repo.allowed_overrides().get("tmux").is_none());
+        assert!(repo.allowed_overrides().get("sound").is_none());
     }
 
     #[test]

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -1256,6 +1256,31 @@ mod tests {
         }
     }
 
+    /// #3229: no field under Repo scope for a category whose section is not
+    /// repo-overridable. Backs up the `categories_for_scope` tab-hide with a
+    /// builder-layer assertion so a direct call with Repo scope cannot yield
+    /// a field whose edit would strand at save time.
+    #[test]
+    fn repo_scope_yields_no_fields_for_tmux_or_sound() {
+        let base = Config::default();
+        let overrides = ProfileConfig::default();
+        for cat in [SettingsCategory::Tmux, SettingsCategory::Sound] {
+            let repo_rows = build_fields_for_category(cat, SettingsScope::Repo, &base, &overrides);
+            assert!(
+                repo_rows.is_empty(),
+                "{cat:?} must yield zero repo-scope fields, got {} rows",
+                repo_rows.len()
+            );
+            // Sanity: the category still has fields under Profile scope.
+            let profile_rows =
+                build_fields_for_category(cat, SettingsScope::Profile, &base, &overrides);
+            assert!(
+                !profile_rows.is_empty(),
+                "{cat:?} must still have profile-scope fields"
+            );
+        }
+    }
+
     #[test]
     fn acp_defaults_custom_widget_round_trips_json() {
         let current = json!({"opencode": {"model": "x", "effort": "high"}});

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -397,8 +397,9 @@ impl SettingsView {
     /// Build the categories-panel layout. Categories are grouped under
     /// section dividers (Appearance / Sessions / Hooks / Environment /
     /// Notifications / System) so the list isn't 14 unrelated tabs in
-    /// arbitrary order. Status Hooks is dropped in Repo scope (the only
-    /// scope-conditional category today).
+    /// arbitrary order. Status Hooks, Tmux, and Sound are dropped in Repo
+    /// scope because their sections are not repo-overridable
+    /// ([`REPO_OVERRIDABLE_SECTIONS`]), so a repo edit would strand at save.
     fn categories_for_scope(scope: SettingsScope) -> Vec<CategoryRow> {
         let mut rows: Vec<CategoryRow> = Vec::new();
         let push_section = |rows: &mut Vec<CategoryRow>, label: &'static str| {
@@ -427,10 +428,14 @@ impl SettingsView {
         push_section(&mut rows, "Environment");
         push_tab(&mut rows, SettingsCategory::Sandbox);
         push_tab(&mut rows, SettingsCategory::Worktree);
-        push_tab(&mut rows, SettingsCategory::Tmux);
+        if scope != SettingsScope::Repo {
+            push_tab(&mut rows, SettingsCategory::Tmux);
+        }
 
         push_section(&mut rows, "Notifications");
-        push_tab(&mut rows, SettingsCategory::Sound);
+        if scope != SettingsScope::Repo {
+            push_tab(&mut rows, SettingsCategory::Sound);
+        }
         push_tab(&mut rows, SettingsCategory::Web);
 
         push_section(&mut rows, "System");
@@ -1190,6 +1195,44 @@ mod plugin_enabled_changes_tests {
         let after = Some(json!({}));
         let changes = plugin_enabled_changes(Some(&before), &after);
         assert_eq!(changes, vec![("gone".to_string(), true)]);
+    }
+}
+
+#[cfg(test)]
+mod categories_for_scope_tests {
+    use super::{CategoryRow, SettingsCategory, SettingsScope, SettingsView};
+
+    fn has_tab(rows: &[CategoryRow], cat: SettingsCategory) -> bool {
+        rows.iter().any(|r| r.as_tab() == Some(cat))
+    }
+
+    /// StatusHooks, Tmux, and Sound are gated off Repo scope because their
+    /// sections are not repo-overridable (#3229); a Repo tab would render
+    /// edits that strand at save time. Global keeps every tab.
+    #[test]
+    fn repo_scope_drops_non_repo_overridable_categories() {
+        let repo = SettingsView::categories_for_scope(SettingsScope::Repo);
+        for cat in [
+            SettingsCategory::StatusHooks,
+            SettingsCategory::Tmux,
+            SettingsCategory::Sound,
+        ] {
+            assert!(!has_tab(&repo, cat), "{cat:?} must be absent under Repo");
+        }
+        // Sanity: a repo-overridable category IS visible.
+        assert!(has_tab(&repo, SettingsCategory::Sandbox));
+
+        let global = SettingsView::categories_for_scope(SettingsScope::Global);
+        for cat in [
+            SettingsCategory::StatusHooks,
+            SettingsCategory::Tmux,
+            SettingsCategory::Sound,
+        ] {
+            assert!(
+                has_tab(&global, cat),
+                "{cat:?} must be present under Global"
+            );
+        }
     }
 }
 

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -398,8 +398,9 @@ impl SettingsView {
     /// section dividers (Appearance / Sessions / Hooks / Environment /
     /// Notifications / System) so the list isn't 14 unrelated tabs in
     /// arbitrary order. Status Hooks, Tmux, and Sound are dropped in Repo
-    /// scope because their sections are not repo-overridable
-    /// ([`REPO_OVERRIDABLE_SECTIONS`]), so a repo edit would strand at save.
+    /// scope because their sections are not repo-overridable (see
+    /// `REPO_OVERRIDABLE_SECTIONS` in `session::repo_config`), so a repo
+    /// edit would strand at save.
     fn categories_for_scope(scope: SettingsScope) -> Vec<CategoryRow> {
         let mut rows: Vec<CategoryRow> = Vec::new();
         let push_section = |rows: &mut Vec<CategoryRow>, label: &'static str| {


### PR DESCRIPTION
## Description

Closes #3229. Also fixes the same class of bug for `[sound]` (surfaced during the sweep the issue explicitly asks for) — see below.

The `tmux` and `sound` sections were listed in `REPO_OVERRIDABLE_SECTIONS` at `SectionPolicy::AllowAll`, so the settings UI rendered a Repo tab for each and the sanitizer wrote a `[tmux]` / `[sound]` block to the repo `config.toml` on save. But every consumer of those sections resolves through profile/global-only paths (`resolve_config_or_warn` or `Config::load*`) and never a repo-aware resolver, so the read side never picked up the block: user edits stranded at save time, and hand-written entries silently no-oped.

The fix is Option 2 from the issue body: stop advertising. Remove both sections from `REPO_OVERRIDABLE_SECTIONS`, gate the Tmux and Sound category tabs off Repo scope in `categories_for_scope` (mirroring the existing `StatusHooks` gate), delete the shipped repo template's `# [tmux]` and `# [sound]` example blocks, and add `[sound]` to the "does not support" list in `docs/guides/configuration.md` (docs already called out `[tmux]` there).

Explicitly rejected Option 1 (threading `project_path` through `tmux_option_config` and `apply_all_tmux_options` to make the repo layer live): repo configs are attacker-controlled, and wiring it would force a trust decision on every future tmux field. It also leaves `socket_name` / `vt_live` (which are `global_only`) at risk of drifting into repo-visibility later since the sanitizer keys on `REPO_OVERRIDABLE_SECTIONS` and does not consult the schema's `global_only` flag. Removing the sections produces the honest signal instead: `configuration.md:506` already documents them as unsupported at repo scope; this PR makes code and docs agree.

### Why bundle `[sound]`

The issue's scope note asks for a sweep of every `REPO_OVERRIDABLE_SECTIONS` entry to check for the same defect. `sound` has the identical shape: same `AllowAll` default, no repo-aware consumer, advertised in the shipped template. Bundling is one word deleted from the same array in the same function, one test case added to the same table, one line changed in the same docs paragraph — a stacked pair of PRs would be pure ceremony. The `worktree`, `sandbox`, `session`, and `hooks` sections were verified to route their primary paths through `resolve_config_with_repo*`, so they are unaffected. `updates` is technically inert at the repo layer too, but its host-scoped semantics deserve their own trust discussion; left for a follow-up.

### Latent related bug left for a follow-up (out of scope)

Under Repo scope, `Acp`, `Web`, `Diff`, and `Logging` tabs render editable fields today whose edits silently strand at save time (they behave like tmux/sound did before this PR, minus the sanitizer-writes-to-file half). Same failure class, different fields, requires deliberately deciding which of those sections should become repo-overridable. This PR is scoped to what #3229 names.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Settings UI + docs change; no visual redesign, no new screen. The behavior change is that two tabs no longer appear under the Repo scope selector, mirroring the existing `StatusHooks` gate one line up. Screenshot skipped.

## Test Coverage Analysis

Web dashboard / structured view (Playwright user story)
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The web has no repo-scope settings editor; it edits global/profile only. No web PATCH path targets repo `[tmux]` / `[sound]`.

TUI / CLI (e2e test)
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

The change is entirely in the settings-model + sanitizer, covered directly by unit tests. Nothing about how the TUI renders, subcommand behavior, or session lifecycle changed.

Tests added / updated:

- `test_repo_may_override_field` in `src/session/repo_config.rs` is now table-driven (per AGENTS.md "one test per behavior, not per input"), covering every allow / deny case including the new `tmux` and `sound` negatives.
- `test_merge_repo_config_strips_tmux_and_sound` in `src/session/repo_config.rs` mirrors the shape of `test_repo_config_cannot_inject_host_hooks`. Each override differs from its section default so the "merge is a no-op" assertion cannot pass on a false-green.
- `categories_for_scope_tests::repo_scope_drops_non_repo_overridable_categories` in `src/tui/settings/mod.rs` locks the tab-hide contract for `StatusHooks`, `Tmux`, and `Sound` (which had zero test coverage before).
- `repo_scope_yields_no_fields_for_tmux_or_sound` in `src/tui/settings/fields.rs` asserts the field builder returns zero rows for those categories under Repo scope, defense-in-depth against a future direct caller.

Verified locally: `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo test --lib` (4493 pass), `cargo test --no-default-features --lib` (4493 pass).

## AI Usage

- [ ] No AI was used
- [x] AI was used

AI Model/Tool used: Claude Code (Opus 4.8)

Any Additional AI Details you'd like to share:

I used subagents to (a) map `REPO_OVERRIDABLE_SECTIONS`, the `SectionPolicy` mechanism, and every `[tmux]` / `[sound]` consumer in the repo; (b) adversarially review the design across correctness / altitude / blast-radius; (c) senior-review the converged plan (which caught a load-bearing rationale error the adversarial pass missed: the TUI never builds fields with `SettingsScope::Repo` because `field_build_inputs` maps `Repo` to `Profile`, so the failure mode is stranded writes at save time, not empty tabs); and (d) run a compensating quality pass over the diff. The design decisions (Option 2 not Option 1; bundle `[sound]`; keep direct `if` gates rather than extracting a generalization that would also hide 6 additional empty tabs) are mine. I reviewed the whole diff, understand it, and answered reviewer feedback in my own words.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Removed repository-level `[tmux]` and `[sound]` overrides.
- Hid their categories and fields from Repo settings.
- Removed their examples from the repository configuration template.
- Documented `[sound]` as unsupported in repository configuration.
- Added tests for permissions, sanitization, field generation, and category visibility.

These changes prevent users from configuring repository settings that have no effect. Future work could add repository-level `tmux` support after defining an explicit trust model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->