### PR TITLE
feat(cli): filter and expose session state in `aoe list`

### DIFF
--- a/contrib/hermes-skill/SKILL.md
+++ b/contrib/hermes-skill/SKILL.md
@@ -68,6 +68,7 @@ aoe add . -t "yolo" -y -l
 aoe list              # human-readable
 aoe list --json       # JSON for parsing
 aoe list --all        # across all profiles
+aoe list --json --state=live   # skip trashed and archived rows
 ```
 
 **JSON shape** (`aoe list --json`):
@@ -81,13 +82,14 @@ aoe list --all        # across all profiles
     "tool": "claude",
     "command": "claude",
     "profile": "default",
+    "state": "live",
     "created_at": "2025-01-01T00:00:00Z",
     "workspace_repos": []
   }
 ]
 ```
 
-`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `list --json` does not include live status: use `aoe status --json` or `aoe session capture --json` for that.
+`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`, with `trashed_at` / `archived_at` present only in those states; a trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status: use `aoe status --json` or `aoe session capture --json` for that.
 
 ## Session Lifecycle
 

--- a/contrib/openclaw-skill/SKILL.md
+++ b/contrib/openclaw-skill/SKILL.md
@@ -69,6 +69,9 @@ aoe list --json
 
 # List across all profiles
 aoe list --all
+
+# Skip trashed and archived rows (default is every persisted session)
+aoe list --json --state=live
 ```
 
 **JSON output shape** (`aoe list --json`):
@@ -82,13 +85,14 @@ aoe list --all
     "tool": "claude",
     "command": "claude",
     "profile": "default",
+    "state": "live",
     "created_at": "2025-01-01T00:00:00Z",
     "workspace_repos": []
   }
 ]
 ```
 
-`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `list --json` does not include live status; use `aoe status --json` or `aoe session capture --json` for that.
+`command` is omitted when empty; `worktree` appears only for worktree-backed sessions. `state` is `live`, `archived`, or `trashed`, with `trashed_at` / `archived_at` present only in those states; a trashed session stays in the listing and keeps its title, so check `state` before treating a row as a live session. `list --json` does not include live status; use `aoe status --json` or `aoe session capture --json` for that.
 
 ### Session lifecycle
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -242,7 +242,7 @@ List all sessions
 
 * `--json` — Output as JSON
 * `--all` — List sessions from all profiles
-* `--state <STATE>` — Filter by session state. Default is `all` (every persisted session, which is what `aoe list` has always shown). #3350 added the flag so a scripted consumer can pass `--state=live` to skip trashed and archived rows without a second `aoe session list-trash` shellout, mirroring the REST API's `state=live|trashed|all` from #3187. Rejects any other value at parse time
+* `--state <STATE>` — Filter by session state. Defaults to `all`, every persisted session, which is what `aoe list` has always shown. Pass `--state=live` to skip trashed and archived rows; the vocabulary matches the REST API's `GET /api/sessions?state=`
 
   Default value: `all`
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -242,6 +242,18 @@ List all sessions
 
 * `--json` — Output as JSON
 * `--all` — List sessions from all profiles
+* `--state <STATE>` — Filter by session state. Default is `all` (every persisted session, which is what `aoe list` has always shown). #3350 added the flag so a scripted consumer can pass `--state=live` to skip trashed and archived rows without a second `aoe session list-trash` shellout, mirroring the REST API's `state=live|trashed|all` from #3187. Rejects any other value at parse time
+
+  Default value: `all`
+
+  Possible values:
+  - `live`:
+    Only sessions that are neither archived nor trashed
+  - `trashed`:
+    Only sessions currently in the trash
+  - `all`:
+    Every persisted session in the profile (default)
+
 
 
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,15 +1,43 @@
 //! `agent-of-empires list` command implementation
 
 use anyhow::Result;
-use clap::Args;
+use clap::{Args, ValueEnum};
 use serde::Serialize;
 
-use crate::session::{Instance, Storage};
+use crate::session::{Instance, SessionScope, Storage};
 
 const TABLE_COL_TITLE: usize = 20;
 const TABLE_COL_GROUP: usize = 15;
 const TABLE_COL_PATH: usize = 40;
 const TABLE_COL_ID_DISPLAY: usize = 12;
