### PR TITLE
fix(tui): report sandbox container usage in System Health

### DIFF
--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod image_update;
 mod runtime;
 pub(crate) mod runtime_base;
+pub mod stats;
 
 use std::collections::HashMap;
 
@@ -47,6 +48,21 @@ pub fn batch_container_health() -> HashMap<String, bool> {
         count = map.len(),
         duration_ms = start.elapsed().as_millis() as u64,
         "batch container health fetched",
+    );
+    map
+}
+
+/// Resource usage of every aoe sandbox container, in a single subprocess call.
+/// Returns a map of container name -> stats; a container the runtime has no
+/// usable sample for is absent rather than zeroed.
+pub fn batch_container_stats() -> stats::StatsMap {
+    let start = std::time::Instant::now();
+    let map = get_container_runtime().batch_stats("aoe-sandbox-");
+    tracing::debug!(
+        target: "containers.runtime",
+        count = map.len(),
+        duration_ms = start.elapsed().as_millis() as u64,
+        "batch container stats fetched",
     );
     map
 }

--- a/src/containers/runtime.rs
+++ b/src/containers/runtime.rs
@@ -408,6 +408,45 @@ impl ContainerRuntime {
             }
         }
     }
+
+    /// Resource usage of every running container named with `prefix`, in a
+    /// single subprocess call.
+    ///
+    /// `--no-stream` still costs seconds, because the runtime samples every
+    /// running container twice to produce a CPU delta; callers go through
+    /// [`super::stats::cached_stats`] rather than calling this on a UI cadence.
+    pub fn batch_stats(&self, prefix: &str) -> super::stats::StatsMap {
+        match self.kind {
+            RuntimeKind::Docker | RuntimeKind::Podman => {
+                let output = self
+                    .base
+                    .command()
+                    .args([
+                        "stats",
+                        "--no-stream",
+                        "--format",
+                        // A literal tab, not the `\t` escape: the argv reaches
+                        // the runtime without a shell, and Go template text is
+                        // emitted verbatim either way.
+                        "{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.PIDs}}",
+                    ])
+                    .output();
+
+                let output = match output {
+                    Ok(o) if o.status.success() => o,
+                    _ => return super::stats::StatsMap::new(),
+                };
+
+                super::stats::parse_stats_output(&String::from_utf8_lossy(&output.stdout), prefix)
+            }
+            // Apple's `container` CLI has no stats subcommand, so a sandbox on
+            // that runtime reports unknown rather than a fabricated number.
+            RuntimeKind::AppleContainer => {
+                let _ = prefix;
+                super::stats::StatsMap::new()
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/containers/runtime.rs
+++ b/src/containers/runtime.rs
@@ -418,6 +418,12 @@ impl ContainerRuntime {
     pub fn batch_stats(&self, prefix: &str) -> super::stats::StatsMap {
         match self.kind {
             RuntimeKind::Docker | RuntimeKind::Podman => {
+                // Stats everything and prefix-filters the rows, unlike
+                // `batch_running_states`, which narrows with `--filter name=`.
+                // The asymmetry is deliberate: `stats` has no `--filter`, and
+                // naming containers positionally fails the whole call with
+                // "No such container" if any one of them is gone, which is a
+                // normal state for a session whose sandbox has stopped.
                 let output = self
                     .base
                     .command()

--- a/src/containers/stats.rs
+++ b/src/containers/stats.rs
@@ -34,44 +34,60 @@ struct Cache {
     fetched_at: Option<Instant>,
 }
 
-fn cache() -> &'static Mutex<Cache> {
+/// The cache guard, recovering from poisoning rather than propagating it. The
+/// data behind the lock is a plain map with no invariant a panicking writer
+/// could have half-broken, and treating a poisoned lock as fatal would strand
+/// every later sandbox row on "?" for the rest of the process.
+fn cache() -> std::sync::MutexGuard<'static, Cache> {
     static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
-    CACHE.get_or_init(|| {
-        Mutex::new(Cache {
-            map: Arc::default(),
-            fetched_at: None,
+    CACHE
+        .get_or_init(|| {
+            Mutex::new(Cache {
+                map: Arc::default(),
+                fetched_at: None,
+            })
         })
-    })
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 /// Set while a refresh thread is in flight, so a caller polling every second
 /// never stacks up a second `docker stats` behind a slow one.
 static REFRESHING: AtomicBool = AtomicBool::new(false);
 
+/// Clears [`REFRESHING`] on drop, so a refresh that panics does not latch the
+/// flag and silently block every later refresh.
+struct RefreshGuard;
+
+impl Drop for RefreshGuard {
+    fn drop(&mut self) {
+        REFRESHING.store(false, Ordering::SeqCst);
+    }
+}
+
 /// The most recent sandbox container stats, starting a background refresh when
-/// the cached map has aged past [`STATS_TTL`].
+/// the cached map has aged past `STATS_TTL`.
 ///
 /// Never blocks. The first call after the pane opens returns an empty map and
 /// the row reads "?" until the refresh lands; that beats stalling the host
 /// CPU/memory sample behind a multi-second subprocess.
 pub fn cached_stats() -> Arc<StatsMap> {
-    let (map, stale) = match cache().lock() {
-        Ok(cache) => (
+    let (map, stale) = {
+        let cache = cache();
+        (
             cache.map.clone(),
             cache.fetched_at.is_none_or(|at| at.elapsed() >= STATS_TTL),
-        ),
-        Err(_) => return Arc::default(),
+        )
     };
     if stale && !REFRESHING.swap(true, Ordering::SeqCst) {
         let spawned = std::thread::Builder::new()
             .name("aoe-container-stats".to_string())
             .spawn(|| {
+                let _guard = RefreshGuard;
                 let fresh = super::batch_container_stats();
-                if let Ok(mut cache) = cache().lock() {
-                    cache.map = Arc::new(fresh);
-                    cache.fetched_at = Some(Instant::now());
-                }
-                REFRESHING.store(false, Ordering::SeqCst);
+                let mut cache = cache();
+                cache.map = Arc::new(fresh);
+                cache.fetched_at = Some(Instant::now());
             });
         if spawned.is_err() {
             REFRESHING.store(false, Ordering::SeqCst);

--- a/src/containers/stats.rs
+++ b/src/containers/stats.rs
@@ -1,0 +1,203 @@
+//! Container resource sampling for the TUI system-health table.
+//!
+//! A sandbox session's tmux pane holds a `docker exec` client, not the agent:
+//! the agent runs inside the container, off the pane's host process tree
+//! entirely (its own cgroup on Linux, a different VM on macOS). Walking the
+//! pane pid therefore measures the CLI client, so sandbox rows read the
+//! runtime's own accounting instead.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// One container's resource usage, as the runtime reports it.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct ContainerStats {
+    /// Percent of a single core, matching `docker stats`: 100.0 is one core
+    /// saturated, so a container busy on four cores reads 400.
+    pub cpu_percent: f64,
+    pub mem_used_bytes: u64,
+    pub pids: usize,
+}
+
+pub type StatsMap = HashMap<String, ContainerStats>;
+
+/// `docker stats --no-stream` re-samples every running container to compute a
+/// CPU delta, which costs ~2s on a host running a couple dozen sandboxes. That
+/// cannot ride the 1s metrics cadence, so the refresh runs on its own thread
+/// and callers read whatever the last completed pass left behind.
+const STATS_TTL: Duration = Duration::from_secs(5);
+
+struct Cache {
+    map: Arc<StatsMap>,
+    fetched_at: Option<Instant>,
+}
+
+fn cache() -> &'static Mutex<Cache> {
+    static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        Mutex::new(Cache {
+            map: Arc::default(),
+            fetched_at: None,
+        })
+    })
+}
+
+/// Set while a refresh thread is in flight, so a caller polling every second
+/// never stacks up a second `docker stats` behind a slow one.
+static REFRESHING: AtomicBool = AtomicBool::new(false);
+
+/// The most recent sandbox container stats, starting a background refresh when
+/// the cached map has aged past [`STATS_TTL`].
+///
+/// Never blocks. The first call after the pane opens returns an empty map and
+/// the row reads "?" until the refresh lands; that beats stalling the host
+/// CPU/memory sample behind a multi-second subprocess.
+pub fn cached_stats() -> Arc<StatsMap> {
+    let (map, stale) = match cache().lock() {
+        Ok(cache) => (
+            cache.map.clone(),
+            cache.fetched_at.is_none_or(|at| at.elapsed() >= STATS_TTL),
+        ),
+        Err(_) => return Arc::default(),
+    };
+    if stale && !REFRESHING.swap(true, Ordering::SeqCst) {
+        let spawned = std::thread::Builder::new()
+            .name("aoe-container-stats".to_string())
+            .spawn(|| {
+                let fresh = super::batch_container_stats();
+                if let Ok(mut cache) = cache().lock() {
+                    cache.map = Arc::new(fresh);
+                    cache.fetched_at = Some(Instant::now());
+                }
+                REFRESHING.store(false, Ordering::SeqCst);
+            });
+        if spawned.is_err() {
+            REFRESHING.store(false, Ordering::SeqCst);
+        }
+    }
+    map
+}
+
+/// Parse the rows of `<runtime> stats --no-stream --format
+/// "{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.PIDs}}"`, keeping only the
+/// containers named with `prefix`.
+pub(crate) fn parse_stats_output(stdout: &str, prefix: &str) -> StatsMap {
+    stdout
+        .lines()
+        .filter_map(parse_stats_line)
+        .filter(|(name, _)| name.starts_with(prefix))
+        .collect()
+}
+
+/// One tab-separated stats row. A container that is restarting reports `--`
+/// for the figures it has no sample for; those rows are dropped rather than
+/// read as a real zero.
+fn parse_stats_line(line: &str) -> Option<(String, ContainerStats)> {
+    let mut parts = line.split('\t');
+    let name = parts.next()?.trim();
+    let cpu = parts.next()?.trim();
+    let mem = parts.next()?.trim();
+    let pids = parts.next()?.trim();
+    if name.is_empty() {
+        return None;
+    }
+    let cpu_percent = cpu.strip_suffix('%')?.trim().parse().ok()?;
+    // MemUsage is "used / limit"; the limit is the container's cap, which no
+    // health surface shows today, so only the used side is kept.
+    let mem_used_bytes = parse_size(mem.split('/').next()?)?;
+    Some((
+        name.to_string(),
+        ContainerStats {
+            cpu_percent,
+            mem_used_bytes,
+            pids: pids.parse().ok()?,
+        },
+    ))
+}
+
+/// A runtime-formatted byte size. Docker prints binary units (`3.085GiB`),
+/// podman decimal ones (`1.045MB`), so both suffix families are accepted.
+fn parse_size(text: &str) -> Option<u64> {
+    let text = text.trim();
+    let unit_at = text.find(|c: char| c.is_ascii_alphabetic())?;
+    let (value, unit) = text.split_at(unit_at);
+    let value: f64 = value.trim().parse().ok()?;
+    let multiplier: f64 = match unit.trim() {
+        "B" => 1.0,
+        "kB" | "KB" => 1e3,
+        "MB" => 1e6,
+        "GB" => 1e9,
+        "TB" => 1e12,
+        "KiB" | "kiB" => 1024.0,
+        "MiB" => 1024f64.powi(2),
+        "GiB" => 1024f64.powi(3),
+        "TiB" => 1024f64.powi(4),
+        _ => return None,
+    };
+    (value >= 0.0).then(|| (value * multiplier).round() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_size_accepts_both_unit_families() {
+        let cases = [
+            ("0B", Some(0)),
+            ("512B", Some(512)),
+            ("1022MiB", Some(1022 * (1 << 20))),
+            ("450.4MiB", Some(472_278_630)),
+            ("3.085GiB", Some(3_312_493_527)),
+            ("20GiB", Some(20 * (1 << 30))),
+            // podman's decimal units must not be read as binary ones.
+            ("1.045MB", Some(1_045_000)),
+            ("16.62GB", Some(16_620_000_000)),
+            ("--", None),
+            ("12", None),
+            ("MiB", None),
+            ("1.2Xb", None),
+        ];
+        for (text, expected) in cases {
+            assert_eq!(parse_size(text), expected, "size {text:?}");
+        }
+    }
+
+    #[test]
+    fn parse_stats_line_reads_a_docker_row() {
+        let (name, stats) =
+            parse_stats_line("aoe-sandbox-32f0940b\t82.30%\t3.085GiB / 20GiB\t36").expect("row");
+        assert_eq!(name, "aoe-sandbox-32f0940b");
+        assert_eq!(stats.cpu_percent, 82.30);
+        assert_eq!(stats.mem_used_bytes, 3_312_493_527);
+        assert_eq!(stats.pids, 36);
+    }
+
+    #[test]
+    fn parse_stats_line_rejects_unusable_rows() {
+        let cases = [
+            // A restarting container reports no sample; a zero would read as
+            // a live, idle container.
+            "aoe-sandbox-a\t--\t-- / --\t0",
+            "aoe-sandbox-a\t12.0\t1MiB / 2MiB\t3", // CPU missing its percent
+            "aoe-sandbox-a\t12.0%\t1MiB / 2MiB",   // truncated row
+            "\t12.0%\t1MiB / 2MiB\t3",             // no name
+            "",
+        ];
+        for line in cases {
+            assert!(parse_stats_line(line).is_none(), "line {line:?}");
+        }
+    }
+
+    #[test]
+    fn parse_stats_output_keeps_only_prefixed_containers() {
+        let stdout = "aoe-sandbox-a1\t1.00%\t100MiB / 20GiB\t7\n\
+                      clawbolt-pg\t0.00%\t75.01MiB / 30.56GiB\t6\n\
+                      not-aoe-sandbox-a2\t2.00%\t200MiB / 20GiB\t8\n";
+        let map = parse_stats_output(stdout, "aoe-sandbox-");
+        assert_eq!(map.keys().collect::<Vec<_>>(), ["aoe-sandbox-a1"]);
+        assert_eq!(map["aoe-sandbox-a1"].pids, 7);
+    }
+}

--- a/src/process/metrics.rs
+++ b/src/process/metrics.rs
@@ -146,6 +146,62 @@ fn eligible_instance(inst: &Instance) -> bool {
         )
 }
 
+/// One row's figures: `(cpu_fraction, memory_bytes, procs)`.
+type RowFigures = (Option<f64>, Option<u64>, Option<usize>);
+
+/// The sandbox container backing `inst`, if it has one. Both agent populations
+/// route through this, so a tmux pane and a structured worker cannot disagree
+/// about whether a session is sandboxed.
+fn sandbox_container_name(inst: &Instance) -> Option<&str> {
+    inst.sandbox_info
+        .as_ref()
+        .filter(|s| s.enabled)
+        .map(|s| s.container_name.as_str())
+}
+
+/// Figures as the container runtime reports them, or all-unknown when it has
+/// no sample for this container: a cold cache, a stopped container, or a
+/// runtime with no stats command. Unknown renders "?"; a zero would read as a
+/// measured idle.
+fn container_figures(stats: &crate::containers::stats::StatsMap, name: &str) -> RowFigures {
+    match stats.get(name) {
+        Some(stats) => (
+            // `cpu_percent` is per-core (100 == one core saturated); the table
+            // reads as a share of the whole host, like the host rows.
+            Some(stats.cpu_percent / 100.0 / logical_cpus() as f64),
+            Some(stats.mem_used_bytes),
+            Some(stats.pids),
+        ),
+        None => (None, None, None),
+    }
+}
+
+/// Figures summed over a host process tree.
+fn host_figures(
+    pids: &[u32],
+    by_pid: &HashMap<u32, &ProcessRecord>,
+    elapsed: Option<f64>,
+    previous: &HashMap<(u32, u64), f64>,
+) -> RowFigures {
+    let rss_bytes = pids
+        .iter()
+        .filter_map(|pid| by_pid.get(pid))
+        .map(|p| p.rss_bytes)
+        .sum();
+    let cpu_fraction = elapsed.filter(|v| *v > 0.0).map(|seconds| {
+        pids.iter()
+            .filter_map(|pid| by_pid.get(pid))
+            .filter_map(|p| {
+                let old = previous.get(&(p.pid, p.start_id))?;
+                Some((p.cpu_seconds - old).max(0.0))
+            })
+            .sum::<f64>()
+            / seconds
+            / logical_cpus() as f64
+    });
+    (cpu_fraction, Some(rss_bytes), Some(pids.len()))
+}
+
 fn aggregate_agents(
     instances: &[Instance],
     processes: &[ProcessRecord],
@@ -168,11 +224,33 @@ fn aggregate_agents(
         .filter(|i| eligible_instance(i))
         .cloned()
         .collect();
-    // Only pay for the runtime's stats pass when a sandbox is actually on
-    // screen; `cached_stats` returns the last completed map without blocking.
-    let container_stats = eligible
-        .iter()
-        .any(|i| i.is_sandboxed())
+    #[cfg(feature = "serve")]
+    let worker_records: Vec<crate::process::worker_registry::WorkerRecord> =
+        crate::process::worker_registry::list()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(crate::process::worker_registry::is_record_live)
+            .collect();
+
+    // Structured sessions are excluded from `eligible`, so their sandboxes
+    // have to be counted here or a host whose only sandbox runs under a
+    // structured worker would never fetch the map its row needs.
+    #[cfg(feature = "serve")]
+    let sandboxed_worker = worker_records.iter().any(|rec| {
+        instances
+            .iter()
+            .any(|i| i.id == rec.session_id && sandbox_container_name(i).is_some())
+    });
+    #[cfg(not(feature = "serve"))]
+    let sandboxed_worker = false;
+
+    // Skip the runtime's stats pass unless a sandbox session is loaded;
+    // `cached_stats` then hands back the last completed map without blocking.
+    // Not gated on the health surface being open: the sampler also runs for
+    // the compact strip and for the undiscovered-tip check, so a host with a
+    // sandbox pays one refresh per TTL whenever the TUI is sampling at all.
+    let container_stats = (eligible.iter().any(|i| sandbox_container_name(i).is_some())
+        || sandboxed_worker)
         .then(crate::containers::stats::cached_stats)
         .unwrap_or_default();
     let alive = crate::session::recovery::orphaned_agents_alive(&eligible);
@@ -203,40 +281,10 @@ fn aggregate_agents(
         // but its figures come from the container instead: the pane holds a
         // `docker exec` client, while the agent runs in the container, off
         // this process tree entirely.
-        let sandbox_container = inst
-            .sandbox_info
-            .as_ref()
-            .filter(|s| s.enabled)
-            .map(|s| s.container_name.as_str());
-        let (cpu_fraction, rss_bytes, procs) = if let Some(name) = sandbox_container {
-            match container_stats.get(name) {
-                Some(stats) => (
-                    // `cpu_percent` is per-core (100 == one core); the table
-                    // reads as a share of the whole host, like the host rows.
-                    Some(stats.cpu_percent / 100.0 / logical_cpus() as f64),
-                    Some(stats.mem_used_bytes),
-                    Some(stats.pids),
-                ),
-                None => (None, None, None),
-            }
-        } else {
-            let rss_bytes = pids
-                .iter()
-                .filter_map(|pid| by_pid.get(pid))
-                .map(|p| p.rss_bytes)
-                .sum();
-            let cpu_fraction = elapsed.filter(|v| *v > 0.0).map(|seconds| {
-                pids.iter()
-                    .filter_map(|pid| by_pid.get(pid))
-                    .filter_map(|p| {
-                        let old = previous.get(&(p.pid, p.start_id))?;
-                        Some((p.cpu_seconds - old).max(0.0))
-                    })
-                    .sum::<f64>()
-                    / seconds
-                    / logical_cpus() as f64
-            });
-            (cpu_fraction, Some(rss_bytes), Some(pids.len()))
+        let sandbox_container = sandbox_container_name(inst);
+        let (cpu_fraction, rss_bytes, procs) = match sandbox_container {
+            Some(name) => container_figures(&container_stats, name),
+            None => host_figures(&pids, &by_pid, elapsed, previous),
         };
         rows.push(AgentMetric {
             id: inst.id.clone(),
@@ -249,11 +297,7 @@ fn aggregate_agents(
     }
 
     #[cfg(feature = "serve")]
-    for rec in crate::process::worker_registry::list()
-        .unwrap_or_default()
-        .into_iter()
-        .filter(crate::process::worker_registry::is_record_live)
-    {
+    for rec in worker_records {
         let Some(root) = by_pid.get(&rec.pid) else {
             continue;
         };
@@ -271,34 +315,25 @@ fn aggregate_agents(
                 stack.extend(children);
             }
         }
-        let rss_bytes = pids
-            .iter()
-            .filter_map(|pid| by_pid.get(pid))
-            .map(|p| p.rss_bytes)
-            .sum();
-        let cpu_fraction = elapsed.filter(|v| *v > 0.0).map(|seconds| {
-            pids.iter()
-                .filter_map(|pid| by_pid.get(pid))
-                .filter_map(|p| {
-                    let old = previous.get(&(p.pid, p.start_id))?;
-                    Some((p.cpu_seconds - old).max(0.0))
-                })
-                .sum::<f64>()
-                / seconds
-                / logical_cpus() as f64
-        });
-        let title = instances
-            .iter()
-            .find(|i| i.id == rec.session_id)
+        // A sandboxed structured session wraps its agent in `docker exec` just
+        // as a tmux pane does (see `spawn_runner_detached`), so the host tree
+        // here is the runner shim plus that client, not the agent.
+        let inst = instances.iter().find(|i| i.id == rec.session_id);
+        let sandbox_container = inst.and_then(sandbox_container_name);
+        let (cpu_fraction, rss_bytes, procs) = match sandbox_container {
+            Some(name) => container_figures(&container_stats, name),
+            None => host_figures(&pids, &by_pid, elapsed, previous),
+        };
+        let title = inst
             .map(|i| i.title.clone())
             .unwrap_or_else(|| rec.agent_name.clone());
         rows.push(AgentMetric {
             id: rec.session_id,
             title,
             cpu_fraction,
-            rss_bytes: Some(rss_bytes),
-            procs: Some(pids.len()),
-            sandboxed: false,
+            rss_bytes,
+            procs,
+            sandboxed: sandbox_container.is_some(),
         });
     }
 

--- a/src/process/metrics.rs
+++ b/src/process/metrics.rs
@@ -36,13 +36,20 @@ pub struct SystemSample {
     pub swap_used_bytes: u64,
 }
 
+/// One agent's resource usage. Every figure is optional because a sandboxed
+/// agent's numbers come from the container runtime, which may not have a
+/// sample yet (or at all, on a runtime without a stats command); reporting
+/// unknown is the honest reading, a zero would not be.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct AgentMetric {
     pub id: String,
     pub title: String,
     pub cpu_fraction: Option<f64>,
-    pub rss_bytes: u64,
-    pub procs: usize,
+    pub rss_bytes: Option<u64>,
+    pub procs: Option<usize>,
+    /// Measured inside a sandbox container rather than on the host process
+    /// tree. The memory figure is then the container's usage, not an RSS sum.
+    pub sandboxed: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -104,7 +111,7 @@ impl MetricsSampler {
         let agents = aggregate_agents(instances, &processes, elapsed, &self.last_process_cpu);
         let counts = AgentCounts {
             agents: agents.len(),
-            procs: agents.iter().map(|a| a.procs).sum(),
+            procs: agents.iter().filter_map(|a| a.procs).sum(),
         };
 
         self.last_at = Some(now);
@@ -161,6 +168,13 @@ fn aggregate_agents(
         .filter(|i| eligible_instance(i))
         .cloned()
         .collect();
+    // Only pay for the runtime's stats pass when a sandbox is actually on
+    // screen; `cached_stats` returns the last completed map without blocking.
+    let container_stats = eligible
+        .iter()
+        .any(|i| i.is_sandboxed())
+        .then(crate::containers::stats::cached_stats)
+        .unwrap_or_default();
     let alive = crate::session::recovery::orphaned_agents_alive(&eligible);
     for (inst, is_alive) in eligible.iter().zip(alive) {
         if !is_alive {
@@ -184,28 +198,53 @@ fn aggregate_agents(
                 stack.extend(children);
             }
         }
-        let rss_bytes = pids
-            .iter()
-            .filter_map(|pid| by_pid.get(pid))
-            .map(|p| p.rss_bytes)
-            .sum();
-        let cpu_fraction = elapsed.filter(|v| *v > 0.0).map(|seconds| {
-            pids.iter()
+        // The pid tree is still walked for a sandboxed session, so its pane
+        // processes are claimed and cannot be double-counted onto a neighbour,
+        // but its figures come from the container instead: the pane holds a
+        // `docker exec` client, while the agent runs in the container, off
+        // this process tree entirely.
+        let sandbox_container = inst
+            .sandbox_info
+            .as_ref()
+            .filter(|s| s.enabled)
+            .map(|s| s.container_name.as_str());
+        let (cpu_fraction, rss_bytes, procs) = if let Some(name) = sandbox_container {
+            match container_stats.get(name) {
+                Some(stats) => (
+                    // `cpu_percent` is per-core (100 == one core); the table
+                    // reads as a share of the whole host, like the host rows.
+                    Some(stats.cpu_percent / 100.0 / logical_cpus() as f64),
+                    Some(stats.mem_used_bytes),
+                    Some(stats.pids),
+                ),
+                None => (None, None, None),
+            }
+        } else {
+            let rss_bytes = pids
+                .iter()
                 .filter_map(|pid| by_pid.get(pid))
-                .filter_map(|p| {
-                    let old = previous.get(&(p.pid, p.start_id))?;
-                    Some((p.cpu_seconds - old).max(0.0))
-                })
-                .sum::<f64>()
-                / seconds
-                / logical_cpus() as f64
-        });
+                .map(|p| p.rss_bytes)
+                .sum();
+            let cpu_fraction = elapsed.filter(|v| *v > 0.0).map(|seconds| {
+                pids.iter()
+                    .filter_map(|pid| by_pid.get(pid))
+                    .filter_map(|p| {
+                        let old = previous.get(&(p.pid, p.start_id))?;
+                        Some((p.cpu_seconds - old).max(0.0))
+                    })
+                    .sum::<f64>()
+                    / seconds
+                    / logical_cpus() as f64
+            });
+            (cpu_fraction, Some(rss_bytes), Some(pids.len()))
+        };
         rows.push(AgentMetric {
             id: inst.id.clone(),
             title: inst.title.clone(),
             cpu_fraction,
             rss_bytes,
-            procs: pids.len(),
+            procs,
+            sandboxed: sandbox_container.is_some(),
         });
     }
 
@@ -257,8 +296,9 @@ fn aggregate_agents(
             id: rec.session_id,
             title,
             cpu_fraction,
-            rss_bytes,
-            procs: pids.len(),
+            rss_bytes: Some(rss_bytes),
+            procs: Some(pids.len()),
+            sandboxed: false,
         });
     }
 

--- a/src/tui/components/diagnostics.rs
+++ b/src/tui/components/diagnostics.rs
@@ -7,7 +7,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::*;
 use unicode_width::UnicodeWidthStr;
 
-use crate::process::metrics::{MemorySample, MetricsSnapshot};
+use crate::process::metrics::{AgentMetric, MemorySample, MetricsSnapshot};
 use crate::tui::components::truncate_to_width;
 use crate::tui::styles::Theme;
 
@@ -21,12 +21,68 @@ const PSI_CRITICAL: f32 = 20.0;
 const PSI_WARN: f32 = 5.0;
 const HEALTH_FIXED_ROWS: u16 = 6;
 const AGENT_TABLE_HEADER_ROWS: u16 = 1;
+/// Display width of the fixed metric block on the agent table, identical on the
+/// header (`{:>7} {:>9} {:>6}`) and on each row (` {cpu:>6} {:>9} {:>6}`). The
+/// name column takes whatever is left, so both lines must derive it the same
+/// way or the columns drift apart.
+const AGENT_METRICS_WIDTH: usize = 24;
 
 pub(crate) fn agent_table_visible_rows(preview_height: u16) -> usize {
     preview_height
         .saturating_sub(2)
         .saturating_sub(HEALTH_FIXED_ROWS)
         .saturating_sub(AGENT_TABLE_HEADER_ROWS) as usize
+}
+
+fn agent_name_width(table_width: u16) -> usize {
+    (table_width as usize)
+        .saturating_sub(AGENT_METRICS_WIDTH)
+        .max(8)
+}
+
+/// Marker on a sandboxed row, matching the session list's `[container]` badge.
+const CONTAINER_BADGE: &str = " [container]";
+
+/// The name cell: the agent title, plus the container marker when the row's
+/// figures come from a sandbox rather than a host process tree (its memory
+/// figure is the container's usage, not an RSS sum). The spans always total
+/// `width`, so the metric columns stay under their headers.
+fn agent_name_spans<'a>(agent: &AgentMetric, width: usize, theme: &Theme) -> Vec<Span<'a>> {
+    // Below this the badge would crowd out the name; the row keeps its
+    // numbers and just loses the marker.
+    let show_badge = agent.sandboxed && width >= CONTAINER_BADGE.width() + 8;
+    let title_width = if show_badge {
+        width - CONTAINER_BADGE.width()
+    } else {
+        width
+    };
+    let mut spans = vec![Span::styled(
+        format_agent_title(&agent.title, title_width),
+        Style::default().fg(theme.text),
+    )];
+    if show_badge {
+        spans.push(Span::styled(
+            CONTAINER_BADGE,
+            Style::default().fg(theme.sandbox),
+        ));
+    }
+    spans
+}
+
+/// The fixed-width CPU / Mem / Procs block of an agent row. A figure the
+/// sampler has no reading for prints "?" rather than a zero, which would read
+/// as a measured idle.
+fn agent_metrics_cell(agent: &AgentMetric) -> String {
+    let cpu = agent
+        .cpu_fraction
+        .map_or_else(|| "?".to_string(), |v| format!("{:.1}%", v * 100.0));
+    let mem = agent
+        .rss_bytes
+        .map_or_else(|| "?".to_string(), format_bytes);
+    let procs = agent
+        .procs
+        .map_or_else(|| "?".to_string(), |procs| procs.to_string());
+    format!(" {cpu:>6} {mem:>9} {procs:>6}")
 }
 
 fn format_agent_title(title: &str, width: usize) -> String {
@@ -318,32 +374,24 @@ pub fn render_system_health(
         );
         return;
     }
+    let name_width = agent_name_width(table_area.width);
     let mut table_lines = vec![Line::from(vec![
         Span::styled(
-            format!("{:<24}", "Agent"),
+            format!("{:<name_width$}", "Agent"),
             Style::default().fg(theme.hint).bold(),
         ),
         Span::styled(
-            format!("{:>7} {:>9} {:>6}", "CPU", "RSS", "Procs"),
+            // "Mem", not "RSS": a sandboxed row reports the container's memory
+            // usage, which is not a resident-set sum.
+            format!("{:>7} {:>9} {:>6}", "CPU", "Mem", "Procs"),
             Style::default().fg(theme.hint).bold(),
         ),
     ])];
     let visible = table_area.height.saturating_sub(1) as usize;
     for agent in snapshot.agents.iter().skip(scroll).take(visible) {
-        let name_width = table_area.width.saturating_sub(24).max(8) as usize;
-        let title = format_agent_title(&agent.title, name_width);
-        let cpu = agent
-            .cpu_fraction
-            .map(|v| format!("{:.1}%", v * 100.0))
-            .unwrap_or_else(|| "?".into());
-        table_lines.push(Line::from(vec![
-            Span::styled(title, Style::default().fg(theme.text)),
-            Span::raw(format!(
-                " {cpu:>6} {:>9} {:>6}",
-                format_bytes(agent.rss_bytes),
-                agent.procs
-            )),
-        ]));
+        let mut spans = agent_name_spans(agent, name_width, theme);
+        spans.push(Span::raw(agent_metrics_cell(agent)));
+        table_lines.push(Line::from(spans));
     }
     frame.render_widget(Paragraph::new(table_lines), table_area);
 }
@@ -445,6 +493,68 @@ mod tests {
             let formatted = format_agent_title(title, 8);
             assert_eq!(formatted.width(), 8, "title {title:?}");
         }
+    }
+
+    #[test]
+    fn agent_table_header_and_rows_share_column_offsets() {
+        // The metric block is fixed-width on both lines, so the name cell must
+        // be the same width on both or the CPU/RSS/Procs columns drift apart.
+        assert_eq!(
+            format!("{:>7} {:>9} {:>6}", "CPU", "RSS", "Procs").width(),
+            AGENT_METRICS_WIDTH
+        );
+        assert_eq!(
+            agent_metrics_cell(&AgentMetric {
+                cpu_fraction: Some(0.999),
+                rss_bytes: Some(22 * (1 << 30)),
+                procs: Some(12),
+                ..AgentMetric::default()
+            })
+            .width(),
+            AGENT_METRICS_WIDTH
+        );
+        // A sandbox with no runtime sample yet still fills its columns.
+        assert_eq!(
+            agent_metrics_cell(&AgentMetric {
+                sandboxed: true,
+                ..AgentMetric::default()
+            }),
+            format!("{:>7} {:>9} {:>6}", "?", "?", "?")
+        );
+        let theme = Theme::default();
+        for table_width in [20u16, 32, 48, 60, 120] {
+            let name_width = agent_name_width(table_width);
+            let header = format!("{:<name_width$}", "Agent").width();
+            for sandboxed in [false, true] {
+                let agent = AgentMetric {
+                    title: "some agent title".into(),
+                    sandboxed,
+                    ..AgentMetric::default()
+                };
+                let cell: usize = agent_name_spans(&agent, name_width, &theme)
+                    .iter()
+                    .map(|s| s.width())
+                    .sum();
+                assert_eq!(header, cell, "table width {table_width}, {sandboxed}");
+            }
+        }
+    }
+
+    #[test]
+    fn container_badge_is_dropped_when_the_name_cell_is_narrow() {
+        let theme = Theme::default();
+        let agent = AgentMetric {
+            title: "sandboxed agent".into(),
+            sandboxed: true,
+            ..AgentMetric::default()
+        };
+        let badged = |width| {
+            agent_name_spans(&agent, width, &theme)
+                .iter()
+                .any(|s| s.content.contains("[container]"))
+        };
+        assert!(!badged(CONTAINER_BADGE.width() + 7));
+        assert!(badged(CONTAINER_BADGE.width() + 8));
     }
 
     #[test]

--- a/src/tui/components/diagnostics.rs
+++ b/src/tui/components/diagnostics.rs
@@ -34,6 +34,19 @@ pub(crate) fn agent_table_visible_rows(preview_height: u16) -> usize {
         .saturating_sub(AGENT_TABLE_HEADER_ROWS) as usize
 }
 
+/// Gutter between the pane border and its contents, widening as the pane does.
+/// The agent table stretches its name column to whatever it is given, so at one
+/// column of padding a wide pane reads as pinned to its edges; a narrow one
+/// needs the width for the columns more than it needs the gutter. `width` is
+/// the outer pane width, borders included.
+fn health_padding(width: u16) -> u16 {
+    match width {
+        0..=47 => 1,
+        48..=79 => 2,
+        _ => 3,
+    }
+}
+
 fn agent_name_width(table_width: u16) -> usize {
     (table_width as usize)
         .saturating_sub(AGENT_METRICS_WIDTH)
@@ -282,7 +295,7 @@ pub fn render_system_health(
             " System Health ",
             Style::default().fg(theme.title).bold(),
         ))
-        .padding(Padding::horizontal(1));
+        .padding(Padding::horizontal(health_padding(area.width)));
     let inner = block.inner(area);
     frame.render_widget(block, area);
     if inner.width == 0 || inner.height == 0 {
@@ -537,6 +550,24 @@ mod tests {
                     .sum();
                 assert_eq!(header, cell, "table width {table_width}, {sandboxed}");
             }
+        }
+    }
+
+    #[test]
+    fn health_padding_never_starves_the_agent_table() {
+        // The gutter must not cost so much width that the metrics block and a
+        // minimum name cell stop fitting, which is what would make a wider
+        // pane render a worse table than a narrower one.
+        let mut previous = 0;
+        for width in 36u16..=200 {
+            let padding = health_padding(width);
+            assert!(padding >= previous, "padding shrank at width {width}");
+            previous = padding;
+            let inner = width - 2 - 2 * padding;
+            assert!(
+                inner as usize >= AGENT_METRICS_WIDTH + 8,
+                "width {width} leaves only {inner} columns for the table"
+            );
         }
     }
 


### PR DESCRIPTION
## Description

Three fixes to the System Health pane. The first two are visible on any host running sandboxed sessions; the third is cosmetic.

**1. Sandbox rows measured the wrong process tree.**

A sandboxed session's tmux pane holds a `docker exec` client, not the agent. The agent runs inside the container, off the pane's host process tree entirely (its own cgroup on Linux, a different VM on macOS), so `aggregate_agents`' pane-pid descendant walk found only the pane shell and the CLI client:

```
  PID  PPID    RSS COMMAND
84835 13437   3040 /bin/zsh
84866 84835  23824 docker exec -it ... aoe-sandbox-e44d6fcc claude --session-id ...
```

Every sandbox row therefore read ~27M / 2 procs / ~0%, no matter what the agent inside was doing. Nothing in `src/process/` or `src/containers/` read a cgroup or `docker stats`.

The same held for sandboxed **structured (ACP)** sessions, which `spawn_runner_detached` also wraps in `docker exec`. Their host tree is the `aoe __acp-runner` shim plus the client, measured live at 34.8M + 24.1M over 2 procs while the agent itself was running 36 processes inside the container. Both populations are fixed here.

Rows for a sandboxed session now come from the runtime's own accounting, one `<runtime> stats --no-stream` per refresh. The cost is the interesting part: that call takes **~1.4-2.2s for 28 containers**, and the metrics sampler runs every 1s, so it cannot ride that cadence. `containers::stats::cached_stats` never blocks — it returns the last completed map and kicks off a refresh on its own thread once the cache passes a 5s TTL, with an in-flight guard so a slow call cannot stack and a drop guard so a panicking refresh cannot latch that guard on. The host CPU/memory sample keeps its 1s cadence untouched.

The stats call is skipped entirely unless a sandboxed session is loaded. It is *not* gated on the health surface being open: the sampler also runs for the compact strip and for the undiscovered-tip check, so a host with a sandbox pays one refresh per TTL whenever the TUI is sampling at all.

The pid tree is still walked for a sandboxed session, so its pane processes stay claimed and cannot be double-counted onto a neighbour; only the reported figures come from the container. CPU is divided by host logical CPUs, so a container row means the same "share of this machine" as a host row.

`AgentMetric`'s figures become `Option`, because a sandbox can legitimately have no reading yet (cold cache, docker down, or Apple's `container`, which has no stats subcommand). Those print `?` rather than a zero that would read as a measured idle.

**2. The header columns did not line up with the row columns.**

The header hardcoded a 24-wide name cell (`format!("{:<24}", "Agent")`) while rows used `table_area.width - 24`, so the two lined up only when the table was exactly 48 columns wide; the drift is `table_width - 48` at any width above that. Both now derive the cell from `agent_name_width`.

The column is labelled `Mem` rather than `RSS`, since a container's usage is not a resident-set sum, and a sandbox row carries the session list's `[container]` badge (same `theme.sandbox` styling) so the different measurement is visible.

**3. The pane had no gutter.**

Because the table stretches its name column to whatever width it is given, one column of padding left a wide pane looking pinned to both borders. Padding now steps to 2 columns at 48 and 3 at 80, staying at 1 where the columns need the width more than the gutter. The captures below predate this tweak, so they show the old single-column gutter; nothing else in them changed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

### After

Debug build, live sandboxed **terminal** session with two busy loops running inside the container. One capture, not a composite:

```
╭ System Health ────────────────────────────────────────────────────────────────────────────╮
│ Status  OK                                                                                │
│ CPU      38%                                                                              │
│ Memory   55%   35.2G / 64G                                                                │
│ Load    8.12 / 6.67 / 6.91                                                                │
│ Swap    865M / 2G                                                                         │
│ Agents  2 running · 29 processes                                                          │
│ Agent                                                                CPU       Mem  Procs │
│ healthtest                                            [container]  14.8%      278M     28 │
│ Slavs                                                               0.0%      266M      1 │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
```

`docker stats` taken immediately after that frame:

```
$ docker stats --no-stream --format '{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.PIDs}}' aoe-sandbox-cf8ab2e5
aoe-sandbox-cf8ab2e5	207.34%	277.9MiB / 30.56GiB	28
```

207.34% / 14 logical CPUs = 14.81% against the 14.8% shown; 277.9MiB renders as 278M; 28 pids. The row counts reconcile with the summary line above them (28 + 1 = 29).

And the same for a sandboxed **structured (ACP)** session, alongside two non-sandboxed structured rows that correctly keep their host-tree figures and no badge:

```
│ Agents  4 running · 43 processes                                                          │
│ Agent                                                                CPU       Mem  Procs │
│ structtest                                            [container]   7.4%      441M     36 │
│ Greeting Response                                                   0.1%      502M      3 │
│ Slavs                                                               0.0%      266M      1 │
│ Test                                                                0.0%      504M      3 │
```

```
$ docker stats --no-stream --format '...' aoe-sandbox-69d3627a
aoe-sandbox-69d3627a	102.55%	440.6MiB / 30.56GiB	36
```

102.55% / 14 = 7.32% against 7.4% shown, 440.6MiB → 441M, 36 pids, and 36 + 3 + 1 + 3 = 43.

Before this change those rows read `27M / 2 procs / 0.0%` and `59M / 2 procs` respectively, with the header columns sitting well left of them.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

`MetricsSnapshot` is consumed only by the TUI (`src/tui/metrics_poller.rs` and `src/tui/home/mod.rs`); no dashboard surface reads it.

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: an e2e test that could actually fail here needs a live sandbox container, which puts it in the `#[ignore]`d Docker tier rather than the suite that runs on every PR. The two things that can break are covered by unit tests instead: the stats parsing (pinned against a real `docker stats` row from a live host, plus podman's decimal units, `--` rows from a restarting container, and prefix filtering) and the table geometry (header and row name cells agree across a table of pane widths; the `?` cell keeps its column width). The container-attribution path itself was verified by hand against live containers for both session types, as shown above.

Verification run: 6182 lib tests pass under `--features serve` (one pre-existing failure, `hooks_install::tests::test_content_shows_settings_path`, which reads the real `~/.claude` and fails identically on a stashed clean tree). `cargo fmt --check` clean, `cargo clippy --lib --tests` clean across every touched file, builds clean both with and without `--features serve`, and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features serve` clean. Live testing ran entirely in the debug namespace (`~/.agent-of-empires-dev`, isolated tmux socket); every test session, container, scratch dir, and the serve daemon were torn down afterward.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Used for the investigation, the implementation, and the live verification against real sandbox containers. The change was then reviewed by a separate agent with no knowledge of how it was built, which caught the rustdoc failure, the structured-session gap, the panic-latch in the refresh guard, and a stitched-together screenshot in an earlier draft of this description. All of those are fixed in the second commit.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
