### PR TITLE
refactor(tmux): dedupe the managed-setting write emitter (#3351 follow-up)

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -2598,15 +2598,18 @@ enum TmuxAutoDefer {
 
 /// One tmux `set-option` aoe writes on its own sessions, at creation.
 ///
-/// The variant is the scope, so an illegal write (a server option carrying a
-/// target, say) does not compile. Scope flags are emitted explicitly (`-s`,
-/// `-w`, `-t`) rather than left to tmux's scope inference, so the write is
-/// unambiguous and resilient to future inference changes (same convention as
-/// `append_remain_on_exit_args`). `quiet` adds tmux's `-q` (ignore unknown
-/// options), which aoe needs for `allow-passthrough` on tmux < 3.3, where
-/// `allow-passthrough` does not exist and the set-option call would otherwise
-/// fail the whole `new-session` invocation; it is a per-write property, not a
-/// scope property.
+/// The variant is the scope the write addresses (session `-t <target>`,
+/// server `-s`, window `-w -t <target>`), so a write's scope flags follow
+/// from its variant alone; the target of session/window writes is a runtime
+/// parameter of the emitter, not a property of the write. Scope flags are
+/// emitted explicitly (`-s`, `-w`, `-t`) rather than left to tmux's scope
+/// inference, so the write is unambiguous and resilient to future inference
+/// changes (same convention as `append_remain_on_exit_args`). `quiet` adds
+/// tmux's `-q` (ignore unknown options), which aoe needs for
+/// `allow-passthrough` on tmux < 3.3, where `allow-passthrough` does not
+/// exist and the set-option call would otherwise fail the whole
+/// `new-session` invocation; it is a per-write property, not a scope
+/// property.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TmuxOptionWrite {
     /// `set-option [-q] -t <target> <option> <value>` on the new session.

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -170,55 +170,35 @@ pub fn append_tmux_setting_args(args: &mut Vec<String>, target: &str, config: &C
 
 /// Append the writes of one managed setting to an in-flight tmux argument
 /// list. Pure over the writes, so the emitted tokens are table-testable.
-pub(crate) fn append_tmux_setting_writes(
-    args: &mut Vec<String>,
-    target: &str,
-    writes: &[TmuxOptionWrite],
-) {
+fn append_tmux_setting_writes(args: &mut Vec<String>, target: &str, writes: &[TmuxOptionWrite]) {
     for write in writes {
         args.push(";".to_string());
         args.push("set-option".to_string());
-        match *write {
+        // Only the scope flags differ per variant; the `-q` guard and the
+        // option/value pushes are shared.
+        let (scope_flags, option, value, quiet) = match *write {
             TmuxOptionWrite::Session {
                 option,
                 value,
                 quiet,
-            } => {
-                if quiet {
-                    args.push("-q".to_string());
-                }
-                args.push("-t".to_string());
-                args.push(target.to_string());
-                args.push(option.to_string());
-                args.push(value.to_string());
-            }
+            } => (&["-t", target][..], option, value, quiet),
             TmuxOptionWrite::Server {
                 option,
                 value,
                 quiet,
-            } => {
-                if quiet {
-                    args.push("-q".to_string());
-                }
-                args.push("-s".to_string());
-                args.push(option.to_string());
-                args.push(value.to_string());
-            }
+            } => (&["-s"][..], option, value, quiet),
             TmuxOptionWrite::Window {
                 option,
                 value,
                 quiet,
-            } => {
-                if quiet {
-                    args.push("-q".to_string());
-                }
-                args.push("-w".to_string());
-                args.push("-t".to_string());
-                args.push(target.to_string());
-                args.push(option.to_string());
-                args.push(value.to_string());
-            }
+            } => (&["-w", "-t", target][..], option, value, quiet),
+        };
+        if quiet {
+            args.push("-q".to_string());
         }
+        args.extend(scope_flags.iter().map(|flag| flag.to_string()));
+        args.push(option.to_string());
+        args.push(value.to_string());
     }
 }
 


### PR DESCRIPTION
## Description

Follow-up to #3351 (already merged), addressing the review feedback that was explicitly left as follow-up material:

- **Dedupe the emitter** (raised by CodeRabbit and the human review): `append_tmux_setting_writes` matched three arms that repeated the `-q` guard and the `option`/`value` pushes, differing only in scope flags. The match now yields `(scope_flags, option, value, quiet)` and the `-q` guard plus option/value emission are shared. Emitted tokens are byte-identical for all six (scope x quiet) combinations (verified against the pre-image); the four reachable ones are pinned by the existing golden tests, which are untouched. The two unreachable combos (Server/Window quiet:false) do not appear in any golden, but they are unreachable from the current table (all Server/Window rows are quiet:true) and share the single emission path, so no regression can affect them alone.
- **Private visibility** (@njbrake): `append_tmux_setting_writes` was `pub(crate)` with no cross-module caller; it is now a private `fn` (only same-module callers exist: `append_tmux_setting_args` and the module's tests).
- **Correct the `TmuxOptionWrite` doc** (@njbrake): the old doc claimed "an illegal write (a server option carrying a target, say) does not compile", which was misleading: no variant holds a target (it is a runtime parameter of the emitter) and all three variants carry the identical `{option, value, quiet}` triple. The new doc states the real guarantee: the variant is the scope the write addresses (session `-t <target>`, server `-s`, window `-w -t <target>`), so a write's scope flags follow from its variant alone.

No behavior change. No test change: the emitted tokens are already pinned by the existing goldens (`test_tmux_option_write_emission`, `test_tmux_setting_writes_table`, `test_append_tmux_setting_args_emits_rows_in_order`, `test_user_config_silent_on_option_still_applies_auto`), and a new test asserting the same tokens would be tautological (per AGENTS.md, a test that cannot fail is a review comment, not a deliverable).

## PR Type

- [x] Refactor
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (doc comment on `TmuxOptionWrite`)
- [x] For UI changes: N/A

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: no `web/` files change

**TUI / CLI (e2e test)**
- [x] N/A: no TUI rendering, CLI subcommand, or session lifecycle change; the emitted tmux args are unchanged and pinned by existing unit goldens

Validation run locally:

- `cargo fmt --all -- --check`: clean
- `cargo clippy -- -D warnings` (the CI invocation): clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features serve`: clean
- `cargo test --lib tmux::utils::tests::`: 26 passed
- `cargo test --lib tmux_setting`: 6 passed (tripwire + anti-drift + decision table)

## AI Usage

- [x] AI was used

**AI Model/Tool used:** opencode-go/deepseek-v4-flash (agentic; multi-agent design and validation per the session template)

**Any Additional AI Details you'd like to share:**

Design ran as two independent multi-agent rounds (3 fresh-eye agents each). Round 1 validated the refactor shape with scratch harnesses (token order byte-identical across the six combinations, temporary-lifetime extension for the mixed `&'static str`/runtime `target` slice, clippy clean, no allocation delta) and produced the corrected doc wording; its two formulation findings were integrated. Round 2 was zero-finding on all three axes (code, tests, semantics). Implementation was a single focused executor.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Refactored tmux setting writes to remove duplicated emission logic.
- Preserved byte-identical output for session, server, and window scopes.
- Made `append_tmux_setting_writes` private.
- Updated `TmuxOptionWrite` documentation to clarify scope and quiet-mode behavior.

## Benefits

- Reduces maintenance overhead.
- Keeps scope handling consistent.
- Preserves existing behavior and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->