+const TABLE_COL_STATE: usize = 9;
+
+/// The `aoe list --state=` vocabulary. Mirrors the REST API's
+/// `SessionScope` (`GET /api/sessions?state=`) so the two vocabularies
+/// share one source of truth (#3350). Kept as a clap-facing enum here
+/// rather than deriving `ValueEnum` on the wire type: the API rejects
+/// unrecognized values via serde with a JSON 400, while clap wants its
+/// own `PossibleValue` list for `--help` and `--state=?` errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "lowercase")]
+enum StateFilter {
+    /// Only sessions that are neither archived nor trashed.
+    Live,
+    /// Only sessions currently in the trash.
+    Trashed,
+    /// Every persisted session in the profile (default).
+    All,
+}
+
+impl From<StateFilter> for SessionScope {
+    fn from(v: StateFilter) -> Self {
+        match v {
+            StateFilter::Live => SessionScope::Live,
+            StateFilter::Trashed => SessionScope::Trashed,
+            StateFilter::All => SessionScope::All,
+        }
+    }
+}
 
 #[derive(Args)]
 pub struct ListArgs {
@@ -20,6 +48,31 @@ pub struct ListArgs {
     /// List sessions from all profiles
     #[arg(long)]
     all: bool,
+
+    /// Filter by session state. Default is `all` (every persisted session,
+    /// which is what `aoe list` has always shown). #3350 added the flag so a
+    /// scripted consumer can pass `--state=live` to skip trashed and
+    /// archived rows without a second `aoe session list-trash` shellout,
+    /// mirroring the REST API's `state=live|trashed|all` from #3187.
+    /// Rejects any other value at parse time.
+    #[arg(long, value_enum, default_value_t = StateFilter::All)]
+    state: StateFilter,
+}
+
+/// Simple string tag describing whether a session is live/archived/trashed,
+/// exposed alongside `trashed_at`/`archived_at` in `--json` so a consumer
+/// keying on state does not have to reason about the timestamps itself. The
+/// wire values match [`SessionScope`] (`live`/`trashed`), plus `archived`
+/// for the archive-but-not-trash case which the API happens to fold into
+/// `live` today.
+fn state_tag(inst: &Instance) -> &'static str {
+    if inst.is_trashed() {
+        "trashed"
+    } else if inst.is_archived() {
+        "archived"
+    } else {
+        "live"
+    }
 }
 
 #[derive(Serialize)]
