### PR TITLE
fix(test): wait for the pane command to exec instead of sleeping 200ms

### DIFF
--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -2025,6 +2025,62 @@ mod tests {
             .unwrap_or(false)
     }
 
+    /// The tmux id (`%N`) of `session_name`'s only pane. Call right after
+    /// `new-session`, before any split or extra window, so `-t <session>`
+    /// resolves unambiguously.
+    fn only_pane_id(session_name: &str) -> String {
+        let out = crate::tmux::tmux_command()
+            .args(["display-message", "-t", session_name, "-p", "#{pane_id}"])
+            .output()
+            .expect("tmux display-message");
+        let id = String::from_utf8(out.stdout)
+            .expect("utf8")
+            .trim()
+            .to_string();
+        assert!(!id.is_empty(), "no pane id for session {session_name}");
+        id
+    }
+
+    /// Block until `pane_id` reports `expected` as its current command.
+    ///
+    /// tmux runs a single-string pane command (`"sleep 30"`) through the
+    /// user's shell, so `pane_current_command` reports that shell, which
+    /// `is_shell_command` matches, until it execs into the real command.
+    /// A fixed sleep is a bet on that exec having happened and loses on a
+    /// cold tmux server, where server startup widens the window; wait for
+    /// the exec instead.
+    ///
+    /// Keyed on the pane's own id rather than the `^.0` target so the wait
+    /// never depends on the pane resolution the callers' assertions exist to
+    /// exercise: a targeting regression still fails on the assertion with its
+    /// own message instead of timing out here.
+    fn wait_for_pane_command(pane_id: &str, expected: &str) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let current = crate::tmux::tmux_command()
+                .args([
+                    "display-message",
+                    "-t",
+                    pane_id,
+                    "-p",
+                    "#{pane_current_command}",
+                ])
+                .output()
+                .ok()
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default();
+            if current == expected {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "pane {pane_id} still reports {current:?}, expected {expected:?}"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
     /// Create a detached session for the composite tests, applying the guards
     /// the rest of this module treats as mandatory:
     ///
@@ -3144,6 +3200,7 @@ mod tests {
             .output()
             .expect("tmux new-session");
         assert!(output.status.success());
+        let agent_pane = only_pane_id(&session_name);
 
         // Force base-index 1 to simulate users who have set base-index 1 in
         // their tmux.conf. With base-index 1, window 0 does not exist, so any
@@ -3161,7 +3218,7 @@ mod tests {
             .expect("tmux new-window");
         assert!(output.status.success());
 
-        std::thread::sleep(std::time::Duration::from_millis(200));
+        wait_for_pane_command(&agent_pane, "sleep");
 
         let session = Session {
             name: session_name.clone(),
@@ -3652,6 +3709,7 @@ mod tests {
             .output()
             .expect("tmux new-session");
         assert!(output.status.success());
+        let agent_pane = only_pane_id(&session_name);
 
         // Force base-index 1 to simulate users who have set base-index 1 in
         // their tmux.conf. With base-index 1, window 0 does not exist, so any
@@ -3669,7 +3727,7 @@ mod tests {
             .expect("tmux new-window");
         assert!(output.status.success());
 
-        std::thread::sleep(std::time::Duration::from_millis(200));
+        wait_for_pane_command(&agent_pane, "sleep");
 
         // Should be false: first window runs 'sleep', not a shell.
         // Would incorrectly return true if the active second window (sh) were checked.
@@ -3718,6 +3776,7 @@ mod tests {
             .output()
             .expect("tmux new-session");
         assert!(output.status.success());
+        let agent_pane = only_pane_id(&session_name);
 
         // Split the window -- this creates a new pane running a shell
         let output = crate::tmux::tmux_command()
@@ -3733,7 +3792,7 @@ mod tests {
             .expect("tmux select-pane");
         assert!(output.status.success());
 
-        std::thread::sleep(std::time::Duration::from_millis(200));
+        wait_for_pane_command(&agent_pane, "sleep");
 
         // The agent pane (pane 0) is still alive
         assert!(
@@ -3790,6 +3849,7 @@ mod tests {
             .output()
             .expect("tmux new-session");
         assert!(output.status.success());
+        let agent_pane = only_pane_id(&session_name);
 
         // Simulate a user with pane-base-index 1 globally by setting it on the
         // window -- but aoe has already pinned pane-base-index 0 on the session,
@@ -3805,7 +3865,7 @@ mod tests {
             .expect("tmux split-window");
         assert!(output.status.success());
 
-        std::thread::sleep(std::time::Duration::from_millis(200));
+        wait_for_pane_command(&agent_pane, "sleep");
 
         assert!(
             !is_pane_dead(&session_name),

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -2046,9 +2046,10 @@ mod tests {
     /// tmux runs a single-string pane command (`"sleep 30"`) through the
     /// user's shell, so `pane_current_command` reports that shell, which
     /// `is_shell_command` matches, until it execs into the real command.
-    /// A fixed sleep is a bet on that exec having happened and loses on a
-    /// cold tmux server, where server startup widens the window; wait for
-    /// the exec instead.
+    /// A fixed sleep is a bet on that exec having happened. The window it
+    /// has to cover is the shell's own startup, around 100ms on an idle
+    /// machine and several times that when the suite is competing for
+    /// cores, so the bet loses under load; wait for the exec instead.
     ///
     /// Keyed on the pane's own id rather than the `^.0` target so the wait
     /// never depends on the pane resolution the callers' assertions exist to


### PR DESCRIPTION
## Description

`test_status_checks_with_split_panes_and_pane_base_index_1` fails intermittently on its `is_pane_running_shell` assertion. Reproduced locally at roughly 1 run in 12.

tmux runs a single-string pane command (`"sleep 30"`) through the user's shell, so `#{pane_current_command}` reports `bash`, which `is_shell_command` matches, until the shell execs into `sleep`. Probing tmux 3.6 directly shows both forms:

```
formA ("sleep 30" as one string):  immediate=bash   after=sleep
formB ("sleep", "30" as argv):     immediate=sleep  after=sleep
```

The affected tests bet a fixed 200ms on that exec having happened; under load the bet loses and the pane still reads `bash`.

This replaces the sleep with a bounded poll for the expected command. The wait keys on the pane's own `%N` id, captured while the session still has exactly one pane, rather than on the `^.0` target: a pane-resolution regression then still fails on the assertion that exists to catch it, with its own message, instead of timing out in setup. That is what keeps the wait from making the assertion vacuous.

Four tests shared the race, so all four now wait rather than just the one that was observed failing:

- `test_capture_pane_targets_first_window_with_multiple_windows`
- `test_is_pane_running_shell_targets_first_window_with_multiple_windows`
- `test_status_checks_target_pane_zero_with_split_panes`
- `test_status_checks_with_split_panes_and_pane_base_index_1`

`test_is_pane_running_shell_on_non_shell_session` passes the command as argv, which tmux execs directly with no intervening shell, so it was never affected and is unchanged.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Test-only change; no user-facing behavior, so no screenshot.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

No new test: this changes how four existing tests wait, and adds no product code. Verified by 20 consecutive runs of the four tests under saturating CPU load with no failures, against a pre-fix reproduction rate of about 1 in 12 with no added load.

`cargo fmt --all -- --check` clean; `cargo test --lib tmux::session` 55 passing.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any Additional AI Details you'd like to share:**

Found while reviewing another PR, when the flake surfaced in a full-suite run. I had it probe tmux directly to establish the mechanism rather than infer it from the failure, confirm which sibling tests shared the pattern, and stress-test the fix under load. I reviewed the change and understand it.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Replaced fixed delays in tmux regression tests with bounded polling.
- Added helpers to identify a session pane and wait for its expected command.
- Updated four tests to avoid timing-related failures when shell startup is slow.

## Benefits

- Improves test reliability under system load.
- Prevents assertions from running before the pane is ready.
- Keeps pane-resolution failures separate from command-readiness timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->