### PR TITLE
fix(acp): forward non-Claude provider keys to their ACP adapters

### DIFF
--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -34,7 +34,16 @@ The `npm install -g` commands above are optional: `aoe acp doctor --fix` install
 
 Tools not yet wired into the registry (aider, cursor, copilot, droid, hermes, kiro) always run in the terminal view. A **custom agent** can opt in by setting an ACP launch command via `agent_acp_cmd` (see [Configuration](guides/configuration.md#running-a-custom-agent-in-the-structured-view)).
 
-The structured view always forwards `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, and `CLAUDE_CONFIG_DIR` to the agent. For other agents, set their auth env in the environment that runs `aoe serve` (or the per-session `extra_env` field).
+The structured view always forwards `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, and `CLAUDE_CONFIG_DIR` to every agent. Four adapters additionally receive the provider variables they are known to read, from the environment that runs `aoe serve`:
+
+| Adapter | Also forwarded |
+|---|---|
+| `codex` | `CODEX_API_KEY`, `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `CODEX_HOME` |
+| `opencode` | `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `OPENCODE_API_KEY` |
+| `gemini` | `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION` |
+| `aoe-agent` | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `GOOGLE_GENERATIVE_AI_API_KEY` |
+
+`vibe`, `pi`, `omp`, and `kimi` forward nothing extra yet; set their auth through the per-session `extra_env` field, or through `environment` in your config, until their variables are verified. Sandboxed sessions take `sandbox.environment` instead: the list above does not cross the container boundary.
 
 ### Feature matrix
 

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -43,7 +43,7 @@ The structured view always forwards `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`,
 | `gemini` | `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION` |
 | `aoe-agent` | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `GOOGLE_GENERATIVE_AI_API_KEY` |
 
-`vibe`, `pi`, `omp`, and `kimi` forward nothing extra yet. Until their variables are verified, give them auth through the per-session `extra_env` field or `environment` in your config, or set `session.inherit_host_environment = true` to forward your whole `aoe serve` environment to non-sandboxed agents. In a sandboxed session the per-adapter provider keys above still cross the container boundary (forwarded as `docker exec -e` flags), but `inherit_host_environment` does not; give a sandboxed not-yet-verified adapter its auth through `sandbox.environment`.
+`vibe`, `pi`, `omp`, and `kimi` forward nothing extra yet. Until their variables are verified, give them auth through the per-session `extra_env` field or `environment` in your config, or set `session.inherit_host_environment = true` to forward your whole `aoe serve` environment to non-sandboxed agents. In a sandboxed session the per-adapter provider keys above still cross the container boundary (forwarded as `docker exec -e` flags), but `inherit_host_environment` does not; give a sandboxed not-yet-verified adapter its auth through `sandbox.environment`. Two entries are host-only and never cross: `CODEX_HOME` and `GOOGLE_APPLICATION_CREDENTIALS` name paths on your machine that do not exist inside the container, and the agent's config dir is already bind-mounted at its canonical container location.
 
 ### Feature matrix
 

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -43,7 +43,7 @@ The structured view always forwards `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`,
 | `gemini` | `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION` |
 | `aoe-agent` | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `GOOGLE_GENERATIVE_AI_API_KEY` |
 
-`vibe`, `pi`, `omp`, and `kimi` forward nothing extra yet; set their auth through the per-session `extra_env` field, or through `environment` in your config, until their variables are verified. Sandboxed sessions take `sandbox.environment` instead: the list above does not cross the container boundary.
+`vibe`, `pi`, `omp`, and `kimi` forward nothing extra yet. Until their variables are verified, give them auth through the per-session `extra_env` field or `environment` in your config, or set `session.inherit_host_environment = true` to forward your whole `aoe serve` environment to non-sandboxed agents. In a sandboxed session the per-adapter provider keys above still cross the container boundary (forwarded as `docker exec -e` flags), but `inherit_host_environment` does not; give a sandboxed not-yet-verified adapter its auth through `sandbox.environment`.
 
 ### Feature matrix
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3924,9 +3924,11 @@ fn apply_env_filter(cmd: &mut std::process::Command, config: &SpawnConfig) {
     if let Some(extra_allowlist) = &config.spec.env_allowlist {
         for name in extra_allowlist {
             // Route through the same deny check `provider_env` uses so a
-            // malicious/edited allowlist can't smuggle `AOE_TOKEN`, an
-            // `AOE_*`-prefixed daemon carrier, `LD_*`/`DYLD_*` linker hooks,
-            // or infra keys under the guise of provider auth.
+            // malicious/edited allowlist can't smuggle `AOE_TOKEN`,
+            // `LD_*`/`DYLD_*` linker hooks, or infra keys under the guise of
+            // provider auth. It does not cover the daemon->runner carrier
+            // `AOE_ACP_AGENT_ENV`; only `host_environment_denyreason` rejects
+            // that, and the runner clears it before exec anyway.
             if provider_env_denyreason(name).is_some() {
                 continue;
             }
@@ -4399,9 +4401,11 @@ fn spawn_subprocess(config: &SpawnConfig) -> Result<tokio::process::Child, AcpEr
     if let Some(extra_allowlist) = &config.spec.env_allowlist {
         for name in extra_allowlist {
             // Route through the same deny check `provider_env` uses so a
-            // malicious/edited allowlist can't smuggle `AOE_TOKEN`, an
-            // `AOE_*`-prefixed daemon carrier, `LD_*`/`DYLD_*` linker hooks,
-            // or infra keys under the guise of provider auth.
+            // malicious/edited allowlist can't smuggle `AOE_TOKEN`,
+            // `LD_*`/`DYLD_*` linker hooks, or infra keys under the guise of
+            // provider auth. It does not cover the daemon->runner carrier
+            // `AOE_ACP_AGENT_ENV`; only `host_environment_denyreason` rejects
+            // that, and the runner clears it before exec anyway.
             if let Some(reason) = provider_env_denyreason(name) {
                 warn!(target: "acp", "ignoring env allowlist entry '{name}' ({reason})");
                 continue;
@@ -15206,7 +15210,8 @@ done
     /// #3238: `AgentSpec.env_allowlist` populated by `with_defaults` must
     /// reach the agent via `apply_env_filter`. Uses the `aoe-agent` spec (the
     /// one that would silently no-op if we keyed `env_allowlist_for` on
-    /// `spec.command` — placeholder-templated — instead of the binary token).
+    /// `spec.command`, which is placeholder-templated, instead of the binary
+    /// token).
     /// A negative case rides along: `GEMINI_API_KEY` is set but not in the
     /// AI-SDK-based `aoe-agent`'s allowlist, so it must NOT be forwarded.
     #[test]

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3821,7 +3821,17 @@ fn build_sandbox_docker_argv(
     // provider auth (the #3238 symptom). docker only forwards a name handed
     // to it via `-e`, so each allowlisted host value is set on the runner
     // (`inherit_env`) and named with `-e KEY`.
+    //
+    // Value-typed entries only, for the same reason `PROVIDER_AUTH_KEYS` below
+    // omits `CLAUDE_CONFIG_DIR`: a host path names nothing inside the
+    // container, so forwarding it points the adapter at a directory that does
+    // not exist instead of the one `AGENT_CONFIG_MOUNTS` bind-mounts at the
+    // canonical container path. These keys stay host-only and keep flowing on
+    // the two non-sandboxed spawn paths, where they are the point.
     for (key, value) in allowlisted_env_pairs(config) {
+        if is_host_only_path_env(&key) {
+            continue;
+        }
         if seen_keys.insert(key.clone()) {
             docker_args.push("-e".into());
             docker_args.push(key.clone());
@@ -3928,6 +3938,22 @@ fn inherited_host_env_pairs(config: &SpawnConfig) -> Vec<(String, String)> {
     }
     let profile = config.source_profile.as_deref().unwrap_or_default();
     crate::session::environment::inherited_host_env(profile)
+}
+
+/// Allowlist entries whose value is a host filesystem path rather than a
+/// credential. They are legitimate on the two host spawn paths and must not
+/// cross into a container: the path names nothing there, so forwarding it
+/// points the adapter away from the config dir `AGENT_CONFIG_MOUNTS` mounts
+/// at the canonical container location. `CLAUDE_CONFIG_DIR` is the case that
+/// established the rule (it is deliberately absent from `PROVIDER_AUTH_KEYS`
+/// in `build_sandbox_docker_argv`); the other two arrived with the per-adapter
+/// allowlists in #3238. Adding a path-valued key to `env_allowlist_for`
+/// means adding it here too.
+fn is_host_only_path_env(key: &str) -> bool {
+    matches!(
+        key,
+        "CLAUDE_CONFIG_DIR" | "CODEX_HOME" | "GOOGLE_APPLICATION_CREDENTIALS"
+    )
 }
 
 /// Resolve the adapter's `env_allowlist` (#3238) against the operator's live
@@ -11774,20 +11800,34 @@ mod tests {
         );
     }
 
-    /// `CLAUDE_CONFIG_DIR` is a host filesystem path, not a value, so
-    /// it must NOT be auto-forwarded into the container even when set
-    /// on the host. The agent's config dir is bind-mounted at the
-    /// canonical container path by `AGENT_CONFIG_MOUNTS`.
+    /// A host filesystem path is not a credential, so it must NOT be
+    /// auto-forwarded into the container even when set on the host and even
+    /// when the adapter's `env_allowlist` names it (#3238). The path resolves
+    /// to nothing inside the container, so forwarding it points the adapter
+    /// away from the config dir `AGENT_CONFIG_MOUNTS` bind-mounts at the
+    /// canonical container location. `CLAUDE_CONFIG_DIR` established the rule;
+    /// `CODEX_HOME` and `GOOGLE_APPLICATION_CREDENTIALS` reach the same
+    /// function through the per-adapter allowlists.
     ///
     /// Tagged `#[serial]` because the test mutates the process-wide
     /// env; parallel readers of `std::env::var` would race.
     #[test]
     #[serial_test::serial]
-    fn build_sandbox_docker_argv_drops_host_only_claude_config_dir() {
-        // Set the env var to simulate the host having it; the function
-        // under test must still skip it.
-        let prev = std::env::var("CLAUDE_CONFIG_DIR").ok();
-        std::env::set_var("CLAUDE_CONFIG_DIR", "/Users/operator/.claude");
+    fn build_sandbox_docker_argv_drops_host_only_path_env() {
+        // Set the vars to simulate the host having them; the function under
+        // test must still skip every one. `OPENAI_API_KEY` rides along as the
+        // control: a value-typed allowlist entry alongside them must still
+        // cross, or the assertion below would pass on a function that forwards
+        // nothing at all.
+        let _env = crate::session::test_support::EnvGuard::set(&[
+            ("CLAUDE_CONFIG_DIR", "/Users/operator/.claude"),
+            ("CODEX_HOME", "/Users/operator/.codex"),
+            (
+                "GOOGLE_APPLICATION_CREDENTIALS",
+                "/Users/operator/gcp-key.json",
+            ),
+            ("OPENAI_API_KEY", "sk-test-value"),
+        ]);
         let tmp = tempfile::tempdir().unwrap();
         let sandbox = SandboxInfo {
             enabled: true,
@@ -11800,13 +11840,18 @@ mod tests {
             container_workdir: None,
         };
         let config = SpawnConfig {
-            agent_key: "claude".into(),
-            tool: "claude".into(),
+            agent_key: "codex".into(),
+            tool: "codex".into(),
             spec: AgentSpec {
-                command: "claude-agent-acp".into(),
+                command: "codex-acp".into(),
                 args: vec![],
                 description: "test".into(),
-                env_allowlist: None,
+                env_allowlist: Some(vec![
+                    "CLAUDE_CONFIG_DIR".into(),
+                    "CODEX_HOME".into(),
+                    "GOOGLE_APPLICATION_CREDENTIALS".into(),
+                    "OPENAI_API_KEY".into(),
+                ]),
             },
             cwd: tmp.path().to_path_buf(),
             additional_dirs: vec![],
@@ -11825,27 +11870,35 @@ mod tests {
         };
         let argv = build_sandbox_docker_argv(&config, &sandbox, "/workspace/proj")
             .expect("docker argv built");
-        match prev {
-            Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
-            None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+
+        for key in [
+            "CLAUDE_CONFIG_DIR",
+            "CODEX_HOME",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+        ] {
+            assert!(
+                !argv.docker_args.iter().any(|a| a == key),
+                "{key} is a host path and must not be forwarded as `-e KEY`"
+            );
+            assert!(
+                !argv
+                    .docker_args
+                    .iter()
+                    .any(|a| a.starts_with(&format!("{key}="))),
+                "{key} must not appear as a literal `KEY=VALUE` either"
+            );
+            assert!(
+                !argv.inherit_env.iter().any(|(k, _)| k == key),
+                "{key} must not land in inherit_env"
+            );
         }
-        assert!(
-            !argv.docker_args.iter().any(|a| a == "CLAUDE_CONFIG_DIR"),
-            "CLAUDE_CONFIG_DIR is a host path and must not be forwarded as `-e KEY`"
-        );
-        assert!(
-            !argv
-                .docker_args
+        assert_eq!(
+            argv.inherit_env
                 .iter()
-                .any(|a| a.starts_with("CLAUDE_CONFIG_DIR=")),
-            "CLAUDE_CONFIG_DIR must not appear as a literal `KEY=VALUE` either"
-        );
-        assert!(
-            !argv
-                .inherit_env
-                .iter()
-                .any(|(k, _)| k == "CLAUDE_CONFIG_DIR"),
-            "CLAUDE_CONFIG_DIR must not land in inherit_env"
+                .find(|(k, _)| k == "OPENAI_API_KEY")
+                .map(|(_, v)| v.as_str()),
+            Some("sk-test-value"),
+            "the value-typed allowlist entry must still cross the boundary"
         );
     }
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3923,7 +3923,11 @@ fn apply_env_filter(cmd: &mut std::process::Command, config: &SpawnConfig) {
     }
     if let Some(extra_allowlist) = &config.spec.env_allowlist {
         for name in extra_allowlist {
-            if name == "AOE_TOKEN" {
+            // Route through the same deny check `provider_env` uses so a
+            // malicious/edited allowlist can't smuggle `AOE_TOKEN`, an
+            // `AOE_*`-prefixed daemon carrier, `LD_*`/`DYLD_*` linker hooks,
+            // or infra keys under the guise of provider auth.
+            if provider_env_denyreason(name).is_some() {
                 continue;
             }
             if let Ok(value) = std::env::var(name) {
@@ -4394,8 +4398,12 @@ fn spawn_subprocess(config: &SpawnConfig) -> Result<tokio::process::Child, AcpEr
     }
     if let Some(extra_allowlist) = &config.spec.env_allowlist {
         for name in extra_allowlist {
-            if name == "AOE_TOKEN" {
-                warn!(target: "acp", "ignoring AOE_TOKEN in agent env allowlist");
+            // Route through the same deny check `provider_env` uses so a
+            // malicious/edited allowlist can't smuggle `AOE_TOKEN`, an
+            // `AOE_*`-prefixed daemon carrier, `LD_*`/`DYLD_*` linker hooks,
+            // or infra keys under the guise of provider auth.
+            if let Some(reason) = provider_env_denyreason(name) {
+                warn!(target: "acp", "ignoring env allowlist entry '{name}' ({reason})");
                 continue;
             }
             if let Ok(value) = std::env::var(name) {
@@ -15193,6 +15201,56 @@ done
                 "{key} must reach a structured-view agent, got {applied:#?}"
             );
         }
+    }
+
+    /// #3238: `AgentSpec.env_allowlist` populated by `with_defaults` must
+    /// reach the agent via `apply_env_filter`. Uses the `aoe-agent` spec (the
+    /// one that would silently no-op if we keyed `env_allowlist_for` on
+    /// `spec.command` — placeholder-templated — instead of the binary token).
+    /// A negative case rides along: `GEMINI_API_KEY` is set but not in the
+    /// AI-SDK-based `aoe-agent`'s allowlist, so it must NOT be forwarded.
+    #[test]
+    #[serial_test::serial]
+    fn apply_env_filter_forwards_agent_env_allowlist() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _app_dir = crate::session::test_support::isolate_app_dir_at(tmp.path());
+        let _env = crate::session::test_support::EnvGuard::set(&[
+            ("OPENAI_API_KEY", "sk-openai"),
+            ("GOOGLE_GENERATIVE_AI_API_KEY", "ai-google"),
+            ("GEMINI_API_KEY", "ai-gemini-cli-key"),
+        ]);
+
+        let mut config = env_test_spawn_config(tmp.path().to_path_buf());
+        let reg = crate::acp::agent_registry::AgentRegistry::with_defaults();
+        config.spec = reg.get("aoe-agent").expect("aoe-agent default").clone();
+
+        let mut cmd = std::process::Command::new("/bin/true");
+        cmd.env_clear();
+        apply_env_filter(&mut cmd, &config);
+
+        let applied: std::collections::HashMap<String, String> = cmd
+            .get_envs()
+            .filter_map(|(k, v)| {
+                Some((
+                    k.to_string_lossy().into_owned(),
+                    v?.to_string_lossy().into_owned(),
+                ))
+            })
+            .collect();
+        assert_eq!(
+            applied.get("OPENAI_API_KEY").map(String::as_str),
+            Some("sk-openai")
+        );
+        assert_eq!(
+            applied
+                .get("GOOGLE_GENERATIVE_AI_API_KEY")
+                .map(String::as_str),
+            Some("ai-google")
+        );
+        assert!(
+            !applied.contains_key("GEMINI_API_KEY"),
+            "aoe-agent (AI-SDK) must not receive the gemini-CLI-native key, got {applied:#?}"
+        );
     }
 
     /// A sandboxed agent's environment is `sandbox.environment` by contract:

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3795,29 +3795,13 @@ fn build_sandbox_docker_argv(
     docker_args.extend(env_argv);
     let mut inherit_env: Vec<(String, String)> = inherit_pairs;
 
-    // Provider auth keys: forward into the container only when set on
-    // the host AND not already in the sandbox env list. Value-typed
-    // only; host filesystem paths (e.g. `CLAUDE_CONFIG_DIR`) must not
-    // cross the namespace boundary because they reference paths that
-    // don't exist inside the container. The agent's config dir is
-    // already bind-mounted at the canonical container path via
-    // `AGENT_CONFIG_MOUNTS`.
-    const PROVIDER_AUTH_KEYS: &[&str] = &[
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-    ];
-    for &key in PROVIDER_AUTH_KEYS {
-        if seen_keys.contains(key) {
-            continue;
-        }
-        if let Ok(value) = std::env::var(key) {
-            seen_keys.insert(key.to_string());
-            docker_args.push("-e".into());
-            docker_args.push(key.into());
-            inherit_env.push((key.into(), value));
-        }
-    }
+    // Auth sources are claimed highest-priority first, because `seen_keys` is
+    // first-claim-wins. The order mirrors the non-sandboxed paths, where the
+    // per-request `provider_env` is applied last and so wins a shared key over
+    // the ambient host keys: request auth (`provider_env`) > per-adapter
+    // allowlist > ambient host Claude keys (`PROVIDER_AUTH_KEYS`). The sandbox
+    // env list (`collect_environment` above) is claimed before all of these,
+    // matching the operator-config precedence on the host paths.
 
     // Per-spawn provider_env entries (the request's auth payload).
     for (key, value) in &config.provider_env {
@@ -3836,13 +3820,35 @@ fn build_sandbox_docker_argv(
     // boundary, or a sandboxed non-Claude session silently loses its
     // provider auth (the #3238 symptom). docker only forwards a name handed
     // to it via `-e`, so each allowlisted host value is set on the runner
-    // (`inherit_env`) and named with `-e KEY`. Claimed after `provider_env`
-    // so a request-scoped credential still wins a key both would set.
+    // (`inherit_env`) and named with `-e KEY`.
     for (key, value) in allowlisted_env_pairs(config) {
         if seen_keys.insert(key.clone()) {
             docker_args.push("-e".into());
             docker_args.push(key.clone());
             inherit_env.push((key, value));
+        }
+    }
+
+    // Ambient host Claude auth keys: forward into the container only when set
+    // on the host AND not already claimed above. Value-typed only; host
+    // filesystem paths (e.g. `CLAUDE_CONFIG_DIR`) must not cross the namespace
+    // boundary because they reference paths that don't exist inside the
+    // container. The agent's config dir is already bind-mounted at the
+    // canonical container path via `AGENT_CONFIG_MOUNTS`.
+    const PROVIDER_AUTH_KEYS: &[&str] = &[
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    ];
+    for &key in PROVIDER_AUTH_KEYS {
+        if seen_keys.contains(key) {
+            continue;
+        }
+        if let Ok(value) = std::env::var(key) {
+            seen_keys.insert(key.to_string());
+            docker_args.push("-e".into());
+            docker_args.push(key.into());
+            inherit_env.push((key.into(), value));
         }
     }
 
@@ -11912,6 +11918,53 @@ mod tests {
                 && !argv.inherit_env.iter().any(|(k, _)| k == "LD_PRELOAD"),
             "a denied linker hook must not cross the boundary even when allowlisted, got {:?}",
             argv.docker_args
+        );
+    }
+
+    /// The per-session `provider_env` auth payload must win a shared key over
+    /// the ambient host `PROVIDER_AUTH_KEYS`, matching the non-sandboxed paths
+    /// (where `provider_env` is applied last). Before the ordering fix the
+    /// sandbox claimed the host key first, so a session that selected a
+    /// different Anthropic credential silently ran under the operator's ambient
+    /// one inside the container.
+    #[test]
+    #[serial_test::serial]
+    fn build_sandbox_docker_argv_provider_env_beats_ambient_host_key() {
+        let prev = std::env::var("ANTHROPIC_API_KEY").ok();
+        std::env::set_var("ANTHROPIC_API_KEY", "sk-host-ambient");
+        let tmp = tempfile::tempdir().unwrap();
+        let sandbox = SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "alpine:latest".into(),
+            container_name: "aoe-sandbox-precedence".into(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: Vec::new(),
+            container_workdir: None,
+        };
+        let mut config = env_test_spawn_config(tmp.path().to_path_buf());
+        config.provider_env = vec![("ANTHROPIC_API_KEY".into(), "sk-session-request".into())];
+        config.sandbox_info = Some(sandbox.clone());
+
+        let argv = build_sandbox_docker_argv(&config, &sandbox, "/workspace/proj")
+            .expect("docker argv built");
+        match prev {
+            Some(v) => std::env::set_var("ANTHROPIC_API_KEY", v),
+            None => std::env::remove_var("ANTHROPIC_API_KEY"),
+        }
+
+        let values: Vec<&str> = argv
+            .inherit_env
+            .iter()
+            .filter(|(k, _)| k == "ANTHROPIC_API_KEY")
+            .map(|(_, v)| v.as_str())
+            .collect();
+        assert_eq!(
+            values,
+            vec!["sk-session-request"],
+            "the request credential must win and be forwarded exactly once, got {:?}",
+            argv.inherit_env
         );
     }
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3831,6 +3831,21 @@ fn build_sandbox_docker_argv(
         }
     }
 
+    // Per-adapter env allowlist (#3238). The same keys `apply_env_filter`
+    // forwards on the non-sandboxed paths must also cross the container
+    // boundary, or a sandboxed non-Claude session silently loses its
+    // provider auth (the #3238 symptom). docker only forwards a name handed
+    // to it via `-e`, so each allowlisted host value is set on the runner
+    // (`inherit_env`) and named with `-e KEY`. Claimed after `provider_env`
+    // so a request-scoped credential still wins a key both would set.
+    for (key, value) in allowlisted_env_pairs(config) {
+        if seen_keys.insert(key.clone()) {
+            docker_args.push("-e".into());
+            docker_args.push(key.clone());
+            inherit_env.push((key, value));
+        }
+    }
+
     // Model override (AOE_AGENT_MODEL): the supervisor folds the
     // requested model into provider_env above, so it's already covered.
 
@@ -3909,6 +3924,33 @@ fn inherited_host_env_pairs(config: &SpawnConfig) -> Vec<(String, String)> {
     crate::session::environment::inherited_host_env(profile)
 }
 
+/// Resolve the adapter's `env_allowlist` (#3238) against the operator's live
+/// environment, dropping any key the provider-env deny policy rejects
+/// (`AOE_TOKEN`, infra keys, `LD_*`/`DYLD_*` linker hooks). Shared by all
+/// three spawn paths (detached runner, in-proc stdio, and the docker-exec
+/// sandbox wrap) so the forwarded set and the deny posture cannot drift
+/// between them. Returns `(key, value)` for each allowlisted key present in
+/// the host env, warning on a rejected one. It deliberately does not cover
+/// the daemon->runner carrier `AOE_ACP_AGENT_ENV`; that is
+/// `host_environment_denyreason`'s job, and the runner clears the carrier
+/// before exec regardless.
+fn allowlisted_env_pairs(config: &SpawnConfig) -> Vec<(String, String)> {
+    let Some(allowlist) = config.spec.env_allowlist.as_ref() else {
+        return Vec::new();
+    };
+    let mut pairs = Vec::new();
+    for name in allowlist {
+        if let Some(reason) = provider_env_denyreason(name) {
+            warn!(target: "acp", key = %name, reason, "ignoring env allowlist entry");
+            continue;
+        }
+        if let Ok(value) = std::env::var(name) {
+            pairs.push((name.clone(), value));
+        }
+    }
+    pairs
+}
+
 /// Apply the env_clear + allowlist + provider_env filtering used by both
 /// the detached-runner path and the in-proc stdio path. Pulled out so
 /// the two spawn sites share the same security posture.
@@ -3921,21 +3963,8 @@ fn apply_env_filter(cmd: &mut std::process::Command, config: &SpawnConfig) {
             cmd.env(name, value);
         }
     }
-    if let Some(extra_allowlist) = &config.spec.env_allowlist {
-        for name in extra_allowlist {
-            // Route through the same deny check `provider_env` uses so a
-            // malicious/edited allowlist can't smuggle `AOE_TOKEN`,
-            // `LD_*`/`DYLD_*` linker hooks, or infra keys under the guise of
-            // provider auth. It does not cover the daemon->runner carrier
-            // `AOE_ACP_AGENT_ENV`; only `host_environment_denyreason` rejects
-            // that, and the runner clears it before exec anyway.
-            if provider_env_denyreason(name).is_some() {
-                continue;
-            }
-            if let Ok(value) = std::env::var(name) {
-                cmd.env(name, value);
-            }
-        }
+    for (key, value) in allowlisted_env_pairs(config) {
+        cmd.env(key, value);
     }
     for (key, value) in &config.provider_env {
         if provider_env_denyreason(key).is_some() {
@@ -4398,23 +4427,12 @@ fn spawn_subprocess(config: &SpawnConfig) -> Result<tokio::process::Child, AcpEr
             forwarded_keys.push(name);
         }
     }
-    if let Some(extra_allowlist) = &config.spec.env_allowlist {
-        for name in extra_allowlist {
-            // Route through the same deny check `provider_env` uses so a
-            // malicious/edited allowlist can't smuggle `AOE_TOKEN`,
-            // `LD_*`/`DYLD_*` linker hooks, or infra keys under the guise of
-            // provider auth. It does not cover the daemon->runner carrier
-            // `AOE_ACP_AGENT_ENV`; only `host_environment_denyreason` rejects
-            // that, and the runner clears it before exec anyway.
-            if let Some(reason) = provider_env_denyreason(name) {
-                warn!(target: "acp", "ignoring env allowlist entry '{name}' ({reason})");
-                continue;
-            }
-            if let Ok(value) = std::env::var(name) {
-                cmd.env(name, value);
-                forwarded_keys.push(name.as_str());
-            }
-        }
+    // Same allowlist + deny posture as the detached-runner path, via the
+    // shared helper so the two spawn sites cannot drift (#3238).
+    let allowlisted = allowlisted_env_pairs(config);
+    for (key, value) in &allowlisted {
+        cmd.env(key, value);
+        forwarded_keys.push(key.as_str());
     }
     let mut provider_keys: Vec<&str> = Vec::new();
     for (key, value) in &config.provider_env {
@@ -11825,6 +11843,78 @@ mod tests {
         );
     }
 
+    /// #3238 regression guard: the per-adapter `env_allowlist` must cross the
+    /// container boundary for a sandboxed session. Before the fix,
+    /// `build_sandbox_docker_argv` forwarded only `PROVIDER_AUTH_KEYS` +
+    /// `provider_env`, so an operator's `OPENAI_API_KEY` never reached a
+    /// sandboxed `codex`/`aoe-agent` session and auth silently failed. The
+    /// value must ride `inherit_env` (not `-e KEY=VALUE`, which would leak the
+    /// secret into argv), and a denied key (`LD_PRELOAD`) must still be
+    /// dropped even when allowlisted.
+    #[test]
+    #[serial_test::serial]
+    fn build_sandbox_docker_argv_forwards_env_allowlist() {
+        let prev_key = std::env::var("OPENAI_API_KEY").ok();
+        let prev_hook = std::env::var("LD_PRELOAD").ok();
+        std::env::set_var("OPENAI_API_KEY", "sk-openai");
+        std::env::set_var("LD_PRELOAD", "/tmp/evil.so");
+        let tmp = tempfile::tempdir().unwrap();
+        let sandbox = SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "alpine:latest".into(),
+            container_name: "aoe-sandbox-allowlist".into(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: Vec::new(),
+            container_workdir: None,
+        };
+        let mut config = env_test_spawn_config(tmp.path().to_path_buf());
+        config.spec.command = "codex-acp".into();
+        config.spec.env_allowlist = Some(vec!["OPENAI_API_KEY".into(), "LD_PRELOAD".into()]);
+        config.sandbox_info = Some(sandbox.clone());
+
+        let argv = build_sandbox_docker_argv(&config, &sandbox, "/workspace/proj")
+            .expect("docker argv built");
+        match prev_key {
+            Some(v) => std::env::set_var("OPENAI_API_KEY", v),
+            None => std::env::remove_var("OPENAI_API_KEY"),
+        }
+        match prev_hook {
+            Some(v) => std::env::set_var("LD_PRELOAD", v),
+            None => std::env::remove_var("LD_PRELOAD"),
+        }
+
+        assert!(
+            argv.docker_args
+                .windows(2)
+                .any(|w| w[0] == "-e" && w[1] == "OPENAI_API_KEY"),
+            "allowlisted OPENAI_API_KEY must be named with `-e KEY`, got {:?}",
+            argv.docker_args
+        );
+        assert_eq!(
+            argv.inherit_env
+                .iter()
+                .find(|(k, _)| k == "OPENAI_API_KEY")
+                .map(|(_, v)| v.as_str()),
+            Some("sk-openai"),
+            "the value must ride inherit_env so it stays out of argv"
+        );
+        assert!(
+            !argv
+                .docker_args
+                .iter()
+                .any(|a| a.starts_with("OPENAI_API_KEY=")),
+            "secret must not appear as `KEY=VALUE` in argv"
+        );
+        assert!(
+            !argv.docker_args.iter().any(|a| a == "LD_PRELOAD")
+                && !argv.inherit_env.iter().any(|(k, _)| k == "LD_PRELOAD"),
+            "a denied linker hook must not cross the boundary even when allowlisted, got {:?}",
+            argv.docker_args
+        );
+    }
+
     /// Write a scripted stdio ACP agent for the conversation-reset tests
     /// (#2979): answers `initialize`, mints `sid-1`, `sid-2`, ... on each
     /// `session/new` (each carrying a `thought_level` config option so the
@@ -15255,6 +15345,59 @@ done
         assert!(
             !applied.contains_key("GEMINI_API_KEY"),
             "aoe-agent (AI-SDK) must not receive the gemini-CLI-native key, got {applied:#?}"
+        );
+    }
+
+    /// #3238 security posture: `spec.env_allowlist` (which a custom-agent
+    /// definition or an edited config could populate) must not become a
+    /// smuggling channel. Every entry runs through `provider_env_denyreason`,
+    /// so `AOE_TOKEN` and `LD_*`/`DYLD_*` linker hooks are dropped even when
+    /// the operator's environment has them set, while a legitimate provider
+    /// key still forwards. The deny predicate the fix routes through had
+    /// positive coverage only.
+    #[test]
+    #[serial_test::serial]
+    fn apply_env_filter_drops_denied_allowlist_entries() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _app_dir = crate::session::test_support::isolate_app_dir_at(tmp.path());
+        let _env = crate::session::test_support::EnvGuard::set(&[
+            ("OPENAI_API_KEY", "sk-openai"),
+            ("AOE_TOKEN", "daemon-secret"),
+            ("LD_PRELOAD", "/tmp/evil.so"),
+        ]);
+
+        let mut config = env_test_spawn_config(tmp.path().to_path_buf());
+        config.spec.env_allowlist = Some(vec![
+            "OPENAI_API_KEY".into(),
+            "AOE_TOKEN".into(),
+            "LD_PRELOAD".into(),
+        ]);
+
+        let mut cmd = std::process::Command::new("/bin/true");
+        cmd.env_clear();
+        apply_env_filter(&mut cmd, &config);
+
+        let applied: std::collections::HashMap<String, String> = cmd
+            .get_envs()
+            .filter_map(|(k, v)| {
+                Some((
+                    k.to_string_lossy().into_owned(),
+                    v?.to_string_lossy().into_owned(),
+                ))
+            })
+            .collect();
+        assert_eq!(
+            applied.get("OPENAI_API_KEY").map(String::as_str),
+            Some("sk-openai"),
+            "a legitimately allowlisted provider key must forward"
+        );
+        assert!(
+            !applied.contains_key("AOE_TOKEN"),
+            "the daemon auth token must never reach the agent, got {applied:#?}"
+        );
+        assert!(
+            !applied.contains_key("LD_PRELOAD"),
+            "a linker hook must be denied even when allowlisted, got {applied:#?}"
         );
     }
 

--- a/src/acp/agent_registry.rs
+++ b/src/acp/agent_registry.rs
@@ -273,7 +273,12 @@ mod tests {
         assert_eq!(
             al("codex").as_deref(),
             Some(
-                &["OPENAI_API_KEY", "OPENAI_BASE_URL", "CODEX_HOME"][..]
+                &[
+                    "CODEX_API_KEY",
+                    "OPENAI_API_KEY",
+                    "OPENAI_BASE_URL",
+                    "CODEX_HOME"
+                ][..]
                     .iter()
                     .map(|s| s.to_string())
                     .collect::<Vec<_>>()[..]
@@ -282,7 +287,11 @@ mod tests {
         assert_eq!(
             al("aoe-agent").as_deref(),
             Some(
-                &["OPENAI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY"][..]
+                &[
+                    "OPENAI_API_KEY",
+                    "OPENAI_BASE_URL",
+                    "GOOGLE_GENERATIVE_AI_API_KEY"
+                ][..]
                     .iter()
                     .map(|s| s.to_string())
                     .collect::<Vec<_>>()[..]
@@ -293,11 +302,32 @@ mod tests {
         let gemini = al("gemini").unwrap_or_default();
         assert!(gemini.iter().any(|k| k == "GEMINI_API_KEY"));
         assert!(!gemini.iter().any(|k| k == "GOOGLE_GENERATIVE_AI_API_KEY"));
+        // Vertex is dead without the switch that selects it and the region
+        // that pairs with the project, so the credential alone is not enough.
+        for key in [
+            "GOOGLE_GENAI_USE_VERTEXAI",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "GOOGLE_CLOUD_PROJECT",
+            "GOOGLE_CLOUD_LOCATION",
+        ] {
+            assert!(gemini.iter().any(|k| k == key), "gemini missing {key}");
+        }
         let aoe = al("aoe-agent").unwrap_or_default();
         assert!(!aoe.iter().any(|k| k == "GEMINI_API_KEY"));
 
+        // opencode resolves providers through models.dev, whose `google` entry
+        // declares all three Google key names, so a user with any one of them
+        // exported must authenticate.
         let opencode = al("opencode").unwrap_or_default();
-        assert!(opencode.iter().any(|k| k == "OPENROUTER_API_KEY"));
+        for key in [
+            "OPENROUTER_API_KEY",
+            "OPENCODE_API_KEY",
+            "GOOGLE_GENERATIVE_AI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+        ] {
+            assert!(opencode.iter().any(|k| k == key), "opencode missing {key}");
+        }
 
         // Deferred + Claude: intentionally None until each adapter's env
         // reads are verified from its own source.

--- a/src/acp/agent_registry.rs
+++ b/src/acp/agent_registry.rs
@@ -2,7 +2,7 @@
 //! `aoe-agent`, `gemini`) to a spawn command + args. Users add agents via
 //! the settings TUI; this module is the in-memory model.
 
-use super::install_hints::{env_allowlist_for, install_hint_for};
+use super::install_hints::{env_allowlist_for, install_hint_for, AOE_AGENT_BINARY};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -189,9 +189,9 @@ impl AgentRegistry {
                 command: "${aoe_data_dir}/acp-worker/dist/aoe-agent".into(),
                 args: vec![],
                 description: "aoe's bundled multi-provider agent (Vercel AI SDK)".into(),
-                // Literal binary token, NOT `command` (which carries an
+                // Shared binary token, NOT `command` (which carries an
                 // unresolved `${aoe_data_dir}` placeholder here).
-                env_allowlist: default_env_allowlist("aoe-agent"),
+                env_allowlist: default_env_allowlist(AOE_AGENT_BINARY),
             },
         );
         reg
@@ -337,6 +337,25 @@ mod tests {
                 "{name} must have None env_allowlist until source-verified"
             );
         }
+
+        // Structural link between the registry and `env_allowlist_for`: exactly
+        // these adapters carry an allowlist. Adding an arm to `env_allowlist_for`
+        // (or a new default agent) without updating this set, or dropping an
+        // existing arm, fails here rather than silently changing what a spawn
+        // forwards.
+        let with_allowlist: std::collections::BTreeSet<&str> = reg
+            .list()
+            .into_iter()
+            .filter(|(_, spec)| spec.env_allowlist.is_some())
+            .map(|(name, _)| name.as_str())
+            .collect();
+        assert_eq!(
+            with_allowlist,
+            ["aoe-agent", "codex", "gemini", "opencode"]
+                .into_iter()
+                .collect::<std::collections::BTreeSet<_>>(),
+            "the set of adapters with an env_allowlist changed; update env_allowlist_for and this assertion together"
+        );
     }
 
     #[test]

--- a/src/acp/agent_registry.rs
+++ b/src/acp/agent_registry.rs
@@ -2,9 +2,18 @@
 //! `aoe-agent`, `gemini`) to a spawn command + args. Users add agents via
 //! the settings TUI; this module is the in-memory model.
 
-use super::install_hints::install_hint_for;
+use super::install_hints::{env_allowlist_for, install_hint_for};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+/// Convert the static per-binary slice from `install_hints::env_allowlist_for`
+/// into the owned `Option<Vec<String>>` field on `AgentSpec`. Empty slice maps
+/// to `None` so Claude/deferred adapters serialize the same as before, and
+/// the JSON shape of a persisted default registry does not change.
+fn default_env_allowlist(binary: &str) -> Option<Vec<String>> {
+    let keys = env_allowlist_for(binary);
+    (!keys.is_empty()).then(|| keys.iter().map(|s| s.to_string()).collect())
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentSpec {
@@ -14,9 +23,14 @@ pub struct AgentSpec {
     /// Human-readable description shown in the settings TUI and
     /// `aoe acp agents`.
     pub description: String,
-    /// Optional: which env vars from aoe to forward to this agent. If
-    /// `None`, only `PATH`, `HOME`, `LANG`, `TERM`, and provider auth env
-    /// (e.g. `ANTHROPIC_API_KEY`) are forwarded.
+    /// Extra env vars forwarded to this agent on top of the base inheritance
+    /// set defined by `ALWAYS_FORWARD_ENV` in `acp_client.rs` (PATH/HOME/
+    /// locale/SSH plus the Claude/Anthropic auth keys). `None` means nothing
+    /// extra. Populated by `default_env_allowlist` for built-in adapters via
+    /// `install_hints::env_allowlist_for`; a custom `from_acp_cmd` spec
+    /// leaves it `None` and can be overridden by
+    /// `session.inherit_host_environment = true` if the user needs more keys
+    /// through.
     pub env_allowlist: Option<Vec<String>>,
 }
 
@@ -89,7 +103,7 @@ impl AgentRegistry {
                 description: format!(
                     "Anthropic Claude via the official ACP adapter ({claude_install})"
                 ),
-                env_allowlist: None,
+                env_allowlist: default_env_allowlist("claude-agent-acp"),
             },
         );
         // Legacy alias used by older session records before the
@@ -101,7 +115,7 @@ impl AgentRegistry {
                 command: "claude-agent-acp".into(),
                 args: vec![],
                 description: "Alias for `claude` (legacy name)".into(),
-                env_allowlist: None,
+                env_allowlist: default_env_allowlist("claude-agent-acp"),
             },
         );
         reg.agents.insert(
@@ -109,8 +123,8 @@ impl AgentRegistry {
             AgentSpec {
                 command: "opencode".into(),
                 args: vec!["acp".into()],
-                description: "OpenCode (SST) — native ACP via `opencode acp`".into(),
-                env_allowlist: None,
+                description: "OpenCode (SST), native ACP via `opencode acp`".into(),
+                env_allowlist: default_env_allowlist("opencode"),
             },
         );
         reg.agents.insert(
@@ -118,8 +132,8 @@ impl AgentRegistry {
             AgentSpec {
                 command: "gemini".into(),
                 args: vec!["--acp".into()],
-                description: "Google Gemini CLI — native ACP via `gemini --acp`".into(),
-                env_allowlist: None,
+                description: "Google Gemini CLI, native ACP via `gemini --acp`".into(),
+                env_allowlist: default_env_allowlist("gemini"),
             },
         );
         reg.agents.insert(
@@ -129,7 +143,7 @@ impl AgentRegistry {
                 args: vec![],
                 description:
                     "OpenAI Codex CLI via ACP adapter (npm i -g @agentclientprotocol/codex-acp@latest)".into(),
-                env_allowlist: None,
+                env_allowlist: default_env_allowlist("codex-acp"),
             },
         );
         reg.agents.insert(
@@ -137,8 +151,8 @@ impl AgentRegistry {
             AgentSpec {
                 command: "vibe-acp".into(),
                 args: vec![],
-                description: "Mistral Vibe — native ACP via the bundled `vibe-acp` binary".into(),
-                env_allowlist: None,
+                description: "Mistral Vibe, native ACP via the bundled `vibe-acp` binary".into(),
+                env_allowlist: default_env_allowlist("vibe-acp"),
             },
         );
         reg.agents.insert(
@@ -148,7 +162,7 @@ impl AgentRegistry {
                 args: vec![],
                 description: "Pi coding agent (`pi`) via the pi-acp adapter (npm i -g pi-acp)"
                     .into(),
-                env_allowlist: None,
+                env_allowlist: default_env_allowlist("pi-acp"),
             },
         );
         reg.agents.insert(
@@ -157,7 +171,7 @@ impl AgentRegistry {
                 command: "omp".into(),
                 args: vec!["acp".into()],
                 description: "Oh My Pi coding agent, native ACP via `omp acp`".into(),
-                env_allowlist: None,
+                env_allowlist: default_env_allowlist("omp"),
             },
         );
         reg.agents.insert(
@@ -165,8 +179,8 @@ impl AgentRegistry {
             AgentSpec {
                 command: "kimi".into(),
                 args: vec!["acp".into()],
-                description: "Kimi Code (Moonshot AI) — native ACP via `kimi acp`".into(),
-                env_allowlist: None,
+                description: "Kimi Code (Moonshot AI), native ACP via `kimi acp`".into(),
+                env_allowlist: default_env_allowlist("kimi"),
             },
         );
         reg.agents.insert(
@@ -174,8 +188,10 @@ impl AgentRegistry {
             AgentSpec {
                 command: "${aoe_data_dir}/acp-worker/dist/aoe-agent".into(),
                 args: vec![],
-                description: "aoe's bundled multi-provider agent (Vercel AI SDK 6)".into(),
-                env_allowlist: None,
+                description: "aoe's bundled multi-provider agent (Vercel AI SDK)".into(),
+                // Literal binary token, NOT `command` (which carries an
+                // unresolved `${aoe_data_dir}` placeholder here).
+                env_allowlist: default_env_allowlist("aoe-agent"),
             },
         );
         reg
@@ -237,6 +253,60 @@ mod tests {
     #[test]
     fn from_acp_cmd_rejects_unbalanced_quotes() {
         assert!(AgentSpec::from_acp_cmd("x", "ocp run \"unterminated").is_err());
+    }
+
+    /// #3238: verified adapters (`codex`, `opencode`, `gemini`, `aoe-agent`)
+    /// forward the operator's provider-auth env; adapters whose real env
+    /// vars couldn't be source-verified (pi, omp, kimi, vibe, and Claude
+    /// which is already covered by `ALWAYS_FORWARD_ENV`) stay `None`.
+    /// One row asserts a specific negative for `aoe-agent`: it must NOT
+    /// receive `GEMINI_API_KEY` (that's the CLI-native name; the bundled
+    /// AI-SDK agent reads `GOOGLE_GENERATIVE_AI_API_KEY` instead). The
+    /// negative row catches the "keyed on `spec.command` instead of the
+    /// binary token" bug, where `${aoe_data_dir}/...` would never match
+    /// and every `aoe-agent` provider key would drop.
+    #[test]
+    fn default_env_allowlists_match_verified_providers() {
+        let reg = AgentRegistry::with_defaults();
+        let al = |name: &str| reg.get(name).and_then(|s| s.env_allowlist.clone());
+
+        assert_eq!(
+            al("codex").as_deref(),
+            Some(
+                &["OPENAI_API_KEY", "OPENAI_BASE_URL", "CODEX_HOME"][..]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect::<Vec<_>>()[..]
+            )
+        );
+        assert_eq!(
+            al("aoe-agent").as_deref(),
+            Some(
+                &["OPENAI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY"][..]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect::<Vec<_>>()[..]
+            )
+        );
+        // gemini CLI uses the CLI-native GEMINI_API_KEY; aoe-agent (AI-SDK)
+        // does not. Verify the two do not share the wrong Google key.
+        let gemini = al("gemini").unwrap_or_default();
+        assert!(gemini.iter().any(|k| k == "GEMINI_API_KEY"));
+        assert!(!gemini.iter().any(|k| k == "GOOGLE_GENERATIVE_AI_API_KEY"));
+        let aoe = al("aoe-agent").unwrap_or_default();
+        assert!(!aoe.iter().any(|k| k == "GEMINI_API_KEY"));
+
+        let opencode = al("opencode").unwrap_or_default();
+        assert!(opencode.iter().any(|k| k == "OPENROUTER_API_KEY"));
+
+        // Deferred + Claude: intentionally None until each adapter's env
+        // reads are verified from its own source.
+        for name in ["claude", "claude-code", "pi", "omp", "kimi", "vibe"] {
+            assert!(
+                al(name).is_none(),
+                "{name} must have None env_allowlist until source-verified"
+            );
+        }
     }
 
     #[test]

--- a/src/acp/install_hints.rs
+++ b/src/acp/install_hints.rs
@@ -39,6 +39,55 @@ pub fn npm_package_for(binary: &str) -> Option<&'static str> {
     })
 }
 
+/// Extra operator env vars to forward to a given ACP binary, on top of
+/// `ALWAYS_FORWARD_ENV` in `acp_client.rs` (which already carries the
+/// Anthropic/Claude keys plus PATH/HOME/locale/SSH). Empty slice means
+/// nothing extra: Claude adapters use `ALWAYS_FORWARD_ENV` verbatim, and
+/// four adapters (`pi-acp`, `omp`, `kimi`, `vibe-acp`) are intentionally
+/// deferred because their env-var names could not be source-verified for
+/// #3238 and shipping a guess that never matches would silently no-op
+/// the fix. Follow-up: verify each adapter's real reads from its own
+/// package/binary and add its arm.
+///
+/// The key is the friendly binary token used at registration time (e.g.
+/// `"aoe-agent"`), NOT `AgentSpec.command`. `command` for `aoe-agent`
+/// carries a `${aoe_data_dir}/...` placeholder that is substituted at
+/// spawn time (`supervisor.rs`), so keying on it here would silently
+/// miss the bundled agent.
+pub fn env_allowlist_for(binary: &str) -> &'static [&'static str] {
+    match binary {
+        // Verified from source: acp-worker/aoe-agent/src/index.ts imports
+        // only @ai-sdk/{anthropic,openai,google}. Anthropic is already in
+        // ALWAYS_FORWARD_ENV. @ai-sdk/google reads GOOGLE_GENERATIVE_AI_API_KEY
+        // (NOT GEMINI_API_KEY, which is the gemini-CLI-native name).
+        "aoe-agent" => &["OPENAI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY"],
+        // Verified from canonical provider env names: codex reads OpenAI SDK
+        // env (OPENAI_API_KEY/BASE_URL) and CODEX_HOME to reuse the operator's
+        // `codex login` auth.json.
+        "codex-acp" => &["OPENAI_API_KEY", "OPENAI_BASE_URL", "CODEX_HOME"],
+        // Verified from canonical AI-SDK provider names: opencode is
+        // AI-SDK-based (Google reads GOOGLE_GENERATIVE_AI_API_KEY, distinct
+        // from gemini CLI-native GEMINI_API_KEY). OPENROUTER is a common
+        // opencode target. OPENCODE_API_KEY covers OpenCode Cloud auth.
+        "opencode" => &[
+            "OPENAI_API_KEY",
+            "GOOGLE_GENERATIVE_AI_API_KEY",
+            "OPENROUTER_API_KEY",
+            "OPENCODE_API_KEY",
+        ],
+        // Verified from canonical Google Gemini CLI env: uses the CLI-native
+        // names (distinct from AI-SDK's GOOGLE_GENERATIVE_AI_API_KEY), plus
+        // Vertex/ADC (GOOGLE_APPLICATION_CREDENTIALS, GOOGLE_CLOUD_PROJECT).
+        "gemini" => &[
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "GOOGLE_CLOUD_PROJECT",
+        ],
+        _ => &[],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/acp/install_hints.rs
+++ b/src/acp/install_hints.rs
@@ -4,6 +4,13 @@
 //! the ACP handshake failure path so the user sees the correct command
 //! for whichever agent they tried to spawn.
 
+/// Friendly binary token for aoe's bundled multi-provider agent. Shared by the
+/// registry's spawn registration and [`env_allowlist_for`] so the two cannot
+/// drift onto different spellings (which would silently drop the agent's
+/// provider keys). Distinct from `AgentSpec.command`, whose value for this
+/// agent is the placeholder-templated `${aoe_data_dir}/...` path.
+pub const AOE_AGENT_BINARY: &str = "aoe-agent";
+
 /// Returns the install command for a known ACP binary, or `None` for
 /// unknown commands so callers can fall through to a generic message.
 pub fn install_hint_for(binary: &str) -> Option<&'static str> {
@@ -51,7 +58,7 @@ pub fn npm_package_for(binary: &str) -> Option<&'static str> {
 /// names came from; do not add one on convention alone.
 ///
 /// The key is the friendly binary token used at registration time (e.g.
-/// `"aoe-agent"`), NOT `AgentSpec.command`. `command` for `aoe-agent`
+/// [`AOE_AGENT_BINARY`]), NOT `AgentSpec.command`. `command` for `aoe-agent`
 /// carries a `${aoe_data_dir}/...` placeholder that is substituted at
 /// spawn time (`supervisor.rs`), so keying on it here would silently
 /// miss the bundled agent.
@@ -64,7 +71,7 @@ pub fn env_allowlist_for(binary: &str) -> &'static [&'static str] {
         // OPENAI_BASE_URL (src/openai-provider.ts); @ai-sdk/google 4.0.31 reads
         // GOOGLE_GENERATIVE_AI_API_KEY, NOT GEMINI_API_KEY (the gemini CLI's
         // own name).
-        "aoe-agent" => &[
+        AOE_AGENT_BINARY => &[
             "OPENAI_API_KEY",
             "OPENAI_BASE_URL",
             "GOOGLE_GENERATIVE_AI_API_KEY",

--- a/src/acp/install_hints.rs
+++ b/src/acp/install_hints.rs
@@ -47,7 +47,8 @@ pub fn npm_package_for(binary: &str) -> Option<&'static str> {
 /// deferred because their env-var names could not be source-verified for
 /// #3238 and shipping a guess that never matches would silently no-op
 /// the fix. Follow-up: verify each adapter's real reads from its own
-/// package/binary and add its arm.
+/// package/binary and add its arm. Every arm below cites the artifact its
+/// names came from; do not add one on convention alone.
 ///
 /// The key is the friendly binary token used at registration time (e.g.
 /// `"aoe-agent"`), NOT `AgentSpec.command`. `command` for `aoe-agent`
@@ -56,33 +57,54 @@ pub fn npm_package_for(binary: &str) -> Option<&'static str> {
 /// miss the bundled agent.
 pub fn env_allowlist_for(binary: &str) -> &'static [&'static str] {
     match binary {
-        // Verified from source: acp-worker/aoe-agent/src/index.ts imports
-        // only @ai-sdk/{anthropic,openai,google}. Anthropic is already in
-        // ALWAYS_FORWARD_ENV. @ai-sdk/google reads GOOGLE_GENERATIVE_AI_API_KEY
-        // (NOT GEMINI_API_KEY, which is the gemini-CLI-native name).
-        "aoe-agent" => &["OPENAI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY"],
-        // Verified from canonical provider env names: codex reads OpenAI SDK
-        // env (OPENAI_API_KEY/BASE_URL) and CODEX_HOME to reuse the operator's
-        // `codex login` auth.json.
-        "codex-acp" => &["OPENAI_API_KEY", "OPENAI_BASE_URL", "CODEX_HOME"],
-        // Verified from canonical AI-SDK provider names: opencode is
-        // AI-SDK-based (Google reads GOOGLE_GENERATIVE_AI_API_KEY, distinct
-        // from gemini CLI-native GEMINI_API_KEY). OPENROUTER is a common
-        // opencode target. OPENCODE_API_KEY covers OpenCode Cloud auth.
+        // Verified from source: acp-worker/aoe-agent/src/index.ts imports only
+        // @ai-sdk/{anthropic,openai,google}, and those providers read their key
+        // from the environment themselves. Anthropic is already in
+        // ALWAYS_FORWARD_ENV. @ai-sdk/openai 4.0.27 reads OPENAI_API_KEY and
+        // OPENAI_BASE_URL (src/openai-provider.ts); @ai-sdk/google 4.0.31 reads
+        // GOOGLE_GENERATIVE_AI_API_KEY, NOT GEMINI_API_KEY (the gemini CLI's
+        // own name).
+        "aoe-agent" => &[
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+            "GOOGLE_GENERATIVE_AI_API_KEY",
+        ],
+        // Verified from codex-acp 1.3.0 (dist, `readApiKeyFromEnv`): it takes
+        // CODEX_API_KEY first, then OPENAI_API_KEY. It then execs the codex
+        // CLI, which resolves its config dir from CODEX_HOME and its endpoint
+        // from OPENAI_BASE_URL, so both ride along for the operator's
+        // `codex login` auth.json and any proxy endpoint.
+        "codex-acp" => &[
+            "CODEX_API_KEY",
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+            "CODEX_HOME",
+        ],
+        // Verified from the models.dev provider registry opencode resolves
+        // against: its `google` entry accepts GOOGLE_API_KEY,
+        // GOOGLE_GENERATIVE_AI_API_KEY, and GEMINI_API_KEY alike, so all three
+        // are here. OPENROUTER_API_KEY and OPENCODE_API_KEY (OpenCode Zen) are
+        // the `openrouter` / `opencode` entries' declared env.
         "opencode" => &[
             "OPENAI_API_KEY",
             "GOOGLE_GENERATIVE_AI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
             "OPENROUTER_API_KEY",
             "OPENCODE_API_KEY",
         ],
-        // Verified from canonical Google Gemini CLI env: uses the CLI-native
-        // names (distinct from AI-SDK's GOOGLE_GENERATIVE_AI_API_KEY), plus
-        // Vertex/ADC (GOOGLE_APPLICATION_CREDENTIALS, GOOGLE_CLOUD_PROJECT).
+        // Verified from @google/gemini-cli 0.55.1: CLI-native GEMINI_API_KEY /
+        // GOOGLE_API_KEY (distinct from AI-SDK's GOOGLE_GENERATIVE_AI_API_KEY),
+        // plus the Vertex set. GOOGLE_GENAI_USE_VERTEXAI is what selects Vertex
+        // at all, and GOOGLE_CLOUD_LOCATION pairs with GOOGLE_CLOUD_PROJECT, so
+        // forwarding the credential without them leaves that path dead.
         "gemini" => &[
             "GEMINI_API_KEY",
             "GOOGLE_API_KEY",
+            "GOOGLE_GENAI_USE_VERTEXAI",
             "GOOGLE_APPLICATION_CREDENTIALS",
             "GOOGLE_CLOUD_PROJECT",
+            "GOOGLE_CLOUD_LOCATION",
         ],
         _ => &[],
     }


### PR DESCRIPTION
## Description

Closes #3238.

Structured-view (ACP) agent spawns clear the environment and forward a fixed allowlist `ALWAYS_FORWARD_ENV` in `src/acp/acp_client.rs` that lists Claude/Anthropic keys only. So `OPENAI_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, etc. set in the environment running `aoe serve` reach terminal-view sessions but are dropped from `codex-acp`, `pi-acp`, `opencode acp`, `gemini --acp`, and every other non-Claude ACP adapter, including the bundled `aoe-agent`. Auth silently fails in the structured view.

The plumbing was already Direction 2 from the issue body: `AgentSpec.env_allowlist: Option<Vec<String>>` at `src/acp/agent_registry.rs` is a per-adapter extra allowlist consumed by both spawn paths in `src/acp/acp_client.rs` (`apply_env_filter` and `spawn_subprocess`). Every default registration passed `env_allowlist: None`. The mechanism was built; the data was empty.

## What this changes

- New `install_hints::env_allowlist_for(binary: &str) -> &'static [&'static str]`, keyed on the friendly binary token used at registration (`"aoe-agent"`, not `spec.command`, whose `${aoe_data_dir}` placeholder is substituted at spawn time).
- `agent_registry::with_defaults` populates each adapter's `env_allowlist` via `default_env_allowlist(binary)` which reads that slice.
- Two spawn sites (`apply_env_filter` and `spawn_subprocess`) route allowlist entries through `provider_env_denyreason` (already used for `provider_env`) so a malicious or edited spec cannot smuggle `AOE_TOKEN`, `AOE_*`-prefixed daemon carriers, or `LD_*` / `DYLD_*` linker hooks under cover of a provider auth key. Not exploitable today (registry never deserialized from disk; `upsert_agent` has zero production callers), but it removes the asymmetry between the allowlist and `provider_env`.
- Doc comment on `AgentSpec.env_allowlist` was stale (enumerated a subset of `ALWAYS_FORWARD_ENV` that omitted several keys and mis-described "provider auth env" as `ANTHROPIC_API_KEY`); rewrote to reference `ALWAYS_FORWARD_ENV` directly. Also dropped the incorrect "Vercel AI SDK 6" from `aoe-agent`'s description (`acp-worker/aoe-agent/package.json` pins `ai ^7`).

## Verified per-adapter allowlists (only)

| Adapter | Allowlist | Source |
|---|---|---|
| `aoe-agent` | `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY` | Verified from `acp-worker/aoe-agent/src/index.ts:20-22` imports `@ai-sdk/{anthropic,openai,google}`. Anthropic is already in `ALWAYS_FORWARD_ENV`. `@ai-sdk/google` reads `GOOGLE_GENERATIVE_AI_API_KEY`, NOT the CLI-native `GEMINI_API_KEY`. |
| `codex-acp` | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `CODEX_HOME` | OpenAI SDK env plus `CODEX_HOME` so the adapter can reuse the operator's `codex login` `auth.json`. |
| `opencode` | `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `OPENROUTER_API_KEY`, `OPENCODE_API_KEY` | AI-SDK-based, so the Google env is the AI-SDK convention (distinct from `gemini --acp`'s CLI-native names). |
| `gemini` | `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT` | Google Gemini CLI-native names plus Vertex / ADC. |

## Explicit deferrals (rather than ship guessed names)

`pi`, `omp`, `kimi`, `vibe`, and both Claude aliases keep `env_allowlist: None`. Shipping a guessed key that never matches would silently no-op the fix; shipping a wrong one would forward a key the adapter doesn't use. Users needing any of those today can flip `session.inherit_host_environment = true` (already forwards arbitrary env, filtered by `passthrough_denyreason`). Follow-up: verify each adapter's real env reads from its own source and add its arm. This is a deliberate correctness-over-completeness call; the issue body explicitly asks for the fix to not silently no-op.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

ACP env-forwarding change; no visual surface. Screenshot skipped.

## Test Coverage Analysis

Web dashboard / structured view (Playwright user story)
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The change is entirely in the ACP spawn plumbing; no dashboard control flow moves.

TUI / CLI (e2e test)
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Covered by two unit tests directly at the mechanism boundary.

Tests added:

- `agent_registry::tests::default_env_allowlists_match_verified_providers`: table-driven, pins all 10 default adapters (4 populated allowlists + 6 explicit `None`s). One row asserts that `aoe-agent` does NOT receive `GEMINI_API_KEY` (that's the CLI-native name; the AI-SDK bundled agent uses `GOOGLE_GENERATIVE_AI_API_KEY` instead). This negative row catches the "keyed on `spec.command`" regression, where the `${aoe_data_dir}` placeholder would never match and every `aoe-agent` provider key would silently drop.
- `acp_client::tests::apply_env_filter_forwards_agent_env_allowlist`: `#[serial]` + `EnvGuard` + `isolate_app_dir_at`. Sets `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `GEMINI_API_KEY`; spawns the real `aoe-agent` spec through `apply_env_filter`; asserts the first two reach the child while `GEMINI_API_KEY` does not.

Verified locally: `cargo fmt --all -- --check`, `cargo clippy -- -D warnings` (both featuresets), `cargo test --features serve --lib` (my new tests pass; the four pre-existing serve-only test flakes in `acp::supervisor::spawn_unknown_agent_errors_cleanly`, `acp::acp_client::reset_*`, and `server::api::acp::wake_prompt_frees_instance_lock_and_publishes_nothing_without_a_worker` are unrelated — they fail the same way with my new tests excluded), `cargo test --no-default-features --lib` clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

AI Model/Tool used: Claude Code (Opus 4.8)

Any Additional AI Details you'd like to share:

I used subagents to (a) map `ALWAYS_FORWARD_ENV`, the two spawn paths, and the `AgentSpec.env_allowlist` field; (b) adversarially review the design across correctness / altitude / blast-radius (which caught that my initial per-adapter key list for `aoe-agent` had the wrong Google key name — I'd assumed `GEMINI_API_KEY` but the source actually reads `GOOGLE_GENERATIVE_AI_API_KEY`); (c) senior-review the converged plan (which caught a second blocking landmine: keying `env_allowlist_for` on `spec.command` would use the templated `${aoe_data_dir}/...` string and silently miss the bundled agent). The design decisions (Option 2 over Option 1; keyed lookup in `install_hints.rs` over inline literals; explicit deferrals over silent no-ops) are mine. I reviewed the whole diff, understand it, and will answer reviewer feedback in my own words.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added per-adapter environment allowlists for ACP structured-view sessions.
- Forwarded approved provider credentials through host, detached, and sandboxed sessions.
- Preserved request-specific credential precedence.
- Blocked protected, daemon, linker-hook, and host-only path variables where required.
- Added support for `aoe-agent`, `codex-acp`, `opencode`, and `gemini`.
- Kept unverified adapters unchanged. They can use `session.inherit_host_environment = true` for broader forwarding.
- Unified the `aoe-agent` registration and allowlist token.
- Updated documentation and added tests for forwarding, precedence, sandbox behavior, adapter mappings, and filtering.

## Benefits

- Provider credentials such as `OPENAI_API_KEY` reach supported ACP agents.
- Structured-view sessions authenticate consistently across providers.
- Adapter-specific forwarding limits unnecessary environment exposure.
- Sandboxed sessions receive approved credentials without exposing host-only paths.
- Clear mappings and tests simplify future adapter updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->