@@ -32,7 +85,20 @@ struct SessionJson {
     #[serde(skip_serializing_if = "String::is_empty")]
     command: String,
     profile: String,
+    /// One of `live`, `archived`, `trashed`; the natural way to distinguish a
+    /// trashed row from a failed one that #3350 was filed for.
+    state: &'static str,
     created_at: chrono::DateTime<chrono::Utc>,
+    /// Set iff the session is currently in the trash. Together with
+    /// `archived_at`, lets a scripted consumer read the state without a
+    /// second `aoe session list-trash` shellout.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trashed_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Set iff the session is currently archived (trash's a strict superset
+    /// of archived on the store, but the two states are semantically distinct
+    /// and #3350's follow-up comment asked for archive to be readable too).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    archived_at: Option<chrono::DateTime<chrono::Utc>>,
     /// Empty for single-repo sessions; populated with one entry per repo
     /// (including the primary) for sessions created with `--repo`/`--project`.
     workspace_repos: Vec<WorkspaceRepoJson>,
@@ -74,7 +140,10 @@ fn session_json(inst: &Instance, profile: &str) -> SessionJson {
         tool: inst.tool.clone(),
         command: inst.command.clone(),
         profile: profile.to_string(),
+        state: state_tag(inst),
         created_at: inst.created_at,
+        trashed_at: inst.trashed_at,
+        archived_at: inst.archived_at,
         workspace_repos: workspace_repos_for(inst),
         worktree: worktree_for(inst),
     }
@@ -93,47 +162,104 @@ fn workspace_repos_for(inst: &Instance) -> Vec<WorkspaceRepoJson> {
         .collect()
 }
 
-fn print_table_header() {
-    println!(
-        "{:<width_title$} {:<width_group$} {:<width_path$} ID",
-        "TITLE",
-        "GROUP",
-        "PATH",
-        width_title = TABLE_COL_TITLE,
-        width_group = TABLE_COL_GROUP,
-        width_path = TABLE_COL_PATH
-    );
-    println!(
-        "{}",
-        "-".repeat(TABLE_COL_TITLE + TABLE_COL_GROUP + TABLE_COL_PATH + TABLE_COL_ID_DISPLAY + 5)
-    );
+fn print_table_header(show_state: bool) {
+    if show_state {
+        println!(
+            "{:<width_title$} {:<width_group$} {:<width_path$} {:<width_state$} ID",
+            "TITLE",
+            "GROUP",
+            "PATH",
+            "STATE",
+            width_title = TABLE_COL_TITLE,
+            width_group = TABLE_COL_GROUP,
+            width_path = TABLE_COL_PATH,
+            width_state = TABLE_COL_STATE,
+        );
+        println!(
+            "{}",
+            "-".repeat(
+                TABLE_COL_TITLE
+                    + TABLE_COL_GROUP
+                    + TABLE_COL_PATH
+                    + TABLE_COL_STATE
+                    + TABLE_COL_ID_DISPLAY
+                    + 6
+            )
+        );
+    } else {
+        println!(
+            "{:<width_title$} {:<width_group$} {:<width_path$} ID",
+            "TITLE",
+            "GROUP",
+            "PATH",
+            width_title = TABLE_COL_TITLE,
+            width_group = TABLE_COL_GROUP,
+            width_path = TABLE_COL_PATH
+        );
+        println!(
+            "{}",
+            "-".repeat(
+                TABLE_COL_TITLE + TABLE_COL_GROUP + TABLE_COL_PATH + TABLE_COL_ID_DISPLAY + 5
+            )
+        );
+    }
 }
 
-fn print_table_row(inst: &Instance) {
+fn print_table_row(inst: &Instance, show_state: bool) {
     let title = super::truncate(&inst.title, TABLE_COL_TITLE);
     let group = super::truncate(&inst.group_path, TABLE_COL_GROUP);
     let path = super::truncate(&inst.project_path, TABLE_COL_PATH);
     let id_display = super::truncate_id(&inst.id, TABLE_COL_ID_DISPLAY);
-    println!(
-        "{:<width_title$} {:<width_group$} {:<width_path$} {}",
-        title,
-        group,
-        path,
-        id_display,
-        width_title = TABLE_COL_TITLE,
-        width_group = TABLE_COL_GROUP,
-        width_path = TABLE_COL_PATH
-    );
+    if show_state {
+        println!(
+            "{:<width_title$} {:<width_group$} {:<width_path$} {:<width_state$} {}",
+            title,
+            group,
+            path,
+            state_tag(inst),
+            id_display,
+            width_title = TABLE_COL_TITLE,
+            width_group = TABLE_COL_GROUP,
+            width_path = TABLE_COL_PATH,
+            width_state = TABLE_COL_STATE,
+        );
+    } else {
+        println!(
+            "{:<width_title$} {:<width_group$} {:<width_path$} {}",
+            title,
+            group,
+            path,
+            id_display,
+            width_title = TABLE_COL_TITLE,
+            width_group = TABLE_COL_GROUP,
+            width_path = TABLE_COL_PATH
+        );
+    }
+}
+
+/// Whether the human table should render the `STATE` column. Off for
+/// `--state=live` (every row is `live` and the column carries no
+/// information) and off when filtering to only `trashed` (same). Only
+/// meaningful under `all`, where rows are mixed and a scripted consumer
+/// or human reader benefits from distinguishing a live row from a trashed
+/// or archived one.
+fn table_shows_state(scope: SessionScope) -> bool {
+    matches!(scope, SessionScope::All)
 }
 
 #[tracing::instrument(target = "cli.list", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, args: ListArgs) -> Result<()> {
+    let scope: SessionScope = args.state.into();
     if args.all {
-        return run_all_profiles(args.json).await;
+        return run_all_profiles(args.json, scope).await;
     }
 
     let storage = Storage::open_unwatched(profile)?;
-    let (instances, _) = storage.load_with_groups()?;
+    let (all_instances, _) = storage.load_with_groups()?;
+    let instances: Vec<Instance> = all_instances
+        .into_iter()
+        .filter(|inst| SessionScope::matches(Some(scope), inst))
+        .collect();
 
     if instances.is_empty() {
         println!("No sessions found in profile '{}'.", storage.profile());
@@ -149,10 +275,11 @@ pub async fn run(profile: &str, args: ListArgs) -> Result<()> {
         return Ok(());
     }
 
+    let show_state = table_shows_state(scope);
     println!("Profile: {}\n", storage.profile());
-    print_table_header();
+    print_table_header(show_state);
     for inst in &instances {
-        print_table_row(inst);
+        print_table_row(inst, show_state);
     }
     println!("\nTotal: {} sessions", instances.len());
 
@@ -161,7 +288,7 @@ pub async fn run(profile: &str, args: ListArgs) -> Result<()> {
     Ok(())
 }
 
-async fn run_all_profiles(json: bool) -> Result<()> {
+async fn run_all_profiles(json: bool, scope: SessionScope) -> Result<()> {
     let profiles = crate::session::list_profiles()?;
 
     if profiles.is_empty() {
@@ -175,6 +302,9 @@ async fn run_all_profiles(json: bool) -> Result<()> {
             if let Ok(storage) = Storage::open_unwatched(profile_name) {
                 if let Ok((instances, _)) = storage.load_with_groups() {
                     for inst in &instances {
+                        if !SessionScope::matches(Some(scope), inst) {
+                            continue;
+                        }
                         all_sessions.push(session_json(inst, profile_name));
                     }
                 }
@@ -184,18 +314,23 @@ async fn run_all_profiles(json: bool) -> Result<()> {
         return Ok(());
     }
 
+    let show_state = table_shows_state(scope);
     let mut total_sessions = 0;
     for profile_name in &profiles {
         if let Ok(storage) = Storage::open_unwatched(profile_name) {
-            if let Ok((instances, _)) = storage.load_with_groups() {
+            if let Ok((all_instances, _)) = storage.load_with_groups() {
+                let instances: Vec<&Instance> = all_instances
+                    .iter()
+                    .filter(|inst| SessionScope::matches(Some(scope), inst))
+                    .collect();
                 if instances.is_empty() {
                     continue;
                 }
 
                 println!("\n═══ Profile: {} ═══\n", profile_name);
-                print_table_header();
+                print_table_header(show_state);
                 for inst in &instances {
-                    print_table_row(inst);
+                    print_table_row(inst, show_state);
                 }
                 println!("({} sessions)", instances.len());
                 total_sessions += instances.len();
@@ -211,4 +346,89 @@ async fn run_all_profiles(json: bool) -> Result<()> {
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_tag_covers_the_three_states() {
+        let live = Instance::new("live", "/repo");
+        assert_eq!(state_tag(&live), "live");
+
+        let mut archived = Instance::new("archived", "/repo");
+        archived.archive();
+        assert_eq!(state_tag(&archived), "archived");
+
+        let mut trashed = Instance::new("trashed", "/repo");
+        trashed.trash();
+        assert_eq!(state_tag(&trashed), "trashed");
+    }
+
+    /// #3350: the whole point of the JSON change. A consumer keying on
+    /// state needs the `state` string AND the timestamp to distinguish
+    /// a trashed session from a genuinely failed one without a second
+    /// `aoe session list-trash` shellout.
+    #[test]
+    fn session_json_exposes_state_and_trashed_at_for_a_trashed_row() {
+        let mut inst = Instance::new("z", "/repo");
+        inst.trash();
+        let json = session_json(&inst, "p");
+        assert_eq!(json.state, "trashed");
+        assert!(json.trashed_at.is_some());
+        assert!(json.archived_at.is_none());
+    }
+
+    /// Companion for the follow-up comment on #3350: archived sessions
+    /// need the same treatment. The two states are semantically distinct
+    /// and both must be observable from a single `aoe list --json` call.
+    #[test]
+    fn session_json_exposes_state_and_archived_at_for_an_archived_row() {
+        let mut inst = Instance::new("z", "/repo");
+        inst.archive();
+        let json = session_json(&inst, "p");
+        assert_eq!(json.state, "archived");
+        assert!(json.archived_at.is_some());
+        assert!(json.trashed_at.is_none());
+    }
+
+    /// The default `state = "live"` and both timestamp fields being
+    /// `None` must not serialize any of the state-tracking keys as
+    /// `null`: consumers depending on `serde_if_none` semantics see no
+    /// difference from the pre-#3350 output. The `state` field is a
+    /// small addition and always serialized, so a v1.14.1 consumer that
+    /// parses JSON strictly will see one new key.
+    #[test]
+    fn session_json_omits_absent_timestamps_and_keeps_state_alive() {
+        let inst = Instance::new("z", "/repo");
+        let json = session_json(&inst, "p");
+        assert_eq!(json.state, "live");
+        let serialized = serde_json::to_string(&json).unwrap();
+        assert!(!serialized.contains("trashed_at"));
+        assert!(!serialized.contains("archived_at"));
+        assert!(serialized.contains("\"state\":\"live\""));
+    }
+
+    /// Backward-compat: `aoe list` (no `--state`) shows what it always
+    /// showed, i.e. every persisted session. Guards against a future
+    /// well-meaning refactor flipping the default to `live` and quietly
+    /// dropping trashed rows for anyone scripted against today's output.
+    #[test]
+    fn default_state_is_all_for_backward_compat() {
+        let default: SessionScope = StateFilter::All.into();
+        assert!(matches!(default, SessionScope::All));
+
+        let live_inst = Instance::new("l", "/r");
+        let mut trashed = Instance::new("t", "/r");
+        trashed.trash();
+        let mut archived = Instance::new("a", "/r");
+        archived.archive();
+        for inst in [&live_inst, &trashed, &archived] {
+            assert!(
+                SessionScope::matches(Some(default), inst),
+                "default state=all must list every session"
+            );
+        }
+    }
 }

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use clap::{Args, ValueEnum};
 use serde::Serialize;
 
-use crate::session::{Instance, SessionScope, Storage};
+use crate::session::{Instance, SessionBucket, SessionScope, Storage};
 
 const TABLE_COL_TITLE: usize = 20;
 const TABLE_COL_GROUP: usize = 15;
@@ -49,29 +49,30 @@ pub struct ListArgs {
     #[arg(long)]
     all: bool,
 
-    /// Filter by session state. Default is `all` (every persisted session,
-    /// which is what `aoe list` has always shown). #3350 added the flag so a
-    /// scripted consumer can pass `--state=live` to skip trashed and
-    /// archived rows without a second `aoe session list-trash` shellout,
-    /// mirroring the REST API's `state=live|trashed|all` from #3187.
-    /// Rejects any other value at parse time.
+    /// Filter by session state. Defaults to `all`, every persisted session,
+    /// which is what `aoe list` has always shown. Pass `--state=live` to skip
+    /// trashed and archived rows; the vocabulary matches the REST API's
+    /// `GET /api/sessions?state=`.
     #[arg(long, value_enum, default_value_t = StateFilter::All)]
     state: StateFilter,
 }
 
 /// Simple string tag describing whether a session is live/archived/trashed,
 /// exposed alongside `trashed_at`/`archived_at` in `--json` so a consumer
-/// keying on state does not have to reason about the timestamps itself. The
-/// wire values match [`SessionScope`] (`live`/`trashed`), plus `archived`
-/// for the archive-but-not-trash case which the API happens to fold into
-/// `live` today.
+/// keying on state does not have to reason about the timestamps itself.
+/// `live` and `trashed` are the [`SessionScope`] filter vocabulary; `archived`
+/// is an output-only third value, since `--state=archived` is not a filter the
+/// API offers either (an archived row is excluded by `live` and by `trashed`,
+/// and only shows under `all`).
+///
+/// Derived from [`Instance::effective_bucket`] so the `Trashed > Archived >
+/// Active` precedence has exactly one definition: an archived row that is then
+/// trashed keeps its `archived_at` but reports `trashed`.
 fn state_tag(inst: &Instance) -> &'static str {
-    if inst.is_trashed() {
-        "trashed"
-    } else if inst.is_archived() {
-        "archived"
-    } else {
-        "live"
+    match inst.effective_bucket() {
+        SessionBucket::Trashed => "trashed",
+        SessionBucket::Archived => "archived",
+        SessionBucket::Active => "live",
     }
 }
 
@@ -94,9 +95,10 @@ struct SessionJson {
     /// second `aoe session list-trash` shellout.
     #[serde(skip_serializing_if = "Option::is_none")]
     trashed_at: Option<chrono::DateTime<chrono::Utc>>,
-    /// Set iff the session is currently archived (trash's a strict superset
-    /// of archived on the store, but the two states are semantically distinct
-    /// and #3350's follow-up comment asked for archive to be readable too).
+    /// Set iff the session is currently archived. Orthogonal to `trashed_at`
+    /// on the store: `trash()` deliberately leaves `archived_at` alone so a
+    /// restore is faithful, so both keys can be present at once and `state`
+    /// reports `trashed` in that case.
     #[serde(skip_serializing_if = "Option::is_none")]
     archived_at: Option<chrono::DateTime<chrono::Utc>>,
     /// Empty for single-repo sessions; populated with one entry per repo
@@ -261,17 +263,22 @@ pub async fn run(profile: &str, args: ListArgs) -> Result<()> {
         .filter(|inst| SessionScope::matches(Some(scope), inst))
         .collect();
 
-    if instances.is_empty() {
-        println!("No sessions found in profile '{}'.", storage.profile());
-        return Ok(());
-    }
-
+    // `--json` is answered before the empty-listing message: an empty result is
+    // `[]`, never human prose on stdout, matching `aoe ps --json` and `aoe group
+    // list --json`. `--state=live` makes this reachable with sessions present
+    // (a profile whose rows are all trashed), which is precisely the scripted
+    // consumer #3350 is about.
     if args.json {
         let sessions: Vec<SessionJson> = instances
             .iter()
             .map(|inst| session_json(inst, storage.profile()))
             .collect();
         super::output::print_json(&sessions)?;
+        return Ok(());
+    }
+
+    if instances.is_empty() {
+        println!("No sessions found in profile '{}'.", storage.profile());
         return Ok(());
     }
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -595,10 +595,6 @@ pub async fn get_recent_projects() -> Json<RecentProjectsResponse> {
     Json(RecentProjectsResponse { projects })
 }
 
-/// Archival scope for `GET /api/sessions?state=`. `Live` excludes archived
-/// and trashed rows so a headless dispatcher polling the list doesn't have
-/// to know to filter `trashed_at`/`archived_at` client-side; `All` (or no
-/// `state` param) keeps the historical unfiltered behavior the web
 /// Query params for `GET /api/sessions`. `state` shares its vocabulary with
 /// the CLI's `aoe list --state` via [`crate::session::SessionScope`] so a
 /// future third caller cannot drift.

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -599,26 +599,12 @@ pub async fn get_recent_projects() -> Json<RecentProjectsResponse> {
 /// and trashed rows so a headless dispatcher polling the list doesn't have
 /// to know to filter `trashed_at`/`archived_at` client-side; `All` (or no
 /// `state` param) keeps the historical unfiltered behavior the web
-/// dashboard's client-side Trash view still relies on. See #3156.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum SessionScope {
-    Live,
-    Trashed,
-    All,
-}
-
+/// Query params for `GET /api/sessions`. `state` shares its vocabulary with
+/// the CLI's `aoe list --state` via [`crate::session::SessionScope`] so a
+/// future third caller cannot drift.
 #[derive(Deserialize)]
 pub struct ListSessionsQuery {
-    pub state: Option<SessionScope>,
-}
-
-fn instance_matches_scope(inst: &Instance, scope: Option<SessionScope>) -> bool {
-    match scope {
-        None | Some(SessionScope::All) => true,
-        Some(SessionScope::Live) => !inst.is_archived() && !inst.is_trashed(),
-        Some(SessionScope::Trashed) => inst.is_trashed(),
-    }
+    pub state: Option<crate::session::SessionScope>,
 }
 
 pub async fn list_sessions(
@@ -642,7 +628,7 @@ pub async fn list_sessions(
         // it never appears in the list. The lifecycle routes apply the matching
         // structured-target gate. See #7.
         .filter(|inst| !state.cityhall_mode || inst.is_structured())
-        .filter(|inst| instance_matches_scope(inst, query.state))
+        .filter(|inst| crate::session::SessionScope::matches(query.state, inst))
         .collect();
     let mut sessions: Vec<SessionResponse> = scoped_instances
         .iter()
@@ -7603,7 +7589,7 @@ mod tests {
         let live_only = list_sessions(
             axum::extract::State(state.clone()),
             axum::extract::Query(ListSessionsQuery {
-                state: Some(SessionScope::Live),
+                state: Some(crate::session::SessionScope::Live),
             }),
         )
         .await;
@@ -7612,7 +7598,7 @@ mod tests {
         let trashed_only = list_sessions(
             axum::extract::State(state.clone()),
             axum::extract::Query(ListSessionsQuery {
-                state: Some(SessionScope::Trashed),
+                state: Some(crate::session::SessionScope::Trashed),
             }),
         )
         .await;
@@ -7621,7 +7607,7 @@ mod tests {
         let explicit_all = list_sessions(
             axum::extract::State(state),
             axum::extract::Query(ListSessionsQuery {
-                state: Some(SessionScope::All),
+                state: Some(crate::session::SessionScope::All),
             }),
         )
         .await;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -33,6 +33,7 @@ pub mod projects;
 pub(crate) mod recovery;
 pub mod repo_config;
 pub mod restart;
+pub mod scope;
 pub mod scratch;
 pub(crate) mod serde_helpers;
 pub mod settings_schema;
@@ -131,6 +132,7 @@ pub use repo_config::{
     resolve_config_with_repo_or_warn, save_repo_config, trust_repo, HookTimeout, HooksConfig,
     RepoConfig, RepoTrust, TrustSurface,
 };
+pub use scope::SessionScope;
 pub(crate) use storage::{atomic_write, resolve_symlink_chain};
 pub use storage::{
     load_recent_projects, load_workspace_ordering, recent_project_entry_for, record_recent_project,

--- a/src/session/scope.rs
+++ b/src/session/scope.rs
@@ -1,0 +1,108 @@
+//! State filter shared by the CLI (`aoe list --state`) and the daemon
+//! REST API (`GET /api/sessions?state=`) so the two vocabularies cannot
+//! drift. See #3350 for the CLI parity motivation and #3156/#3187 for
+//! the API's original design.
+
+use serde::Deserialize;
+
+use super::Instance;
+
+/// Which "state" of session a caller wants. The variants are the wire
+/// vocabulary (`state=live|trashed|all`); `#[serde(rename_all = "lowercase")]`
+/// pins that and rejects any other value at deserialize time so a typo
+/// surfaces as an error rather than silently returning every session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionScope {
+    /// The default in every current caller: sessions that are neither
+    /// archived nor trashed. Matches what a user thinks of as "my active
+    /// sessions".
+    Live,
+    /// Sessions currently in the trash (`remove` but not yet purged). Kept
+    /// separate because #3156 flagged that an external supervisor keying on
+    /// "does my session still exist" would otherwise treat a trashed row as
+    /// alive.
+    Trashed,
+    /// Every persisted session, regardless of state. Used by the dashboard's
+    /// client-side Trash view (which still filters locally, #3187) and by
+    /// tests that need to count everything.
+    All,
+}
+
+impl SessionScope {
+    /// Does `inst` belong in a listing filtered by `scope`? `None` (no filter
+    /// specified by the caller) behaves like `All`, matching the historical
+    /// unfiltered behavior so nothing breaks.
+    pub fn matches(scope: Option<SessionScope>, inst: &Instance) -> bool {
+        match scope {
+            None | Some(SessionScope::All) => true,
+            Some(SessionScope::Live) => !inst.is_archived() && !inst.is_trashed(),
+            Some(SessionScope::Trashed) => inst.is_trashed(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The lowercase wire names are how the REST API and the CLI both parse
+    /// the value. Pin them so a rename can't drift out of sync.
+    #[test]
+    fn deserializes_lowercase_wire_names() {
+        assert_eq!(
+            serde_json::from_str::<SessionScope>("\"live\"").unwrap(),
+            SessionScope::Live
+        );
+        assert_eq!(
+            serde_json::from_str::<SessionScope>("\"trashed\"").unwrap(),
+            SessionScope::Trashed
+        );
+        assert_eq!(
+            serde_json::from_str::<SessionScope>("\"all\"").unwrap(),
+            SessionScope::All
+        );
+    }
+
+    #[test]
+    fn rejects_unrecognized_value() {
+        assert!(serde_json::from_str::<SessionScope>("\"archived\"").is_err());
+        assert!(serde_json::from_str::<SessionScope>("\"LIVE\"").is_err());
+        assert!(serde_json::from_str::<SessionScope>("\"\"").is_err());
+    }
+
+    #[test]
+    fn matches_no_scope_returns_everything() {
+        let mut live = Instance::new("live", "/repo");
+        assert!(SessionScope::matches(None, &live));
+        live.archive();
+        assert!(SessionScope::matches(None, &live));
+    }
+
+    #[test]
+    fn matches_live_excludes_archived_and_trashed() {
+        let live = Instance::new("live", "/repo");
+        let mut archived = Instance::new("arch", "/repo");
+        archived.archive();
+        let mut trashed = Instance::new("trash", "/repo");
+        trashed.trash();
+
+        assert!(SessionScope::matches(Some(SessionScope::Live), &live));
+        assert!(!SessionScope::matches(Some(SessionScope::Live), &archived));
+        assert!(!SessionScope::matches(Some(SessionScope::Live), &trashed));
+    }
+
+    #[test]
+    fn matches_trashed_is_trashed_only() {
+        let mut trashed = Instance::new("t", "/repo");
+        trashed.trash();
+        let mut archived = Instance::new("a", "/repo");
+        archived.archive();
+
+        assert!(SessionScope::matches(Some(SessionScope::Trashed), &trashed));
+        assert!(!SessionScope::matches(
+            Some(SessionScope::Trashed),
+            &archived
+        ));
+    }
+}

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -2067,5 +2067,10 @@ fn test_cli_list_state_filter_and_json_shape() {
     let trashed: serde_json::Value =
         serde_json::from_slice(&h.run_cli(&["list", "--json", "--state=trashed"]).stdout)
             .expect("list --json --state=trashed must emit JSON");
+    // Assert the row's state, not just its title: with a single-row fixture a
+    // title-only check would still pass if `--state=trashed` were ignored and
+    // the live row returned instead. The state field pins the filter contract.
     assert_eq!(trashed[0]["title"], "State Probe");
+    assert_eq!(trashed[0]["state"], "trashed");
+    assert!(trashed[0]["trashed_at"].is_string());
 }

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -2018,3 +2018,54 @@ fn test_cli_send_waits_for_slow_boot_before_typing() {
         .args(["kill-session", "-t", &tmux_name])
         .output();
 }
+
+/// #3350: the `aoe list --state` contract a scripted consumer relies on.
+/// A trashed session must report `state: "trashed"` with a `trashed_at`
+/// stamp, must be excluded by `--state=live`, and the resulting empty
+/// listing must still be `[]` on the `--json` path rather than the
+/// human "No sessions found" line, which a `jq` consumer cannot parse.
+#[test]
+#[parallel]
+fn test_cli_list_state_filter_and_json_shape() {
+    let h = TuiTestHarness::new("cli_list_state");
+    let project = h.project_path();
+
+    let add = h.run_cli(&["add", project.to_str().unwrap(), "-t", "State Probe"]);
+    assert!(
+        add.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    let live: serde_json::Value =
+        serde_json::from_slice(&h.run_cli(&["list", "--json", "--state=live"]).stdout)
+            .expect("list --json --state=live must emit JSON");
+    assert_eq!(live[0]["state"], "live");
+    assert!(live[0].get("trashed_at").is_none());
+
+    let rm = h.run_cli(&["rm", "State Probe"]);
+    assert!(
+        rm.status.success(),
+        "aoe rm failed: {}",
+        String::from_utf8_lossy(&rm.stderr)
+    );
+
+    let all: serde_json::Value = serde_json::from_slice(&h.run_cli(&["list", "--json"]).stdout)
+        .expect("list --json must emit JSON");
+    assert_eq!(all[0]["state"], "trashed");
+    assert!(all[0]["trashed_at"].is_string());
+
+    let out = h.run_cli(&["list", "--json", "--state=live"]);
+    let empty: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap_or_else(|e| {
+        panic!(
+            "list --json with no matching rows must emit `[]`, got {:?} ({e})",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    });
+    assert_eq!(empty, serde_json::json!([]));
+
+    let trashed: serde_json::Value =
+        serde_json::from_slice(&h.run_cli(&["list", "--json", "--state=trashed"]).stdout)
+            .expect("list --json --state=trashed must emit JSON");
+    assert_eq!(trashed[0]["title"], "State Probe");
+}


### PR DESCRIPTION
## Description

Closes #3350.

`aoe list --json` records carried no `state` field and no `trashed_at`/`archived_at` timestamps, so a scripted consumer that provisions sessions could not distinguish a trashed session from a genuinely failed one. `aoe list` still shows the trashed row (title, path, id, etc.), so an external tool sees a title-collision on `aoe add` and cannot tell whether the existing row is live, trashed, or archived without a second `aoe session list-trash` shellout — and that command has no `--json` output either.

The REST API already solved this in #3187 with `GET /api/sessions?state=live|trashed|all`, rejecting an unrecognized value with a `400`. This PR mirrors that vocabulary in the CLI.

## Changes

- New `aoe list --state <live|trashed|all>` clap flag, defaulting to `all` (today's unfiltered behavior, preserved verbatim so nothing scripted against v1.14.1 breaks). Clap rejects an unrecognized value at parse time, mirroring the API's `400` behavior.
- New fields on the `SessionJson` record: `state: "live" | "trashed" | "archived"` (always present, one new key on the wire) plus `trashed_at` and `archived_at` (both `skip_if_none`, so a live row's JSON adds only the `state` key relative to v1.14.1).
- Human-readable table gains a `STATE` column only under `--state=all` where rows are mixed. Under `--state=live` or `--state=trashed` every row has the same state, so the column would carry no information and the header stays as it was.
- New `src/session/scope.rs` moves the API's `SessionScope` enum out of `src/server/api/sessions.rs` into a bare-core module so the CLI (bare-core) and the serve daemon share one source of truth and cannot drift. The API's inline `instance_matches_scope` collapses into `SessionScope::matches`.

## Follow-ups the issue mentions but this PR does not cover

The issue reporter listed a few adjacent gaps that would be well-suited to follow-up PRs; this PR is deliberately scoped to the `aoe list` changes it names:

- Archive-only, snooze, and favorite filters on `aoe list` (`--state` covers `trashed` and `archived` as observable state today; distinct filters would let a consumer split them further).
- Matching `--state` / `--json` treatment on `aoe session show` and `aoe session list-trash`.
- Applying the `state` field to `aoe status --json` counts so trashed rows are not double-counted (adjacent to #3258).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

Titled `feat(cli):` because the observable behavior of `aoe list` (new flag, new JSON keys) is additive, but the motivating class of bug is the trashed/failed indistinguishability the issue is filed under. Either prefix would be defensible; happy to rename the commit before merge if the maintainer prefers.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

CLI change, no visual surface. `docs/cli/reference.md` regenerated via `cargo xtask gen-docs` and committed.

## Test Coverage Analysis

Web dashboard / structured view (Playwright user story)
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The REST API's existing behavior is unchanged; the API's `SessionScope` enum moved to a shared module but keeps its serde behavior (round-trip tests preserved on the shared type). No dashboard control flow moves.

TUI / CLI (e2e test)
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

The change adds an optional flag and additional JSON keys; no lifecycle. Full unit coverage on the state tag, JSON output shape, backward-compat default, and the shared filter predicate.

Tests added (all bare-core, no `#[serial]` needed since none touch `HOME`/env):

- `src/session/scope.rs`: `SessionScope` deserializes lowercase wire names; rejects unrecognized values (mirrors API's #3187); `matches` predicates for no-scope / live / trashed.
- `src/cli/list.rs`: `state_tag` covers all three states; `session_json` exposes state+timestamp for trashed and archived rows; a live row's JSON omits `trashed_at`/`archived_at` (backward-compat with pre-#3350 parsers that don't expect the keys); `default_state_is_all_for_backward_compat` guards against a future refactor flipping the default to `live` and dropping trashed rows for anyone scripted against today's output.

Verified locally: `cargo fmt --all -- --check`, `cargo clippy -- -D warnings` (both featuresets), `cargo test --lib` (4500 pass), `cargo test --no-default-features --lib` (4500 pass), `cargo xtask gen-docs` (committed).

## AI Usage

- [ ] No AI was used
- [x] AI was used

AI Model/Tool used: Claude Code (Opus 4.8)

Any Additional AI Details you'd like to share:

Skipped the multi-agent chain for this issue: the issue body pinpoints the exact touch points (`ListArgs`, `session_json`, the API's `SessionScope`) and the design is a small mirror of the already-shipped `GET /api/sessions?state=` from #3187. I read the API's implementation, moved `SessionScope` to a bare-core module, and wired the CLI through it. I reviewed the whole diff, understand it, and will answer reviewer feedback in my own words.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `aoe list --state <live|trashed|all>`, with `all` as the default.
- Added session state and optional `trashed_at` and `archived_at` fields to JSON output.
- Added a `STATE` column to human-readable listings when needed.
- Centralized `SessionScope` for shared use by the CLI and REST API.
- Added validation, documentation, and unit and end-to-end test coverage.

## Benefits

- Consumers can identify live, trashed, and archived sessions without extra CLI calls.
- Existing listing behavior remains unchanged by default.
- Shared state handling reduces duplicated CLI and API logic.

## Potential follow-up

- Add state handling for archive-only, snooze, favorite, and related commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->